### PR TITLE
Show no change when deltaPercent is null

### DIFF
--- a/src/pages/awsDetails/detailsItem.tsx
+++ b/src/pages/awsDetails/detailsItem.tsx
@@ -130,13 +130,14 @@ class CostItemBase extends React.Component<CostItemProps> {
     const month = (today.getMonth() - 1) % 12;
 
     const value = formatCurrency(Math.abs(item.deltaValue));
-    const percentage = Math.abs(item.deltaPercent).toFixed(2);
+    const percentage =
+      item.deltaValue !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
 
     let iconOverride = 'iconOverride';
-    if (item.deltaValue < 0) {
+    if (item.deltaPercent !== null && item.deltaValue < 0) {
       iconOverride += ' decrease';
     }
-    if (item.deltaValue > 0) {
+    if (item.deltaPercent !== null && item.deltaValue > 0) {
       iconOverride += ' increase';
     }
 
@@ -157,17 +158,17 @@ class CostItemBase extends React.Component<CostItemProps> {
           <ListView.InfoItem key="1" stacked>
             <strong className={iconOverride}>
               {t('percent', { value: percentage })}
-              {Boolean(item.deltaValue > 0) && (
+              {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
                 <span className={css('fa fa-sort-asc', styles.infoItemArrow)} />
               )}
-              {Boolean(item.deltaValue < 0) && (
+              {Boolean(item.deltaPercent !== null && item.deltaValue < 0) && (
                 <span
                   className={css('fa fa-sort-desc', styles.infoItemArrow)}
                 />
               )}
             </strong>
             <span>
-              {(Boolean(item.deltaValue > 0) &&
+              {(Boolean(item.deltaPercent !== null && item.deltaValue > 0) &&
                 ((Boolean(date < 31) &&
                   t('aws_details.increase_since_date', {
                     date,
@@ -179,7 +180,7 @@ class CostItemBase extends React.Component<CostItemProps> {
                     month,
                     value,
                   }))) ||
-                (Boolean(item.deltaValue < 0) &&
+                (Boolean(item.deltaPercent !== null && item.deltaValue < 0) &&
                   ((Boolean(date < 31) &&
                     t('aws_details.decrease_since_date', {
                       date,

--- a/src/pages/ocpDetails/detailsItem.tsx
+++ b/src/pages/ocpDetails/detailsItem.tsx
@@ -88,13 +88,14 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
     const month = (today.getMonth() - 1) % 12;
 
     const value = formatCurrency(Math.abs(item.deltaValue));
-    const percentage = Math.abs(item.deltaPercent).toFixed(2);
+    const percentage =
+      item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
 
     let iconOverride = 'iconOverride';
-    if (item.deltaValue < 0) {
+    if (item.deltaPercent !== null && item.deltaValue < 0) {
       iconOverride += ' decrease';
     }
-    if (item.deltaValue > 0) {
+    if (item.deltaPercent !== null && item.deltaValue > 0) {
       iconOverride += ' increase';
     }
 
@@ -115,17 +116,17 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
           <ListView.InfoItem key="1" stacked>
             <strong className={iconOverride}>
               {t('percent', { value: percentage })}
-              {Boolean(item.deltaValue > 0) && (
+              {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
                 <span className={css('fa fa-sort-asc', styles.infoItemArrow)} />
               )}
-              {Boolean(item.deltaValue < 0) && (
+              {Boolean(item.deltaPercent !== null && item.deltaValue < 0) && (
                 <span
                   className={css('fa fa-sort-desc', styles.infoItemArrow)}
                 />
               )}
             </strong>
             <span>
-              {(Boolean(item.deltaValue > 0) &&
+              {(Boolean(item.deltaPercent !== null && item.deltaValue > 0) &&
                 ((Boolean(date < 31) &&
                   t('ocp_details.increase_since_date', {
                     date,
@@ -137,7 +138,7 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
                     month,
                     value,
                   }))) ||
-                (Boolean(item.deltaValue < 0) &&
+                (Boolean(item.deltaPercent !== null && item.deltaValue < 0) &&
                   ((Boolean(date < 31) &&
                     t('ocp_details.decrease_since_date', {
                       date,


### PR DESCRIPTION
The API is changing to return a null for the deltaPercent value. The UI should be able to handle a null value and not display the up/down arrow in that scenario. That is, show no change.

Fixes https://github.com/project-koku/koku-ui/issues/357

![screen shot 2018-12-13 at 10 11 34 am](https://user-images.githubusercontent.com/17481322/49947717-e8a2eb80-febf-11e8-8c78-1a49fb448386.png)
