### PR TITLE
Dashboard legend to indicate full date range for previous month

### DIFF
--- a/src/components/commonChart/chartUtils.ts
+++ b/src/components/commonChart/chartUtils.ts
@@ -1,5 +1,6 @@
 import { AwsReport } from 'api/awsReports';
 import { OcpReport } from 'api/ocpReports';
+import endOfMonth from 'date-fns/end_of_month';
 import format from 'date-fns/format';
 import getDate from 'date-fns/get_date';
 import startOfMonth from 'date-fns/start_of_month';
@@ -126,13 +127,18 @@ export function getDatumDateRange(datums: ChartDatum[]): [Date, Date] {
 
 export function getDateRangeString(
   datums: ChartDatum[],
-  firstOfMonth: boolean = true
+  firstOfMonth: boolean = true,
+  lastOfMonth: boolean = false
 ) {
   const [start, end] = getDatumDateRange(datums);
 
   // Show the date range we are trying to cover (i.e., days 1-30/31)
   if (firstOfMonth && start.setDate) {
     start.setDate(1);
+  }
+  if (lastOfMonth && start.setDate) {
+    const lastDate = endOfMonth(start).getDate();
+    end.setDate(lastDate);
   }
 
   const monthName = format(start, 'MMM');

--- a/src/components/trendChart/trendChart.tsx
+++ b/src/components/trendChart/trendChart.tsx
@@ -74,7 +74,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     const legendData = [];
     if (previousData && previousData.length) {
       legendData.push({
-        name: getDateRangeString(previousData),
+        name: getDateRangeString(previousData, true, true),
       });
     }
     if (currentData && currentData.length) {

--- a/src/pages/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/pages/ocpDashboard/ocpDashboardWidget.tsx
@@ -199,10 +199,10 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
       date: getDateRangeString(currentUsageData),
     });
     const previousRequestLabel = t(trend.previousRequestLabelKey, {
-      date: getDateRangeString(previousRequestData),
+      date: getDateRangeString(previousRequestData, true, true),
     });
     const previousUsageLabel = t(trend.previousUsageLabel, {
-      date: getDateRangeString(previousUsageData),
+      date: getDateRangeString(previousUsageData, true, true),
     });
 
     return (


### PR DESCRIPTION
Modified the legend to show the date range we're trying to cover for the previous month. For example, the label for the previous month should be Nov 1-30.

Fixes https://github.com/project-koku/koku-ui/issues/360

![screen shot 2018-12-15 at 9 25 28 pm](https://user-images.githubusercontent.com/17481322/50049302-2b2b1a80-00b0-11e9-9bf6-9c1872e4ca07.png)
