### PR TITLE
Handle null units from the api

### DIFF
--- a/src/api/reports.ts
+++ b/src/api/reports.ts
@@ -44,7 +44,7 @@ export interface Report {
     [filter: string]: any;
   };
   total?: {
-    units: string;
+    units?: string;
     value: number;
   };
 }

--- a/src/components/trendChart/trendChart.tsx
+++ b/src/components/trendChart/trendChart.tsx
@@ -79,6 +79,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
           style={chartStyles.group}
           height={height}
           width={this.state.width}
+          domainPadding={{ y: [0, 8] }}
           containerComponent={
             <VictoryVoronoiContainer
               voronoiDimension="x"

--- a/src/utils/formatValue.ts
+++ b/src/utils/formatValue.ts
@@ -13,6 +13,10 @@ export const formatValue: ValueFormatter = (
   unit: string,
   options: FormatOptions = {}
 ) => {
+  if (!unit) {
+    return value;
+  }
+
   const lookup = unit.split('-')[0].toLowerCase();
   switch (lookup) {
     case 'usd':


### PR DESCRIPTION
The api can at times return null for the units in total for reports. Add a null check and return value if that is the case.