### PR TITLE
Legend should be reordered to show previous month first

### DIFF
--- a/src/components/trendChart/trendChart.styles.ts
+++ b/src/components/trendChart/trendChart.styles.ts
@@ -8,7 +8,7 @@ import {
 import { VictoryStyleInterface } from 'victory';
 
 export const chartStyles = {
-  colorScale: [global_primary_color_100.value, global_success_color_100.value],
+  colorScale: [global_success_color_100.value, global_primary_color_100.value],
   previousMonth: {
     data: {
       fill: global_success_color_200.value,

--- a/src/components/trendChart/trendChart.tsx
+++ b/src/components/trendChart/trendChart.tsx
@@ -71,14 +71,14 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     const { title, currentData, previousData, height } = this.props;
 
     const legendData = [];
-    if (currentData && currentData.length) {
-      legendData.push({
-        name: getDateRangeString(currentData),
-      });
-    }
     if (previousData && previousData.length) {
       legendData.push({
         name: getDateRangeString(previousData),
+      });
+    }
+    if (currentData && currentData.length) {
+      legendData.push({
+        name: getDateRangeString(currentData),
       });
     }
     const container = <ChartVoronoiContainer labels={this.getTooltipLabel} />;

--- a/src/components/usageChart/usageChart.styles.ts
+++ b/src/components/usageChart/usageChart.styles.ts
@@ -9,13 +9,13 @@ import { VictoryStyleInterface } from 'victory';
 
 export const chartStyles = {
   currentColorScale: [
-    global_primary_color_100.value,
     global_success_color_100.value,
+    global_primary_color_100.value,
   ],
   currentRequestData: {
     data: {
       fill: 'none',
-      stroke: global_success_color_100.value,
+      stroke: global_warning_color_100.value,
     },
   } as VictoryStyleInterface,
   currentUsageData: {
@@ -25,8 +25,8 @@ export const chartStyles = {
     },
   } as VictoryStyleInterface,
   previousColorScale: [
-    global_warning_color_100.value,
     global_warning_color_200.value,
+    global_warning_color_100.value,
   ],
   previousRequestData: {
     data: {
@@ -37,7 +37,7 @@ export const chartStyles = {
   previousUsageData: {
     data: {
       fill: 'none',
-      stroke: global_warning_color_100.value,
+      stroke: global_success_color_100.value,
     },
   } as VictoryStyleInterface,
 };

--- a/src/components/usageChart/usageChart.tsx
+++ b/src/components/usageChart/usageChart.tsx
@@ -88,21 +88,23 @@ class UsageChart extends React.Component<UsageChartProps, State> {
       title,
     } = this.props;
 
-    const currentLegendData = [];
-    if (currentUsageData && currentUsageData.length) {
-      currentLegendData.push({ name: currentUsageLabel });
-    }
-    if (currentRequestData && currentRequestData.length) {
-      currentLegendData.push({ name: currentRequestLabel });
-    }
+    const firstRowLegendData = [];
+    const secondRowLegendData = [];
 
-    const previousLegendData = [];
     if (previousUsageData && previousUsageData.length) {
-      previousLegendData.push({ name: previousUsageLabel });
+      firstRowLegendData.push({ name: previousUsageLabel });
     }
     if (previousRequestData && previousRequestData.length) {
-      previousLegendData.push({ name: previousRequestLabel });
+      secondRowLegendData.push({ name: previousRequestLabel });
     }
+
+    if (currentUsageData && currentUsageData.length) {
+      firstRowLegendData.push({ name: currentUsageLabel });
+    }
+    if (currentRequestData && currentRequestData.length) {
+      secondRowLegendData.push({ name: currentRequestLabel });
+    }
+
     const container = <ChartVoronoiContainer labels={this.getTooltipLabel} />;
 
     return (
@@ -143,7 +145,8 @@ class UsageChart extends React.Component<UsageChartProps, State> {
           title={title}
           theme={ChartTheme.dark.blue}
           colorScale={chartStyles.currentColorScale}
-          data={currentLegendData}
+          data={firstRowLegendData}
+          gutter={55}
           height={25}
           width={this.state.width}
         />
@@ -151,9 +154,10 @@ class UsageChart extends React.Component<UsageChartProps, State> {
           title={title}
           theme={ChartTheme.dark.blue}
           colorScale={chartStyles.previousColorScale}
-          data={previousLegendData}
+          data={secondRowLegendData}
           height={25}
           width={this.state.width}
+          style={{ data: { strokeDasharray: '5,5' } }}
         />
       </div>
     );


### PR DESCRIPTION
Modified the order of the chart lengends shown on the dashboards. That is, the previous month is now shown before the current month.

AWS
![screen shot 2018-12-13 at 5 05 25 pm](https://user-images.githubusercontent.com/17481322/49970912-cf6b6080-fefa-11e8-8bc2-1b197c60cdf2.png)

OCP
![screen shot 2018-12-13 at 5 05 14 pm](https://user-images.githubusercontent.com/17481322/49970962-f4f86a00-fefa-11e8-950f-6a61970f1efc.png)

Fixes https://github.com/project-koku/koku-ui/issues/351