### PR TITLE
Fix TypeError in OCP details page

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -165,7 +165,7 @@
       "name": "Sort by: Name"
     },
     "title": "OpenShift Charges",
-    "total_charge": "Total OpenShift Charge"
+    "total_charge": "Total Charge"
   },
   "overview": {
     "aws": "Amazon Web Services",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -165,7 +165,7 @@
       "name": "Sort by: Name"
     },
     "title": "OpenShift Charges",
-    "total_charge": "Total OpenShift Charge"
+    "total_charge": "Total Charge"
   },
   "overview": {
     "aws": "Amazon Web Services",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -165,7 +165,7 @@
       "name": "Sort by: Name"
     },
     "title": "OpenShift Charges",
-    "total_charge": "Total OpenShift Charge"
+    "total_charge": "Total Charge"
   },
   "overview": {
     "aws": "Amazon Web Services",

--- a/src/pages/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/ocpDetails/detailsToolbar.tsx
@@ -35,9 +35,14 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
     currentFilterType: this.props.filterFields[0],
     currentValue: '',
     currentSortType: this.props.sortField,
-    isSortNumeric: this.props.sortField.isNumeric,
+    isSortNumeric:
+      this.props.sortField && this.props.sortField.isNumeric
+        ? this.props.sortField.isNumeric
+        : false,
     isSortAscending: !(
       this.props.query &&
+      this.props.sortField &&
+      this.props.sortField.id &&
       this.props.query.order_by[this.props.sortField.id] === 'desc'
     ),
     currentViewType: 'list',

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -51,8 +51,7 @@ type Props = StateProps & OwnProps & DispatchProps;
 const reportType = OcpReportType.charge;
 
 const baseQuery: OcpQuery = {
-  // Todo: change to 'charge' for OCP APIs
-  delta: 'total',
+  delta: 'charge',
   filter: {
     time_scope_units: 'month',
     time_scope_value: -1,
@@ -376,7 +375,7 @@ class OcpDetails extends React.Component<Props> {
               </Title>
               <div className={css(styles.chargeLabel)}>
                 <div className={css(styles.chargeLabelUnit)}>
-                  {t('ocp_details.charge_charge')}
+                  {t('ocp_details.total_charge')}
                 </div>
                 <div className={css(styles.chargeLabelDate)}>
                   {t('since_date', { month: today.getMonth(), date: 1 })}
@@ -469,8 +468,7 @@ const mapStateToProps = createMapStateToProps<OwnProps, StateProps>(
   (state, props) => {
     const queryFromRoute = parseQuery<OcpQuery>(props.location.search);
     const query = {
-      // Todo: change to 'charge' for OCP APIs
-      delta: 'total',
+      delta: 'charge',
       filter: {
         ...baseQuery.filter,
         ...queryFromRoute.filter,


### PR DESCRIPTION
Fixed a TypeError issue in OCP details page.

Note that the OCP page still needs some refactoring to use the OCP APIs properly. For example, the toolbar is missing the filter and sort. That will be updated via another PR. This just gets the page working after the work to refactor the OCP dashboard.

Fixes https://github.com/project-koku/koku-ui/issues/337

Sreenshot
![screen shot 2018-12-05 at 10 40 09 am](https://user-images.githubusercontent.com/17481322/49524682-3a24f800-f87a-11e8-8fad-6d43d988f548.png)
