### PR TITLE
Always show group by cost dropdown in detail item

### DIFF
--- a/src/pages/awsDetails/detailsChart.tsx
+++ b/src/pages/awsDetails/detailsChart.tsx
@@ -68,9 +68,8 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
           legendData={legendData}
         />
       );
-    } else {
-      return <></>;
     }
+    return null;
   }
 }
 

--- a/src/pages/awsDetails/detailsChart.tsx
+++ b/src/pages/awsDetails/detailsChart.tsx
@@ -57,16 +57,20 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
       symbol: { type: 'square' },
     }));
 
-    return (
-      <PieChart
-        height={200}
-        width={200}
-        data={currentData}
-        formatDatumValue={formatValue}
-        groupBy={currentGroupBy}
-        legendData={legendData}
-      />
-    );
+    if (currentData && currentData.length) {
+      return (
+        <PieChart
+          height={200}
+          width={200}
+          data={currentData}
+          formatDatumValue={formatValue}
+          groupBy={currentGroupBy}
+          legendData={legendData}
+        />
+      );
+    } else {
+      return <></>;
+    }
   }
 }
 

--- a/src/pages/ocpDetails/detailsChart.tsx
+++ b/src/pages/ocpDetails/detailsChart.tsx
@@ -68,9 +68,8 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
           legendData={legendData}
         />
       );
-    } else {
-      return <></>;
     }
+    return null;
   }
 }
 

--- a/src/pages/ocpDetails/detailsChart.tsx
+++ b/src/pages/ocpDetails/detailsChart.tsx
@@ -57,16 +57,20 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
       symbol: { type: 'square' },
     }));
 
-    return (
-      <PieChart
-        height={200}
-        width={200}
-        data={currentData}
-        formatDatumValue={formatValue}
-        groupBy={currentGroupBy}
-        legendData={legendData}
-      />
-    );
+    if (currentData && currentData.length) {
+      return (
+        <PieChart
+          height={200}
+          width={200}
+          data={currentData}
+          formatDatumValue={formatValue}
+          groupBy={currentGroupBy}
+          legendData={legendData}
+        />
+      );
+    } else {
+      return <></>;
+    }
   }
 }
 


### PR DESCRIPTION
This change shows the `group by cost` dropdown for the list detail item (i.e., expandable list row) when no data is available. It's possible that there may be data for `region`, but not `service`. If there is no data for either, then the chart is not shown.

Related to https://github.com/project-koku/koku-ui/issues/326