### PR TITLE
Add a variable for defining the APP_BUILD_DIR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,3 +16,4 @@ env:
     - REPO="git@github.com:RedHatInsights/cost-management-build"
     - REPO_DIR="cost-management-build"
     - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
+    - APP_BUILD_DIR="public"


### PR DESCRIPTION
Deployment hit the following issue assuming the build directory:
```
++node -e 'console.log(require("./package.json").insights.appname)'
+APP_NAME=cost-management
+cd dist
.travis/release.sh: line 8: cd: dist: No such file or directory
+cd build
.travis/release.sh: line 8: cd: build: No such file or directory
```
Following update was made from the Insights team to handle variable build directories:
https://github.com/RedHatInsights/insights-frontend-builder-common/commit/b8821a464e85a643e7346392618f0a6ce4380caf