### PR TITLE
[WIP] refactor(details): break aws/ocpDetails into small components

### DIFF
--- a/src/components/list/GroupBySelector.test.tsx
+++ b/src/components/list/GroupBySelector.test.tsx
@@ -1,0 +1,32 @@
+import { Title } from '@patternfly/react-core';
+import * as emotion from 'emotion';
+import { shallow } from 'enzyme';
+import { createSerializer } from 'jest-emotion';
+import React from 'react';
+import { GroupBySelector } from './GroupBySelector';
+
+expect.addSnapshotSerializer(createSerializer(emotion));
+
+test('render GroupBySelector without options', () => {
+  const view = shallow(
+    <GroupBySelector
+      title="My Charges"
+      label="GROUP CHRGS BY"
+      onChange={jest.fn()}
+    />
+  );
+  expect(view).toMatchSnapshot();
+});
+
+test('render GroupBySelector with options', () => {
+  const view = shallow(
+    <GroupBySelector
+      title="My Charges"
+      label="GROUP CHRGS BY"
+      onChange={jest.fn()}
+      initValue="initial value!"
+      options={[{ value: '14', label: '14th' }, { value: '21', label: '21st' }]}
+    />
+  );
+  expect(view).toMatchSnapshot();
+});

--- a/src/components/list/GroupBySelector.tsx
+++ b/src/components/list/GroupBySelector.tsx
@@ -1,0 +1,53 @@
+import { Select, SelectOption, Title } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import React from 'react';
+import { noop } from '../../utils/noop';
+import { styles } from './header.styles';
+
+interface GroupByOption {
+  value: string;
+  label: string;
+}
+
+interface GroupByProps {
+  title: string;
+  label: string;
+  onChange: (value) => void;
+  options?: GroupByOption[];
+  initValue?: string;
+}
+
+export const GroupBySelector: React.SFC<GroupByProps> = ({
+  title,
+  label,
+  onChange,
+  options,
+  initValue,
+}) => (
+  <React.Fragment>
+    <Title size="2xl">{title}</Title>
+    <div className={css(styles.groupBySelector)}>
+      <label className={css(styles.groupBySelectorLabel)}>{label}</label>
+    </div>
+    <Select
+      onBlur={noop}
+      onFocus={noop}
+      value={initValue}
+      aria-label="group by selector"
+      onChange={onChange}
+    >
+      {options.map(option => (
+        <SelectOption
+          key={`group-by-${option.value}`}
+          value={option.value}
+          label={option.label}
+        />
+      ))}
+    </Select>
+  </React.Fragment>
+);
+
+GroupBySelector.defaultProps = {
+  options: [],
+  initValue: '',
+};

--- a/src/components/list/ListHeader.test.tsx
+++ b/src/components/list/ListHeader.test.tsx
@@ -1,0 +1,18 @@
+import { Title } from '@patternfly/react-core';
+import * as emotion from 'emotion';
+import { shallow } from 'enzyme';
+import { createSerializer } from 'jest-emotion';
+import React from 'react';
+import { ListHeader } from './ListHeader';
+
+expect.addSnapshotSerializer(createSerializer(emotion));
+
+test('render list header', () => {
+  const view = shallow(
+    <ListHeader>
+      <h1>Header Title</h1>
+      <small>small description</small>
+    </ListHeader>
+  );
+  expect(view).toMatchSnapshot();
+});

--- a/src/components/list/ListHeader.tsx
+++ b/src/components/list/ListHeader.tsx
@@ -1,0 +1,11 @@
+import { css } from '@patternfly/react-styles';
+import React, { ReactNode } from 'react';
+import { styles } from './header.styles';
+
+interface ListHeaderProps {
+  children: ReactNode;
+}
+
+export const ListHeader: React.SFC<ListHeaderProps> = ({ children }) => (
+  <header className={css(styles.header)}>{children}</header>
+);

--- a/src/components/list/Toolbar.tsx
+++ b/src/components/list/Toolbar.tsx
@@ -1,0 +1,54 @@
+// import { css } from '@patternfly/react-styles';
+import {
+  Button,
+  Select,
+  SelectOption,
+  TextInput,
+  Toolbar as PFToolbar,
+  ToolbarGroup,
+  ToolbarItem,
+} from '@patternfly/react-core';
+import { DownloadIcon, SortNumericDownIcon } from '@patternfly/react-icons';
+import React from 'react';
+import { noop } from '../../utils/noop';
+
+export const Toolbar = ({ placeholder, value, onChange }) => (
+  <PFToolbar>
+    <ToolbarGroup>
+      <ToolbarItem>
+        <TextInput
+          isAlt
+          placeholder={placeholder}
+          aria-label="filter text input"
+          onChange={onChange}
+        />
+      </ToolbarItem>
+    </ToolbarGroup>
+    <ToolbarGroup>
+      <ToolbarItem>
+        <Select
+          value={'Sort by: Cost'}
+          onBlur={noop}
+          onFocus={noop}
+          onChange={noop}
+          aria-label="sort by selector"
+        >
+          <SelectOption value="cost" label={'Sort by: Cost'} />
+          <SelectOption value="rate" label={'Sort by: Rate'} />
+        </Select>
+      </ToolbarItem>
+      <ToolbarItem>
+        <Button variant="plain" aria-label="sort">
+          <SortNumericDownIcon />
+        </Button>
+      </ToolbarItem>
+    </ToolbarGroup>
+    <ToolbarGroup>
+      <ToolbarItem>
+        <Button variant="plain" aria-label="download as CSV">
+          <DownloadIcon /> Export
+        </Button>
+      </ToolbarItem>
+    </ToolbarGroup>
+  </PFToolbar>
+);

--- a/src/components/list/TotalSummary.test.tsx
+++ b/src/components/list/TotalSummary.test.tsx
@@ -1,0 +1,19 @@
+import { Title } from '@patternfly/react-core';
+import * as emotion from 'emotion';
+import { shallow } from 'enzyme';
+import { createSerializer } from 'jest-emotion';
+import React from 'react';
+import { TotalSummary } from './TotalSummary';
+
+expect.addSnapshotSerializer(createSerializer(emotion));
+
+test('render total summary', () => {
+  const view = shallow(
+    <TotalSummary
+      value="$27.12"
+      totalLabel={'Total Cost'}
+      dateLabel={'5 weeks ago'}
+    />
+  );
+  expect(view).toMatchSnapshot();
+});

--- a/src/components/list/TotalSummary.tsx
+++ b/src/components/list/TotalSummary.tsx
@@ -1,0 +1,26 @@
+import { Title } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import React from 'react';
+import { styles } from './header.styles';
+
+interface TotalSummaryProps {
+  value: string | number;
+  totalLabel: string;
+  dateLabel: string;
+}
+
+export const TotalSummary: React.SFC<TotalSummaryProps> = ({
+  value,
+  totalLabel,
+  dateLabel,
+}) => (
+  <div className={css(styles.total)}>
+    <Title className={css(styles.totalValue)} size="4xl">
+      {value}
+    </Title>
+    <div className={css(styles.totalLabel)}>
+      <div className={css(styles.totalLabelUnit)}>{totalLabel}</div>
+      <div className={css(styles.totalLabelDate)}>{dateLabel}</div>
+    </div>
+  </div>
+);

--- a/src/components/list/__snapshots__/GroupBySelector.test.tsx.snap
+++ b/src/components/list/__snapshots__/GroupBySelector.test.tsx.snap
@@ -1,0 +1,108 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`render GroupBySelector with options 1`] = `
+.emotion-1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-0 {
+  margin-bottom: 0;
+  margin-right: var(--pf-global--spacer--md);
+}
+
+<React.Fragment>
+  <Title
+    className=""
+    size="2xl"
+  >
+    My Charges
+  </Title>
+  <div
+    className="emotion-1"
+  >
+    <label
+      className="emotion-0"
+    >
+      GROUP CHRGS BY
+    </label>
+  </div>
+  <Select
+    aria-label="group by selector"
+    className=""
+    isDisabled={false}
+    isValid={true}
+    onBlur={[Function]}
+    onChange={[MockFunction]}
+    onFocus={[Function]}
+    value="initial value!"
+  >
+    <SelectOption
+      className=""
+      isDisabled={false}
+      key="group-by-14"
+      label="14th"
+      value="14"
+    />
+    <SelectOption
+      className=""
+      isDisabled={false}
+      key="group-by-21"
+      label="21st"
+      value="21"
+    />
+  </Select>
+</React.Fragment>
+`;
+
+exports[`render GroupBySelector without options 1`] = `
+.emotion-1 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-0 {
+  margin-bottom: 0;
+  margin-right: var(--pf-global--spacer--md);
+}
+
+<React.Fragment>
+  <Title
+    className=""
+    size="2xl"
+  >
+    My Charges
+  </Title>
+  <div
+    className="emotion-1"
+  >
+    <label
+      className="emotion-0"
+    >
+      GROUP CHRGS BY
+    </label>
+  </div>
+  <Select
+    aria-label="group by selector"
+    className=""
+    isDisabled={false}
+    isValid={true}
+    onBlur={[Function]}
+    onChange={[MockFunction]}
+    onFocus={[Function]}
+    value=""
+  />
+</React.Fragment>
+`;

--- a/src/components/list/__snapshots__/ListHeader.test.tsx.snap
+++ b/src/components/list/__snapshots__/ListHeader.test.tsx.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`render list header 1`] = `
+.emotion-0 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-box-pack: justify;
+  -webkit-justify-content: space-between;
+  -ms-flex-pack: justify;
+  justify-content: space-between;
+  padding: var(--pf-global--spacer--xl);
+  background-color: var(--pf-global--BackgroundColor--100);
+}
+
+<header
+  className="emotion-0"
+>
+  <h1>
+    Header Title
+  </h1>
+  <small>
+    small description
+  </small>
+</header>
+`;

--- a/src/components/list/__snapshots__/TotalSummary.test.tsx.snap
+++ b/src/components/list/__snapshots__/TotalSummary.test.tsx.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`render total summary 1`] = `
+.emotion-4 {
+  display: -webkit-box;
+  display: -webkit-flex;
+  display: -ms-flexbox;
+  display: flex;
+  -webkit-align-items: center;
+  -webkit-box-align: center;
+  -ms-flex-align: center;
+  align-items: center;
+}
+
+.emotion-0 {
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-right: var(--pf-global--spacer--md);
+}
+
+.emotion-1 {
+  font-size: 0.875rem;
+  color: var(--pf-global--Color--100);
+}
+
+.emotion-2 {
+  font-size: 0.875rem;
+  color: var(--pf-global--Color--200);
+}
+
+<div
+  className="emotion-4"
+>
+  <Title
+    className="emotion-0"
+    size="4xl"
+  >
+    $27.12
+  </Title>
+  <div
+    className="emotion-3"
+  >
+    <div
+      className="emotion-1"
+    >
+      Total Cost
+    </div>
+    <div
+      className="emotion-2"
+    >
+      5 weeks ago
+    </div>
+  </div>
+</div>
+`;

--- a/src/components/list/header.styles.tsx
+++ b/src/components/list/header.styles.tsx
@@ -1,0 +1,44 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import {
+  global_BackgroundColor_100,
+  global_Color_100,
+  global_Color_200,
+  global_FontSize_sm,
+  global_spacer_md,
+  global_spacer_xl,
+} from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: global_spacer_xl.var,
+    backgroundColor: global_BackgroundColor_100.var,
+  },
+  total: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  totalLabel: {},
+  totalValue: {
+    marginTop: 0,
+    marginBottom: 0,
+    marginRight: global_spacer_md.var,
+  },
+  totalLabelUnit: {
+    fontSize: global_FontSize_sm.value,
+    color: global_Color_100.var,
+  },
+  totalLabelDate: {
+    fontSize: global_FontSize_sm.value,
+    color: global_Color_200.var,
+  },
+  groupBySelector: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  groupBySelectorLabel: {
+    marginBottom: 0,
+    marginRight: global_spacer_md.var,
+  },
+});

--- a/src/components/list/index.tsx
+++ b/src/components/list/index.tsx
@@ -1,3 +1,4 @@
 export { TotalSummary } from './TotalSummary';
 export { GroupBySelector } from './GroupBySelector';
 export { ListHeader } from './ListHeader';
+export { Toolbar } from './Toolbar';

--- a/src/components/list/index.tsx
+++ b/src/components/list/index.tsx
@@ -1,0 +1,3 @@
+export { TotalSummary } from './TotalSummary';
+export { GroupBySelector } from './GroupBySelector';
+export { ListHeader } from './ListHeader';

--- a/src/pages/awsDetails/awsDetails.tsx
+++ b/src/pages/awsDetails/awsDetails.tsx
@@ -1,4 +1,3 @@
-import { Title } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { getQuery, parseQuery, Query } from 'api/query';
 import { Report, ReportType } from 'api/reports';
@@ -16,6 +15,11 @@ import {
   getIdKeyForGroupBy,
   getUnsortedComputedReportItems,
 } from 'utils/getComputedReportItems';
+import {
+  GroupBySelector,
+  ListHeader,
+  TotalSummary,
+} from '../../components/list';
 import { ComputedReportItem } from '../../utils/getComputedReportItems';
 import { listViewOverride, styles, toolbarOverride } from './awsDetails.styles';
 import { DetailsItem } from './detailsItem';
@@ -95,10 +99,9 @@ class AwsDetails extends React.Component<Props> {
     }
   }
 
-  public handleSelectChange = (event: React.FormEvent<HTMLSelectElement>) => {
+  public handleSelectChange = (value: string) => {
     const { history } = this.props;
-    const groupByKey: keyof Query['group_by'] = event.currentTarget
-      .value as any;
+    const groupByKey: keyof Query['group_by'] = value as keyof Query['group_by'];
     const newQuery: Query = {
       group_by: {
         [groupByKey]: '*',
@@ -320,38 +323,32 @@ class AwsDetails extends React.Component<Props> {
 
     return (
       <div className={css(styles.awsDetails)}>
-        <header className={css(styles.header)}>
-          <div>
-            <Title size="2xl">{t('aws_details.title')}</Title>
-            <div className={css(styles.groupBySelector)}>
-              <label className={css(styles.groupBySelectorLabel)}>
-                {t('group_by.cost')}:
-              </label>
-              <select value={groupById} onChange={this.handleSelectChange}>
-                {groupByOptions.map(option => (
-                  <option key={option.value} value={option.value}>
-                    {t(`group_by.values.${option.label}`)}
-                  </option>
-                ))}
-              </select>
+        <ListHeader>
+          <React.Fragment>
+            <div>
+              <GroupBySelector
+                title={t('aws_details.title')}
+                label={t('group_by.cost')}
+                onChange={this.handleSelectChange}
+                initValue={groupById}
+                options={groupByOptions.map(opt => ({
+                  ...opt,
+                  label: t(`group_by.values.${opt.label}`),
+                }))}
+              />
             </div>
-          </div>
-          {Boolean(report) && (
-            <div className={css(styles.total)}>
-              <Title className={css(styles.totalValue)} size="4xl">
-                {formatCurrency(report.total.value)}
-              </Title>
-              <div className={css(styles.totalLabel)}>
-                <div className={css(styles.totalLabelUnit)}>
-                  {t('aws_details.total_cost')}
-                </div>
-                <div className={css(styles.totalLabelDate)}>
-                  {t('since_date', { month: today.getMonth(), date: 1 })}
-                </div>
-              </div>
-            </div>
-          )}
-        </header>
+            {Boolean(report) && (
+              <TotalSummary
+                value={formatCurrency(report.total.value)}
+                totalLabel={t('aws_details.total_cost')}
+                dateLabel={t('since_date', {
+                  month: today.getMonth(),
+                  date: 1,
+                })}
+              />
+            )}
+          </React.Fragment>
+        </ListHeader>
         <div className={css(styles.content)}>
           <div className={css(styles.toolbarContainer)}>
             <div className={toolbarOverride}>

--- a/src/pages/awsDetails/awsDetails.tsx
+++ b/src/pages/awsDetails/awsDetails.tsx
@@ -18,6 +18,7 @@ import {
 import {
   GroupBySelector,
   ListHeader,
+  Toolbar,
   TotalSummary,
 } from '../../components/list';
 import { ComputedReportItem } from '../../utils/getComputedReportItems';
@@ -40,6 +41,7 @@ interface DispatchProps {
 
 interface State {
   selectedItems: ComputedReportItem[];
+  filterValue: string;
 }
 
 type OwnProps = RouteComponentProps<void> & InjectedTranslateProps;
@@ -75,6 +77,7 @@ const groupByOptions: {
 class AwsDetails extends React.Component<Props> {
   protected defaultState: State = {
     selectedItems: [],
+    filterValue: '',
   };
   public state: State = { ...this.defaultState };
 
@@ -352,19 +355,9 @@ class AwsDetails extends React.Component<Props> {
         <div className={css(styles.content)}>
           <div className={css(styles.toolbarContainer)}>
             <div className={toolbarOverride}>
-              <DetailsToolbar
-                exportText={t('aws_details.export_link')}
-                filterFields={filterFields}
-                isExportDisabled={selectedItems.length === 0}
-                onExportClicked={this.onExportClicked}
-                onFilterAdded={this.onFilterAdded}
-                onFilterRemoved={this.onFilterRemoved}
-                onSortChanged={this.onSortChanged}
-                sortField={sortField}
-                sortFields={sortFields}
-                report={report}
-                resultsTotal={computedItems.length}
-                query={query}
+              <Toolbar
+                value={this.state.filterValue}
+                placeholder={filterFields.placeholder}
               />
               <ExportModal
                 isAllItems={selectedItems.length === computedItems.length}

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -1,4 +1,3 @@
-import { Title } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { getQuery, parseQuery, Query } from 'api/query';
 import { Report, ReportType } from 'api/reports';
@@ -16,6 +15,11 @@ import {
   getIdKeyForGroupBy,
   getUnsortedComputedReportItems,
 } from 'utils/getComputedReportItems';
+import {
+  GroupBySelector,
+  ListHeader,
+  TotalSummary,
+} from '../../components/list';
 import { ComputedReportItem } from '../../utils/getComputedReportItems';
 import { DetailsItem } from './detailsItem';
 import { DetailsToolbar } from './detailsToolbar';
@@ -95,10 +99,9 @@ class OcpDetails extends React.Component<Props> {
     }
   }
 
-  public handleSelectChange = (event: React.FormEvent<HTMLSelectElement>) => {
+  public handleSelectChange = value => {
     const { history } = this.props;
-    const groupByKey: keyof Query['group_by'] = event.currentTarget
-      .value as any;
+    const groupByKey: keyof Query['group_by'] = value;
     const newQuery: Query = {
       group_by: {
         [groupByKey]: '*',
@@ -320,38 +323,32 @@ class OcpDetails extends React.Component<Props> {
 
     return (
       <div className={css(styles.ocpDetails)}>
-        <header className={css(styles.header)}>
-          <div>
-            <Title size="2xl">{t('ocp_details.title')}</Title>
-            <div className={css(styles.groupBySelector)}>
-              <label className={css(styles.groupBySelectorLabel)}>
-                {t('group_by.charges')}:
-              </label>
-              <select value={groupById} onChange={this.handleSelectChange}>
-                {groupByOptions.map(option => (
-                  <option key={option.value} value={option.value}>
-                    {t(`group_by.values.${option.label}`)}
-                  </option>
-                ))}
-              </select>
+        <ListHeader>
+          <React.Fragment>
+            <div>
+              <GroupBySelector
+                title={t('ocp_details.title')}
+                label={t('group_by.charges')}
+                onChange={this.handleSelectChange}
+                initValue={groupById}
+                options={groupByOptions.map(opt => ({
+                  ...opt,
+                  label: t(`group_by.values.${opt.label}`),
+                }))}
+              />
             </div>
-          </div>
-          {Boolean(report) && (
-            <div className={css(styles.total)}>
-              <Title className={css(styles.totalValue)} size="4xl">
-                {formatCurrency(report.total.value)}
-              </Title>
-              <div className={css(styles.totalLabel)}>
-                <div className={css(styles.totalLabelUnit)}>
-                  {t('ocp_details.total_charges')}
-                </div>
-                <div className={css(styles.totalLabelDate)}>
-                  {t('since_date', { month: today.getMonth(), date: 1 })}
-                </div>
-              </div>
-            </div>
-          )}
-        </header>
+            {Boolean(report) && (
+              <TotalSummary
+                value={formatCurrency(report.total.value)}
+                totalLabel={t('ocp_details.total_charges')}
+                dateLabel={t('since_date', {
+                  month: today.getMonth(),
+                  date: 1,
+                })}
+              />
+            )}
+          </React.Fragment>
+        </ListHeader>
         <div className={css(styles.content)}>
           <div className={css(styles.toolbarContainer)}>
             <div className={toolbarOverride}>


### PR DESCRIPTION
This is WIP. It is just hard to read a code with more than 100 LOC.

I am not sure if I am going to test components using snapshot, although it makes the testing really fast. I will probably figure out a better way to test stateless components later.

TODO:
 - [x] Break the header into components
 - [ ] Break List Items into components
 - [ ] Move Logic to Redux/utils