### PR TITLE
Sort icon is not visible

### DIFF
--- a/src/pages/ocpDetails/ocpDetails.styles.ts
+++ b/src/pages/ocpDetails/ocpDetails.styles.ts
@@ -338,7 +338,6 @@ export const toolbarOverride = css`
 
   .btn-link .fa {
     font-size: ${global_FontSize_lg.value};
-    color: ${global_Color_100.value};
   }
 
   .pf-m-plain {


### PR DESCRIPTION
Ensured the sort icon is visible in the AWS/OCP detail pages by removing the white color property. It's possible that this was set to white due to the dark theme?

Fixes https://github.com/project-koku/koku-ui/issues/409