### PR TITLE
fix(Tabs): render when selected tab is not found

### DIFF
--- a/src/components/tabs/tabs.test.tsx
+++ b/src/components/tabs/tabs.test.tsx
@@ -34,3 +34,21 @@ test('tabs renders tab content with the right props', () => {
   expect(tabCnt.length).toBe(1);
   expect(tabCnt.at(0).props().data).toBe(props.tabs[1]);
 });
+
+test('tabs renders "no data was found" when tabs is an empty array', () => {
+  const view = shallow(<Tabs {...props} tabs={[]} />).find('div');
+  expect(view.text()).toBe('No data was found');
+});
+
+test('tabs renders first tab when selected tab does not exist in tabs', () => {
+  const view = shallow(<Tabs {...props} selected={'id10'} />);
+  const tabCnt = view.find(TabContent);
+  const tabNav = view.find(TabNavigation);
+
+  expect(tabCnt.length).toBe(1);
+  expect(tabNav.length).toBe(1);
+
+  expect(tabCnt.props().data).toBe(props.tabs[0]);
+  expect(tabNav.at(0).props().selected).toBe(props.tabs[0]);
+  expect(tabNav.at(0).props().tabs).toBe(props.tabs);
+});

--- a/src/components/tabs/tabs.tsx
+++ b/src/components/tabs/tabs.tsx
@@ -11,6 +11,10 @@ interface TabsProps {
 }
 
 const Tabs: React.SFC<TabsProps> = ({ isShrink, selected, tabs, onChange }) => {
+  if (tabs.length === 0) {
+    return <div>No data was found</div>;
+  }
+
   const selectedTab = tabs.find(tab => tab.id === selected);
 
   return (
@@ -18,10 +22,10 @@ const Tabs: React.SFC<TabsProps> = ({ isShrink, selected, tabs, onChange }) => {
       <TabNavigation
         isShrink={isShrink}
         tabs={tabs}
-        selected={selectedTab}
+        selected={selectedTab || tabs[0]}
         onChange={onChange}
       />
-      <TabContent data={selectedTab} />
+      <TabContent data={selectedTab || tabs[0]} />
     </div>
   );
 };


### PR DESCRIPTION
fixes #353 

## why it exploded?
`Tabs` takes a tab list `tab` and an id of the selected tab to show by default `selected`.

If `selected` is not found in `tabs`, `undefined` is passed to `TabContent` and `TabNavigation` which ends up with an error message and nothing rendered.

## how did I fix it?

I added a few checks before rendering the `Tabs` component.
First, checking that `tabs` is not empty. If it is empty, render a simple `div` saying "No data was found".
Another check is whether `selected` is in `tabs`, if it is then everything is rendered as usual. Otherwise, we take the first item in `tabs` as `selected` (this must be true because `tabs` is not empty and thus it does have at least one item).
