### PR TITLE
Export modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "i18next-express-middleware": "^1.1.1",
     "i18next-json-sync": "^2.2.0",
     "i18next-xhr-backend": "^1.5.1",
+    "js-file-download": "^0.4.4",
     "mini-css-extract-plugin": "^0.4.0",
     "patternfly-react": "^2.19.0",
     "qs": "^6.5.2",

--- a/src/api/export.ts
+++ b/src/api/export.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import { ReportType, reportTypePaths } from './reports';
+
+export function runExport(reportType: ReportType, query: string) {
+  const path = reportTypePaths[reportType];
+  return axios.get<string>(`${path}?${query}`, {
+    headers: {
+      Accept: 'text/csv',
+    },
+  });
+}

--- a/src/api/reports.ts
+++ b/src/api/reports.ts
@@ -62,7 +62,7 @@ export const enum ReportType {
   instanceType = 'instance_type',
 }
 
-const reportTypePaths: Record<ReportType, string> = {
+export const reportTypePaths: Record<ReportType, string> = {
   [ReportType.cost]: 'reports/costs/',
   [ReportType.storage]: 'reports/inventory/storage/',
   [ReportType.instanceType]: 'reports/inventory/instance-type/',

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -43,6 +43,16 @@
     "widget_subtitle": "for $t(months.{{month}}) {{startDate}}",
     "widget_subtitle_plural": "for $t(months.{{month}}) {{startDate}} - $t(months.{{month}}) {{endDate}}"
   },
+  "export": {
+    "aggregate_type": "Select aggregate type",
+    "cancel": "Cancel",
+    "confirm": "Generate & Download",
+    "daily": "Daily",
+    "heading": "Aggregates of the following {{groupBy}}s will be exported to a .csv file.",
+    "monthly": "Monthly",
+    "selected": "Selected {{groupBy}}s",
+    "title": "Export"
+  },
   "group_by": {
     "all": "All $t(group_by.values.{{groupBy}}, { 'count': 5 })",
     "label": "Cost By",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -43,6 +43,16 @@
     "widget_subtitle": "for $t(months.{{month}}) {{startDate}}",
     "widget_subtitle_plural": "for $t(months.{{month}}) {{startDate}} - $t(months.{{month}}) {{endDate}}"
   },
+  "export": {
+    "aggregate_type": "Select aggregate type",
+    "cancel": "Cancel",
+    "confirm": "Generate & Download",
+    "daily": "Daily",
+    "heading": "Aggregates of the following {{groupBy}}s will be exported to a .csv file.",
+    "monthly": "Monthly",
+    "selected": "Selected {{groupBy}}s",
+    "title": "Export"
+  },
   "group_by": {
     "all": "All $t(group_by.values.{{groupBy}}, { 'count': 5 })",
     "label": "Cost By",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -43,6 +43,16 @@
     "widget_subtitle": "for $t(months.{{month}}) {{startDate}}",
     "widget_subtitle_plural": "for $t(months.{{month}}) {{startDate}} - $t(months.{{month}}) {{endDate}}"
   },
+  "export": {
+    "aggregate_type": "Select aggregate type",
+    "cancel": "Cancel",
+    "confirm": "Generate & Download",
+    "daily": "Daily",
+    "heading": "Aggregates of the following {{groupBy}}s will be exported to a .csv file.",
+    "monthly": "Monthly",
+    "selected": "Selected {{groupBy}}s",
+    "title": "Export"
+  },
   "group_by": {
     "all": "All $t(group_by.values.{{groupBy}}, { 'count': 5 })",
     "label": "Cost By",

--- a/src/pages/costDetails/detailItem.tsx
+++ b/src/pages/costDetails/detailItem.tsx
@@ -20,6 +20,8 @@ interface DetailsItemOwnProps {
   parentQuery: Query;
   parentGroupBy: any;
   item: ComputedReportItem;
+  onCheckboxChange(checked: boolean, item: ComputedReportItem);
+  selected: boolean;
   total: number;
 }
 
@@ -112,6 +114,11 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
     this.setState({ expanded: false });
   };
 
+  public handleCheckboxChange = event => {
+    const { item, onCheckboxChange } = this.props;
+    onCheckboxChange(event.currentTarget.checked, item);
+  };
+
   public handleSelectChange = (event: React.FormEvent<HTMLSelectElement>) => {
     const groupByKey: keyof Query['group_by'] = event.currentTarget
       .value as any;
@@ -120,13 +127,19 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
   };
 
   public render() {
-    const { t, item, parentGroupBy, total } = this.props;
+    const { t, item, parentGroupBy, selected, total } = this.props;
     const { currentGroupBy, queryString } = this.state;
     return (
       <ListView.Item
         key={item.label}
         heading={item.label}
-        checkboxInput={<input type="checkbox" />}
+        checkboxInput={
+          <input
+            type="checkbox"
+            checked={selected}
+            onChange={this.handleCheckboxChange}
+          />
+        }
         actions={[
           <ListView.InfoItem key="1" stacked>
             <strong>{formatCurrency(item.total)}</strong>

--- a/src/pages/costDetails/detailsToolbar.styles.ts
+++ b/src/pages/costDetails/detailsToolbar.styles.ts
@@ -1,0 +1,7 @@
+import { css } from 'emotion';
+
+export const btnOverride = css`
+  &.pf-c-button {
+    --pf-c-button--m-disabled--BackgroundColor: none;
+  }
+`;

--- a/src/pages/costDetails/detailsToolbar.tsx
+++ b/src/pages/costDetails/detailsToolbar.tsx
@@ -7,15 +7,18 @@ import { TextInput } from 'components/textInput';
 import { Filter, Icon, noop, Sort, Toolbar } from 'patternfly-react';
 import { isEqual } from 'utils/equal';
 
+import { btnOverride } from './detailsToolbar.styles';
+
 interface DetailsToolbarOwnProps {
+  isExportDisabled: boolean;
   filterFields: any[];
   sortField: any;
   sortFields: any[];
   exportText: string;
+  onExportClicked();
   onFilterAdded(filterType: string, filterValue: string);
   onFilterRemoved(filterType: string, filterValue: string);
-  onSortChanged?(value: string, isSortAscending: boolean);
-  onActionPerformed?(evt: React.ChangeEvent<HTMLButtonElement>);
+  onSortChanged(value: string, isSortAscending: boolean);
   report?: Report;
   resultsTotal: number;
   query?: Query;
@@ -177,6 +180,10 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
     return filterText;
   };
 
+  public handleExportClicked = () => {
+    this.props.onExportClicked();
+  };
+
   public onValueKeyPress = (e: React.KeyboardEvent) => {
     const { currentValue, currentFilterType } = this.state;
     if (e.key === 'Enter' && currentValue && currentValue.length > 0) {
@@ -248,6 +255,7 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
   }
 
   public render() {
+    const { isExportDisabled } = this.props;
     const {
       activeFilters,
       currentFilterType,
@@ -279,7 +287,12 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
           />
         </Sort>
         <div className="form-group">
-          <Button variant={ButtonVariant.link}>
+          <Button
+            className={btnOverride}
+            isDisabled={isExportDisabled}
+            onClick={this.handleExportClicked}
+            variant={ButtonVariant.link}
+          >
             <Icon name="download" />
             Export
           </Button>

--- a/src/pages/costDetails/exportModal.styles.ts
+++ b/src/pages/costDetails/exportModal.styles.ts
@@ -1,0 +1,20 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import {
+  global_spacer_sm,
+  global_spacer_xl,
+  global_spacer_xs,
+} from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  modal: {
+    h2: {
+      marginBottom: global_spacer_xl.value,
+    },
+    input: {
+      marginRight: global_spacer_xs.var,
+    },
+    ul: {
+      marginLeft: global_spacer_sm.var,
+    },
+  },
+});

--- a/src/pages/costDetails/exportModal.tsx
+++ b/src/pages/costDetails/exportModal.tsx
@@ -1,0 +1,180 @@
+import { Button, ButtonVariant, Modal, Radio } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import { getQuery, Query } from 'api/query';
+import { AxiosError } from 'axios';
+import fileDownload from 'js-file-download';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { exportActions, exportSelectors } from 'store/export';
+import { uiActions, uiSelectors } from 'store/ui';
+import { getTestProps, testIds } from 'testIds';
+import { ReportType } from '../../api/reports';
+import { FormGroup } from '../../components/formGroup';
+import { ComputedReportItem } from '../../utils/getComputedReportItems';
+import { sort, SortDirection } from '../../utils/sort';
+import { styles } from './exportModal.styles';
+
+export interface Props extends InjectedTranslateProps {
+  closeExportModal?: typeof uiActions.closeExportModal;
+  error?: AxiosError;
+  export?: string;
+  exportReport?: typeof exportActions.exportReport;
+  fetchStatus?: FetchStatus;
+  groupById?: string;
+  isAllItems?: boolean;
+  isExportModalOpen?: boolean;
+  isProviderModalOpen?: boolean;
+  items?: ComputedReportItem[];
+  query?: Query;
+  queryString?: string;
+}
+
+interface State {
+  resolution: string;
+}
+
+const resolutionOptions: {
+  label: string;
+  value: string;
+}[] = [
+  { label: 'Daily', value: 'daily' },
+  { label: 'Monthly', value: 'monthly' },
+];
+
+export class ExportModal extends React.Component<Props, State> {
+  protected defaultState: State = {
+    resolution: 'daily',
+  };
+  public state: State = { ...this.defaultState };
+
+  public componentDidUpdate(prevProps: Props) {
+    const { closeExportModal, fetchStatus, isExportModalOpen } = this.props;
+    if (isExportModalOpen && !prevProps.isExportModalOpen) {
+      this.setState({ ...this.defaultState });
+    }
+    if (
+      this.props.export !== prevProps.export &&
+      fetchStatus === FetchStatus.complete
+    ) {
+      fileDownload(this.props.export, 'report.csv', 'text/csv');
+      closeExportModal();
+    }
+  }
+
+  private getQueryString = () => {
+    const { groupById, isAllItems, items, query } = this.props;
+    const { resolution } = this.state;
+    const newQuery: Query = {
+      ...query,
+      group_by: undefined,
+      order_by: undefined,
+    };
+    newQuery.filter.resolution = resolution as any;
+    let queryString = getQuery(newQuery);
+
+    if (isAllItems) {
+      queryString += `&group_by[${groupById}]=*`;
+    } else {
+      for (const item of items) {
+        queryString += `&group_by[${groupById}]=` + item.label;
+      }
+    }
+    return queryString;
+  };
+
+  private handleCancel = () => {
+    this.props.closeExportModal();
+  };
+
+  private handleFetchReport = () => {
+    const { exportReport } = this.props;
+    exportReport(ReportType.cost, this.getQueryString());
+  };
+
+  public handleResolutionChange = (_, event) => {
+    this.setState({ resolution: event.currentTarget.value });
+  };
+
+  public render() {
+    const { fetchStatus, groupById, items, t } = this.props;
+    const { resolution } = this.state;
+
+    if (this.props.isExportModalOpen) {
+      sort(items, {
+        key: 'id',
+        direction: SortDirection.asc,
+      });
+    }
+    return (
+      <Modal
+        className={css(styles.modal)}
+        isLarge
+        isOpen={this.props.isExportModalOpen}
+        onClose={this.handleCancel}
+        title={t('export.title')}
+        actions={[
+          <Button
+            {...getTestProps(testIds.export.cancel_btn)}
+            key="cancel"
+            onClick={this.handleCancel}
+            variant={ButtonVariant.secondary}
+          >
+            {t('export.cancel')}
+          </Button>,
+          <Button
+            {...getTestProps(testIds.export.submit_btn)}
+            isDisabled={fetchStatus === FetchStatus.inProgress}
+            key="confirm"
+            onClick={this.handleFetchReport}
+            variant={ButtonVariant.primary}
+          >
+            {t('export.confirm')}
+          </Button>,
+        ]}
+      >
+        <h2>{t('export.heading', { groupBy: groupById })}</h2>
+        <FormGroup label={t('export.aggregate_type')}>
+          <React.Fragment>
+            {resolutionOptions.map((option, index) => (
+              <div>
+                <Radio
+                  isDisabled={false}
+                  isValid={option.value !== undefined}
+                  key={index}
+                  value={option.value}
+                  checked={resolution === option.value}
+                  name="resolution"
+                  onChange={this.handleResolutionChange}
+                  aria-label={t(option.label)}
+                />
+                <span>{t(option.label)}</span>
+              </div>
+            ))}
+          </React.Fragment>
+        </FormGroup>
+        <FormGroup label={t('export.selected', { groupBy: groupById })}>
+          <ul>
+            {items.map((groupItem, index) => {
+              return <li key={index}>{groupItem.label}</li>;
+            })}
+          </ul>
+        </FormGroup>
+      </Modal>
+    );
+  }
+}
+
+export default connect(
+  createMapStateToProps(state => ({
+    error: exportSelectors.selectExportError(state),
+    export: exportSelectors.selectExport(state),
+    fetchStatus: exportSelectors.selectExportFetchStatus(state),
+    isExportModalOpen: uiSelectors.selectIsExportModalOpen(state),
+  })),
+  {
+    exportReport: exportActions.exportReport,
+    closeExportModal: uiActions.closeExportModal,
+  }
+)(translate()(ExportModal));

--- a/src/pages/providersModal/providersModal.tsx
+++ b/src/pages/providersModal/providersModal.tsx
@@ -161,7 +161,7 @@ export class ProvidersModal extends React.Component<Props, State> {
         isLarge
         isOpen={this.props.isProviderModalOpen}
         onClose={this.handleCancel}
-        title={'Add Account'}
+        title={t('providers.add_account')}
         actions={[
           <Button
             {...getTestProps(testIds.providers.cancel_btn)}

--- a/src/store/export/__snapshots__/export.test.ts.snap
+++ b/src/store/export/__snapshots__/export.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`default state 1`] = `
+Object {
+  "export": null,
+  "exportError": null,
+  "exportFetchStatus": 0,
+}
+`;
+
+exports[`fetch export success 1`] = `"data"`;

--- a/src/store/export/export.test.ts
+++ b/src/store/export/export.test.ts
@@ -1,0 +1,67 @@
+jest.mock('api/export');
+
+import { runExport } from 'api/export';
+import { ReportType } from 'api/reports';
+import { wait } from 'testUtils';
+import { FetchStatus } from '../common';
+import { createMockStoreCreator } from '../mockStore';
+import * as actions from './exportActions';
+import { exportReducer, stateKey } from './exportReducer';
+import * as selectors from './exportSelectors';
+
+const createExportStore = createMockStoreCreator({
+  [stateKey]: exportReducer,
+});
+
+const runExportMock = runExport as jest.Mock;
+
+const mockExport: string = 'data';
+
+const query = 'query';
+const reportType = ReportType.cost;
+
+runExportMock.mockResolvedValue({ data: mockExport });
+
+test('default state', () => {
+  const store = createExportStore();
+  expect(selectors.selectExportState(store.getState())).toMatchSnapshot();
+});
+
+test('fetch export success', async () => {
+  const store = createExportStore();
+  store.dispatch(actions.exportReport(reportType, query));
+  expect(runExportMock).toBeCalled();
+  expect(
+    selectors.selectExportFetchStatus(store.getState())
+  ).toBe(FetchStatus.inProgress);
+  await wait();
+  const finishedState = store.getState();
+  expect(
+    selectors.selectExport(finishedState)
+  ).toMatchSnapshot();
+  expect(
+    selectors.selectExportFetchStatus(finishedState)
+  ).toBe(FetchStatus.complete);
+  expect(selectors.selectExportError(finishedState)).toBe(
+    null
+  );
+});
+
+test('fetch export failure', async () => {
+  const store = createExportStore();
+  const error = Symbol('export error');
+  runExportMock.mockRejectedValueOnce(error);
+  store.dispatch(actions.exportReport(reportType, query));
+  expect(runExport).toBeCalled();
+  expect(
+    selectors.selectExportFetchStatus(store.getState())
+  ).toBe(FetchStatus.inProgress);
+  await wait();
+  const finishedState = store.getState();
+  expect(
+    selectors.selectExportFetchStatus(finishedState)
+  ).toBe(FetchStatus.complete);
+  expect(selectors.selectExportError(finishedState)).toBe(
+    error
+  );
+});

--- a/src/store/export/exportActions.ts
+++ b/src/store/export/exportActions.ts
@@ -1,0 +1,32 @@
+import { runExport } from 'api/export';
+import { ReportType } from 'api/reports';
+import { AxiosError } from 'axios';
+import { ThunkAction } from 'redux-thunk';
+import { createAsyncAction } from 'typesafe-actions';
+import { RootState } from '../rootReducer';
+
+export const {
+  request: fetchExportRequest,
+  success: fetchExportSuccess,
+  failure: fetchExportFailure,
+} = createAsyncAction('export/request', 'export/success', 'export/failure')<
+  void,
+  string,
+  AxiosError
+>();
+
+export function exportReport(
+  reportType: ReportType,
+  query: string
+): ThunkAction<void, RootState, void, any> {
+  return (dispatch, getState) => {
+    dispatch(fetchExportRequest());
+    runExport(reportType, query)
+      .then(res => {
+        dispatch(fetchExportSuccess(res.data));
+      })
+      .catch(err => {
+        dispatch(fetchExportFailure(err));
+      });
+  };
+}

--- a/src/store/export/exportReducer.ts
+++ b/src/store/export/exportReducer.ts
@@ -1,0 +1,57 @@
+import { AxiosError } from 'axios';
+import { ActionType, getType } from 'typesafe-actions';
+import { FetchStatus } from '../common';
+import {
+  fetchExportFailure,
+  fetchExportRequest,
+  fetchExportSuccess,
+} from './exportActions';
+
+export type ExportAction = ActionType<
+  | typeof fetchExportFailure
+  | typeof fetchExportRequest
+  | typeof fetchExportSuccess
+>;
+
+export type ExportState = Readonly<{
+  export: string;
+  exportError: AxiosError;
+  exportFetchStatus: FetchStatus;
+}>;
+
+export const defaultState: ExportState = {
+  export: null,
+  exportError: null,
+  exportFetchStatus: FetchStatus.none,
+};
+
+export const stateKey = 'export';
+
+export function exportReducer(
+  state = defaultState,
+  action: ExportAction
+): ExportState {
+  switch (action.type) {
+    case getType(fetchExportRequest):
+      return {
+        ...state,
+        exportFetchStatus: FetchStatus.inProgress,
+      };
+    case getType(fetchExportSuccess):
+      return {
+        ...state,
+        export: action.payload,
+        exportError: null,
+        exportFetchStatus: FetchStatus.complete,
+      };
+    case getType(fetchExportFailure):
+      return {
+        ...state,
+        export: null,
+        exportError: action.payload,
+        exportFetchStatus: FetchStatus.complete,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/store/export/exportSelectors.ts
+++ b/src/store/export/exportSelectors.ts
@@ -1,0 +1,13 @@
+import { RootState } from '../rootReducer';
+import { stateKey } from './exportReducer';
+
+export const selectExportState = (state: RootState) => state[stateKey];
+
+export const selectExport = (state: RootState) =>
+  selectExportState(state).export;
+
+export const selectExportFetchStatus = (state: RootState) =>
+  selectExportState(state).exportFetchStatus;
+
+export const selectExportError = (state: RootState) =>
+  selectExportState(state).exportError;

--- a/src/store/export/index.ts
+++ b/src/store/export/index.ts
@@ -1,0 +1,17 @@
+import * as exportActions from './exportActions';
+import {
+  ExportAction,
+  exportReducer,
+  ExportState,
+  stateKey as exportStateKey,
+} from './exportReducer';
+import * as exportSelectors from './exportSelectors';
+
+export {
+  ExportAction,
+  exportActions,
+  exportReducer,
+  exportSelectors,
+  ExportState,
+  exportStateKey,
+};

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -1,6 +1,7 @@
 import { combineReducers } from 'redux';
 import { StateType } from 'typesafe-actions';
 import { dashboardReducer, dashboardStateKey } from './dashboard';
+import { exportReducer, exportStateKey } from './export';
 import { providersReducer, providersStateKey } from './providers';
 import { reportsReducer, reportsStateKey } from './reports';
 import { sessionReducer, sessionStateKey } from './session';
@@ -15,5 +16,6 @@ export const rootReducer = combineReducers({
   [uiStateKey]: uiReducer,
   [reportsStateKey]: reportsReducer,
   [dashboardStateKey]: dashboardReducer,
+  [exportStateKey]: exportReducer,
   [providersStateKey]: providersReducer,
 });

--- a/src/store/ui/__snapshots__/ui.test.ts.snap
+++ b/src/store/ui/__snapshots__/ui.test.ts.snap
@@ -2,6 +2,7 @@
 
 exports[`default state 1`] = `
 Object {
+  "isExportModalOpen": false,
   "isProvidersModalOpen": false,
   "isSidebarOpen": false,
 }

--- a/src/store/ui/ui.test.ts
+++ b/src/store/ui/ui.test.ts
@@ -15,6 +15,18 @@ test('default state', async () => {
   expect(selectors.selectUIState(store.getState())).toMatchSnapshot();
 });
 
+test('close export modal', async () => {
+  const store = createUIStore();
+  store.dispatch(actions.closeExportModal());
+  expect(uiSelectors.selectIsExportModalOpen(store.getState())).toBe(false);
+});
+
+test('open export modal', async () => {
+  const store = createUIStore();
+  store.dispatch(actions.openExportModal());
+  expect(uiSelectors.selectIsExportModalOpen(store.getState())).toBe(true);
+});
+
 test('close providers modal', async () => {
   const store = createUIStore();
   store.dispatch(actions.closeProvidersModal());

--- a/src/store/ui/uiActions.ts
+++ b/src/store/ui/uiActions.ts
@@ -1,5 +1,9 @@
 import { createAction } from 'typesafe-actions';
 
+export const closeExportModal = createAction('ui/close_export_modal');
+
+export const openExportModal = createAction('ui/open_export_modal');
+
 export const closeProvidersModal = createAction('ui/close_providers_modal');
 
 export const openProvidersModal = createAction('ui/open_providers_modal');

--- a/src/store/ui/uiReducer.ts
+++ b/src/store/ui/uiReducer.ts
@@ -1,20 +1,28 @@
 import { ActionType, getType } from 'typesafe-actions';
 import {
+  closeExportModal,
   closeProvidersModal,
+  openExportModal,
   openProvidersModal,
   toggleSidebar,
 } from './uiActions';
 
 export type UIAction = ActionType<
-  typeof closeProvidersModal | typeof openProvidersModal | typeof toggleSidebar
+  | typeof closeExportModal
+  | typeof closeProvidersModal
+  | typeof openExportModal
+  | typeof openProvidersModal
+  | typeof toggleSidebar
 >;
 
 export type UIState = Readonly<{
+  isExportModalOpen: boolean;
   isProvidersModalOpen: boolean;
   isSidebarOpen: boolean;
 }>;
 
 export const defaultState: UIState = {
+  isExportModalOpen: false,
   isProvidersModalOpen: false,
   isSidebarOpen: false,
 };
@@ -23,10 +31,20 @@ export const stateKey = 'ui';
 
 export function uiReducer(state = defaultState, action: UIAction): UIState {
   switch (action.type) {
+    case getType(closeExportModal):
+      return {
+        ...state,
+        isExportModalOpen: false,
+      };
     case getType(closeProvidersModal):
       return {
         ...state,
         isProvidersModalOpen: false,
+      };
+    case getType(openExportModal):
+      return {
+        ...state,
+        isExportModalOpen: true,
       };
     case getType(openProvidersModal):
       return {

--- a/src/store/ui/uiSelectors.ts
+++ b/src/store/ui/uiSelectors.ts
@@ -3,6 +3,9 @@ import { stateKey } from './uiReducer';
 
 export const selectUIState = (state: RootState) => state[stateKey];
 
+export const selectIsExportModalOpen = (state: RootState) =>
+  selectUIState(state).isExportModalOpen;
+
 export const selectIsProvidersModalOpen = (state: RootState) =>
   selectUIState(state).isProvidersModalOpen;
 

--- a/src/testIds.ts
+++ b/src/testIds.ts
@@ -2,6 +2,10 @@ export const testIdProp = 'data-testid';
 export const getTestProps = (id: string) => ({ [testIdProp]: id });
 
 export const testIds = {
+  export: {
+    cancel_btn: 'cancel-btn',
+    submit_btn: 'submit-btn',
+  },
   login: {
     alert: 'alert',
     form: 'login-form',

--- a/yarn.lock
+++ b/yarn.lock
@@ -5919,6 +5919,10 @@ js-base64@^2.1.9:
   version "2.4.3"
   resolved "https://registry.yarnpkg.com/js-base64/-/js-base64-2.4.3.tgz#2e545ec2b0f2957f41356510205214e98fad6582"
 
+js-file-download@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/js-file-download/-/js-file-download-0.4.4.tgz#51ffa5d421fc5fc25c9d1a724255a7184e4dc92b"
+
 js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"


### PR DESCRIPTION
Added the export modal to download csv files. 

After the request returns, the browser is triggered to save data to a file as if it was downloaded, and the modal closes.

This also enables the checkboxes and select all features. If all rows are selected, the select all checkbox is also selected. In addition, the export button is disabled when there are no selections.

Based on the mockup below (click on Export)
https://redhat.invisionapp.com/share/HEO4ISHAT8Z#/screens/323822462

Screenshot
![screen shot 2018-10-11 at 3 16 32 am](https://user-images.githubusercontent.com/17481322/46786910-4ec69300-cd04-11e8-898a-968d0cbd18cc.png)


