### PR TITLE
Enable sorting for cost details page

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "precommit": "lint-staged",
     "start": "webpack-dev-server",
     "start:dev": "APP_NAMESPACE=koku-dev yarn start",
-    "start:insights": "APP_NAMESPACE=hccm-staging yarn start",
+    "start:insights": "APP_NAMESPACE=hccm-staging APP_PROTOCOL=https yarn start",
     "start:staging": "APP_NAMESPACE=koku-staging APP_PROTOCOL=https yarn start",
     "test": "jest",
     "container:test": "docker stop -t 0 koku-ui-test >/dev/null; docker build -t koku-ui-test . && docker run -i --rm -p 8080:8080 --name koku-ui-test koku-ui-test",

--- a/src/pages/costDetails/costDetails.tsx
+++ b/src/pages/costDetails/costDetails.tsx
@@ -147,7 +147,6 @@ class CostDetails extends React.Component<Props> {
       history.replace(
         this.getRouteForQuery({
           group_by: query.group_by,
-          // order_by: { [groupById]: 'desc' },
           order_by: { total: 'desc' },
         })
       );

--- a/src/pages/costDetails/detailItem.tsx
+++ b/src/pages/costDetails/detailItem.tsx
@@ -127,15 +127,6 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
         key={item.label}
         heading={item.label}
         checkboxInput={<input type="checkbox" />}
-        additionalInfo={[
-          <ListView.InfoItem key="1" stacked>
-            <strong>{formatCurrency(item.total)}</strong>
-            <span>
-              {((item.total / total) * 100).toFixed(2)}
-              {t('percent_of_cost')}
-            </span>
-          </ListView.InfoItem>,
-        ]}
         actions={[
           <ListView.InfoItem key="1" stacked>
             <strong>{formatCurrency(item.total)}</strong>
@@ -156,7 +147,7 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
                   {t('group_by.label')}:
                 </label>
                 <select
-                  id={item.label.toString()}
+                  id={item.label ? item.label.toString() : ''}
                   onChange={this.handleSelectChange}
                 >
                   {groupByOptions.map(option => {

--- a/src/pages/costDetails/detailsToolbar.tsx
+++ b/src/pages/costDetails/detailsToolbar.tsx
@@ -41,8 +41,8 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
     report: undefined,
   };
 
-  public componentDidUpdate(prevProps: DetailsToolbarProps) {
-    const { query, report } = this.props;
+  public componentDidUpdate(prevProps: DetailsToolbarProps, prevState) {
+    const { filterFields, query, report, sortField } = this.props;
     const cacheReport = this.state.report === null && query.group_by.account;
     if (report && (!isEqual(report, prevProps.report) || cacheReport)) {
       // Cache inital report containing so we can find account aliases after multiple filters
@@ -58,6 +58,17 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
         );
       } else {
         this.addQuery(query);
+      }
+      if (!isEqual(filterFields, prevProps.filterFields)) {
+        this.setState({
+          currentFilterType: this.props.filterFields[0],
+        });
+      }
+      if (!isEqual(sortField, prevProps.sortField)) {
+        this.setState({
+          currentSortType: sortField,
+          isSortAscending: !(query && query.order_by[sortField.id] === 'desc'),
+        });
       }
     }
   }

--- a/src/pages/dashboard/dashboardWidget.tsx
+++ b/src/pages/dashboard/dashboardWidget.tsx
@@ -26,7 +26,6 @@ import {
 import { reportsSelectors } from 'store/reports';
 import { formatValue } from 'utils/formatValue';
 import { GetComputedReportItemsParams } from 'utils/getComputedReportItems';
-import { getIdKeyForGroupBy } from '../../utils/getComputedReportItems';
 
 interface DashboardWidgetOwnProps {
   widgetId: number;
@@ -90,10 +89,9 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   private buildDetailsLink = () => {
     const { currentQuery } = this.props;
     const groupBy = parseQuery<Query>(currentQuery).group_by;
-    const groupById = getIdKeyForGroupBy(groupBy);
     return `/cost?${getQuery({
       group_by: groupBy,
-      order_by: { [groupById]: 'asc' },
+      order_by: { total: 'desc' },
     })}`;
   };
 

--- a/src/utils/getComputedReportItems.ts
+++ b/src/utils/getComputedReportItems.ts
@@ -27,6 +27,26 @@ export function getComputedReportItems({
   sortKey = 'total',
   sortDirection = SortDirection.asc,
 }: GetComputedReportItemsParams) {
+  return sort(
+    getUnsortedComputedReportItems({
+      report,
+      idKey,
+      labelKey,
+      sortDirection,
+      sortKey,
+    }),
+    {
+      key: sortKey,
+      direction: sortDirection,
+    }
+  );
+}
+
+export function getUnsortedComputedReportItems({
+  report,
+  idKey,
+  labelKey = idKey,
+}: GetComputedReportItemsParams) {
   if (!report) {
     return [];
   }
@@ -64,11 +84,7 @@ export function getComputedReportItems({
     });
   };
   report.data.forEach(visitDataPoint);
-
-  return sort(Object.values(itemMap), {
-    key: sortKey,
-    direction: sortDirection,
-  });
+  return Object.values(itemMap);
 }
 
 export function getIdKeyForGroupBy(


### PR DESCRIPTION
This change enables sorting by cost and name on the cost details page.

Sort Cost Descending
![screen shot 2018-10-01 at 4 19 22 pm](https://user-images.githubusercontent.com/17481322/46313790-c1ae6c00-c596-11e8-80f4-d333b34f83ee.png)

Sort Cost Ascending
![screen shot 2018-10-01 at 4 26 02 pm](https://user-images.githubusercontent.com/17481322/46313787-c07d3f00-c596-11e8-9857-fdf9409cfd25.png)