### PR TITLE
fix(package.json): tslint hack to check test files too

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "clean": "rimraf public/",
     "lint": "yarn lint:ts && yarn lint:locales",
     "lint:locales": "node scripts/syncLocales --check",
-    "lint:ts": "tslint --project tsconfig.json",
+    "lint:ts": "tslint --project tsconfig.lint.json",
     "precommit": "lint-staged",
     "start": "webpack-dev-server",
     "start:dev": "APP_NAMESPACE=koku-dev yarn start",

--- a/tsconfig.lint.json
+++ b/tsconfig.lint.json
@@ -1,0 +1,29 @@
+{
+  "compilerOptions": {
+    "baseUrl": "./src",
+    "outDir": "./public",
+    "allowJs": true,
+    "jsx": "react",
+    "target": "es2017",
+    "module": "esnext",
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true,
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "lib": [
+      "dom",
+      "es2017"
+    ]
+  },
+  "include": [
+    "./src/**/*",
+    "./scripts/**/*",
+    "./test/**/*",
+    "jest.config.js",
+    "webpack.config.js"
+  ],
+  "exclude": [
+    "node_modules/**",
+  ]
+}


### PR DESCRIPTION
`tsconfig.json` is used by both `webpack` and `tslint`. `tslint` is using it to determine what files to run lint checking.

If a file is passed to `tslint` which is excluded `tslint` prints an error message saying the file was excluded and quits.
    
In `tsconfig.json` test files were excluded because they are not necessary for the UI. However, they are necessary for linting.
    
To fix this, I am using two different ts-configs. `tsconfig.lint.json` for tslint and `tsconfig.json` for webpack.

That way test files can be linted successfully and not be necessary to run the UI.