### PR TITLE
fix(Login): Alert title is not string

### DIFF
--- a/src/pages/login/login.test.tsx
+++ b/src/pages/login/login.test.tsx
@@ -44,7 +44,7 @@ test('triggers login on form submit', () => {
 test('Alert is shown with login error', () => {
   const mockAxiosResponse: AxiosResponse = {
     data: {
-      non_field_errors: 'Unable to log in with provided credentials.',
+      non_field_errors: ['Unable to log in with provided credentials.'],
     },
     status: 1,
     statusText: '',

--- a/src/pages/login/login.tsx
+++ b/src/pages/login/login.tsx
@@ -76,7 +76,7 @@ export class Login extends React.Component<Props, State> {
     if (error && !error.response) {
       loginError = defaultError;
     } else if (nonFieldErrors || usernameError || passwordError) {
-      loginError = nonFieldErrors || usernameError || passwordError;
+      loginError = String(nonFieldErrors || usernameError || passwordError);
     }
 
     return (


### PR DESCRIPTION
Apparently the API returns the error data as an array.
For example, if `username` is missing the following error is returned:

```js
{
 ...
 "data": {
  ...
  "username": ["This field may not be blank"]
 }
}
```

This array is passed to the `title` props in `Alert` but it is supposed to be a string which ends up with printing a warning message in the console.

This commit fixes this by converting the array to string by using the `String` method.