### PR TITLE
fix(details): show group-by label selector text

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -64,6 +64,7 @@
     "all": "All $t(group_by.values.{{groupBy}}, { 'count': 5 })",
     "charges": "Group charges by",
     "cost": "Group cost by",
+    "label": "Group cost by",
     "top": "Top $t(group_by.values.{{groupBy}}, { 'count': 5 })",
     "values": {
       "account": "Account",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -64,6 +64,7 @@
     "all": "All $t(group_by.values.{{groupBy}}, { 'count': 5 })",
     "charges": "Group charges by",
     "cost": "Group cost by",
+    "label": "Group cost by",
     "top": "Top $t(group_by.values.{{groupBy}}, { 'count': 5 })",
     "values": {
       "account": "Account",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -64,6 +64,7 @@
     "all": "All $t(group_by.values.{{groupBy}}, { 'count': 5 })",
     "charges": "Group charges by",
     "cost": "Group cost by",
+    "label": "Group cost by",
     "top": "Top $t(group_by.values.{{groupBy}}, { 'count': 5 })",
     "values": {
       "account": "Account",


### PR DESCRIPTION
It seems like the text is not rendered in the group by selector because it doesn't have it in the locales files.
fixes #210 