### PR TITLE
 Set navigation toggle button according to the mockup

### DIFF
--- a/src/components/masthead/masthead.styles.ts
+++ b/src/components/masthead/masthead.styles.ts
@@ -1,6 +1,6 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
-  global_Color_100,
+  global_Color_light_100,
   global_spacer_md,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
@@ -26,7 +26,7 @@ export const styles = StyleSheet.create({
     backgroundColor: '#000',
   },
   navToggle: {
-    color: global_Color_100.value,
+    color: global_Color_light_100.value,
     marginRight: global_spacer_sm.value,
     [theme.page_breakpoint]: {
       display: 'none',

--- a/src/components/masthead/masthead.test.tsx
+++ b/src/components/masthead/masthead.test.tsx
@@ -14,21 +14,12 @@ const props: Props = {
     username: 'David Lightman',
     email: 'david.lightman@test.test',
   },
+  isSidebarOpen: true,
   toggleSidebar: jest.fn(),
   logout: jest.fn(),
 };
 
 jest.spyOn(window, 'addEventListener');
-
-test('toggle sidebar on sidebar toggle click', () => {
-  const view = mount(<MastheadBase {...props} />);
-  const sidebarToggleButton = findByTestId(
-    view,
-    testIds.masthead.sidebarToggle
-  );
-  sidebarToggleButton.simulate('click');
-  expect(props.toggleSidebar).toBeCalled();
-});
 
 test('renders username', () => {
   const view = mount(<MastheadBase {...props} />);

--- a/src/components/masthead/masthead.tsx
+++ b/src/components/masthead/masthead.tsx
@@ -1,5 +1,4 @@
 import { Button, ButtonVariant } from '@patternfly/react-core';
-import { BarsIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import { User } from 'api/users';
 import React from 'react';
@@ -7,13 +6,15 @@ import { I18n } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { sessionActions } from 'store/session';
-import { uiActions } from 'store/ui';
+import { uiActions, uiSelectors } from 'store/ui';
 import { usersSelectors } from 'store/users';
 import { getTestProps, testIds } from 'testIds';
 import { styles } from './masthead.styles';
+import { NavToggleButtonBase } from './navToggleButton';
 
 interface Props {
   user: User;
+  isSidebarOpen: boolean;
   logout: typeof sessionActions.logout;
   toggleSidebar: typeof uiActions.toggleSidebar;
 }
@@ -44,7 +45,7 @@ class MastheadBase extends React.Component<Props, State> {
   };
 
   public render() {
-    const { user, logout, toggleSidebar } = this.props;
+    const { user, logout, isSidebarOpen, toggleSidebar } = this.props;
     const { hasScrolled } = this.state;
 
     return (
@@ -55,18 +56,11 @@ class MastheadBase extends React.Component<Props, State> {
             {...getTestProps(testIds.masthead.masthead)}
           >
             <div className={css(styles.section)}>
-              <Button
-                className={css(styles.navToggle)}
+              <NavToggleButtonBase
+                title={t('navigation_toggle')}
+                isSidebarOpen={isSidebarOpen}
                 onClick={toggleSidebar}
-                variant={ButtonVariant.plain}
-                {...getTestProps(testIds.masthead.sidebarToggle)}
-              >
-                <BarsIcon
-                  color="#fff"
-                  title={t('navigation_toggle')}
-                  size="md"
-                />
-              </Button>
+              />
               {t('app_title')}
             </div>
             {user && (
@@ -96,6 +90,7 @@ class MastheadBase extends React.Component<Props, State> {
 const Masthead = connect(
   createMapStateToProps(state => ({
     user: usersSelectors.selectCurrentUser(state),
+    isSidebarOpen: uiSelectors.selectIsSidebarOpen(state),
   })),
   {
     toggleSidebar: uiActions.toggleSidebar,

--- a/src/components/masthead/navToggleButton.test.tsx
+++ b/src/components/masthead/navToggleButton.test.tsx
@@ -1,0 +1,31 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { testIds } from 'testIds';
+import { findByTestId } from 'testUtils';
+import { NavToggleButtonBase, Props } from './navToggleButton';
+
+const props: Props = {
+  isSidebarOpen: true,
+  title: 'nav_toggle',
+  onClick: jest.fn(),
+};
+
+test('clicking on navigation toggle button calls onClick', () => {
+  const view = mount(<NavToggleButtonBase {...props} />);
+  const sidebarToggleButton = findByTestId(
+    view,
+    testIds.masthead.sidebarToggle
+  );
+  sidebarToggleButton.simulate('click');
+  expect(props.onClick).toBeCalled();
+});
+
+test('show BarsIcon when sidebar is closed', () => {
+  const view = mount(<NavToggleButtonBase {...props} isSidebarOpen={false} />);
+  expect(view.find('BarsIcon').length).toBe(1);
+});
+
+test('show TimesIcon when sidebar is open', () => {
+  const view = mount(<NavToggleButtonBase {...props} />);
+  expect(view.find('TimesIcon').length).toBe(1);
+});

--- a/src/components/masthead/navToggleButton.tsx
+++ b/src/components/masthead/navToggleButton.tsx
@@ -1,0 +1,33 @@
+import { Button, ButtonVariant } from '@patternfly/react-core';
+import { BarsIcon, TimesIcon } from '@patternfly/react-icons';
+import { css } from '@patternfly/react-styles';
+import React from 'react';
+import { uiActions } from 'store/ui';
+import { getTestProps, testIds } from 'testIds';
+import { styles } from './masthead.styles';
+
+interface Props {
+  title: string;
+  isSidebarOpen: boolean;
+  onClick: typeof uiActions.toggleSidebar;
+}
+
+class NavToggleButtonBase extends React.Component<Props> {
+  public render() {
+    const ToggleButtonIcon: React.SFC<any> = this.props.isSidebarOpen
+      ? TimesIcon
+      : BarsIcon;
+    return (
+      <Button
+        className={css(styles.navToggle)}
+        onClick={this.props.onClick}
+        variant={ButtonVariant.plain}
+        {...getTestProps(testIds.masthead.sidebarToggle)}
+      >
+        <ToggleButtonIcon title={this.props.title} size="md" />
+      </Button>
+    );
+  }
+}
+
+export { NavToggleButtonBase, Props };

--- a/src/components/sidebar/sidebar.styles.ts
+++ b/src/components/sidebar/sidebar.styles.ts
@@ -4,17 +4,15 @@ import { theme } from 'styles/theme';
 export const styles = StyleSheet.create({
   sidebar: {
     position: 'fixed',
-    top: 0,
+    top: theme.page_masthead_height,
     bottom: 0,
     left: 0,
-    width: '80vw',
+    width: theme.page_sidebar_width,
     backgroundColor: theme.page_sidebar_background,
     transform: 'translateX(-110%)',
     transition: 'transform ease-in-out 200ms',
     boxShadow: theme.page_sidebar_boxShadow,
     [theme.page_breakpoint]: {
-      top: theme.page_masthead_height,
-      width: theme.page_sidebar_width,
       transform: 'translateX(0)',
     },
   },


### PR DESCRIPTION
On small devices such as Android the `nav toggle button` is displayed but can't be seen because both `masthead` and `bars icon` are black.

To fix this, the `bars icon` color is set to white by changing the color to `global_Color_light_100` in `navToggle`.

In addition, show the times icon when sidebar open.

![screenshot_2018-08-27 koku ui](https://user-images.githubusercontent.com/2453279/44649112-a4144280-a9eb-11e8-91b2-8ac5b9510c0e.png)
![screenshot_2018-08-27 koku ui 1](https://user-images.githubusercontent.com/2453279/44649113-a4144280-a9eb-11e8-93fd-1e816d4c15c5.png)

