### PR TITLE
OCP details page should show "charge" label instead of "cost"

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -142,8 +142,8 @@
   },
   "ocp_details": {
     "change_column_title": "Month Over Month Change",
-    "cost_column_subtitle": " (Total {{total}})",
-    "cost_column_title": "Charges",
+    "charge_column_subtitle": " (Total {{total}})",
+    "charge_column_title": "Charges",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
     "export_link": "Export",
@@ -175,6 +175,7 @@
     "title": "Cost Management Overview"
   },
   "percent": "{{value}}%",
+  "percent_of_charge": "% of Charge",
   "percent_of_cost": "% of Cost",
   "providers": {
     "add_source": "Add a Source",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -142,8 +142,8 @@
   },
   "ocp_details": {
     "change_column_title": "Month Over Month Change",
-    "cost_column_subtitle": " (Total {{total}})",
-    "cost_column_title": "Charges",
+    "charge_column_subtitle": " (Total {{total}})",
+    "charge_column_title": "Charges",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
     "export_link": "Export",
@@ -175,6 +175,7 @@
     "title": "Cost Management Overview"
   },
   "percent": "{{value}}%",
+  "percent_of_charge": "% of Charge",
   "percent_of_cost": "% of Cost",
   "providers": {
     "add_source": "Add a Source",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -142,8 +142,8 @@
   },
   "ocp_details": {
     "change_column_title": "Month Over Month Change",
-    "cost_column_subtitle": " (Total {{total}})",
-    "cost_column_title": "Charges",
+    "charge_column_subtitle": " (Total {{total}})",
+    "charge_column_title": "Charges",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
     "export_link": "Export",
@@ -175,6 +175,7 @@
     "title": "Cost Management Overview"
   },
   "percent": "{{value}}%",
+  "percent_of_charge": "% of Charge",
   "percent_of_cost": "% of Cost",
   "providers": {
     "add_source": "Add a Source",

--- a/src/pages/ocpDetails/detailsItem.tsx
+++ b/src/pages/ocpDetails/detailsItem.tsx
@@ -203,7 +203,7 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
             <strong>{formatCurrency(item.charge)}</strong>
             <span>
               {((item.charge / charge) * 100).toFixed(2)}
-              {t('percent_of_cost')}
+              {t('percent_of_charge')}
             </span>
           </ListView.InfoItem>,
         ]}

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -432,10 +432,10 @@ class OcpDetails extends React.Component<Props> {
                 actions={[
                   <ListView.InfoItem key="2">
                     <strong>
-                      {t('ocp_details.cost_column_title')}
+                      {t('ocp_details.charge_column_title')}
                       {Boolean(report) && (
                         <React.Fragment>
-                          {t('ocp_details.cost_column_subtitle', {
+                          {t('ocp_details.charge_column_subtitle', {
                             charge: formatCurrency(report.total.charge),
                           })}
                         </React.Fragment>


### PR DESCRIPTION
This PR changes the "cost" label to "charge" for OCP details page