### PR TITLE
Styling Select to look like Dropdown

### DIFF
--- a/src/pages/awsDetails/awsDetails.styles.ts
+++ b/src/pages/awsDetails/awsDetails.styles.ts
@@ -2,6 +2,7 @@ import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_100,
   global_BackgroundColor_300,
+  global_BorderColor_light,
   global_BorderRadius_sm,
   global_BoxShadow_sm,
   global_Color_100,
@@ -16,6 +17,7 @@ import {
   global_FontSize_xs,
   global_FontWeight_bold,
   global_FontWeight_normal,
+  global_FontWeight_semi_bold,
   global_LineHeight_md,
   global_primary_color_100,
   global_spacer_3xl,
@@ -50,6 +52,20 @@ export const styles = StyleSheet.create({
   headerRight: {
     display: 'flex',
     justifyContent: 'flex-end',
+  },
+  select: {
+    borderStyle: 'solid',
+    height: '34px',
+    borderTopLeftRadius: global_BorderRadius_sm.value,
+    borderTopRightRadius: global_BorderRadius_sm.value,
+    borderBottomRightRadius: global_BorderRadius_sm.value,
+    borderBottomLeftRadius: global_BorderRadius_sm.value,
+    backgroundColor: global_BackgroundColor_100.var,
+    borderColor: global_BorderColor_light.var,
+    color: '#4d5258',
+    fontSize: global_FontSize_md.value,
+    fontWeight: global_FontWeight_semi_bold.var,
+    paddingRight: global_spacer_md.var,
   },
   total: {
     display: 'flex',

--- a/src/pages/awsDetails/awsDetails.tsx
+++ b/src/pages/awsDetails/awsDetails.tsx
@@ -327,9 +327,17 @@ class AwsDetails extends React.Component<Props> {
               <label className={css(styles.groupBySelectorLabel)}>
                 {t('group_by.cost')}:
               </label>
-              <select value={groupById} onChange={this.handleSelectChange}>
+              <select
+                className={css(styles.select)}
+                value={groupById}
+                onChange={this.handleSelectChange}
+              >
                 {groupByOptions.map(option => (
-                  <option key={option.value} value={option.value}>
+                  <option
+                    className={css(styles.option)}
+                    key={option.value}
+                    value={option.value}
+                  >
                     {t(`group_by.values.${option.label}`)}
                   </option>
                 ))}

--- a/src/pages/ocpDetails/ocpDetails.styles.ts
+++ b/src/pages/ocpDetails/ocpDetails.styles.ts
@@ -2,6 +2,7 @@ import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_100,
   global_BackgroundColor_300,
+  global_BorderColor_light,
   global_BorderRadius_sm,
   global_BoxShadow_sm,
   global_Color_100,
@@ -16,6 +17,7 @@ import {
   global_FontSize_xs,
   global_FontWeight_bold,
   global_FontWeight_normal,
+  global_FontWeight_semi_bold,
   global_LineHeight_md,
   global_primary_color_100,
   global_spacer_3xl,
@@ -50,6 +52,20 @@ export const styles = StyleSheet.create({
   ocpDetails: {
     backgroundColor: global_BackgroundColor_300.var,
     minHeight: '100%',
+  },
+  select: {
+    borderStyle: 'solid',
+    height: '34px',
+    borderTopLeftRadius: global_BorderRadius_sm.value,
+    borderTopRightRadius: global_BorderRadius_sm.value,
+    borderBottomRightRadius: global_BorderRadius_sm.value,
+    borderBottomLeftRadius: global_BorderRadius_sm.value,
+    backgroundColor: global_BackgroundColor_100.var,
+    borderColor: global_BorderColor_light.var,
+    color: '#4d5258',
+    fontSize: global_FontSize_md.value,
+    fontWeight: global_FontWeight_semi_bold.var,
+    paddingRight: global_spacer_md.var,
   },
   total: {
     display: 'flex',

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -327,9 +327,17 @@ class OcpDetails extends React.Component<Props> {
               <label className={css(styles.groupBySelectorLabel)}>
                 {t('group_by.charges')}:
               </label>
-              <select value={groupById} onChange={this.handleSelectChange}>
+              <select
+                className={css(styles.select)}
+                value={groupById}
+                onChange={this.handleSelectChange}
+              >
                 {groupByOptions.map(option => (
-                  <option key={option.value} value={option.value}>
+                  <option
+                    className={css(styles.option)}
+                    key={option.value}
+                    value={option.value}
+                  >
                     {t(`group_by.values.${option.label}`)}
                   </option>
                 ))}


### PR DESCRIPTION
This PR closes #235. 

The goal was to style the select component like the dropdowns in PF4. 

I tried to do as much as I could, but I had trouble overriding the select arrow and replacing it with the icon we use in pf4, as well as restyling options. I think this is as much as I can do unless we change the actual component to be a dropdown rather than a select.