### PR TITLE
Fix typo in the data-test-id for Add Account modal confirm (submit button)

### DIFF
--- a/src/testIds.ts
+++ b/src/testIds.ts
@@ -21,7 +21,7 @@ export const testIds = {
     cancel_btn: 'cancel-btn',
     name_input: 'provider-name-input',
     resource_name_input: 'provider-resource-name-input',
-    submit_btn: 'submit-byn',
+    submit_btn: 'submit-btn',
     type_input: 'provider-type-input',
   },
   sidebar: {


### PR DESCRIPTION
Simple change for the data-test-id for providers[submit_btn] from 'submit-byn'  to 'submit-btn'