### PR TITLE
Update delta param to string with defaults

### DIFF
--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -24,7 +24,7 @@ interface OrderBys {
 }
 
 export interface Query {
-  delta?: boolean;
+  delta?: string;
   filter?: Filters;
   group_by?: GroupBys;
   order_by?: OrderBys;

--- a/src/pages/awsDetails/awsDetails.tsx
+++ b/src/pages/awsDetails/awsDetails.tsx
@@ -51,7 +51,7 @@ type Props = StateProps & OwnProps & DispatchProps;
 const reportType = ReportType.cost;
 
 const baseQuery: Query = {
-  delta: true,
+  delta: 'total',
   filter: {
     time_scope_units: 'month',
     time_scope_value: -1,
@@ -69,10 +69,10 @@ const groupByOptions: {
   label: string;
   value: GetComputedReportItemsParams['idKey'];
 }[] = [
-  { label: 'account', value: 'account' },
-  { label: 'service', value: 'service' },
-  { label: 'region', value: 'region' },
-];
+    { label: 'account', value: 'account' },
+    { label: 'service', value: 'service' },
+    { label: 'region', value: 'region' },
+  ];
 
 class AwsDetails extends React.Component<Props> {
   protected defaultState: State = {
@@ -468,7 +468,7 @@ const mapStateToProps = createMapStateToProps<OwnProps, StateProps>(
   (state, props) => {
     const queryFromRoute = parseQuery<Query>(props.location.search);
     const query = {
-      delta: true,
+      delta: 'total',
       filter: {
         ...baseQuery.filter,
         ...queryFromRoute.filter,

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -51,7 +51,7 @@ type Props = StateProps & OwnProps & DispatchProps;
 const reportType = ReportType.cost;
 
 const baseQuery: Query = {
-  delta: true,
+  delta: 'charge',
   filter: {
     time_scope_units: 'month',
     time_scope_value: -1,
@@ -69,10 +69,10 @@ const groupByOptions: {
   label: string;
   value: GetComputedReportItemsParams['idKey'];
 }[] = [
-  { label: 'account', value: 'account' },
-  { label: 'service', value: 'service' },
-  { label: 'region', value: 'region' },
-];
+    { label: 'account', value: 'account' },
+    { label: 'service', value: 'service' },
+    { label: 'region', value: 'region' },
+  ];
 
 class OcpDetails extends React.Component<Props> {
   protected defaultState: State = {
@@ -468,7 +468,7 @@ const mapStateToProps = createMapStateToProps<OwnProps, StateProps>(
   (state, props) => {
     const queryFromRoute = parseQuery<Query>(props.location.search);
     const query = {
-      delta: true,
+      delta: 'charge',
       filter: {
         ...baseQuery.filter,
         ...queryFromRoute.filter,


### PR DESCRIPTION
## Summary
I _believe_ this will accommodate the change for delta from being a Boolean to a string.

* The accepted delta value for AWS is currently `total`. 
* The accepted delta values for OCP are currently `charge`, `usage`, and `request` for memory and cpu inventory APIs, and `charge` for the charge API. The default value is `charge`.