### PR TITLE
Wire up cost details filter within toolbar.

### DIFF
--- a/src/components/textInput/textInput.tsx
+++ b/src/components/textInput/textInput.tsx
@@ -6,6 +6,7 @@ import { styles } from './textInput.styles';
 interface Props extends Omit<React.HTMLProps<HTMLInputElement>, 'onChange'> {
   value: string;
   onChange(value: string, evt: React.FormEvent<HTMLInputElement>);
+  onKeyPress?(evt: React.KeyboardEvent);
   isError?: boolean;
   isFlat?: boolean;
 }
@@ -13,6 +14,12 @@ interface Props extends Omit<React.HTMLProps<HTMLInputElement>, 'onChange'> {
 export class TextInput extends React.Component<Props> {
   private handleChange = (evt: React.FormEvent<HTMLInputElement>) => {
     this.props.onChange(evt.currentTarget.value, evt);
+  };
+  private handleKeyPressed = (evt: React.KeyboardEvent) => {
+    if (this.props.onKeyPress && evt.key === 'Enter') {
+      evt.preventDefault();
+      this.props.onKeyPress(evt);
+    }
   };
 
   public render() {
@@ -27,6 +34,7 @@ export class TextInput extends React.Component<Props> {
           isError && styles.error
         )}
         onChange={this.handleChange}
+        onKeyPress={this.handleKeyPressed}
       />
     );
   }

--- a/src/pages/costDetails/costDetails.tsx
+++ b/src/pages/costDetails/costDetails.tsx
@@ -61,6 +61,11 @@ const groupByOptions: {
 ];
 
 class CostDetails extends React.Component<Props> {
+  constructor(stateProps, dispatchProps) {
+    super(stateProps, dispatchProps);
+    this.onFiltersChanged = this.onFiltersChanged.bind(this);
+  }
+
   public componentDidMount() {
     const { query, location, fetchReport, history, queryString } = this.props;
     if (!location.search) {
@@ -93,6 +98,21 @@ class CostDetails extends React.Component<Props> {
 
   private getRouteForQuery(query: Query) {
     return `/cost?${getQuery(query)}`;
+  }
+
+  public onFiltersChanged(filterType: string, filterValue: string) {
+    const { history, query } = this.props;
+    let filter = filterValue;
+    if (filterValue === '') {
+      filter = '*';
+    }
+    if (query.group_by[filterType]) {
+      query.group_by[filterType] = filter;
+    } else {
+      query.filter[filterType] = filter;
+    }
+    const filteredQuery = this.getRouteForQuery(query);
+    history.replace(filteredQuery);
   }
 
   public render() {
@@ -178,6 +198,7 @@ class CostDetails extends React.Component<Props> {
                 filterFields={filterFields}
                 sortFields={sortFields}
                 exportText={exportText}
+                onFiltersChanged={this.onFiltersChanged}
               />
             </div>
           </div>

--- a/src/pages/costDetails/detailsToolbar.tsx
+++ b/src/pages/costDetails/detailsToolbar.tsx
@@ -8,7 +8,7 @@ interface DetailsToolbarOwnProps {
   filterFields: any;
   sortFields: any;
   exportText: string;
-  onFiltersChanged?(value: string, evt: React.FormEvent<HTMLInputElement>);
+  onFiltersChanged(filterType: string, filterValue: string);
   onSortChanged?(value: string, evt: React.ChangeEvent<HTMLSelectElement>);
   onActionPerformed?(evt: React.ChangeEvent<HTMLButtonElement>);
 }
@@ -16,15 +16,10 @@ interface DetailsToolbarOwnProps {
 type DetailsToolbarProps = DetailsToolbarOwnProps;
 
 export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
-  public static defaultProps = {
-    onFiltersChanged: noop,
-    onSortChanged: noop,
-    onActionPerformed: noop,
-  };
+  public static defaultProps = { onSortChanged: noop, onActionPerformed: noop };
 
   public state = {
     currentFilterType: this.props.filterFields[0],
-    activeFilters: [],
     currentValue: '',
     currentSortType: this.props.sortFields[0],
     isSortNumeric: this.props.sortFields[0].isNumeric,
@@ -33,36 +28,10 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
     filterCategory: undefined,
   };
 
-  public filterAdded = (field, value) => {
-    let filterText = '';
-    if (field.title) {
-      filterText = field.title;
-    } else {
-      filterText = field;
-    }
-    filterText += ': ';
-
-    if (value.filterCategory) {
-      filterText += `${value.filterCategory.title ||
-        value.filterCategory}-${value.filterValue.title || value.filterValue}`;
-    } else if (value.title) {
-      filterText += value.title;
-    } else {
-      filterText += value;
-    }
-
-    const activeFilters = [...this.state.activeFilters, { label: filterText }];
-    this.setState({ activeFilters });
-  };
-
   public filterValueSelected = filterValue => {
-    const { currentFilterType, currentValue } = this.state;
-
+    const { currentValue } = this.state;
     if (filterValue !== currentValue) {
       this.setState({ currentValue: filterValue });
-      if (filterValue) {
-        this.filterAdded(currentFilterType, filterValue);
-      }
     }
   };
 
@@ -73,10 +42,6 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
         currentValue: '',
         currentFilterType: filterType,
       });
-
-      if (filterType.filterType === 'complex-select') {
-        this.setState({ filterCategory: undefined });
-      }
     }
   };
 
@@ -98,8 +63,16 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
     }
   };
 
-  public updateCurrentValue = (currentValue: string) => {
+  public updateCurrentValue = (
+    currentValue: string,
+    e: React.FormEvent<HTMLInputElement>
+  ) => {
     this.setState({ currentValue });
+  };
+
+  public executeFilter = (e: React.KeyboardEvent) => {
+    const { currentValue, currentFilterType } = this.state;
+    this.props.onFiltersChanged(currentFilterType.id, currentValue);
   };
 
   public renderInput() {
@@ -111,6 +84,7 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
       <TextInput
         value={currentValue}
         onChange={this.updateCurrentValue}
+        onKeyPress={this.executeFilter}
         type="text"
         placeholder={currentFilterType.placeholder}
       />


### PR DESCRIPTION
Added filtering to the toolbar.

Current setup is:

1. You select what you want to filter (e.g. Services)
2. Then type  your filter and hit enter (e.g. AmazonEC2)

<img width="984" alt="image" src="https://user-images.githubusercontent.com/29379759/45359835-c4233480-b59b-11e8-8f7c-6630e714559e.png">


To clear the filter, delete the text and press Enter.

<img width="994" alt="image" src="https://user-images.githubusercontent.com/29379759/45359874-ecab2e80-b59b-11e8-904a-eaba203a0c9e.png">
