### PR TITLE
fix(detailsToolbar): show filter type selector

### DIFF
--- a/src/pages/costDetails/detailsToolbar.tsx
+++ b/src/pages/costDetails/detailsToolbar.tsx
@@ -250,6 +250,7 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
       <Toolbar>
         <Filter>
           <Filter.TypeSelector
+            placeholder={'Select Filter Type'}
             filterTypes={this.props.filterFields}
             currentFilterType={currentFilterType}
             onFilterTypeSelected={this.selectFilterType}


### PR DESCRIPTION
Filter.TypeSelector is not rendered because it has only one type right now which is confusing.

This is a small fix - adding a placeholder will display the type selector.

## Before
![screenshot_2018-09-26 koku ui 3](https://user-images.githubusercontent.com/2453279/46075784-3f880700-c194-11e8-8583-8d091c6b185b.png)

## After
### default
![screenshot_2018-09-26 koku ui](https://user-images.githubusercontent.com/2453279/46075810-53cc0400-c194-11e8-9f4b-79117c3d4ea9.png)

### choosing filter type
![screenshot_2018-09-26 koku ui 1](https://user-images.githubusercontent.com/2453279/46075817-5fb7c600-c194-11e8-8341-de015957e5ac.png)

### selecting the placeholder
![screenshot_2018-09-26 koku ui 2](https://user-images.githubusercontent.com/2453279/46075841-73632c80-c194-11e8-854b-c48512031b52.png)
