### PR TITLE
Added target for koku-staging

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "precommit": "lint-staged",
     "start": "webpack-dev-server",
     "start:dev": "APP_NAMESPACE=koku-dev yarn start",
+    "start:staging": "APP_NAMESPACE=koku-staging APP_PROTOCOL=https yarn start",
     "test": "jest",
     "container:test": "docker stop -t 0 koku-ui-test >/dev/null; docker build -t koku-ui-test . && docker run -i --rm -p 8080:8080 --name koku-ui-test koku-ui-test",
     "verify": "tsc --noEmit"


### PR DESCRIPTION
This PR should also trigger a snapshot on Netlify.com which allows me to log into the staging environment.

Update: The https://deploy-preview-89--project-koku.netlify.com URL below allows me to log into koku-staging. Will follow up with Doug to transfer ownership of the older Netlify site.