### PR TITLE
Update pf-react to support webpack production

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN printf "[nginx]\nname=nginx repo\nbaseurl=http://nginx.org/packages/centos/7
 
 RUN chmod 777 /var/log/nginx && chmod 777 /var/cache/nginx && chmod 777 /var/run && rm -rf /var/log/nginx/* && rm -rf /var/cache/nginx/*
 
-ENV NODE_ENV=development \
+ENV NODE_ENV=production \
     NODE_PORT=8080
 
 WORKDIR /opt/koku-ui

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "private": true,
   "scripts": {
     "build": "yarn build:client",
-    "build:client": "yarn clean && webpack --env development",
+    "build:client": "yarn clean && webpack --env production",
     "clean": "rimraf public/",
     "lint": "yarn lint:ts && yarn lint:locales",
     "lint:locales": "node scripts/syncLocales --check",
@@ -77,7 +77,7 @@
     "jest": "^22.4.3",
     "jest-emotion": "^9.2.7",
     "mini-css-extract-plugin": "^0.4.0",
-    "patternfly-react": "^2.13.1",
+    "patternfly-react": "^2.19.0",
     "qs": "^6.5.2",
     "react": "^16.3.1",
     "react-dom": "^16.3.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7134,15 +7134,15 @@ patternfly-bootstrap-treeview@~2.1.0:
     bootstrap "3.3.x"
     jquery ">= 2.1.x"
 
-patternfly-react@^2.13.1:
-  version "2.13.1"
-  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.13.1.tgz#198fd0335d8a1609d813ba13e5ebfa12a273fd38"
+patternfly-react@^2.19.0:
+  version "2.19.0"
+  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.19.0.tgz#4efd6fd9bc9178a3fb95cd35334a89bd03154dfd"
   dependencies:
     bootstrap-slider-without-jquery "^10.0.0"
     breakjs "^1.0.0"
     classnames "^2.2.5"
     css-element-queries "^1.0.1"
-    patternfly "^3.52.1"
+    patternfly "^3.52.4"
     react-bootstrap "^0.32.1"
     react-bootstrap-switch "^15.5.3"
     react-bootstrap-typeahead "^3.1.3"
@@ -7157,9 +7157,9 @@ patternfly-react@^2.13.1:
     sortabular "^1.5.1"
     table-resolver "^3.2.0"
 
-patternfly@^3.52.1:
-  version "3.54.1"
-  resolved "https://registry.yarnpkg.com/patternfly/-/patternfly-3.54.1.tgz#a0f8b52076aa405486e77ecb504460b1ff35fe92"
+patternfly@^3.52.4:
+  version "3.54.8"
+  resolved "https://registry.yarnpkg.com/patternfly/-/patternfly-3.54.8.tgz#fd6c69714dc460575d2534c9f29017a58b442a83"
   dependencies:
     bootstrap "~3.3.7"
     font-awesome "^4.7.0"


### PR DESCRIPTION
This pf-react update allows webpack 4 to run in production mode. Tested with `container:test` and `webpack-dev-server --env production`

Note that there may still be issues that pf-react must address. However, this update appears to be working with the PF3 components currently in use on the cost details page.

See: https://github.com/patternfly/patternfly-react/pull/564