### PR TITLE
Filter fix for OCP details page

### DIFF
--- a/src/pages/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/ocpDetails/detailsToolbar.tsx
@@ -48,17 +48,17 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
     const { filterFields, query, report, sortField } = this.props;
     if (report && !isEqual(report, prevProps.report)) {
       this.addQuery(query);
-      if (!isEqual(filterFields, prevProps.filterFields)) {
-        this.setState({
-          currentFilterType: this.props.filterFields[0],
-        });
-      }
-      if (!isEqual(sortField, prevProps.sortField)) {
-        this.setState({
-          currentSortType: sortField,
-          isSortAscending: !(query && query.order_by[sortField.id] === 'desc'),
-        });
-      }
+    }
+    if (!isEqual(filterFields, prevProps.filterFields)) {
+      this.setState({
+        currentFilterType: this.props.filterFields[0],
+      });
+    }
+    if (!isEqual(sortField, prevProps.sortField)) {
+      this.setState({
+        currentSortType: sortField,
+        isSortAscending: !(query && query.order_by[sortField.id] === 'desc'),
+      });
     }
   }
 


### PR DESCRIPTION
Simple filter fix for OCP details page, which mimics the fix applied to the AWS details page.

Fixes https://github.com/project-koku/koku-ui/issues/222