### PR TITLE
Match dashboard cost with cost shown on details page

### DIFF
--- a/src/store/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/awsDashboard/awsDashboardWidgets.ts
@@ -12,7 +12,7 @@ export const costSummaryWidget: AwsDashboardWidget = {
   details: {
     labelKey: 'aws_details.total_cost',
     formatOptions: {
-      fractionDigits: 0,
+      fractionDigits: 2,
     },
   },
   trend: {

--- a/src/store/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/ocpDashboard/ocpDashboardWidgets.ts
@@ -12,7 +12,7 @@ export const costSummaryWidget: OcpDashboardWidget = {
   details: {
     labelKey: 'ocp_details.total_charge',
     formatOptions: {
-      fractionDigits: 0,
+      fractionDigits: 2,
     },
   },
   trend: {


### PR DESCRIPTION
This ensures the cost shown on the dashboard matches what is shown on the details page.

Fixes https://github.com/project-koku/koku-ui/issues/216

AWS dashboard
![screen shot 2018-11-05 at 2 56 57 pm](https://user-images.githubusercontent.com/17481322/48023274-4eef5e00-e10b-11e8-8044-31c057d879de.png)

OCP dashboard
![screen shot 2018-11-05 at 2 57 14 pm](https://user-images.githubusercontent.com/17481322/48023285-56af0280-e10b-11e8-877f-8d2b8494b4eb.png)
