### PR TITLE
Add project tags to OCP details page

### DIFF
--- a/src/api/ocpQuery.ts
+++ b/src/api/ocpQuery.ts
@@ -5,6 +5,7 @@ export interface OcpFilters {
   time_scope_units?: 'month' | 'day';
   resolution?: 'daily' | 'monthly';
   limit?: number;
+  project?: string | number;
 }
 
 type OcpGroupByValue = string | string[];
@@ -27,6 +28,7 @@ export interface OcpQuery {
   filter?: OcpFilters;
   group_by?: OcpGroupBys;
   order_by?: OcpOrderBys;
+  key_only?: boolean;
 }
 
 export function getQuery(query: OcpQuery) {

--- a/src/api/ocpReports.ts
+++ b/src/api/ocpReports.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import { Omit } from 'react-redux';
 
 export interface OcpReportValue {
+  app?: string;
   capacity?: number;
   charge?: number;
   cluster?: string;
@@ -70,6 +71,7 @@ export const enum OcpReportType {
   cpu = 'cpu',
   limit = 'limit',
   memory = 'memory',
+  tag = 'tag',
 }
 
 export const ocpReportTypePaths: Record<OcpReportType, string> = {
@@ -77,6 +79,7 @@ export const ocpReportTypePaths: Record<OcpReportType, string> = {
   [OcpReportType.cpu]: 'reports/inventory/ocp/cpu/',
   [OcpReportType.limit]: 'reports/inventory/ocp/limit/',
   [OcpReportType.memory]: 'reports/inventory/ocp/memory/',
+  [OcpReportType.tag]: 'tags/ocp/',
 };
 
 export function runReport(reportType: OcpReportType, query: string) {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -156,6 +156,7 @@
     "change_column_title": "Month Over Month Change",
     "charge_column_subtitle": " (Total {{total}})",
     "charge_column_title": "Charges",
+    "cluster_label": "Cluster",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
     "export_link": "Export",
@@ -170,7 +171,6 @@
     "historical": {
       "charge_label": "Charge ($)",
       "charge_title": "Month over Month Total $t(group_by.values.{{groupBy}}) Charge",
-      "cluster_label": "Cluster",
       "cpu_capacity_label": "Capacity ({{date}})",
       "cpu_label": "Core-Hours",
       "cpu_limit_label": "Limity ({{date}})",
@@ -185,8 +185,7 @@
       "memory_title": "Month over Month Total $t(group_by.values.{{groupBy}}) CPU Usage, Request, Limit, and Capacity",
       "memory_usage_label": "Used ({{date}})",
       "modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Historical Data",
-      "project_title": "Top Projects",
-      "tags_label": "Tags"
+      "project_title": "Top Projects"
     },
     "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
     "increase_since_last_month": "{{value}} increase since last month",
@@ -197,6 +196,7 @@
       "charge_delta": "Sort by: Charges Delta",
       "name": "Sort by: Name"
     },
+    "tags_label": "Tags",
     "title": "OpenShift Charges",
     "total_charge": "Total Charge"
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -156,6 +156,7 @@
     "change_column_title": "Month Over Month Change",
     "charge_column_subtitle": " (Total {{total}})",
     "charge_column_title": "Charges",
+    "cluster_label": "Cluster",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
     "export_link": "Export",
@@ -170,7 +171,6 @@
     "historical": {
       "charge_label": "Charge ($)",
       "charge_title": "Month over Month Total $t(group_by.values.{{groupBy}}) Charge",
-      "cluster_label": "Cluster",
       "cpu_capacity_label": "Capacity ({{date}})",
       "cpu_label": "Core-Hours",
       "cpu_limit_label": "Limit ({{date}})",
@@ -185,8 +185,7 @@
       "memory_title": "Month over Month Total $t(group_by.values.{{groupBy}}) Memory Usage, Request, Limit, and Capacity",
       "memory_usage_label": "Used ({{date}})",
       "modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Historical Data",
-      "project_title": "Top Projects",
-      "tags_label": "Tags"
+      "project_title": "Top Projects"
     },
     "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
     "increase_since_last_month": "{{value}} increase since last month",
@@ -197,6 +196,7 @@
       "charge_delta": "Sort by: Charges Delta",
       "name": "Sort by: Name"
     },
+    "tags_label": "Tags",
     "title": "OpenShift Charges",
     "total_charge": "Total Charge"
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -156,6 +156,7 @@
     "change_column_title": "Month Over Month Change",
     "charge_column_subtitle": " (Total {{total}})",
     "charge_column_title": "Charges",
+    "cluster_label": "Cluster",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
     "export_link": "Export",
@@ -170,7 +171,6 @@
     "historical": {
       "charge_label": "Charge ($)",
       "charge_title": "Month over Month Total $t(group_by.values.{{groupBy}}) Charge",
-      "cluster_label": "Cluster",
       "cpu_capacity_label": "Capacity ({{date}})",
       "cpu_label": "Core-Hours",
       "cpu_limit_label": "Limity ({{date}})",
@@ -185,8 +185,7 @@
       "memory_title": "Month over Month Total $t(group_by.values.{{groupBy}}) CPU Usage, Request, Limit, and Capacity",
       "memory_usage_label": "Used ({{date}})",
       "modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Historical Data",
-      "project_title": "Top Projects",
-      "tags_label": "Tags"
+      "project_title": "Top Projects"
     },
     "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
     "increase_since_last_month": "{{value}} increase since last month",
@@ -197,6 +196,7 @@
       "charge_delta": "Sort by: Charges Delta",
       "name": "Sort by: Name"
     },
+    "tags_label": "Tags",
     "title": "OpenShift Charges",
     "total_charge": "Total Charge"
   },

--- a/src/pages/ocpDetails/detailsCluster.tsx
+++ b/src/pages/ocpDetails/detailsCluster.tsx
@@ -1,0 +1,99 @@
+import { FormGroup } from '@patternfly/react-core';
+import { OcpReport, OcpReportType } from 'api/ocpReports';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { ocpReportsActions, ocpReportsSelectors } from 'store/ocpReports';
+import { getComputedOcpReportItems } from 'utils/getComputedOcpReportItems';
+
+interface DetailsClusterOwnProps {
+  idKey: any;
+  label?: string;
+  queryString: string;
+}
+
+interface DetailsClusterStateProps {
+  report?: OcpReport;
+  reportFetchStatus?: FetchStatus;
+}
+
+interface DetailsClusterDispatchProps {
+  fetchReport?: typeof ocpReportsActions.fetchReport;
+}
+
+type DetailsClusterProps = DetailsClusterOwnProps &
+  DetailsClusterStateProps &
+  DetailsClusterDispatchProps &
+  InjectedTranslateProps;
+
+class DetailsClusterBase extends React.Component<DetailsClusterProps> {
+  public componentDidMount() {
+    const { report, queryString } = this.props;
+    if (!report) {
+      this.props.fetchReport(OcpReportType.charge, queryString);
+    }
+  }
+
+  public componentDidUpdate(prevProps: DetailsClusterProps) {
+    if (prevProps.queryString !== this.props.queryString) {
+      this.props.fetchReport(OcpReportType.charge, this.props.queryString);
+    }
+  }
+
+  private getItems() {
+    const { report, idKey } = this.props;
+
+    const computedItems = getComputedOcpReportItems({
+      report,
+      idKey,
+    } as any);
+
+    return computedItems;
+  }
+
+  public render() {
+    const { label } = this.props;
+    const items = this.getItems();
+    const clusterName = items && items.length ? items[0].label : '';
+
+    return (
+      <FormGroup label={label} fieldId="cluster-name">
+        <div>{clusterName}</div>
+      </FormGroup>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  DetailsClusterOwnProps,
+  DetailsClusterStateProps
+>((state, { queryString }) => {
+  const report = ocpReportsSelectors.selectReport(
+    state,
+    OcpReportType.charge,
+    queryString
+  );
+  const reportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
+    state,
+    OcpReportType.charge,
+    queryString
+  );
+  return {
+    report,
+    reportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: DetailsClusterDispatchProps = {
+  fetchReport: ocpReportsActions.fetchReport,
+};
+
+const DetailsCluster = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(DetailsClusterBase)
+);
+
+export { DetailsCluster, DetailsClusterBase, DetailsClusterProps };

--- a/src/pages/ocpDetails/detailsItem.tsx
+++ b/src/pages/ocpDetails/detailsItem.tsx
@@ -31,7 +31,7 @@ interface DetailsItemOwnProps {
   parentGroupBy: any;
   item: ComputedOcpReportItem;
   onCheckboxChange(checked: boolean, item: ComputedOcpReportItem);
-  onTagClicked(tag: string);
+  onTagClicked(key: string, value: string);
   selected: boolean;
 }
 
@@ -118,9 +118,9 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
     this.setState({ isHistoricalModalOpen: true });
   };
 
-  public handleTagClicked = (tag: string) => {
+  public handleTagClicked = (key: string, value: string) => {
     const { onTagClicked } = this.props;
-    onTagClicked(tag);
+    onTagClicked(key, value);
   };
 
   public render() {

--- a/src/pages/ocpDetails/detailsItem.tsx
+++ b/src/pages/ocpDetails/detailsItem.tsx
@@ -2,6 +2,7 @@ import {
   Button,
   ButtonType,
   ButtonVariant,
+  Form,
   Grid,
   GridItem,
 } from '@patternfly/react-core';
@@ -18,6 +19,7 @@ import { formatCurrency } from 'utils/formatValue';
 import { ComputedOcpReportItem } from 'utils/getComputedOcpReportItems';
 import { getTestProps, testIds } from '../../testIds';
 import { DetailsChart } from './detailsChart';
+import { DetailsCluster } from './detailsCluster';
 import { DetailsSummary } from './detailsSummary';
 import { DetailsTag } from './detailsTag';
 import { HistoricalModal } from './historicalModal';
@@ -29,6 +31,7 @@ interface DetailsItemOwnProps {
   parentGroupBy: any;
   item: ComputedOcpReportItem;
   onCheckboxChange(checked: boolean, item: ComputedOcpReportItem);
+  onTagClicked(tag: string);
   selected: boolean;
 }
 
@@ -113,6 +116,11 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
 
   public handleHistoricalModalOpen = () => {
     this.setState({ isHistoricalModalOpen: true });
+  };
+
+  public handleTagClicked = (tag: string) => {
+    const { onTagClicked } = this.props;
+    onTagClicked(tag);
   };
 
   public render() {
@@ -208,21 +216,29 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
           <GridItem lg={12} xl={5}>
             <div className={css(styles.projectsContainer)}>
               {Boolean(parentGroupBy === 'project') && (
-                <DetailsTag
-                  clusterLabel={t('ocp_details.historical.cluster_label')}
-                  idKey={'cluster'}
-                  queryString={this.getChargeQueryString('cluster')}
-                  tagsLabel={t('ocp_details.historical.tags_label')}
-                />
+                <Form>
+                  <DetailsCluster
+                    label={t('ocp_details.cluster_label')}
+                    idKey={'cluster'}
+                    queryString={this.getChargeQueryString('cluster')}
+                  />
+                  <DetailsTag
+                    label={t('ocp_details.tags_label')}
+                    project={item.label || item.id}
+                    onTagClicked={this.handleTagClicked}
+                  />
+                </Form>
               )}
               {Boolean(
                 parentGroupBy === 'cluster' || parentGroupBy === 'node'
               ) && (
-                <DetailsSummary
-                  idKey={'project'}
-                  queryString={this.getChargeQueryString('project')}
-                  title={t('ocp_details.historical.project_title')}
-                />
+                <div className={css(styles.summaryContainer)}>
+                  <DetailsSummary
+                    idKey={'project'}
+                    queryString={this.getChargeQueryString('project')}
+                    title={t('ocp_details.historical.project_title')}
+                  />
+                </div>
               )}
             </div>
           </GridItem>
@@ -234,7 +250,7 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
           <GridItem lg={12} xl={3}>
             <div className={css(styles.historicalLinkContainer)}>
               <Button
-                {...getTestProps(testIds.providers.add_btn)}
+                {...getTestProps(testIds.details.historical_data_btn)}
                 onClick={this.handleHistoricalModalOpen}
                 type={ButtonType.button}
                 variant={ButtonVariant.secondary}

--- a/src/pages/ocpDetails/detailsTag.tsx
+++ b/src/pages/ocpDetails/detailsTag.tsx
@@ -17,7 +17,7 @@ import { styles } from './ocpDetails.styles';
 
 interface DetailsTagOwnProps {
   label?: string;
-  onTagClicked(tag: string);
+  onTagClicked(key: string, value: string);
   project: string | number;
   queryString?: string;
 }
@@ -53,14 +53,14 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
     }
   }
 
-  public handleTagClicked = (tag: string) => {
+  public handleTagClicked = (key: string, value: string) => {
     const { onTagClicked } = this.props;
-    onTagClicked(tag);
+    onTagClicked(key, value);
   };
 
-  private getTags(): string[] {
+  private getTags(): any[] {
     const { report } = this.props;
-    return report ? (report.data as string[]) : undefined;
+    return report ? report.data : undefined;
   }
 
   public render() {
@@ -70,18 +70,20 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
     return (
       <FormGroup label={label} fieldId="tags">
         {Boolean(tags) &&
-          tags.map((tag, index) => (
-            <div className={css(styles.tagButton)} key={index}>
-              <Button
-                {...getTestProps(testIds.details.tag_btn)}
-                onClick={() => this.handleTagClicked(tag)}
-                type={ButtonType.button}
-                variant={ButtonVariant.secondary}
-              >
-                {tag}
-              </Button>
-            </div>
-          ))}
+          tags.map((tag, tagIndex) =>
+            tag.values.map((val, valIndex) => (
+              <div className={css(styles.tagButton)} key={valIndex}>
+                <Button
+                  {...getTestProps(testIds.details.tag_btn)}
+                  onClick={() => this.handleTagClicked(tag.key, val)}
+                  type={ButtonType.button}
+                  variant={ButtonVariant.secondary}
+                >
+                  {`${tag.key}: ${val}`}
+                </Button>
+              </div>
+            ))
+          )}
       </FormGroup>
     );
   }
@@ -94,8 +96,10 @@ const mapStateToProps = createMapStateToProps<
   const queryString = getQuery({
     filter: {
       project,
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
     },
-    key_only: true,
   });
   const report = ocpReportsSelectors.selectReport(
     state,

--- a/src/pages/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/ocpDetails/detailsToolbar.tsx
@@ -112,7 +112,7 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
     const { currentFilterType } = this.state;
     const filterLabel = this.getFilterLabel(field, value);
     return {
-      field: currentFilterType.id,
+      field: field === 'tag:app' ? field : currentFilterType.id,
       label: filterLabel,
       value,
     };

--- a/src/pages/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/ocpDetails/detailsToolbar.tsx
@@ -112,7 +112,7 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
     const { currentFilterType } = this.state;
     const filterLabel = this.getFilterLabel(field, value);
     return {
-      field: field === 'tag:app' ? field : currentFilterType.id,
+      field: field.indexOf('tag:') === 0 ? field : currentFilterType.id,
       label: filterLabel,
       value,
     };
@@ -125,8 +125,14 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
     } else {
       filterText = field;
     }
-    filterText =
-      filterText.charAt(0).toUpperCase() + filterText.slice(1) + ': ';
+
+    const index = filterText.indexOf('tag:');
+    if (index === 0) {
+      filterText = 'Tag: ' + filterText.slice(4) + ': ';
+    } else {
+      filterText =
+        filterText.charAt(0).toUpperCase() + filterText.slice(1) + ': ';
+    }
 
     if (value.filterCategory) {
       filterText += `${value.filterCategory.title ||

--- a/src/pages/ocpDetails/ocpDetails.styles.ts
+++ b/src/pages/ocpDetails/ocpDetails.styles.ts
@@ -91,7 +91,6 @@ export const styles = StyleSheet.create({
   },
   projectsContainer: {
     paddingTop: global_spacer_xl.value,
-    paddingRight: global_spacer_3xl.value,
   },
   projectsProgressBar: {
     paddingTop: global_spacer_md.value,
@@ -104,6 +103,12 @@ export const styles = StyleSheet.create({
   },
   descArrow: {
     bottom: global_spacer_xs.value,
+  },
+  summaryContainer: {
+    marginRight: global_spacer_3xl.value,
+  },
+  tagButton: {
+    paddingBottom: global_spacer_sm.value,
   },
 });
 

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -188,7 +188,13 @@ class OcpDetails extends React.Component<Props> {
 
   public onFilterRemoved(filterType: string, filterValue: string) {
     const { history, query } = this.props;
-    if (filterValue === '' || !Array.isArray(query.group_by[filterType])) {
+    if (filterType.indexOf('tag:') === 0) {
+      query.group_by[filterType] = undefined;
+    } else if (filterValue === '') {
+      query.group_by = {
+        [filterType]: '*',
+      };
+    } else if (!Array.isArray(query.group_by[filterType])) {
       query.group_by[filterType] = '*';
     } else {
       const index = query.group_by[filterType].indexOf(filterValue);

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -211,8 +211,8 @@ class OcpDetails extends React.Component<Props> {
     history.replace(filteredQuery);
   }
 
-  public onTagClicked = (tag: string) => {
-    this.onFilterAdded('tag:app', tag);
+  public onTagClicked = (key: string, value: string) => {
+    this.onFilterAdded(`tag:${key}`, value);
   };
 
   public updateReport = () => {

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -211,6 +211,10 @@ class OcpDetails extends React.Component<Props> {
     history.replace(filteredQuery);
   }
 
+  public onTagClicked = (tag: string) => {
+    this.onFilterAdded('tag:app', tag);
+  };
+
   public updateReport = () => {
     const { query, location, fetchReport, history, queryString } = this.props;
     if (!location.search) {
@@ -453,6 +457,7 @@ class OcpDetails extends React.Component<Props> {
                     parentGroupBy={groupById}
                     item={groupItem}
                     onCheckboxChange={this.onCheckboxChange}
+                    onTagClicked={this.onTagClicked}
                     selected={this.isSelected(groupItem)}
                   />
                 );

--- a/src/testIds.ts
+++ b/src/testIds.ts
@@ -2,6 +2,10 @@ export const testIdProp = 'data-testid';
 export const getTestProps = (id: string) => ({ [testIdProp]: id });
 
 export const testIds = {
+  details: {
+    historical_data_btn: 'historical-data-btn',
+    tag_btn: 'tag-btn',
+  },
   export: {
     cancel_btn: 'cancel-btn',
     submit_btn: 'submit-btn',

--- a/src/utils/getComputedOcpReportItems.ts
+++ b/src/utils/getComputedOcpReportItems.ts
@@ -4,6 +4,7 @@ import { Omit } from 'react-redux';
 import { sort, SortDirection } from './sort';
 
 export interface ComputedOcpReportItem {
+  app?: string;
   capacity?: number;
   charge: number;
   deltaPercent: number;
@@ -24,7 +25,7 @@ export interface GetComputedOcpReportItemsParams {
   sortDirection?: SortDirection;
 }
 
-const groups = ['clusters', 'nodes', 'projects'];
+const groups = ['apps', 'clusters', 'nodes', 'projects'];
 
 export function getComputedOcpReportItems({
   report,
@@ -74,6 +75,7 @@ export function getUnsortedComputedOcpReportItems({
         const usage = value.usage;
         if (!itemMap[id]) {
           itemMap[id] = {
+            app: value.app,
             capacity,
             charge,
             deltaPercent: value.delta_percent,


### PR DESCRIPTION
Adds tags to OCP details page for groupBy project. This also allows the user to filter by clicking on a tag.

Note that there are 20 tags for the "metering-koku" project. 

Fixes https://github.com/project-koku/koku-ui/issues/392

![screen shot 2019-01-08 at 10 36 12 pm](https://user-images.githubusercontent.com/17481322/50875358-f56b1000-1395-11e9-8af9-4473945f781b.png)
