### PR TITLE
Cost details: Add month over month change

### DIFF
--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -24,6 +24,7 @@ interface OrderBys {
 }
 
 export interface Query {
+  delta?: boolean;
   filter?: Filters;
   group_by?: GroupBys;
   order_by?: OrderBys;

--- a/src/api/reports.ts
+++ b/src/api/reports.ts
@@ -3,6 +3,8 @@ import { Omit } from 'react-redux';
 
 export interface ReportValue {
   date: string;
+  delta_percent?: number;
+  delta_value?: number;
   total: number;
   units: string;
   account?: string;
@@ -32,6 +34,8 @@ export interface GroupByInstanceTypeData
 
 export interface ReportData {
   date?: string;
+  delta_percent?: number;
+  delta_value?: number;
   services?: GroupByServiceData[];
   accounts?: GroupByAccountData[];
   regions?: GroupByRegionData[];
@@ -41,6 +45,10 @@ export interface ReportData {
 
 export interface Report {
   data: ReportData[];
+  delta?: {
+    percent: number;
+    value: number;
+  };
   group_by?: {
     [group: string]: string[];
   };

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -1,8 +1,11 @@
 {
   "app_title": "Koku",
   "cost_details": {
+    "change_column_title": "Month Over Month Change",
     "cost_column_subtitle": "(Total {{total}})",
     "cost_column_title": "Cost",
+    "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
+    "decrease_since_last_month": "{{value}} decrease since last month",
     "export_link": "Export",
     "filter": {
       "account_placeholder": "Filter by Account",
@@ -12,7 +15,10 @@
       "service_placeholder": "Filter by Service",
       "service_select": "Service"
     },
+    "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
+    "increase_since_last_month": "{{value}} increase since last month",
     "name_column_title": "$t(group_by.values.{{groupBy}}) Names",
+    "no_change_since_date": "No change since $t(months.{{month}}) {{date}}",
     "order": {
       "cost": "Sort by: Cost",
       "cost_delta": "Sort by: Cost Delta",
@@ -92,6 +98,7 @@
     "December"
   ],
   "navigation_toggle": "navigation toggle",
+  "percent": "{{value}}%",
   "percent_of_cost": "% of Cost",
   "providers": {
     "add_account": "Add Account",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,8 +1,11 @@
 {
   "app_title": "Koku",
   "cost_details": {
+    "change_column_title": "Month Over Month Change",
     "cost_column_subtitle": "(Total {{total}})",
     "cost_column_title": "Cost",
+    "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
+    "decrease_since_last_month": "{{value}} decrease since last month",
     "export_link": "Export",
     "filter": {
       "account_placeholder": "Filter by Account",
@@ -12,7 +15,10 @@
       "service_placeholder": "Filter by Service",
       "service_select": "Service"
     },
+    "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
+    "increase_since_last_month": "{{value}} increase since last month",
     "name_column_title": "$t(group_by.values.{{groupBy}}) Names",
+    "no_change_since_date": "No change since $t(months.{{month}}) {{date}}",
     "order": {
       "cost": "Sort by: Cost",
       "cost_delta": "Sort by: Cost Delta",
@@ -92,6 +98,7 @@
     "December"
   ],
   "navigation_toggle": "navigation toggle",
+  "percent": "{{value}}%",
   "percent_of_cost": "% of Cost",
   "providers": {
     "add_account": "Add Account",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -1,8 +1,11 @@
 {
   "app_title": "Koku",
   "cost_details": {
+    "change_column_title": "Month Over Month Change",
     "cost_column_subtitle": "(Total {{total}})",
     "cost_column_title": "Cost",
+    "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
+    "decrease_since_last_month": "{{value}} decrease since last month",
     "export_link": "Export",
     "filter": {
       "account_placeholder": "Filter by Account",
@@ -12,7 +15,10 @@
       "service_placeholder": "Filter by Service",
       "service_select": "Service"
     },
+    "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
+    "increase_since_last_month": "{{value}} increase since last month",
     "name_column_title": "$t(group_by.values.{{groupBy}}) Names",
+    "no_change_since_date": "No change since $t(months.{{month}}) {{date}}",
     "order": {
       "cost": "Sort by: Cost",
       "cost_delta": "Sort by: Cost Delta",
@@ -92,6 +98,7 @@
     "December"
   ],
   "navigation_toggle": "navigation toggle",
+  "percent": "{{value}}%",
   "percent_of_cost": "% of Cost",
   "providers": {
     "add_account": "Add Account",

--- a/src/pages/costDetails/costDetails.styles.ts
+++ b/src/pages/costDetails/costDetails.styles.ts
@@ -8,6 +8,7 @@ import {
   global_Color_200,
   global_Color_light_100,
   global_Color_light_200,
+  global_danger_color_100,
   global_disabled_color_100,
   global_FontSize_lg,
   global_FontSize_md,
@@ -23,6 +24,7 @@ import {
   global_spacer_sm,
   global_spacer_xl,
   global_spacer_xs,
+  global_success_color_100,
 } from '@patternfly/react-tokens';
 import { css } from 'emotion';
 
@@ -174,20 +176,45 @@ export const listViewOverride = css`
   }
 
   .list-view-pf-additional-info-item {
-    align-items: flex-start;
+    align-items: flex-end;
     text-align: left;
     word-break: break-word;
+    .fa {
+      margin-right 0;
+    }
   }
 
   .list-view-pf-actions .list-view-pf-additional-info-item {
     align-items: flex-end;
   }
 
-  .list-view-pf-additional-info-item strong {
-    display: block;
-    margin-right: 0;
-    margin-bottom: ${global_spacer_xs.value};
-    font-size: ${global_FontSize_md.value};
+  .list-view-pf-additional-info-item 
+    strong {
+      display: block;
+      margin-right: 0;
+      margin-bottom: ${global_spacer_xs.value};
+      font-size: ${global_FontSize_md.value};
+      &.iconOverride {
+        &.decrease {
+          color: ${global_success_color_100.value};
+        }
+        &.increase {
+          color: ${global_danger_color_100.value};
+        }
+        .fa-sort-asc, .fa-sort-desc {
+          margin-left: 10px;
+        }
+        .fa-sort-asc::before {
+          color: ${global_danger_color_100.value};
+        }
+        .fa-sort-desc::before {
+          color: ${global_success_color_100.value};
+        }
+        span {
+          margin-right: -17px !important;
+        }
+      }
+    }
   }
 
   .list-view-pf-additional-info-item span {
@@ -223,7 +250,9 @@ export const listViewOverride = css`
   .list-group-item-container {
     padding: ${global_spacer_lg.value} ${global_spacer_3xl.value}
       ${global_spacer_lg.value} ${global_spacer_3xl.value};
-    margin: ${global_spacer_lg.value} -${global_spacer_xl.value} -${global_spacer_lg.value} -${global_spacer_xl.value};
+    margin: ${global_spacer_lg.value} -${global_spacer_xl.value} -${
+  global_spacer_lg.value
+} -${global_spacer_xl.value};
     background-image: linear-gradient(
       to right,
       ${global_primary_color_100.value},

--- a/src/pages/costDetails/costDetails.tsx
+++ b/src/pages/costDetails/costDetails.tsx
@@ -49,6 +49,7 @@ type Props = StateProps & OwnProps & DispatchProps;
 const reportType = ReportType.cost;
 
 const baseQuery: Query = {
+  delta: true,
   filter: {
     time_scope_units: 'month',
     time_scope_value: -1,
@@ -394,6 +395,11 @@ class CostDetails extends React.Component<Props> {
                     onChange={this.onCheckboxAllChange}
                   />
                 }
+                additionalInfo={[
+                  <ListView.InfoItem key="1">
+                    <strong>{t('cost_details.change_column_title')}</strong>
+                  </ListView.InfoItem>,
+                ]}
                 actions={[
                   <ListView.InfoItem key="1">
                     <strong>
@@ -434,6 +440,7 @@ const mapStateToProps = createMapStateToProps<OwnProps, StateProps>(
   (state, props) => {
     const queryFromRoute = parseQuery<Query>(props.location.search);
     const query = {
+      delta: true,
       filter: {
         ...baseQuery.filter,
         ...queryFromRoute.filter,

--- a/src/pages/costDetails/detailItem.tsx
+++ b/src/pages/costDetails/detailItem.tsx
@@ -129,6 +129,22 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
   public render() {
     const { t, item, parentGroupBy, selected, total } = this.props;
     const { currentGroupBy, queryString } = this.state;
+
+    const today = new Date();
+    const date = today.getDate();
+    const month = (today.getMonth() - 1) % 12;
+
+    const value = formatCurrency(Math.abs(item.deltaValue));
+    const percentage = Math.abs(item.deltaPercent).toFixed(2);
+
+    let iconOverride = 'iconOverride';
+    if (item.deltaValue < 0) {
+      iconOverride += ' decrease';
+    }
+    if (item.deltaValue > 0) {
+      iconOverride += ' increase';
+    }
+
     return (
       <ListView.Item
         key={item.label}
@@ -140,6 +156,46 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
             onChange={this.handleCheckboxChange}
           />
         }
+        additionalInfo={[
+          <ListView.InfoItem key="1" stacked>
+            <strong className={iconOverride}>
+              {t('percent', { value: percentage })}
+              {Boolean(item.deltaValue > 0) && (
+                <span className={'fa fa-sort-asc'} />
+              )}
+              {Boolean(item.deltaValue < 0) && (
+                <span className={'fa fa-sort-desc'} />
+              )}
+            </strong>
+            <span>
+              {(Boolean(item.deltaValue > 0) &&
+                ((Boolean(date < 31) &&
+                  t('cost_details.increase_since_date', {
+                    date,
+                    month,
+                    value,
+                  })) ||
+                  t('cost_details.increase_since_last_month', {
+                    date,
+                    month,
+                    value,
+                  }))) ||
+                (Boolean(item.deltaValue < 0) &&
+                  ((Boolean(date < 31) &&
+                    t('cost_details.decrease_since_date', {
+                      date,
+                      month,
+                      value,
+                    })) ||
+                    t('cost_details.decrease_since_last_month', {
+                      date,
+                      month,
+                      value,
+                    }))) ||
+                t('cost_details.no_change_since_date', { date, month })}
+            </span>
+          </ListView.InfoItem>,
+        ]}
         actions={[
           <ListView.InfoItem key="1" stacked>
             <strong>{formatCurrency(item.total)}</strong>

--- a/src/utils/getComputedReportItems.ts
+++ b/src/utils/getComputedReportItems.ts
@@ -4,6 +4,8 @@ import { Omit } from 'react-redux';
 import { sort, SortDirection } from './sort';
 
 export interface ComputedReportItem {
+  deltaPercent: number;
+  deltaValue: number;
   id: string | number;
   label: string | number;
   total: number;
@@ -64,6 +66,8 @@ export function getUnsortedComputedReportItems({
         }
         if (!itemMap[id]) {
           itemMap[id] = {
+            deltaPercent: value.delta_percent,
+            deltaValue: value.delta_value,
             id,
             total,
             label,


### PR DESCRIPTION
This adds the month over month change to the cost details page. The following scenarios are handled per the mocks.

- Cost increase shows red text & arrow with "increase since <date>" text
- Cost decrease shows green text & arrow with "decrease since <date>" text
- When delta value is 0, the "no change since <date>" text is shown
- When the date is 31, the "since last month" text is shown

Note that start:dev / Insights proxy currently returns 0 for all delta_percent values; although, I believe this is just a matter of populating the data manually (e.g., koku-dev has values for delta_percent)? I had to hard code the percentages to get the screenshots.

Fixes https://github.com/project-koku/koku-ui/issues/168

Cost decrease:
![screen shot 2018-10-15 at 8 03 40 pm](https://user-images.githubusercontent.com/17481322/46985681-9741d000-d0b9-11e8-9edb-a4953c7f17ee.png)

Cost Increase:
![screen shot 2018-10-15 at 8 04 47 pm](https://user-images.githubusercontent.com/17481322/46985738-dd972f00-d0b9-11e8-8bf3-5f44628fe4b2.png)

