### PR TITLE
fix(Providers): Do not timeout HTTP requests

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -9,7 +9,6 @@ export interface PagedResponse<D = any> {
 
 export function initApi({ version }: { version: string }) {
   axios.defaults.baseURL = `/r/insights/platform/cost-management/api/${version}/`;
-  axios.defaults.timeout = 4000;
   axios.interceptors.request.use(authInterceptor);
 }
 


### PR DESCRIPTION
fixes #250 

In PR #151 axios timeout setting was set to 4 seconds to make sure the integration with 3scales works properly.

However, this setting is no longer relevant because:
 1. 3scale timeouts requests if it takes too long to respond
 2. requests might fail because of that even though it is reasonable to wait for a response

-------
To solve this I used the default settings in `axios` which is no timeouts as you can see [here](https://github.com/axios/axios/blob/release/1.0.0/lib/defaults.js#L83-L87).

I ran some tests locally on my machine and it seems to work (I see that on the first time it takes 7-9 seconds to get the providers and in the second and the third refreshes it takes it much less time)