### PR TITLE
Increase font size for tabs

### DIFF
--- a/src/components/tabs/tabItem.styles.ts
+++ b/src/components/tabs/tabItem.styles.ts
@@ -1,6 +1,6 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
-  global_FontSize_sm,
+  global_FontSize_md,
   global_primary_color_200,
   global_spacer_md,
   global_spacer_sm,
@@ -11,7 +11,7 @@ export const styles = StyleSheet.create({
     position: 'relative',
     flexGrow: 1,
     textAlign: 'center',
-    fontSize: global_FontSize_sm.value,
+    fontSize: global_FontSize_md.value,
     padding: global_spacer_sm.value,
     cursor: 'pointer',
     marginBottom: global_spacer_md.value,


### PR DESCRIPTION
This closes issue #239 .

Currently, tab font size is 14px and progress bar text is 16px. This PR changes the tab font size to 16px to match what is the pf designs.

<img width="1176" alt="screen shot 2018-11-07 at 1 44 52 pm" src="https://user-images.githubusercontent.com/20118816/48153044-56da0a00-e293-11e8-8e2a-013f07f56071.png">
