### PR TITLE
Use light theme per high fidelity mock

### DIFF
--- a/src/components/trendChart/trendChart.styles.ts
+++ b/src/components/trendChart/trendChart.styles.ts
@@ -8,6 +8,20 @@ import {
 import { VictoryStyleInterface } from 'victory';
 
 export const chartStyles = {
+  axis: {
+    axisLabel: {
+      padding: 15,
+    },
+    grid: {
+      stroke: 'none',
+    },
+    ticks: {
+      stroke: 'none',
+    },
+    tickLabels: {
+      fontSize: 0,
+    },
+  } as VictoryStyleInterface,
   colorScale: [global_success_color_100.value, global_primary_color_100.value],
   previousMonth: {
     data: {

--- a/src/components/trendChart/trendChart.test.tsx
+++ b/src/components/trendChart/trendChart.test.tsx
@@ -1,6 +1,6 @@
 jest.mock('date-fns/format');
 
-import { ChartArea, ChartGroup } from '@patternfly/react-charts';
+import { Chart, ChartArea } from '@patternfly/react-charts';
 import { AwsReport, AwsReportData } from 'api/awsReports';
 import * as utils from 'components/commonChart/chartUtils';
 import formatDate from 'date-fns/format';
@@ -51,7 +51,7 @@ test('null previous and current reports are handled', () => {
 
 test('height from props is used', () => {
   const view = shallow(<TrendChart {...props} />);
-  expect(view.find(ChartGroup).prop('height')).toBe(props.height);
+  expect(view.find(Chart).prop('height')).toBe(props.height);
 });
 
 test('labels formats with datum and value formatted from props', () => {
@@ -66,7 +66,7 @@ test('labels formats with datum and value formatted from props', () => {
     key: '1-1-1',
     units: 'units',
   };
-  const group = view.find(ChartGroup);
+  const group = view.find(Chart);
   group.props().containerComponent.props.labels(datum);
   expect(getTooltipLabel).toBeCalledWith(
     datum,
@@ -80,7 +80,7 @@ test('labels formats with datum and value formatted from props', () => {
     props.formatDatumOptions
   );
   expect(formatDate).toBeCalledWith(datum.key, expect.any(String));
-  expect(view.find(ChartGroup).prop('height')).toBe(props.height);
+  expect(view.find(Chart).prop('height')).toBe(props.height);
 });
 
 test('labels ignores datums without a date', () => {
@@ -91,7 +91,7 @@ test('labels ignores datums without a date', () => {
     key: '',
     units: 'units',
   };
-  const group = view.find(ChartGroup);
+  const group = view.find(Chart);
   const value = group.props().containerComponent.props.labels(datum);
   expect(value).toBe('');
   expect(props.formatDatumValue).not.toBeCalled();

--- a/src/components/trendChart/trendChart.tsx
+++ b/src/components/trendChart/trendChart.tsx
@@ -1,6 +1,6 @@
 import {
+  Chart,
   ChartArea,
-  ChartGroup,
   ChartLegend,
   ChartTheme,
   ChartVoronoiContainer,
@@ -14,6 +14,7 @@ import {
 } from 'components/commonChart/chartUtils';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
+import { VictoryAxis } from 'victory';
 import { chartStyles, styles } from './trendChart.styles';
 
 interface TrendChartProps {
@@ -87,7 +88,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     return (
       <div className={css(styles.reportSummaryTrend)} ref={this.containerRef}>
         <div>
-          <ChartGroup
+          <Chart
             containerComponent={container}
             height={height}
             width={this.state.width}
@@ -101,12 +102,14 @@ class TrendChart extends React.Component<TrendChartProps, State> {
             {Boolean(currentData && currentData.length) && (
               <ChartArea style={chartStyles.currentMonth} data={currentData} />
             )}
-          </ChartGroup>
+            <VictoryAxis style={chartStyles.axis} />
+            <VictoryAxis dependentAxis style={chartStyles.axis} />
+          </Chart>
         </div>
         {Boolean(legendData && legendData.length) && (
           <ChartLegend
             title={title}
-            theme={ChartTheme.dark.blue}
+            theme={ChartTheme.light.blue}
             colorScale={chartStyles.colorScale}
             data={legendData}
             height={50}

--- a/src/components/usageChart/usageChart.styles.ts
+++ b/src/components/usageChart/usageChart.styles.ts
@@ -8,6 +8,20 @@ import {
 import { VictoryStyleInterface } from 'victory';
 
 export const chartStyles = {
+  axis: {
+    axisLabel: {
+      padding: 15,
+    },
+    grid: {
+      stroke: 'none',
+    },
+    ticks: {
+      stroke: 'none',
+    },
+    tickLabels: {
+      fontSize: 0,
+    },
+  } as VictoryStyleInterface,
   currentColorScale: [
     global_success_color_100.value,
     global_primary_color_100.value,

--- a/src/components/usageChart/usageChart.test.tsx
+++ b/src/components/usageChart/usageChart.test.tsx
@@ -1,6 +1,6 @@
 jest.mock('date-fns/format');
 
-import { ChartArea, ChartGroup } from '@patternfly/react-charts';
+import { Chart, ChartArea } from '@patternfly/react-charts';
 import { OcpReport, OcpReportData } from 'api/ocpReports';
 import * as utils from 'components/commonChart/chartUtils';
 import formatDate from 'date-fns/format';
@@ -83,7 +83,7 @@ test('null previous and current reports are handled', () => {
 
 test('height from props is used', () => {
   const view = shallow(<UsageChart {...props} />);
-  expect(view.find(ChartGroup).prop('height')).toBe(props.height);
+  expect(view.find(Chart).prop('height')).toBe(props.height);
 });
 
 test('labels formats with datum and value formatted from props', () => {
@@ -94,7 +94,7 @@ test('labels formats with datum and value formatted from props', () => {
     key: '1-1-1',
     units: 'units',
   };
-  const group = view.find(ChartGroup);
+  const group = view.find(Chart);
   group.props().containerComponent.props.labels(datum);
   expect(getTooltipLabel).toBeCalledWith(
     datum,
@@ -108,7 +108,7 @@ test('labels formats with datum and value formatted from props', () => {
     props.formatDatumOptions
   );
   expect(formatDate).toBeCalledWith(datum.key, expect.any(String));
-  expect(view.find(ChartGroup).prop('height')).toBe(props.height);
+  expect(view.find(Chart).prop('height')).toBe(props.height);
 });
 
 test('labels ignores datums without a date', () => {
@@ -119,7 +119,7 @@ test('labels ignores datums without a date', () => {
     key: '',
     units: 'units',
   };
-  const group = view.find(ChartGroup);
+  const group = view.find(Chart);
   const value = group.props().containerComponent.props.labels(datum);
   expect(value).toBe('');
   expect(props.formatDatumValue).not.toBeCalled();

--- a/src/components/usageChart/usageChart.tsx
+++ b/src/components/usageChart/usageChart.tsx
@@ -1,6 +1,6 @@
 import {
+  Chart,
   ChartArea,
-  ChartGroup,
   ChartLegend,
   ChartTheme,
   ChartVoronoiContainer,
@@ -13,6 +13,7 @@ import {
 } from 'components/commonChart/chartUtils';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
+import { VictoryAxis } from 'victory';
 import { chartStyles, styles } from './usageChart.styles';
 
 interface UsageChartProps {
@@ -114,7 +115,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
     return (
       <div className={css(styles.reportSummaryTrend)} ref={this.containerRef}>
         <div>
-          <ChartGroup
+          <Chart
             containerComponent={container}
             height={height}
             width={this.state.width}
@@ -143,12 +144,14 @@ class UsageChart extends React.Component<UsageChartProps, State> {
                 data={previousRequestData}
               />
             )}
-          </ChartGroup>
+            <VictoryAxis style={chartStyles.axis} />
+            <VictoryAxis dependentAxis style={chartStyles.axis} />
+          </Chart>
         </div>
         {Boolean(firstRowLegendData && firstRowLegendData.length) && (
           <ChartLegend
             title={title}
-            theme={ChartTheme.dark.blue}
+            theme={ChartTheme.light.blue}
             colorScale={chartStyles.currentColorScale}
             data={firstRowLegendData}
             gutter={55}
@@ -159,7 +162,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
         {Boolean(secondRowLegendData && secondRowLegendData.length) && (
           <ChartLegend
             title={title}
-            theme={ChartTheme.dark.blue}
+            theme={ChartTheme.light.blue}
             colorScale={chartStyles.previousColorScale}
             data={secondRowLegendData}
             height={25}

--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -93,7 +93,7 @@ class OverviewBase extends React.Component<OverviewProps> {
     );
 
     return (
-      <div className="pf-m-dark-100 pf-l-page__main-section pf-u-pb-xl pf-u-px-xl">
+      <div className="pf-l-page__main-section pf-u-pb-xl pf-u-px-xl">
         <header className="pf-u-display-flex pf-u-justify-content-space-between pf-u-align-items-center">
           <Title size={TitleSize.lg}>{t('overview.title')}</Title>
           {addSourceBtn}


### PR DESCRIPTION
Also adds axis lines to overview charts in order to look better with a light theme

Fixes https://github.com/project-koku/koku-ui/issues/385

![screen shot 2019-01-07 at 8 14 32 pm](https://user-images.githubusercontent.com/17481322/50803797-39d4ae00-12b9-11e9-9ff0-318708bbd0e5.png)
