### PR TITLE
Added space to column table headers

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -24,7 +24,7 @@
   },
   "aws_details": {
     "change_column_title": "Month Over Month Change",
-    "cost_column_subtitle": "(Total {{total}})",
+    "cost_column_subtitle": " (Total {{total}})",
     "cost_column_title": "Cost",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
@@ -130,7 +130,7 @@
   },
   "ocp_details": {
     "change_column_title": "Month Over Month Change",
-    "cost_column_subtitle": "(Total {{total}})",
+    "cost_column_subtitle": " (Total {{total}})",
     "cost_column_title": "Charges",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -24,7 +24,7 @@
   },
   "aws_details": {
     "change_column_title": "Month Over Month Change",
-    "cost_column_subtitle": "(Total {{total}})",
+    "cost_column_subtitle": " (Total {{total}})",
     "cost_column_title": "Cost",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
@@ -130,7 +130,7 @@
   },
   "ocp_details": {
     "change_column_title": "Month Over Month Change",
-    "cost_column_subtitle": "(Total {{total}})",
+    "cost_column_subtitle": " (Total {{total}})",
     "cost_column_title": "Charges",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -24,7 +24,7 @@
   },
   "aws_details": {
     "change_column_title": "Month Over Month Change",
-    "cost_column_subtitle": "(Total {{total}})",
+    "cost_column_subtitle": " (Total {{total}})",
     "cost_column_title": "Cost",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
@@ -130,7 +130,7 @@
   },
   "ocp_details": {
     "change_column_title": "Month Over Month Change",
-    "cost_column_subtitle": "(Total {{total}})",
+    "cost_column_subtitle": " (Total {{total}})",
     "cost_column_title": "Charges",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",


### PR DESCRIPTION
Added space to column table headers for AWS & OCP details page

Fixes https://github.com/project-koku/koku-ui/issues/236

AWS details page
![screen shot 2018-11-05 at 2 48 40 pm](https://user-images.githubusercontent.com/17481322/48022719-e05dd080-e109-11e8-9f45-40d64376510c.png)

OCP details page
![screen shot 2018-11-05 at 2 48 29 pm](https://user-images.githubusercontent.com/17481322/48022739-ed7abf80-e109-11e8-9a8f-386b3949bcd6.png)

