### PR TITLE
Remove insights:proxy target

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "start:dev": "APP_ENV=proxy yarn start",
     "test": "jest",
     "container:test": "docker stop -t 0 koku-ui-test >/dev/null; docker build -t koku-ui-test . && docker run -i --rm -p 8080:8080 --name koku-ui-test koku-ui-test",
-    "insights:proxy": "docker stop -t 0 insightsproxy >/dev/null; docker run -e LOCAL_CHROME -e PLATFORM -e PORT -e LOCAL_API -e SPANDX_HOST -e SPANDX_PORT --rm -t --name insightsproxy -p 1337:1337 docker.io/redhatinsights/insights-proxy",
     "verify": "tsc --noEmit"
   },
   "lint-staged": {


### PR DESCRIPTION
Since the run.sh script must be executed within insights-proxy repo, this target is no longer valid -- it needs an absolute path to LOCAL_CHROME.