### PR TITLE
Cpu & memory cards to show last 30 days

### DIFF
--- a/src/components/commonChart/chartUtils.ts
+++ b/src/components/commonChart/chartUtils.ts
@@ -73,17 +73,18 @@ export function transformOcpReport(
     sortDirection: SortDirection.desc,
   } as any;
   const computedItems = getComputedOcpReportItems(items);
+  const idKey = reportItem === 'charge' ? key : ''; // Uses computed item label instead of day for x value
 
   if (type === ChartType.daily) {
-    return computedItems.map(i => createDatum(i[reportItem], i, key));
+    return computedItems.map(i => createDatum(i[reportItem], i, idKey));
   }
   if (type === ChartType.monthly) {
-    return computedItems.map(i => createDatum(i[reportItem], i, key));
+    return computedItems.map(i => createDatum(i[reportItem], i, idKey));
   }
 
   return computedItems.reduce<ChartDatum[]>((acc, d) => {
     const prevValue = acc.length ? acc[acc.length - 1].y : 0;
-    return [...acc, createDatum(prevValue + d[reportItem], d, key)];
+    return [...acc, createDatum(prevValue + d[reportItem], d, idKey)];
   }, []);
 }
 

--- a/src/components/trendChart/trendChart.styles.ts
+++ b/src/components/trendChart/trendChart.styles.ts
@@ -8,7 +8,7 @@ import {
 import { VictoryStyleInterface } from 'victory';
 
 export const chartStyles = {
-  colorScale: [global_success_color_100.value, global_primary_color_100.value],
+  colorScale: [global_primary_color_100.value, global_success_color_100.value],
   previousMonth: {
     data: {
       fill: global_success_color_200.value,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -138,7 +138,7 @@
     "title": "OpenShit Container Platform",
     "trend_group_legend": "$t(months.{{month}}) {{startDate}} - {{endDate}}",
     "widget_subtitle": "$t(months.{{month}}) {{startDate}}",
-    "widget_subtitle_plural": "$t(months.{{month}}) {{startDate}} - $t(months.{{month}}) {{endDate}}"
+    "widget_subtitle_plural": "$t(months.{{startMonth}}) {{startDate}} - $t(months.{{endMonth}}) {{endDate}}"
   },
   "ocp_details": {
     "change_column_title": "Month Over Month Change",

--- a/src/pages/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/pages/ocpDashboard/ocpDashboardWidget.tsx
@@ -1,6 +1,9 @@
 import { getQuery, OcpQuery, parseQuery } from 'api/ocpQuery';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
-import { transformOcpReport } from 'components/commonChart/chartUtils';
+import {
+  getDatumDateRange,
+  transformOcpReport,
+} from 'components/commonChart/chartUtils';
 import { Link } from 'components/link';
 import {
   OcpReportSummary,
@@ -131,6 +134,28 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
     this.props.updateTab(this.props.id, tabId);
   };
 
+  private getSubTitle = (
+    endDateVal,
+    endMonthVal,
+    startDateVal,
+    startMonthVal,
+    countVal
+  ) => {
+    const { t } = this.props;
+    const count = getDate(countVal);
+    const endDate = formatDate(endDateVal, 'Do');
+    const endMonth = getMonth(endMonthVal);
+    const startDate = formatDate(startDateVal, 'Do');
+    const startMonth = getMonth(startMonthVal);
+    return t('ocp_dashboard.widget_subtitle', {
+      endDate,
+      endMonth,
+      startDate,
+      startMonth,
+      count,
+    });
+  };
+
   public render() {
     const {
       t,
@@ -144,19 +169,6 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
       reportType,
       status,
     } = this.props;
-
-    const today = new Date();
-    const month = getMonth(today);
-    const endDate = formatDate(today, 'Do');
-    const startDate = formatDate(startOfMonth(today), 'Do');
-
-    const title = t(titleKey, { endDate, month, startDate });
-    const subTitle = t('ocp_dashboard.widget_subtitle', {
-      endDate,
-      month,
-      startDate,
-      count: getDate(today),
-    });
 
     const detailLabel = t(details.labelKey);
     const requestLabel = t(details.requestLabelKey);
@@ -178,9 +190,24 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
         ? transformOcpReport(current, trend.type, 'request')
         : undefined;
 
+    let subTitle;
+    if (reportType === OcpReportType.charge) {
+      const start = new Date();
+      subTitle = this.getSubTitle(
+        start,
+        start,
+        startOfMonth(start),
+        start,
+        start
+      );
+    } else {
+      const [start, end] = getDatumDateRange(currentData);
+      subTitle = this.getSubTitle(end, end, start, start, start);
+    }
+
     return (
       <OcpReportSummary
-        title={title}
+        title={t(titleKey)}
         subTitle={subTitle}
         detailsLink={detailsLink}
         status={status}

--- a/src/store/ocpDashboard/ocpDashboardCommon.ts
+++ b/src/store/ocpDashboard/ocpDashboardCommon.ts
@@ -9,6 +9,10 @@ export const ocpDashboardDefaultFilters: OcpFilters = {
   resolution: 'daily',
   limit: 5,
 };
+export const ocpDashboard30DayFilters: OcpFilters = {
+  resolution: 'daily',
+  limit: 5,
+};
 
 interface ValueFormatOptions {
   fractionDigits?: number;
@@ -45,6 +49,7 @@ export interface OcpDashboardWidget {
   topItems: {
     formatOptions: {};
   };
+  queryFilters?: OcpFilters;
 }
 
 // Todo: cluster, project, node

--- a/src/store/ocpDashboard/ocpDashboardSelectors.ts
+++ b/src/store/ocpDashboard/ocpDashboardSelectors.ts
@@ -19,15 +19,16 @@ export const selectCurrentWidgets = (state: RootState) =>
 
 export const selectWidgetQueries = (state: RootState, id: number) => {
   const widget = selectWidget(state, id);
+  const queryFilters = widget.queryFilters || ocpDashboardDefaultFilters;
 
   return {
     previous: getQueryForWidget(widget, {
-      ...ocpDashboardDefaultFilters,
+      ...queryFilters,
       time_scope_value: -2,
     }),
-    current: getQueryForWidget(widget, ocpDashboardDefaultFilters),
+    current: getQueryForWidget(widget, queryFilters),
     tabs: getQueryForWidget(widget, {
-      ...ocpDashboardDefaultFilters,
+      ...queryFilters,
       resolution: 'monthly',
     }),
   };

--- a/src/store/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/ocpDashboard/ocpDashboardWidgets.ts
@@ -1,6 +1,10 @@
 import { OcpReportType } from 'api/ocpReports';
 import { ChartType } from 'components/commonChart/chartUtils';
-import { OcpDashboardTab, OcpDashboardWidget } from './ocpDashboardCommon';
+import {
+  ocpDashboard30DayFilters,
+  OcpDashboardTab,
+  OcpDashboardWidget,
+} from './ocpDashboardCommon';
 
 let currrentId = 0;
 const getId = () => currrentId++;
@@ -50,6 +54,7 @@ export const cpuWidget: OcpDashboardWidget = {
   },
   availableTabs: [OcpDashboardTab.projects, OcpDashboardTab.clusters],
   currentTab: OcpDashboardTab.projects,
+  queryFilters: ocpDashboard30DayFilters,
 };
 
 export const memoryWidget: OcpDashboardWidget = {
@@ -76,4 +81,5 @@ export const memoryWidget: OcpDashboardWidget = {
   },
   availableTabs: [OcpDashboardTab.projects, OcpDashboardTab.clusters],
   currentTab: OcpDashboardTab.projects,
+  queryFilters: ocpDashboard30DayFilters,
 };


### PR DESCRIPTION
Per a review with @nlcwong , the cpu & memory cards for the OCP dashboard should show last 30 days. Currently, they display data only for the last month.

Fixes https://github.com/project-koku/koku-ui/issues/335

Screenshot
![screen shot 2018-12-04 at 10 44 26 pm](https://user-images.githubusercontent.com/17481322/49489953-6eb59700-f81b-11e8-9820-bd745f8e242e.png)
