### PR TITLE
test(dashboardWidget): add two more tests

### DIFF
--- a/src/pages/dashboard/dashboardWidget.test.tsx
+++ b/src/pages/dashboard/dashboardWidget.test.tsx
@@ -6,6 +6,7 @@ jest
 
 import { ReportType } from 'api/reports';
 import { ChartType } from 'components/commonChart/chartUtils';
+import { Tabs } from 'components/tabs';
 import formatDate from 'date-fns/format';
 import getDate from 'date-fns/get_date';
 import getMonth from 'date-fns/get_month';
@@ -15,7 +16,11 @@ import React from 'react';
 import { DashboardTab } from 'store/dashboard';
 import { mockDate } from 'testUtils';
 import { FetchStatus } from '../../store/common';
-import { DashboardWidgetBase, DashboardWidgetProps } from './dashboardWidget';
+import {
+  DashboardWidgetBase,
+  DashboardWidgetProps,
+  getIdKeyForTab,
+} from './dashboardWidget';
 
 const props: DashboardWidgetProps = {
   widgetId: 1,
@@ -93,6 +98,25 @@ test('subtitle is translated with date range', () => {
 test('trend title is translated', () => {
   shallow(<DashboardWidgetBase {...props} />);
   expect(getTranslateCallForKey(props.trend.titleKey)).toMatchSnapshot();
+});
+
+test('id key for dashboard tab is the tab name in singular form', () => {
+  [DashboardTab.services, DashboardTab.accounts, DashboardTab.regions].forEach(
+    value => {
+      expect(getIdKeyForTab(value)).toEqual(value.slice(0, -1));
+    }
+  );
+
+  expect(getIdKeyForTab(DashboardTab.instanceType)).toEqual(
+    DashboardTab.instanceType
+  );
+});
+
+test('change tab triggers updateTab', () => {
+  const tabId = DashboardTab.regions;
+  const view = shallow(<DashboardWidgetBase {...props} />);
+  view.find(Tabs).simulate('change', { tabId });
+  expect(props.updateTab).toBeCalledWith(props.id, { tabId });
 });
 
 function getTranslateCallForKey(key: string) {

--- a/src/pages/dashboard/dashboardWidget.tsx
+++ b/src/pages/dashboard/dashboardWidget.tsx
@@ -49,6 +49,21 @@ type DashboardWidgetProps = DashboardWidgetOwnProps &
   DashboardWidgetDispatchProps &
   InjectedTranslateProps;
 
+export const getIdKeyForTab = (
+  tab: DashboardTab
+): GetComputedReportItemsParams['idKey'] => {
+  switch (tab) {
+    case DashboardTab.services:
+      return 'service';
+    case DashboardTab.accounts:
+      return 'account';
+    case DashboardTab.regions:
+      return 'region';
+    case DashboardTab.instanceType:
+      return 'instance_type';
+  }
+};
+
 class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   public componentDidMount() {
     const { fetchReports, widgetId } = this.props;
@@ -57,64 +72,17 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
 
   private getTabTitle = (tab: DashboardTab) => {
     const { t } = this.props;
-    let key = '';
-
-    switch (tab) {
-      case DashboardTab.services:
-        key = 'service';
-        break;
-      case DashboardTab.accounts:
-        key = 'account';
-        break;
-      case DashboardTab.regions:
-        key = 'region';
-        break;
-      case DashboardTab.instanceType:
-        key = 'instance_type';
-        break;
-    }
+    const key = getIdKeyForTab(tab) || '';
 
     return t('group_by.top', { groupBy: key });
   };
 
   private getDetailsLinkTitle = (tab: DashboardTab) => {
     const { t } = this.props;
-    let key = '';
-
-    switch (tab) {
-      case DashboardTab.services:
-        key = 'service';
-        break;
-      case DashboardTab.accounts:
-        key = 'account';
-        break;
-      case DashboardTab.regions:
-        key = 'region';
-        break;
-      case DashboardTab.instanceType:
-        key = 'instance_type';
-        break;
-    }
+    const key = getIdKeyForTab(tab) || '';
 
     return t('group_by.all', { groupBy: key });
   };
-
-  private getIdKeyForTab(
-    tab: DashboardTab
-  ): GetComputedReportItemsParams['idKey'] {
-    switch (tab) {
-      case DashboardTab.services:
-        return 'service';
-      case DashboardTab.accounts:
-        return 'account';
-      case DashboardTab.regions:
-        return 'region';
-      case DashboardTab.instanceType:
-        return 'instance_type';
-      default:
-        return null;
-    }
-  }
 
   private buildDetailsLink = () => {
     const { currentQuery } = this.props;
@@ -128,10 +96,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     const currentTab = tabData.id as DashboardTab;
 
     return (
-      <ReportSummaryItems
-        idKey={this.getIdKeyForTab(currentTab)}
-        report={current}
-      >
+      <ReportSummaryItems idKey={getIdKeyForTab(currentTab)} report={current}>
         {({ items }) =>
           items.map(tabItem => (
             <ReportSummaryItem


### PR DESCRIPTION
Added two more tests:
 - getIdKeyForTabs
 - updateTab

I had to move `getIdKeyFromTabs` to be external function as it can be used both in `getTabTitle` and `getDetailsLinkTitle`. In addition, it was easy to test it that way.