### PR TITLE
Truncate decimal places for unknown values

### DIFF
--- a/src/utils/__snapshots__/formatValue.test.ts.snap
+++ b/src/utils/__snapshots__/formatValue.test.ts.snap
@@ -3,3 +3,7 @@
 exports[`formatCurrency defaults fractionDigits 1`] = `"$100.11"`;
 
 exports[`formatCurrency uses specified fractionDigits 1`] = `"$100"`;
+
+exports[`formatValue null unit returns value fixed to fractionDigits 1`] = `"100.1"`;
+
+exports[`formatValue unknown unit returns value fixed to fractionDigits 1`] = `"100"`;

--- a/src/utils/formatValue.test.ts
+++ b/src/utils/formatValue.test.ts
@@ -1,20 +1,33 @@
 import * as format from './formatValue';
 
 jest.spyOn(format, 'formatCurrency');
+jest.spyOn(format, 'formatStorage');
 
 describe('formatValue', () => {
   const formatOptions: format.FormatOptions = {};
   const value = 100.11;
 
-  test('defaults to returning the value', () => {
+  test('unknown unit returns value fixed to fractionDigits', () => {
     const formatted = format.formatValue(value, 'unknownUnit');
-    expect(formatted).toBe(value);
+    expect(formatted).toMatchSnapshot();
   });
 
   test('usd unit calls formatCurrency', () => {
     const unit = 'usd';
     format.formatValue(value, unit, formatOptions);
     expect(format.formatCurrency).toBeCalledWith(value, unit, formatOptions);
+  });
+
+  test('gb unit calls format storage', () => {
+    const unit = 'gb-mo';
+    format.formatValue(value, unit, formatOptions);
+    expect(format.formatStorage).toBeCalledWith(value, 'gb', formatOptions);
+  });
+
+  test('null unit returns value fixed to fractionDigits', () => {
+    const unit = null;
+    const formatted = format.formatValue(value, unit, { fractionDigits: 1 });
+    expect(formatted).toMatchSnapshot();
   });
 });
 

--- a/src/utils/formatValue.ts
+++ b/src/utils/formatValue.ts
@@ -13,19 +13,24 @@ export const formatValue: ValueFormatter = (
   unit: string,
   options: FormatOptions = {}
 ) => {
-  if (!unit) {
-    return value;
-  }
+  const lookup = unit && unit.split('-')[0].toLowerCase();
 
-  const lookup = unit.split('-')[0].toLowerCase();
   switch (lookup) {
     case 'usd':
       return formatCurrency(value, lookup, options);
     case 'gb':
       return formatStorage(value, lookup, options);
     default:
-      return value;
+      return unknownTypeFormatter(value, lookup, options);
   }
+};
+
+const unknownTypeFormatter: ValueFormatter = (
+  value,
+  _unit,
+  { fractionDigits } = {}
+) => {
+  return value.toFixed(fractionDigits);
 };
 
 export const formatCurrency: ValueFormatter = (


### PR DESCRIPTION
At times the API can return units as an empty string. The UI needs to handle this by truncating the values as expected.