### PR TITLE
chore(overview): replace custom CSS with utility classes

### DIFF
--- a/src/pages/overview/overview.styles.ts
+++ b/src/pages/overview/overview.styles.ts
@@ -1,9 +1,0 @@
-import { StyleSheet } from '@patternfly/react-styles';
-
-export const styles = StyleSheet.create({
-  banner: {
-    display: 'flex',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-  },
-});

--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -5,7 +5,6 @@ import {
   Title,
   TitleSize,
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { Providers } from 'api/providers';
 import { TabData, Tabs } from 'components/tabs';
 import React from 'react';
@@ -18,7 +17,6 @@ import { uiActions } from 'store/ui';
 import { getTestProps, testIds } from 'testIds';
 import AwsDashboard from '../awsDashboard';
 import OcpDashboard from '../ocpDashboard';
-import { styles } from './overview.styles';
 
 export const enum OverviewTab {
   cloud = 'cloud',
@@ -78,7 +76,7 @@ class OverviewBase extends React.Component<OverviewProps> {
 
     return (
       <div className="pf-m-dark-100 pf-l-page__main-section pf-u-pb-xl pf-u-px-xl">
-        <header className={css(styles.banner)}>
+        <header className="pf-u-display-flex pf-u-justify-content-space-between pf-u-align-items-center">
           <Title size={TitleSize.lg}>{t('overview.title')}</Title>
           <Button
             {...getTestProps(testIds.providers.add_btn)}

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,10 @@ module.exports = env => {
     entry: [
       require.resolve('patternfly/dist/css/patternfly.css'),
       require.resolve('patternfly/dist/css/patternfly-additions.css'),
+      require.resolve(
+        '@patternfly/patternfly-next/utilities/Display/display.css'
+      ),
+      require.resolve('@patternfly/patternfly-next/utilities/Flex/flex.css'),
       path.join(srcDir, './styles/global.css'),
       path.join(srcDir, 'index.tsx'),
     ],


### PR DESCRIPTION
fixes https://github.com/project-koku/koku-ui/issues/274

@dlabrecq we're pulling in fairly large utility class stylesheets to make this change. While I think it's beneficial to use the utilities and write as little custom CSS as possible, do you think it's worth it in this case to replace the custom CSS here?