### PR TITLE
Fix pie chart look using a workaround

### DIFF
--- a/src/components/commonChart/chartUtils.ts
+++ b/src/components/commonChart/chartUtils.ts
@@ -59,7 +59,7 @@ export function createDatum(
   const xVal = idKey === 'date' ? getDate(computedItem.id) : computedItem.label;
   return {
     x: xVal,
-    y: value,
+    y: parseFloat(value.toFixed(2)),
     key: computedItem.id,
     name: computedItem.id,
     units: computedItem.units,

--- a/src/components/pieChart/pieChart.styles.ts
+++ b/src/components/pieChart/pieChart.styles.ts
@@ -12,7 +12,7 @@ export const chartStyles = {
   padding: { top: 8, bottom: 8 },
   pie: {
     data: {
-      strokeWidth: 1,
+      strokeWidth: 0,
       fillOpacity: 0.7,
       stroke: global_primary_color_200.value,
     },

--- a/src/components/pieChart/pieChart.tsx
+++ b/src/components/pieChart/pieChart.tsx
@@ -9,12 +9,7 @@ import {
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
 import { formatCurrency } from 'utils/formatValue';
-import {
-  VictoryGroup,
-  VictoryLegend,
-  VictoryPie,
-  VictoryTooltip,
-} from 'victory';
+import { VictoryLegend, VictoryPie, VictoryTooltip } from 'victory';
 import { chartStyles, styles } from './pieChart.styles';
 
 interface PieChartProps {
@@ -82,27 +77,23 @@ class PieChart extends React.Component<PieChartProps, State> {
 
     return (
       <div className={css(styles.pieGroup)} ref={this.containerRef}>
-        <VictoryGroup
-          padding={chartStyles.padding}
-          height={height}
-          width={width}
-          colorScale={colors}
-        >
-          {Boolean(currentData.length) && (
-            <VictoryPie
-              colorScale={colors}
-              style={chartStyles.pie}
-              data={currentData}
-              labels={this.getTooltipLabel}
-              labelComponent={
-                <VictoryTooltip
-                  cornerRadius={0}
-                  flyoutStyle={chartStyles.tooltipFlyout}
-                />
-              }
-            />
-          )}
-        </VictoryGroup>
+        {Boolean(currentData.length) && (
+          <VictoryPie
+            padding={chartStyles.padding}
+            height={height}
+            width={width}
+            colorScale={colors}
+            style={chartStyles.pie}
+            data={currentData}
+            labels={this.getTooltipLabel}
+            labelComponent={
+              <VictoryTooltip
+                cornerRadius={0}
+                flyoutStyle={chartStyles.tooltipFlyout}
+              />
+            }
+          />
+        )}
         <svg width={300} height={250}>
           {Boolean(currentData.length) && (
             <VictoryLegend


### PR DESCRIPTION
`VictoryGroup` changes the style of the `colorScale`. It takes the two items in the array and applies them as the border and the background color.

In addition, setting the `strokeWidth` makes the style similar to what shown in the mockup design.

@chambridge can you look at this, please?

![screenshot-2018-9-5 koku ui 1](https://user-images.githubusercontent.com/2453279/45058952-e94b0b00-b0a2-11e8-98f9-c926610e86fc.png)

