### PR TITLE
Remove custom bullet chart legend & axis tics

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "i18next-xhr-backend": "^1.5.1",
     "js-file-download": "^0.4.4",
     "mini-css-extract-plugin": "^0.4.0",
-    "patternfly-react": "^2.25.5",
+    "patternfly-react": "^2.26.1",
     "qs": "^6.5.2",
     "react-bootstrap": "^0.32.4",
     "react-dom": "^16.6.3",

--- a/src/components/bulletChart/bulletChart.tsx
+++ b/src/components/bulletChart/bulletChart.tsx
@@ -1,10 +1,4 @@
-import {
-  BulletChart as ChartBullet,
-  BulletChartAxis,
-  BulletChartAxisTic,
-  BulletChartLegend,
-  BulletChartLegendItem,
-} from 'patternfly-react';
+import { BulletChart as PFBulletChart } from 'patternfly-react';
 import React from 'react';
 import { bulletChartOverride } from './bulletChart.styles';
 
@@ -12,7 +6,7 @@ interface BulletChartProps {
   id?: string;
   legend?: any[];
   label?: string;
-  maxDomain?: number;
+  maxValue?: number;
   ranges?: any[];
   threshold?: number;
   values: any[];
@@ -27,50 +21,24 @@ class BulletChart extends React.Component<BulletChartProps> {
   }
 
   public render() {
-    const {
-      id,
-      label,
-      legend,
-      maxDomain,
-      ranges,
-      threshold,
-      values,
-    } = this.props;
-    const maxDomainVal = maxDomain > 0 ? maxDomain : 100;
+    const { id, label, maxValue, ranges, threshold, values } = this.props;
 
     return (
       <>
         {Boolean(values.length) && (
           <div className={bulletChartOverride}>
-            <ChartBullet
-              customAxis={
-                <BulletChartAxis>
-                  <BulletChartAxisTic value={0} text={'0'} />
-                  <BulletChartAxisTic value={50} text={`${maxDomainVal / 2}`} />
-                  <BulletChartAxisTic value={100} text={`${maxDomainVal}`} />
-                </BulletChartAxis>
-              }
+            <PFBulletChart
               id={id}
               label={label}
+              maxValue={maxValue}
+              percents={false}
               ranges={ranges}
               showAxis
+              showLegend
               thresholdError={threshold}
               thresholdWarning={threshold}
               values={values}
             />
-            <BulletChartLegend id="cpu-legend">
-              {legend.map((value, index) => {
-                return (
-                  <BulletChartLegendItem
-                    key={`legend-${index}`}
-                    title={value.title}
-                    value={value.value}
-                    color={value.color}
-                    tooltipFunction={value.tooltipFunction}
-                  />
-                );
-              })}
-            </BulletChartLegend>
           </div>
         )}
       </>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -142,12 +142,16 @@
   },
   "ocp_details": {
     "bullet": {
-      "capacity": "Capacity - {{value}} GB-Hours",
+      "cpu_capacity": "Capacity - {{value}} Core-Hours",
       "cpu_label": "CPU",
-      "limit": "Limit - {{value}} GB-Hours",
+      "cpu_requests": "Requests - {{value}} Core-Hours",
+      "cpu_usage": "Usage - {{value}} Core-Hours",
+      "cpu_limit": "Limit - {{value}} Core-Hours",
+      "memory_capacity": "Capacity - {{value}} GB-Hours",
       "memory_label": "Memory",
-      "requests": "Requests - {{value}} Core-Hours",
-      "usage": "Usage - {{value}} Core-Hours"
+      "memory_requests": "Requests - {{value}} GB-Hours",
+      "memory_usage": "Usage - {{value}} GB-Hours",
+      "memory_limit": "Limit - {{value}} GB-Hours"
     },
     "change_column_title": "Month Over Month Change",
     "charge_column_subtitle": " (Total {{total}})",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -144,14 +144,14 @@
     "bullet": {
       "cpu_capacity": "Capacity - {{value}} Core-Hours",
       "cpu_label": "CPU",
+      "cpu_limit": "Limit - {{value}} Core-Hours",
       "cpu_requests": "Requests - {{value}} Core-Hours",
       "cpu_usage": "Usage - {{value}} Core-Hours",
-      "cpu_limit": "Limit - {{value}} Core-Hours",
       "memory_capacity": "Capacity - {{value}} GB-Hours",
       "memory_label": "Memory",
+      "memory_limit": "Limit - {{value}} GB-Hours",
       "memory_requests": "Requests - {{value}} GB-Hours",
-      "memory_usage": "Usage - {{value}} GB-Hours",
-      "memory_limit": "Limit - {{value}} GB-Hours"
+      "memory_usage": "Usage - {{value}} GB-Hours"
     },
     "change_column_title": "Month Over Month Change",
     "charge_column_subtitle": " (Total {{total}})",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -142,12 +142,16 @@
   },
   "ocp_details": {
     "bullet": {
-      "capacity": "Capacity - {{value}} GB-Hours",
+      "cpu_capacity": "Capacity - {{value}} Core-Hours",
       "cpu_label": "CPU",
-      "limit": "Limit - {{value}} GB-Hours",
+      "cpu_requests": "Requests - {{value}} Core-Hours",
+      "cpu_usage": "Usage - {{value}} Core-Hours",
+      "cpu_limit": "Limit - {{value}} Core-Hours",
+      "memory_capacity": "Capacity - {{value}} GB-Hours",
       "memory_label": "Memory",
-      "requests": "Requests - {{value}} Core-Hours",
-      "usage": "Usage - {{value}} Core-Hours"
+      "memory_requests": "Requests - {{value}} GB-Hours",
+      "memory_usage": "Usage - {{value}} GB-Hours",
+      "memory_limit": "Limit - {{value}} GB-Hours"
     },
     "change_column_title": "Month Over Month Change",
     "charge_column_subtitle": " (Total {{total}})",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -144,14 +144,14 @@
     "bullet": {
       "cpu_capacity": "Capacity - {{value}} Core-Hours",
       "cpu_label": "CPU",
+      "cpu_limit": "Limit - {{value}} Core-Hours",
       "cpu_requests": "Requests - {{value}} Core-Hours",
       "cpu_usage": "Usage - {{value}} Core-Hours",
-      "cpu_limit": "Limit - {{value}} Core-Hours",
       "memory_capacity": "Capacity - {{value}} GB-Hours",
       "memory_label": "Memory",
+      "memory_limit": "Limit - {{value}} GB-Hours",
       "memory_requests": "Requests - {{value}} GB-Hours",
-      "memory_usage": "Usage - {{value}} GB-Hours",
-      "memory_limit": "Limit - {{value}} GB-Hours"
+      "memory_usage": "Usage - {{value}} GB-Hours"
     },
     "change_column_title": "Month Over Month Change",
     "charge_column_subtitle": " (Total {{total}})",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -142,12 +142,16 @@
   },
   "ocp_details": {
     "bullet": {
-      "capacity": "Capacity - {{value}} GB-Hours",
+      "cpu_capacity": "Capacity - {{value}} Core-Hours",
       "cpu_label": "CPU",
-      "limit": "Limit - {{value}} GB-Hours",
+      "cpu_requests": "Requests - {{value}} Core-Hours",
+      "cpu_usage": "Usage - {{value}} Core-Hours",
+      "cpu_limit": "Limit - {{value}} Core-Hours",
+      "memory_capacity": "Capacity - {{value}} GB-Hours",
       "memory_label": "Memory",
-      "requests": "Requests - {{value}} Core-Hours",
-      "usage": "Usage - {{value}} Core-Hours"
+      "memory_requests": "Requests - {{value}} GB-Hours",
+      "memory_usage": "Usage - {{value}} GB-Hours",
+      "memory_limit": "Limit - {{value}} GB-Hours"
     },
     "change_column_title": "Month Over Month Change",
     "charge_column_subtitle": " (Total {{total}})",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -144,14 +144,14 @@
     "bullet": {
       "cpu_capacity": "Capacity - {{value}} Core-Hours",
       "cpu_label": "CPU",
+      "cpu_limit": "Limit - {{value}} Core-Hours",
       "cpu_requests": "Requests - {{value}} Core-Hours",
       "cpu_usage": "Usage - {{value}} Core-Hours",
-      "cpu_limit": "Limit - {{value}} Core-Hours",
       "memory_capacity": "Capacity - {{value}} GB-Hours",
       "memory_label": "Memory",
+      "memory_limit": "Limit - {{value}} GB-Hours",
       "memory_requests": "Requests - {{value}} GB-Hours",
-      "memory_usage": "Usage - {{value}} GB-Hours",
-      "memory_limit": "Limit - {{value}} GB-Hours"
+      "memory_usage": "Usage - {{value}} GB-Hours"
     },
     "change_column_title": "Month Over Month Change",
     "charge_column_subtitle": " (Total {{total}})",

--- a/src/pages/ocpDetails/detailsChart.tsx
+++ b/src/pages/ocpDetails/detailsChart.tsx
@@ -1,14 +1,9 @@
 import { Grid, GridItem } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
-import {
-  global_active_color_100,
-  global_danger_color_100,
-  global_disabled_color_200,
-  global_primary_color_light_100,
-} from '@patternfly/react-tokens';
+// import { global_danger_color_100 } from '@patternfly/react-tokens';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
 import { BulletChart } from 'components/bulletChart';
-import { Tooltip } from 'patternfly-react';
+// import { Tooltip } from 'patternfly-react';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -20,7 +15,7 @@ export interface ChartDatum {
   capacity: number;
   legend: any[];
   limit: number;
-  maxDomain: number;
+  maxValue: number;
   ranges: any[];
   values: any[];
 }
@@ -46,13 +41,13 @@ type DetailsChartProps = DetailsChartOwnProps &
   DetailsChartDispatchProps &
   InjectedTranslateProps;
 
-const randomId = () => Date.now();
+// const randomId = () => Date.now();
 
-const TooltipFunction = value => {
-  return () => {
-    return <Tooltip id={randomId()}>{`${value.title}`}</Tooltip>;
-  };
-};
+// const TooltipFunction = value => {
+//   return () => {
+//     return <Tooltip id={randomId()}>{`${value.title}`}</Tooltip>;
+//   };
+// };
 
 class DetailsChartBase extends React.Component<DetailsChartProps> {
   public componentDidMount() {
@@ -72,13 +67,13 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
     }
   }
 
-  private getChartDatum(report: OcpReport): ChartDatum {
+  private getChartDatum(report: OcpReport, labelKey: string): ChartDatum {
     const { t } = this.props;
     const datum: ChartDatum = {
       capacity: 0,
       legend: [],
       limit: 0,
-      maxDomain: 0,
+      maxValue: 100,
       ranges: [],
       values: [],
     };
@@ -87,58 +82,36 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
       datum.capacity = Math.trunc(report.total.capacity);
       const request = Math.trunc(report.total.request);
       const usage = Math.trunc(report.total.usage);
-      datum.maxDomain = Math.max(usage, request, datum.limit, datum.capacity);
+      datum.maxValue = Math.max(usage, request, datum.limit, datum.capacity);
 
       datum.ranges = [
         {
-          color: global_disabled_color_200.value,
-          title: t('ocp_details.bullet.capacity', { value: datum.capacity }),
-          value: Math.trunc((datum.capacity / datum.maxDomain) * 100),
+          title: t(`ocp_details.bullet.${labelKey}_capacity`, {
+            value: datum.capacity,
+          }),
+          value: Math.trunc(datum.capacity),
         },
       ];
       datum.values = [
         {
-          color: global_active_color_100.value,
-          title: t('ocp_details.bullet.usage', { value: usage }),
-          value: Math.trunc((usage / datum.maxDomain) * 100),
+          title: t(`ocp_details.bullet.${labelKey}_usage`, { value: usage }),
+          value: Math.trunc(usage),
         },
         {
-          color: global_primary_color_light_100.value,
-          title: t('ocp_details.bullet.requests', { value: request }),
-          value: Math.trunc((request / datum.maxDomain) * 100),
+          title: t(`ocp_details.bullet.${labelKey}_requests`, {
+            value: request,
+          }),
+          value: Math.trunc(request),
         },
       ];
-      const legend = [
-        {
-          className: 'limit',
-          color: global_danger_color_100.value,
-          title: t('ocp_details.bullet.limit', { value: datum.limit }),
-        },
-        {
-          color: global_disabled_color_200.value,
-          title: t('ocp_details.bullet.capacity', { value: datum.capacity }),
-        },
-      ] as any;
-
-      datum.ranges.map((value, index) => {
-        value.tooltipFunction = TooltipFunction(value);
-      });
-      datum.values.map((value, index) => {
-        value.tooltipFunction = TooltipFunction(value);
-      });
-      legend.map((value, index) => {
-        value.tooltipFunction = TooltipFunction(value);
-      });
-      datum.legend = [...datum.values, ...legend];
-      datum.limit = Math.trunc((datum.limit / datum.maxDomain) * 100);
     }
     return datum;
   }
 
   public render() {
     const { cpuReport, memoryReport, t } = this.props;
-    const cpuDatum = this.getChartDatum(cpuReport);
-    const memoryDatum = this.getChartDatum(memoryReport);
+    const cpuDatum = this.getChartDatum(cpuReport, 'cpu');
+    const memoryDatum = this.getChartDatum(memoryReport, 'memory');
 
     return (
       <>
@@ -152,8 +125,7 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
                 <BulletChart
                   id="cpu-chart"
                   label={t('ocp_details.bullet.cpu_label')}
-                  legend={cpuDatum.legend}
-                  maxDomain={cpuDatum.maxDomain}
+                  maxValue={cpuDatum.maxValue}
                   ranges={cpuDatum.ranges}
                   threshold={cpuDatum.limit}
                   values={cpuDatum.values}
@@ -172,8 +144,7 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
                 <BulletChart
                   id="memory-chart"
                   label={t('ocp_details.bullet.memory_label')}
-                  legend={memoryDatum.legend}
-                  maxDomain={memoryDatum.maxDomain}
+                  maxValue={memoryDatum.maxValue}
                   ranges={memoryDatum.ranges}
                   threshold={memoryDatum.limit}
                   values={memoryDatum.values}

--- a/src/pages/ocpDetails/detailsChart.tsx
+++ b/src/pages/ocpDetails/detailsChart.tsx
@@ -1,9 +1,7 @@
 import { Grid, GridItem } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
-// import { global_danger_color_100 } from '@patternfly/react-tokens';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
 import { BulletChart } from 'components/bulletChart';
-// import { Tooltip } from 'patternfly-react';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -40,14 +38,6 @@ type DetailsChartProps = DetailsChartOwnProps &
   DetailsChartStateProps &
   DetailsChartDispatchProps &
   InjectedTranslateProps;
-
-// const randomId = () => Date.now();
-
-// const TooltipFunction = value => {
-//   return () => {
-//     return <Tooltip id={randomId()}>{`${value.title}`}</Tooltip>;
-//   };
-// };
 
 class DetailsChartBase extends React.Component<DetailsChartProps> {
   public componentDidMount() {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6401,7 +6401,7 @@ lodash@^4.17.10:
   version "4.17.10"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
-lodash@^4.2.1:
+lodash@^4.17.11, lodash@^4.2.1:
   version "4.17.11"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
 
@@ -7502,14 +7502,15 @@ patternfly-react@^2.17.3:
     sortabular "^1.5.1"
     table-resolver "^3.2.0"
 
-patternfly-react@^2.25.5:
-  version "2.25.5"
-  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.25.5.tgz#05d7df2680113807e3069fdcf3e21c8c82a53113"
+patternfly-react@^2.26.1:
+  version "2.26.1"
+  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.26.1.tgz#a3880c839f3553057c03dfbdb5b9aaf630871627"
   dependencies:
     bootstrap-slider-without-jquery "^10.0.0"
     breakjs "^1.0.0"
     classnames "^2.2.5"
     css-element-queries "^1.0.1"
+    lodash "^4.17.11"
     patternfly "^3.58.0"
     react-bootstrap "^0.32.1"
     react-bootstrap-switch "^15.5.3"
@@ -7521,6 +7522,7 @@ patternfly-react@^2.25.5:
     react-motion "^0.5.2"
     reactabular-table "^8.14.0"
     recompose "^0.26.0"
+    uuid "^3.3.2"
   optionalDependencies:
     sortabular "^1.5.1"
     table-resolver "^3.2.0"


### PR DESCRIPTION
Now that the PF3 bullet chart no longer assumes given values are percentages, I've removed the custom code to override the axis tics and legend. See: patternfly/patternfly-react#1031

This also adds the correct units (Core-Hours Vs GB-Hours) for the CPU and memory charts.

Fixes https://github.com/project-koku/koku-ui/issues/362

![screen shot 2018-12-15 at 10 10 37 pm](https://user-images.githubusercontent.com/17481322/50049663-210d1a00-00b8-11e9-8713-9e91f788bac7.png)