### PR TITLE
Add sort functionality

### DIFF
--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -16,9 +16,17 @@ interface GroupBys {
   region?: GroupByValue;
 }
 
+interface OrderBys {
+  account?: string;
+  region?: string;
+  service?: string;
+  total?: string;
+}
+
 export interface Query {
   filter?: Filters;
   group_by?: GroupBys;
+  order_by?: OrderBys;
 }
 
 export function getQuery(query: Query) {

--- a/src/pages/dashboard/dashboardWidget.tsx
+++ b/src/pages/dashboard/dashboardWidget.tsx
@@ -26,6 +26,7 @@ import {
 import { reportsSelectors } from 'store/reports';
 import { formatValue } from 'utils/formatValue';
 import { GetComputedReportItemsParams } from 'utils/getComputedReportItems';
+import { getIdKeyForGroupBy } from '../../utils/getComputedReportItems';
 
 interface DashboardWidgetOwnProps {
   widgetId: number;
@@ -87,7 +88,11 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   private buildDetailsLink = () => {
     const { currentQuery } = this.props;
     const groupBy = parseQuery<Query>(currentQuery).group_by;
-    return `/cost?${getQuery({ group_by: groupBy })}`;
+    const groupById = getIdKeyForGroupBy(groupBy);
+    return `/cost?${getQuery({
+      group_by: groupBy,
+      order_by: { [groupById]: 'asc' },
+    })}`;
   };
 
   private renderTab = (tabData: TabData) => {


### PR DESCRIPTION
The sort dropdown and direction indicator are now functional. The query params update properly and state can be restored upon a page refresh, allowing bookmarking. Although, the sort has been intentionally disabled for now.

The "Cost Details" and "All Services" links have been fixed to also include the query params as expected. Previously, clicking on the "Cost Details" link (a second time) would lose all query params.

Note that order_by has been temporarily omitted from the request. This is due to the issue below when order_by is included, generating bad requests. When this issue has been resolved, we can easily enable the sort in another PR.

https://github.com/project-koku/koku/issues/375