### PR TITLE
Bad month over month value

### DIFF
--- a/src/pages/awsDetails/detailsItem.tsx
+++ b/src/pages/awsDetails/detailsItem.tsx
@@ -127,7 +127,7 @@ class CostItemBase extends React.Component<CostItemProps> {
 
     const today = new Date();
     const date = today.getDate();
-    const month = (today.getMonth() - 1) % 12;
+    const month = (((today.getMonth() - 1) % 12) + 12) % 12;
 
     const value = formatCurrency(Math.abs(item.deltaValue));
     const percentage =

--- a/src/pages/ocpDetails/detailsItem.tsx
+++ b/src/pages/ocpDetails/detailsItem.tsx
@@ -99,7 +99,7 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
 
     const today = new Date();
     const date = today.getDate();
-    const month = (today.getMonth() - 1) % 12;
+    const month = (((today.getMonth() - 1) % 12) + 12) % 12;
 
     const value = formatCurrency(Math.abs(item.deltaValue));
     const percentage =


### PR DESCRIPTION
This fixes an issue with a bad mod calculation for month over month value. This only happens when subtracting one from January's position in the localization index. This solution accounts for negative numbers.

Fixes https://github.com/project-koku/koku-ui/issues/379