### PR TITLE
fix(NavToggleButtonBase): add aria-label to Button

### DIFF
--- a/src/components/masthead/navToggleButton.tsx
+++ b/src/components/masthead/navToggleButton.tsx
@@ -22,6 +22,7 @@ class NavToggleButtonBase extends React.Component<Props> {
         className={css(styles.navToggle)}
         onClick={this.props.onClick}
         variant={ButtonVariant.plain}
+        {...{ 'aria-label': 'toggle-navigation-button' }}
         {...getTestProps(testIds.masthead.sidebarToggle)}
       >
         <ToggleButtonIcon title={this.props.title} size="md" />


### PR DESCRIPTION
Added "aria-label" to the button in `NavToggleButtonBase` to fix the warning message in the console:

```
Warning: Failed prop type: aria-label is required for Buttons with the plain variant
```

As mentioned in the [docs](https://patternfly-react.netlify.com/components/button) under `Button Props`:
> Adds accessible text to the button. Required for plain buttons