### PR TITLE
Add column headers for cost details list page.

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1,6 +1,9 @@
 {
   "app_title": "Koku",
   "cost_details": {
+    "cost_column_subtitle": "(Total {{total}})",
+    "cost_column_title": "Cost",
+    "name_column_title": "$t(group_by.values.{{groupBy}}) Names",
     "title": "Cost"
   },
   "dashboard": "Dashboard",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,6 +1,9 @@
 {
   "app_title": "Koku",
   "cost_details": {
+    "cost_column_subtitle": "(Total {{total}})",
+    "cost_column_title": "Cost",
+    "name_column_title": "$t(group_by.values.{{groupBy}}) Names",
     "title": "Cost"
   },
   "dashboard": "Dashboard",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,6 +1,9 @@
 {
   "app_title": "Koku",
   "cost_details": {
+    "cost_column_subtitle": "(Total {{total}})",
+    "cost_column_title": "Cost",
+    "name_column_title": "$t(group_by.values.{{groupBy}}) Names",
     "title": "Cost"
   },
   "dashboard": "Dashboard",

--- a/src/pages/costDetails/costDetails.tsx
+++ b/src/pages/costDetails/costDetails.tsx
@@ -65,7 +65,10 @@ class CostDetails extends React.Component<Props> {
   }
 
   public componentDidUpdate(prevProps: Props) {
-    if (prevProps.queryString !== this.props.queryString) {
+    if (
+      prevProps.queryString !== this.props.queryString ||
+      !this.props.report
+    ) {
       this.props.fetchReport(reportType, this.props.queryString);
     }
   }
@@ -131,6 +134,25 @@ class CostDetails extends React.Component<Props> {
         </header>
         <div className={listViewOverride}>
           <ListView>
+            <ListView.Item
+              key="header_item"
+              heading={t('cost_details.name_column_title', {
+                groupBy: groupById,
+              })}
+              checkboxInput={<input type="checkbox" />}
+              additionalInfo={[
+                <ListView.InfoItem key="1">
+                  <strong>{t('cost_details.cost_column_title')}</strong>
+                  {Boolean(report) && (
+                    <span>
+                      {t('cost_details.cost_column_subtitle', {
+                        total: formatCurrency(report.total.value),
+                      })}
+                    </span>
+                  )}
+                </ListView.InfoItem>,
+              ]}
+            />
             {computedItems.map(groupItem => (
               <ListView.Item
                 key={groupItem.label}


### PR DESCRIPTION
* Fix an issue where initial page could be empty because report wasn't fetched yet.