### PR TITLE
Update chroming based on deployment so it aligns with publicPath

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "git-revision-webpack-plugin": "^3.0.3",
     "helmet": "^3.12.0",
     "html-loader": "^0.5.5",
+    "html-replace-webpack-plugin": "^2.5.3",
     "html-webpack-plugin": "^3.2.0",
     "i18next": "^11.1.1",
     "i18next-express-middleware": "^1.1.1",

--- a/src/index.html
+++ b/src/index.html
@@ -6,16 +6,16 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <meta name="theme-color" content="#000000">
   <title>Cost Management</title>
-  <esi:include src="/insights/static/chrome/snippets/head.html" />
+  <esi:include src="/@@insights/static/chrome/snippets/head.html" />
 </head>
 
 <body>
   <div class="pf-c-background-image"></div>
   <div class="pf-l-page" id="page">
-    <esi:include src="/insights/static/chrome/snippets/header.html" />
-    <esi:include src="/insights/static/chrome/snippets/sidebar.html" />
+    <esi:include src="/@@insights/static/chrome/snippets/header.html" />
+    <esi:include src="/@@insights/static/chrome/snippets/sidebar.html" />
     <main role="main" class="pf-l-page__main" id="root">
-      <esi:include src="/insights/static/chrome/snippets/footer.html" />
+      <esi:include src="/@@insights/static/chrome/snippets/footer.html" />
     </main>
   </div>
 </body>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@ const log = weblog({
   name: 'wds',
 });
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const HtmlReplaceWebpackPlugin = require('html-replace-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
@@ -122,7 +123,12 @@ module.exports = env => {
       new HtmlWebpackPlugin({
         template: path.join(srcDir, 'index.html'),
       }),
-
+      new HtmlReplaceWebpackPlugin([
+        {
+          pattern: '@@insights',
+          replacement: insightsDeployment,
+        },
+      ]),
       new MiniCssExtractPlugin({
         filename: isProduction ? '[contenthash].css' : '[name].css',
         chunkFilename: isProduction ? '[contenthash].css' : '[id].css',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4918,6 +4918,10 @@ html-parse-stringify2@2.0.1:
   dependencies:
     void-elements "^2.0.1"
 
+html-replace-webpack-plugin@^2.5.3:
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/html-replace-webpack-plugin/-/html-replace-webpack-plugin-2.5.3.tgz#a2fef7d3825b9040b10085d452c1ddefc43a0991"
+
 html-tokenize@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/html-tokenize/-/html-tokenize-2.0.0.tgz#8b3a9a5deb475cae6a6f9671600d2c20ab298251"


### PR DESCRIPTION
Essentially updates @@insights in the `<esi:include src=` to be either `insights` or `insightsbeta` so the include here aligns with the target deployment dependent on branch.