### PR TITLE
fix(TrendChart): move tooltip label format logic to chart utils

### DIFF
--- a/src/components/commonChart/chartUtils.test.ts
+++ b/src/components/commonChart/chartUtils.test.ts
@@ -1,0 +1,22 @@
+jest.mock('i18next');
+import i18next from 'i18next';
+import { getTooltipContent } from './chartUtils';
+
+describe('gettTooltipContent', () => {
+  test('format hrs and gb', () => {
+    [
+      { unit: 'hrs', translate: 'units.hrs' },
+      { unit: 'gb', translate: 'units.gb' },
+      { unit: 'gb-mo', translate: 'units.gb' },
+    ].forEach(tc => {
+      const labelFormatFunc = getTooltipContent(jest.fn(v => v));
+      const x = labelFormatFunc(10, tc.unit);
+      expect(i18next.t).toBeCalledWith(tc.translate, { value: '10' });
+    });
+  });
+  test('format unknown units', () => {
+    const labelFormatFunc = getTooltipContent(jest.fn(v => v));
+    expect(i18next.t).not.toBeCalled();
+    expect(labelFormatFunc(10)).toBe('10');
+  });
+});

--- a/src/components/commonChart/chartUtils.ts
+++ b/src/components/commonChart/chartUtils.ts
@@ -3,7 +3,12 @@ import { OcpReport } from 'api/ocpReports';
 import format from 'date-fns/format';
 import getDate from 'date-fns/get_date';
 import startOfMonth from 'date-fns/start_of_month';
-import { FormatOptions, ValueFormatter } from 'utils/formatValue';
+import i18next from 'i18next';
+import {
+  FormatOptions,
+  unitLookupKey,
+  ValueFormatter,
+} from 'utils/formatValue';
 import {
   ComputedAwsReportItem,
   getComputedAwsReportItems,
@@ -136,6 +141,25 @@ export function getDateRangeString(
   return `${monthName} ${getDate(start)}${
     startDate !== endDate ? ` - ${endDate}` : ''
   }`;
+}
+
+export function getTooltipContent(formatValue) {
+  return function labelFormatter(
+    value: number,
+    unit: string = null,
+    options: FormatOptions = {}
+  ) {
+    const lookup = unitLookupKey(unit);
+    switch (lookup) {
+      case 'hrs':
+      case 'gb':
+        return i18next.t(`units.${lookup}`, {
+          value: `${formatValue(value, unit, options)}`,
+        });
+      default:
+        return `${formatValue(value, unit, options)}`;
+    }
+  };
 }
 
 export function getTooltipLabel(

--- a/src/components/trendChart/trendChart.test.tsx
+++ b/src/components/trendChart/trendChart.test.tsx
@@ -55,6 +55,10 @@ test('height from props is used', () => {
 });
 
 test('labels formats with datum and value formatted from props', () => {
+  const tooltipFormatMock = jest.spyOn(utils, 'getTooltipContent');
+  const formatLabel = jest.fn();
+  tooltipFormatMock.mockImplementation(() => formatLabel);
+
   const view = shallow(<TrendChart {...props} />);
   const datum: utils.ChartDatum = {
     x: 1,
@@ -64,13 +68,13 @@ test('labels formats with datum and value formatted from props', () => {
   };
   const group = view.find(ChartGroup);
   group.props().containerComponent.props.labels(datum);
-  expect(getTooltipLabel).toBeCalledWith(
+  expect(utils.getTooltipLabel).toBeCalledWith(
     datum,
-    props.formatDatumValue,
+    formatLabel,
     props.formatDatumOptions,
     'date'
   );
-  expect(props.formatDatumValue).toBeCalledWith(
+  expect(formatLabel).toBeCalledWith(
     datum.y,
     datum.units,
     props.formatDatumOptions

--- a/src/components/trendChart/trendChart.tsx
+++ b/src/components/trendChart/trendChart.tsx
@@ -9,6 +9,7 @@ import { css } from '@patternfly/react-styles';
 import {
   ChartDatum,
   getDateRangeString,
+  getTooltipContent,
   getTooltipLabel,
 } from 'components/commonChart/chartUtils';
 import React from 'react';
@@ -22,6 +23,7 @@ interface TrendChartProps {
   previousData?: any;
   formatDatumValue: ValueFormatter;
   formatDatumOptions?: FormatOptions;
+  translateFunction?(text: string): string;
 }
 
 interface State {
@@ -43,13 +45,12 @@ class TrendChart extends React.Component<TrendChartProps, State> {
 
   private getTooltipLabel = (datum: ChartDatum) => {
     const { formatDatumValue, formatDatumOptions } = this.props;
-    const label = getTooltipLabel(
+    return getTooltipLabel(
       datum,
-      formatDatumValue,
+      getTooltipContent(formatDatumValue),
       formatDatumOptions,
       'date'
     );
-    return label;
   };
 
   private handleResize = () => {

--- a/src/components/usageChart/usageChart.test.tsx
+++ b/src/components/usageChart/usageChart.test.tsx
@@ -98,7 +98,7 @@ test('labels formats with datum and value formatted from props', () => {
   group.props().containerComponent.props.labels(datum);
   expect(getTooltipLabel).toBeCalledWith(
     datum,
-    props.formatDatumValue,
+    expect.any(Function),
     props.formatDatumOptions,
     'date'
   );

--- a/src/components/usageChart/usageChart.tsx
+++ b/src/components/usageChart/usageChart.tsx
@@ -6,7 +6,11 @@ import {
   ChartVoronoiContainer,
 } from '@patternfly/react-charts';
 import { css } from '@patternfly/react-styles';
-import { ChartDatum, getTooltipLabel } from 'components/commonChart/chartUtils';
+import {
+  ChartDatum,
+  getTooltipContent,
+  getTooltipLabel,
+} from 'components/commonChart/chartUtils';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
 import { chartStyles, styles } from './usageChart.styles';
@@ -50,13 +54,12 @@ class UsageChart extends React.Component<UsageChartProps, State> {
 
   private getTooltipLabel = (datum: ChartDatum) => {
     const { formatDatumValue, formatDatumOptions } = this.props;
-    const label = getTooltipLabel(
+    return getTooltipLabel(
       datum,
-      formatDatumValue,
+      getTooltipContent(formatDatumValue),
       formatDatumOptions,
       'date'
     );
-    return label;
   };
 
   private handleResize = () => {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -60,7 +60,6 @@
     "selected": "Selected {{groupBy}}s",
     "title": "Export"
   },
-  "gb": "GB",
   "group_by": {
     "all": "All $t(group_by.values.{{groupBy}}, { 'count': 5 })",
     "charges": "Group charges by",
@@ -86,7 +85,6 @@
       "service_plural": "Services"
     }
   },
-  "hrs": "hours",
   "loading": "Loading",
   "login": {
     "default_error": "Cannot connect to service.",
@@ -194,5 +192,9 @@
     "resource_name_label": "Provider Resource Name",
     "type_label": "Provider Type"
   },
-  "since_date": "Since $t(months.{{month}}) {{date}}"
+  "since_date": "Since $t(months.{{month}}) {{date}}",
+  "units": {
+    "gb": "{{value}} GB",
+    "hrs": "{{value}} Hours"
+  }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -60,7 +60,6 @@
     "selected": "Selected {{groupBy}}s",
     "title": "Export"
   },
-  "gb": "GB",
   "group_by": {
     "all": "All $t(group_by.values.{{groupBy}}, { 'count': 5 })",
     "charges": "Group charges by",
@@ -86,7 +85,6 @@
       "service_plural": "Services"
     }
   },
-  "hrs": "hours",
   "loading": "Loading",
   "login": {
     "default_error": "Cannot connect to service.",
@@ -194,5 +192,9 @@
     "resource_name_label": "Provider Resource Name",
     "type_label": "Provider Type"
   },
-  "since_date": "Since $t(months.{{month}}) {{date}}"
+  "since_date": "Since $t(months.{{month}}) {{date}}",
+  "units": {
+    "gb": "{{value}} GB",
+    "hrs": "{{value}} Hours"
+  }
 }

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -60,7 +60,6 @@
     "selected": "Selected {{groupBy}}s",
     "title": "Export"
   },
-  "gb": "GB",
   "group_by": {
     "all": "All $t(group_by.values.{{groupBy}}, { 'count': 5 })",
     "charges": "Group charges by",
@@ -86,7 +85,6 @@
       "service_plural": "Services"
     }
   },
-  "hrs": "hours",
   "loading": "Loading",
   "login": {
     "default_error": "Cannot connect to service.",
@@ -194,5 +192,9 @@
     "resource_name_label": "Provider Resource Name",
     "type_label": "Provider Type"
   },
-  "since_date": "Since $t(months.{{month}}) {{date}}"
+  "since_date": "Since $t(months.{{month}}) {{date}}",
+  "units": {
+    "gb": "{{value}} GB",
+    "hrs": "{{value}} Hours"
+  }
 }

--- a/src/pages/awsDashboard/awsDashboardWidget.tsx
+++ b/src/pages/awsDashboard/awsDashboardWidget.tsx
@@ -182,7 +182,7 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
           title={trendTitle}
           currentData={currentData}
           formatDatumValue={formatValue}
-          formatDatumOptions={{ ...trend.formatOptions, translateFunction: t }}
+          formatDatumOptions={trend.formatOptions}
           previousData={previousData}
         />
         <Tabs

--- a/src/pages/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/pages/ocpDashboard/ocpDashboardWidget.tsx
@@ -225,10 +225,7 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
             title={t(trend.titleKey)}
             currentData={currentUsageData}
             formatDatumValue={formatValue}
-            formatDatumOptions={{
-              ...trend.formatOptions,
-              translateFunction: t,
-            }}
+            formatDatumOptions={trend.formatOptions}
             previousData={previousUsageData}
           />
         ) : (

--- a/src/utils/formatValue.test.ts
+++ b/src/utils/formatValue.test.ts
@@ -1,20 +1,18 @@
 import * as format from './formatValue';
 
 jest.spyOn(format, 'formatCurrency');
-jest.spyOn(format, 'unknownTypeFormatter');
+jest.spyOn(format, 'formatStorage');
 
 describe('formatValue', () => {
   const formatOptions: format.FormatOptions = {};
   const value = 100.11;
 
+  test('null value returns 0', () => {
+    expect(format.formatValue(null, 'unknownUnit')).toBe('0');
+  });
   test('unknown unit returns value fixed to fractionDigits', () => {
     const formatted = format.formatValue(value, 'unknownUnit');
     expect(formatted).toMatchSnapshot();
-  });
-
-  test('undefined value set value to 0', () => {
-    const formatted = format.formatValue(undefined, 'unknownUnit');
-    expect(formatted).toBe('0');
   });
 
   test('usd unit calls formatCurrency', () => {
@@ -23,20 +21,10 @@ describe('formatValue', () => {
     expect(format.formatCurrency).toBeCalledWith(value, unit, formatOptions);
   });
 
-  test('gb unit calls unknownTypeFormatter', () => {
+  test('gb unit calls format storage', () => {
     const unit = 'gb-mo';
     format.formatValue(value, unit, formatOptions);
-    expect(format.unknownTypeFormatter).toBeCalledWith(value, 'gb', {
-      fractionDigits: 2,
-    });
-  });
-
-  test('hrs unit calls unknownTypeFormatter', () => {
-    const unit = 'hrs';
-    format.formatValue(value, unit, formatOptions);
-    expect(format.unknownTypeFormatter).toBeCalledWith(value, unit, {
-      fractionDigits: 2,
-    });
+    expect(format.formatStorage).toBeCalledWith(value, 'gb', formatOptions);
   });
 
   test('null unit returns value fixed to fractionDigits', () => {
@@ -61,20 +49,10 @@ describe('formatCurrency', () => {
     });
     expect(formattedValue).toMatchSnapshot();
   });
-});
 
-describe('unknownTypeFormatter', () => {
-  test('default formatOptions', () => {
-    const formatted = format.unknownTypeFormatter(10.421, 'Hours');
-    expect(formatted).toBe('10 Hours');
-  });
-
-  test('custom formatOptions', () => {
-    const options = {
-      fractionDigits: 2,
-      translateFunction: (text: string) => `-${text}-`,
-    };
-    const formatted = format.unknownTypeFormatter(10.421, 'Hours', options);
-    expect(formatted).toBe('10.42 -Hours-');
+  test('null value returns $0', () => {
+    expect(format.formatCurrency(null, 'usd', { fractionDigits: 0 })).toBe(
+      '$0'
+    );
   });
 });

--- a/src/utils/formatValue.ts
+++ b/src/utils/formatValue.ts
@@ -1,6 +1,5 @@
 export interface FormatOptions {
   fractionDigits?: number;
-  translateFunction?(text: string): string;
 }
 
 export type ValueFormatter = (
@@ -9,37 +8,33 @@ export type ValueFormatter = (
   options?: FormatOptions
 ) => string | number;
 
+export const unitLookupKey = unit =>
+  unit ? unit.split('-')[0].toLowerCase() : '';
+
 export const formatValue: ValueFormatter = (
   value: number,
   unit: string,
   options: FormatOptions = {}
 ) => {
-  const lookup = unit && unit.split('-')[0].toLowerCase();
+  const lookup = unitLookupKey(unit);
   const fValue = value || 0;
 
   switch (lookup) {
     case 'usd':
       return formatCurrency(fValue, lookup, options);
-    case 'hrs':
     case 'gb':
-      return unknownTypeFormatter(fValue, lookup, {
-        fractionDigits: 2,
-        ...options,
-      });
+      return formatStorage(fValue, lookup, options);
     default:
-      return unknownTypeFormatter(fValue, null, options);
+      return unknownTypeFormatter(fValue, lookup, options);
   }
 };
 
-export const unknownTypeFormatter: ValueFormatter = (
+const unknownTypeFormatter: ValueFormatter = (
   value,
   _unit,
-  { fractionDigits, translateFunction } = {}
+  { fractionDigits } = {}
 ) => {
-  const fixedVal = value.toFixed(fractionDigits);
-  return _unit
-    ? `${fixedVal} ${translateFunction ? translateFunction(_unit) : _unit}`
-    : `${fixedVal}`;
+  return value.toFixed(fractionDigits);
 };
 
 export const formatCurrency: ValueFormatter = (
@@ -57,4 +52,12 @@ export const formatCurrency: ValueFormatter = (
     minimumFractionDigits: fractionDigits,
     maximumFractionDigits: fractionDigits,
   });
+};
+
+export const formatStorage: ValueFormatter = (
+  value,
+  _unit,
+  { fractionDigits = 2 } = {}
+) => {
+  return value.toFixed(fractionDigits);
 };


### PR DESCRIPTION
This should fix the current error by using a different format for the report summary trend and the report summary details.