### PR TITLE
fix(dashboardWidget): display daily data in tabs

### DIFF
--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -1,6 +1,6 @@
 import { parse, stringify } from 'qs';
 
-interface Filters {
+export interface Filters {
   time_scope_value?: number;
   time_scope_units?: 'month' | 'day';
   resolution?: 'daily' | 'monthly';

--- a/src/pages/dashboard/dashboardWidget.test.tsx
+++ b/src/pages/dashboard/dashboardWidget.test.tsx
@@ -28,6 +28,7 @@ const props: DashboardWidgetProps = {
   t: jest.fn(v => v),
   current: { data: [] },
   previous: { data: [] },
+  tabs: { data: [] },
   fetchReports: jest.fn(),
   updateTab: jest.fn(),
   titleKey: 'title',
@@ -40,6 +41,7 @@ const props: DashboardWidgetProps = {
   status: FetchStatus.none,
   currentQuery: '',
   previousQuery: '',
+  tabsQuery: '',
   details: {
     labelKey: 'detail label',
     labelKeyContext: 'label context',

--- a/src/pages/dashboard/dashboardWidget.tsx
+++ b/src/pages/dashboard/dashboardWidget.tsx
@@ -34,8 +34,10 @@ interface DashboardWidgetOwnProps {
 interface DashboardWidgetStateProps extends DashboardWidgetStatic {
   current: Report;
   previous: Report;
+  tabs: Report;
   currentQuery: string;
   previousQuery: string;
+  tabsQuery: string;
   status: number;
 }
 
@@ -91,12 +93,12 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   };
 
   private renderTab = (tabData: TabData) => {
-    const { current, topItems } = this.props;
+    const { tabs, topItems } = this.props;
 
     const currentTab = tabData.id as DashboardTab;
 
     return (
-      <ReportSummaryItems idKey={getIdKeyForTab(currentTab)} report={current}>
+      <ReportSummaryItems idKey={getIdKeyForTab(currentTab)} report={tabs}>
         {({ items }) =>
           items.map(tabItem => (
             <ReportSummaryItem
@@ -104,7 +106,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
               formatOptions={topItems.formatOptions}
               formatValue={formatValue}
               label={tabItem.label}
-              totalValue={current.total.value}
+              totalValue={tabs.total.value}
               units={tabItem.units}
               value={tabItem.total}
             />
@@ -201,6 +203,7 @@ const mapStateToProps = createMapStateToProps<
     ...widget,
     currentQuery: queries.current,
     previousQuery: queries.previous,
+    tabsQuery: queries.tabs,
     current: reportsSelectors.selectReport(
       state,
       widget.reportType,
@@ -211,6 +214,7 @@ const mapStateToProps = createMapStateToProps<
       widget.reportType,
       queries.previous
     ),
+    tabs: reportsSelectors.selectReport(state, widget.reportType, queries.tabs),
     status: reportsSelectors.selectReportFetchStatus(
       state,
       widget.reportType,

--- a/src/store/dashboard/__snapshots__/dashboard.test.ts.snap
+++ b/src/store/dashboard/__snapshots__/dashboard.test.ts.snap
@@ -10,12 +10,22 @@ Array [
     "cost",
     "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily&filter[limit]=5&group_by[service]=*",
   ],
+  Array [
+    "cost",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=5&group_by[service]=*",
+  ],
 ]
 `;
 
 exports[`getGroupByForTab accounts tab 1`] = `
 Object {
   "account": "*",
+}
+`;
+
+exports[`getGroupByForTab instance types tab 1`] = `
+Object {
+  "instance_type": "*",
 }
 `;
 

--- a/src/store/dashboard/dashboard.test.ts
+++ b/src/store/dashboard/dashboard.test.ts
@@ -1,5 +1,7 @@
 jest.mock('../reports/reportsActions');
 
+import { ReportType } from '../../api/reports';
+import { ChartType } from '../../components/commonChart/chartUtils';
 import { createMockStoreCreator } from '../mockStore';
 import { reportsActions } from '../reports';
 import * as actions from './dashboardActions';
@@ -7,6 +9,7 @@ import {
   dashboardStateKey,
   DashboardTab,
   getGroupByForTab,
+  getQueryForWidget,
 } from './dashboardCommon';
 import { dashboardReducer } from './dashboardReducer';
 import * as selectors from './dashboardSelectors';
@@ -52,12 +55,16 @@ test('changeWidgetTab', () => {
   );
   const widget = selectors.selectWidget(store.getState(), costSummaryWidget.id);
   expect(widget.currentTab).toBe(DashboardTab.regions);
-  expect(fetchReportMock).toHaveBeenCalledTimes(2);
+  expect(fetchReportMock).toHaveBeenCalledTimes(3);
 });
 
 describe('getGroupByForTab', () => {
   test('services tab', () => {
     expect(getGroupByForTab(DashboardTab.services)).toMatchSnapshot();
+  });
+
+  test('instance types tab', () => {
+    expect(getGroupByForTab(DashboardTab.instanceType)).toMatchSnapshot();
   });
 
   test('accounts tab', () => {
@@ -70,5 +77,35 @@ describe('getGroupByForTab', () => {
 
   test('unknown tab', () => {
     expect(getGroupByForTab('unknown' as any)).toMatchSnapshot();
+  });
+});
+
+test('getQueryForWidget', () => {
+  const widget = {
+    id: 1,
+    titleKey: '',
+    reportType: ReportType.cost,
+    availableTabs: [DashboardTab.accounts],
+    currentTab: DashboardTab.accounts,
+    details: { labelKey: '', formatOptions: {} },
+    trend: {
+      titleKey: '',
+      type: ChartType.daily,
+      formatOptions: {},
+    },
+    topItems: {
+      formatOptions: {},
+    },
+  };
+
+  [
+    [
+      undefined,
+      'filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&filter[limit]=5&group_by[account]=*',
+    ],
+    [{}, 'group_by[account]=*'],
+    [{ limit: 5 }, 'filter[limit]=5&group_by[account]=*'],
+  ].forEach(value => {
+    expect(getQueryForWidget(widget, value[0])).toEqual(value[1]);
   });
 });

--- a/src/store/dashboard/dashboardActions.ts
+++ b/src/store/dashboard/dashboardActions.ts
@@ -8,9 +8,10 @@ export const fetchWidgetReports = (id: number): ThunkAction => {
   return (dispatch, getState) => {
     const state = getState();
     const widget = selectWidget(state, id);
-    const { previous, current } = selectWidgetQueries(state, id);
+    const { previous, current, tabs } = selectWidgetQueries(state, id);
     dispatch(reportsActions.fetchReport(widget.reportType, current));
     dispatch(reportsActions.fetchReport(widget.reportType, previous));
+    dispatch(reportsActions.fetchReport(widget.reportType, tabs));
   };
 };
 

--- a/src/store/dashboard/dashboardCommon.ts
+++ b/src/store/dashboard/dashboardCommon.ts
@@ -1,8 +1,14 @@
-import { getQuery, Query } from 'api/query';
+import { Filters, getQuery, Query } from 'api/query';
 import { ReportType } from 'api/reports';
 import { ChartType } from 'components/commonChart/chartUtils';
 
 export const dashboardStateKey = 'dashboard';
+export const dashboardDefaultFilters: Filters = {
+  time_scope_units: 'month',
+  time_scope_value: -1,
+  resolution: 'daily',
+  limit: 5,
+};
 
 interface ValueFormatOptions {
   fractionDigits?: number;
@@ -54,14 +60,12 @@ export function getGroupByForTab(tab: DashboardTab): Query['group_by'] {
   }
 }
 
-export function getQueryForWidget(widget: DashboardWidget, timeScope: number) {
+export function getQueryForWidget(
+  widget: DashboardWidget,
+  filter: Filters = dashboardDefaultFilters
+) {
   const query: Query = {
-    filter: {
-      time_scope_units: 'month',
-      time_scope_value: timeScope,
-      resolution: 'daily',
-      limit: 5,
-    },
+    filter,
     group_by: getGroupByForTab(widget.currentTab),
   };
 

--- a/src/store/dashboard/dashboardSelectors.ts
+++ b/src/store/dashboard/dashboardSelectors.ts
@@ -1,5 +1,9 @@
 import { RootState } from '../rootReducer';
-import { dashboardStateKey, getQueryForWidget } from './dashboardCommon';
+import {
+  dashboardDefaultFilters,
+  dashboardStateKey,
+  getQueryForWidget,
+} from './dashboardCommon';
 
 export const selectDashboardState = (state: RootState) =>
   state[dashboardStateKey];
@@ -17,7 +21,14 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
   const widget = selectWidget(state, id);
 
   return {
-    previous: getQueryForWidget(widget, -2),
-    current: getQueryForWidget(widget, -1),
+    previous: getQueryForWidget(widget, {
+      ...dashboardDefaultFilters,
+      time_scope_value: -2,
+    }),
+    current: getQueryForWidget(widget, dashboardDefaultFilters),
+    tabs: getQueryForWidget(widget, {
+      ...dashboardDefaultFilters,
+      resolution: 'monthly',
+    }),
   };
 };


### PR DESCRIPTION
The data that is rendered in tabs is taken from the current computed results which its resolution is set to 'daily' while it should be 'monthly'.

In this commit, another API call is done to fetch this data with the right parameters and render tabs according to it.

closes #114 