### PR TITLE
fix(formGroup): Do not override children id props

### DIFF
--- a/src/components/formGroup/formGroup.test.tsx
+++ b/src/components/formGroup/formGroup.test.tsx
@@ -1,0 +1,21 @@
+import { mount } from 'enzyme';
+import React from 'react';
+import { FormGroup, formGroupIdProp } from './formGroup';
+
+test('render form group', () => {
+  const labelName = 'username';
+  const idProp = 'div-id';
+  const testProp = 'div-test-id';
+  const view = mount(
+    <FormGroup label={labelName}>
+      <div id={idProp} testid={testProp} />
+    </FormGroup>
+  );
+  expect(view.find('label').text()).toBe(labelName);
+  expect(view.find('label').props().htmlFor).toBe(`${labelName}0`);
+  expect(view.find(`#${idProp}`).length).toBe(1);
+  expect(view.find(`#${idProp}`).props().testid).toBe(testProp);
+  expect(view.find(`#${idProp}`).props()[formGroupIdProp]).toBe(
+    `${labelName}0`
+  );
+});

--- a/src/components/formGroup/formGroup.tsx
+++ b/src/components/formGroup/formGroup.tsx
@@ -8,6 +8,7 @@ interface Props {
   children?: React.ReactElement<any>;
 }
 
+export const formGroupIdProp = 'data-label-for';
 export const FormGroup: React.SFC<Props> = ({ label, children }) => (
   <RandomId prefix={label}>
     {({ id }) => (
@@ -15,7 +16,11 @@ export const FormGroup: React.SFC<Props> = ({ label, children }) => (
         <label className={css(styles.label)} htmlFor={id}>
           {label}
         </label>
-        <div>{React.cloneElement(React.Children.only(children), { id })}</div>
+        <div>
+          {React.cloneElement(React.Children.only(children), {
+            [formGroupIdProp]: id,
+          })}
+        </div>
       </div>
     )}
   </RandomId>


### PR DESCRIPTION
Fixes #113 

Although I couldn't reproduce what @dlabrecq wrote. I did find that the `id` prop is being overridden by RandomId children function.

This commit fixes this problem by setting the `randomId` as `data-label-for` instead of `id`.
Hope this is good enough.

In addition, added unit test to make sure it won't happen again.

// cc @dlabrecq @LandoCalrizzian 