### PR TITLE
If an AWS account has an alias it should be shown in the UI.

### DIFF
--- a/src/api/reports.ts
+++ b/src/api/reports.ts
@@ -6,6 +6,7 @@ export interface ReportValue {
   total: number;
   units: string;
   account?: string;
+  account_alias?: string;
   count?: number;
   instance_type?: string;
   service?: string;

--- a/src/utils/getComputedReportItems.ts
+++ b/src/utils/getComputedReportItems.ts
@@ -38,11 +38,15 @@ export function getComputedReportItems({
       dataPoint.values.forEach(value => {
         const total = value.total;
         const id = value[idKey];
+        let label = value[labelKey];
+        if (labelKey === 'account' && value.account_alias) {
+          label = value.account_alias;
+        }
         if (!itemMap[id]) {
           itemMap[id] = {
             id,
             total,
-            label: value[labelKey],
+            label,
             units: value.units,
           };
           return;


### PR DESCRIPTION
Show Account alias instead of account numbers as the label if available.
Dashboard:
<img width="299" alt="image" src="https://user-images.githubusercontent.com/29379759/45638908-9303a200-ba7c-11e8-97fa-ec4fe971e0c4.png">

Cost Details:
<img width="1000" alt="image" src="https://user-images.githubusercontent.com/29379759/45638935-a1ea5480-ba7c-11e8-8bcf-9f5a23270c8a.png">

 