### PR TITLE
Update the OCP details to reflect the latest high fedelity mock

### DIFF
--- a/src/components/measureChart/measureChart.styles.ts
+++ b/src/components/measureChart/measureChart.styles.ts
@@ -1,5 +1,15 @@
-import { global_danger_color_100 } from '@patternfly/react-tokens';
+import { StyleSheet } from '@patternfly/react-styles';
+import {
+  global_danger_color_100,
+  global_spacer_md,
+} from '@patternfly/react-tokens';
 import { css } from 'emotion';
+
+export const styles = StyleSheet.create({
+  measureChart: {
+    paddingTop: global_spacer_md.value,
+  },
+});
 
 export const bulletChartOverride = css`
   & .bullet-chart-pf-title-container {

--- a/src/components/measureChart/measureChart.tsx
+++ b/src/components/measureChart/measureChart.tsx
@@ -1,6 +1,7 @@
+import { css } from '@patternfly/react-styles';
 import { BulletChart } from 'patternfly-react';
 import React from 'react';
-import { bulletChartOverride } from './measureChart.styles';
+import { bulletChartOverride, styles } from './measureChart.styles';
 
 interface MeasureChartProps {
   id?: string;
@@ -36,20 +37,22 @@ class MeasureChart extends React.Component<MeasureChartProps> {
       <>
         {Boolean(values.length) && (
           <div className={bulletChartOverride}>
-            <div>{label}</div>
-            <BulletChart
-              id={id}
-              maxValue={maxValue}
-              percents={false}
-              ranges={ranges}
-              showAxis
-              showLegend
-              thresholdError={thresholdError}
-              thresholdErrorLegendText={thresholdErrorLegendText}
-              thresholdWarning={0}
-              useExtendedColors
-              values={values}
-            />
+            {label}
+            <div className={css(styles.measureChart)}>
+              <BulletChart
+                id={id}
+                maxValue={maxValue}
+                percents={false}
+                ranges={ranges}
+                showAxis
+                showLegend
+                thresholdError={thresholdError}
+                thresholdErrorLegendText={thresholdErrorLegendText}
+                thresholdWarning={0}
+                useExtendedColors
+                values={values}
+              />
+            </div>
           </div>
         )}
       </>

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -170,7 +170,7 @@
     "historical": {
       "charge_label": "Charge ($)",
       "charge_title": "Month over Month Total $t(group_by.values.{{groupBy}}) Charge",
-      "cluster_label": "Cluster:",
+      "cluster_label": "Cluster",
       "cpu_capacity_label": "Capacity ({{date}})",
       "cpu_label": "Core-Hours",
       "cpu_limit_label": "Limity ({{date}})",
@@ -186,7 +186,7 @@
       "memory_usage_label": "Used ({{date}})",
       "modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Historical Data",
       "project_title": "Top Projects",
-      "tags_label": "Tags:"
+      "tags_label": "Tags"
     },
     "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
     "increase_since_last_month": "{{value}} increase since last month",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -170,7 +170,7 @@
     "historical": {
       "charge_label": "Charge ($)",
       "charge_title": "Month over Month Total $t(group_by.values.{{groupBy}}) Charge",
-      "cluster_label": "Cluster:",
+      "cluster_label": "Cluster",
       "cpu_capacity_label": "Capacity ({{date}})",
       "cpu_label": "Core-Hours",
       "cpu_limit_label": "Limit ({{date}})",
@@ -186,7 +186,7 @@
       "memory_usage_label": "Used ({{date}})",
       "modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Historical Data",
       "project_title": "Top Projects",
-      "tags_label": "Tags:"
+      "tags_label": "Tags"
     },
     "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
     "increase_since_last_month": "{{value}} increase since last month",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -170,7 +170,7 @@
     "historical": {
       "charge_label": "Charge ($)",
       "charge_title": "Month over Month Total $t(group_by.values.{{groupBy}}) Charge",
-      "cluster_label": "Cluster:",
+      "cluster_label": "Cluster",
       "cpu_capacity_label": "Capacity ({{date}})",
       "cpu_label": "Core-Hours",
       "cpu_limit_label": "Limity ({{date}})",
@@ -186,7 +186,7 @@
       "memory_usage_label": "Used ({{date}})",
       "modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Historical Data",
       "project_title": "Top Projects",
-      "tags_label": "Tags:"
+      "tags_label": "Tags"
     },
     "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
     "increase_since_last_month": "{{value}} increase since last month",

--- a/src/pages/ocpDetails/detailsChart.tsx
+++ b/src/pages/ocpDetails/detailsChart.tsx
@@ -104,22 +104,20 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
     return (
       <>
         {Boolean(cpuDatum && cpuDatum.values.length) && (
-          <div className={css(styles.bulletContainer)}>
-            <MeasureChart
-              id="cpu-chart"
-              label={t('ocp_details.bullet.cpu_label')}
-              maxValue={cpuDatum.maxValue}
-              ranges={cpuDatum.ranges}
-              thresholdError={cpuDatum.limit}
-              thresholdErrorLegendText={t(`ocp_details.bullet.cpu_limit`, {
-                value: cpuDatum.limit,
-              })}
-              values={cpuDatum.values}
-            />
-          </div>
+          <MeasureChart
+            id="cpu-chart"
+            label={t('ocp_details.bullet.cpu_label')}
+            maxValue={cpuDatum.maxValue}
+            ranges={cpuDatum.ranges}
+            thresholdError={cpuDatum.limit}
+            thresholdErrorLegendText={t(`ocp_details.bullet.cpu_limit`, {
+              value: cpuDatum.limit,
+            })}
+            values={cpuDatum.values}
+          />
         )}
         {Boolean(memoryDatum && memoryDatum.values.length) && (
-          <div className={css(styles.historicalBulletContainer)}>
+          <div className={css(styles.memoryBulletContainer)}>
             <MeasureChart
               id="memory-chart"
               label={t('ocp_details.bullet.memory_label')}

--- a/src/pages/ocpDetails/detailsItem.tsx
+++ b/src/pages/ocpDetails/detailsItem.tsx
@@ -21,7 +21,7 @@ import { DetailsChart } from './detailsChart';
 import { DetailsSummary } from './detailsSummary';
 import { DetailsTag } from './detailsTag';
 import { HistoricalModal } from './historicalModal';
-import { btnOverride, styles } from './ocpDetails.styles';
+import { styles } from './ocpDetails.styles';
 
 interface DetailsItemOwnProps {
   charge: number;
@@ -205,8 +205,8 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
         onExpandClose={this.handleExpandClose}
       >
         <Grid>
-          <GridItem md={12} lg={6}>
-            <div className={css(styles.historicalProjectsContainer)}>
+          <GridItem lg={12} xl={5}>
+            <div className={css(styles.projectsContainer)}>
               {Boolean(parentGroupBy === 'project') && (
                 <DetailsTag
                   clusterLabel={t('ocp_details.historical.cluster_label')}
@@ -224,21 +224,23 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
                   title={t('ocp_details.historical.project_title')}
                 />
               )}
-              <div className={`${btnOverride} ${css(styles.historicalLink)}`}>
-                <Button
-                  {...getTestProps(testIds.providers.add_btn)}
-                  onClick={this.handleHistoricalModalOpen}
-                  type={ButtonType.button}
-                  variant={ButtonVariant.link}
-                >
-                  View Historical Data
-                </Button>
-              </div>
             </div>
           </GridItem>
-          <GridItem md={12} lg={6}>
-            <div className={css(styles.historicalBulletContainer)}>
+          <GridItem lg={12} xl={4}>
+            <div className={css(styles.measureChartContainer)}>
               <DetailsChart queryString={this.getQueryString(true, true)} />
+            </div>
+          </GridItem>
+          <GridItem lg={12} xl={3}>
+            <div className={css(styles.historicalLinkContainer)}>
+              <Button
+                {...getTestProps(testIds.providers.add_btn)}
+                onClick={this.handleHistoricalModalOpen}
+                type={ButtonType.button}
+                variant={ButtonVariant.secondary}
+              >
+                View Historical Data
+              </Button>
             </div>
           </GridItem>
         </Grid>

--- a/src/pages/ocpDetails/detailsSummary.tsx
+++ b/src/pages/ocpDetails/detailsSummary.tsx
@@ -50,28 +50,26 @@ class DetailsSummaryBase extends React.Component<DetailsSummaryProps> {
     const { idKey, report, title } = this.props;
 
     return (
-      <>
-        <div className={css(styles.historicalProgressBarTitle)}>{title}</div>
-        <div className={css(styles.historicalProgressBarContainer)}>
-          <div className={css(styles.historicalProgressBar)}>
-            <OcpReportSummaryItems idKey={idKey} report={report}>
-              {({ items }) =>
-                items.map(reportItem => (
-                  <OcpReportSummaryItem
-                    key={reportItem.id}
-                    formatOptions={{}}
-                    formatValue={formatValue}
-                    label={reportItem.label.toString()}
-                    totalValue={report.total.charge}
-                    units={reportItem.units}
-                    value={reportItem.charge}
-                  />
-                ))
-              }
-            </OcpReportSummaryItems>
-          </div>
+      <div>
+        {title}
+        <div className={css(styles.projectsProgressBar)}>
+          <OcpReportSummaryItems idKey={idKey} report={report}>
+            {({ items }) =>
+              items.map(reportItem => (
+                <OcpReportSummaryItem
+                  key={reportItem.id}
+                  formatOptions={{}}
+                  formatValue={formatValue}
+                  label={reportItem.label.toString()}
+                  totalValue={report.total.charge}
+                  units={reportItem.units}
+                  value={reportItem.charge}
+                />
+              ))
+            }
+          </OcpReportSummaryItems>
         </div>
-      </>
+      </div>
     );
   }
 }

--- a/src/pages/ocpDetails/detailsTag.tsx
+++ b/src/pages/ocpDetails/detailsTag.tsx
@@ -69,12 +69,12 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
     const clusterName = items && items.length ? items[0].label : '';
 
     return (
-      <Form isHorizontal>
+      <Form>
         <FormGroup label={clusterLabel} fieldId="cluster-name">
-          <span>{clusterName}</span>
+          <div>{clusterName}</div>
         </FormGroup>
         <FormGroup label={tagsLabel} fieldId="tags-name">
-          <span>n/a</span>
+          <div>n/a</div>
         </FormGroup>
       </Form>
     );

--- a/src/pages/ocpDetails/ocpDetails.styles.ts
+++ b/src/pages/ocpDetails/ocpDetails.styles.ts
@@ -63,32 +63,8 @@ export const styles = StyleSheet.create({
     display: 'flex',
     justifyContent: 'flex-end',
   },
-  historicalBulletContainer: {
+  memoryBulletContainer: {
     paddingTop: global_spacer_xl.value,
-  },
-  historicalLink: {
-    display: 'flex',
-    alignItems: 'flex-end',
-    flexGrow: '1',
-  },
-  historicalProjectsContainer: {
-    display: 'flex',
-    flexDirection: 'column',
-    height: '100%',
-    paddingRight: global_spacer_3xl.value,
-    paddingTop: global_spacer_xl.value,
-  },
-  historicalProgressBarContainer: {
-    display: 'flex',
-    alignItems: 'flex-start',
-    paddingTop: global_spacer_xl.value,
-  },
-  historicalProgressBar: {
-    width: '100%',
-  },
-  historicalProgressBarTitle: {
-    display: 'flex',
-    alignItems: 'flex-start',
   },
   title: {
     paddingBottom: global_spacer_sm.var,
@@ -97,6 +73,14 @@ export const styles = StyleSheet.create({
     backgroundColor: global_BackgroundColor_300.var,
     minHeight: '100%',
   },
+  measureChartContainer: {
+    paddingTop: global_spacer_xl.value,
+  },
+  historicalLinkContainer: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    paddingTop: global_spacer_xl.value,
+  },
   groupBySelector: {
     display: 'flex',
     alignItems: 'center',
@@ -104,6 +88,13 @@ export const styles = StyleSheet.create({
   groupBySelectorLabel: {
     marginBottom: 0,
     marginRight: global_spacer_md.var,
+  },
+  projectsContainer: {
+    paddingTop: global_spacer_xl.value,
+    paddingRight: global_spacer_3xl.value,
+  },
+  projectsProgressBar: {
+    paddingTop: global_spacer_md.value,
   },
   toolbarContainer: {
     backgroundColor: global_BackgroundColor_300.value,
@@ -401,11 +392,5 @@ export const toolbarOverride = css`
       display: inline-flex;
       font-weight: ${global_FontWeight_normal.value};
     }
-  }
-`;
-
-export const btnOverride = css`
-  & .pf-c-button {
-    --pf-c-button--PaddingLeft: 0;
   }
 `;


### PR DESCRIPTION
Updated the OCP detail (expanded) list items to reflect the latest high fidelity mock layout. For example, "View Historical Data" should be a button at the top right, extra padding around the titles, etc.

Fixes https://github.com/project-koku/koku-ui/issues/384

![screen shot 2019-01-07 at 2 16 42 pm](https://user-images.githubusercontent.com/17481322/50788297-feb98700-1286-11e9-9f9e-1975e5870163.png)
