### PR TITLE
Add insights:proxy target for convenience

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "start:staging": "APP_NAMESPACE=access.stage.itop yarn start",
     "test": "jest",
     "container:test": "docker stop -t 0 koku-ui-test >/dev/null; docker build -t koku-ui-test . && docker run -i --rm -p 8080:8080 --name koku-ui-test koku-ui-test",
+    "insights:proxy": "docker run -e LOCAL_CHROME -v config:/config -e PLATFORM -e PORT -e LOCAL_API -e SPANDX_HOST -e SPANDX_PORT --rm -t --name insightsproxy -p 1337:1337 docker.io/redhatinsights/insights-proxy",
     "verify": "tsc --noEmit"
   },
   "lint-staged": {


### PR DESCRIPTION
Added an `insights:proxy` target for convenience. This allows an IDE to run the Inisghts proxy as well as `start:dev`.