### PR TITLE
fix(Charts): fix the null error in usage/trend charts

### DIFF
--- a/src/components/trendChart/trendChart.tsx
+++ b/src/components/trendChart/trendChart.tsx
@@ -58,10 +58,11 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   };
 
   public componentDidMount() {
-    setTimeout(() => {
-      this.setState({ width: this.containerRef.current.clientWidth });
-      window.addEventListener('resize', this.handleResize);
-    });
+    const node = this.containerRef.current;
+    if (node) {
+      this.setState({ width: node.clientWidth });
+    }
+    window.addEventListener('resize', this.handleResize);
   }
 
   public componentWillUnmount() {

--- a/src/components/usageChart/usageChart.tsx
+++ b/src/components/usageChart/usageChart.tsx
@@ -67,10 +67,11 @@ class UsageChart extends React.Component<UsageChartProps, State> {
   };
 
   public componentDidMount() {
-    setTimeout(() => {
-      this.setState({ width: this.containerRef.current.clientWidth });
-      window.addEventListener('resize', this.handleResize);
-    });
+    const node = this.containerRef.current;
+    if (node) {
+      this.setState({ width: node.clientWidth });
+    }
+    window.addEventListener('resize', this.handleResize);
   }
 
   public componentWillUnmount() {


### PR DESCRIPTION
A small nitpick fix.

When the chart is mounted there is a chance that `containerRef.current` wasn't set yet.
Thus, getting the following error:

```
TypeError: this.containerRef.current is null
```

To avoid this, added a check that `containerRef.current` is  not `null` and only then update the state.
In addition, removed the `setTimeout` function as `containerRef` updates before componentDidMount and so `componentDidMount` will be called twice - once when `containerRef` is null and when it is set to the node in the DOM. Read more [here](https://reactjs.org/docs/refs-and-the-dom.html#adding-a-ref-to-a-dom-element)