### PR TITLE
Remove padding to move hero value closer to title

### DIFF
--- a/src/components/reportSummary/reportSummary.styles.ts
+++ b/src/components/reportSummary/reportSummary.styles.ts
@@ -5,14 +5,9 @@ export const styles = StyleSheet.create({
   reportSummary: {
     height: '100%',
   },
-  cardHeader: {
-    paddingBottom: '0px !important',
-  },
-  cardBody: {
-    paddingTop: '0px !important',
-  },
   subtitle: {
     fontSize: global_FontSize_xs.value,
     color: global_Color_200.var,
+    marginBottom: '0',
   },
 });

--- a/src/components/reportSummary/reportSummary.styles.ts
+++ b/src/components/reportSummary/reportSummary.styles.ts
@@ -5,6 +5,12 @@ export const styles = StyleSheet.create({
   reportSummary: {
     height: '100%',
   },
+  cardHeader: {
+    paddingBottom: '0px !important',
+  },
+  cardBody: {
+    paddingTop: '0px !important',
+  },
   subtitle: {
     fontSize: global_FontSize_xs.value,
     color: global_Color_200.var,

--- a/src/components/reportSummary/reportSummary.tsx
+++ b/src/components/reportSummary/reportSummary.tsx
@@ -28,11 +28,11 @@ const ReportSummaryBase: React.SFC<ReportSummaryProps> = ({
   t,
 }) => (
   <Card className={css(styles.reportSummary)}>
-    <CardHeader>
+    <CardHeader className={css(styles.cardHeader)}>
       <Title size="lg">{title}</Title>
       {Boolean(subTitle) && <p className={css(styles.subtitle)}>{subTitle}</p>}
     </CardHeader>
-    <CardBody>
+    <CardBody className={css(styles.cardBody)}>
       {status === FetchStatus.inProgress ? `${t('loading')}...` : children}
     </CardBody>
     {Boolean(detailsLink) && <CardFooter>{detailsLink}</CardFooter>}

--- a/src/components/reportSummary/reportSummary.tsx
+++ b/src/components/reportSummary/reportSummary.tsx
@@ -28,11 +28,11 @@ const ReportSummaryBase: React.SFC<ReportSummaryProps> = ({
   t,
 }) => (
   <Card className={css(styles.reportSummary)}>
-    <CardHeader className={css(styles.cardHeader)}>
+    <CardHeader>
       <Title size="lg">{title}</Title>
       {Boolean(subTitle) && <p className={css(styles.subtitle)}>{subTitle}</p>}
     </CardHeader>
-    <CardBody className={css(styles.cardBody)}>
+    <CardBody>
       {status === FetchStatus.inProgress ? `${t('loading')}...` : children}
     </CardBody>
     {Boolean(detailsLink) && <CardFooter>{detailsLink}</CardFooter>}


### PR DESCRIPTION
This closes issue #242 

Padding removed from card header and body so that hero value is moved closer to title.