### PR TITLE
Remove subscript next to dollar value

### DIFF
--- a/src/pages/awsDashboard/awsDashboardWidget.tsx
+++ b/src/pages/awsDashboard/awsDashboardWidget.tsx
@@ -150,9 +150,12 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
       count: getDate(today),
     });
 
-    const detailLabel = t(details.labelKey, {
-      context: details.labelKeyContext,
-    });
+    const detailLabel =
+      details.labelKey.indexOf('total_cost') !== -1
+        ? undefined
+        : t(details.labelKey, {
+            context: details.labelKeyContext,
+          });
 
     const detailsLink = reportType === ReportType.cost && (
       <Link to={this.buildDetailsLink()}>

--- a/src/pages/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/pages/ocpDashboard/ocpDashboardWidget.tsx
@@ -150,9 +150,12 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
       count: getDate(today),
     });
 
-    const detailLabel = t(details.labelKey, {
-      context: details.labelKeyContext,
-    });
+    const detailLabel =
+      details.labelKey.indexOf('total_charge') !== -1
+        ? undefined
+        : t(details.labelKey, {
+            context: details.labelKeyContext,
+          });
 
     const detailsLink = reportType === ReportType.cost && (
       <Link to={this.buildDetailsLink()}>


### PR DESCRIPTION
Removes the "Total Cost" subscript next to dollar value. This is shown on each dashboard card.

Fixes https://github.com/project-koku/koku-ui/issues/246

AWS dashboard
![screen shot 2018-11-05 at 2 14 27 pm](https://user-images.githubusercontent.com/17481322/48020908-24020b80-e105-11e8-8cb2-294ab1f9a777.png)

OCP dashboard
![screen shot 2018-11-05 at 2 15 08 pm](https://user-images.githubusercontent.com/17481322/48020933-3714db80-e105-11e8-94a9-ed0c7b60354c.png)
