### PR TITLE
Fix cluster sort in OCP details

### DIFF
--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -273,7 +273,7 @@ class OcpDetails extends React.Component<Props> {
     if (groupById === 'cluster') {
       return [
         {
-          id: 'cluster_alias',
+          id: 'cluster',
           isNumeric: false,
           title: t('ocp_details.order.name'),
         },


### PR DESCRIPTION
Changed sort to use `cluster` instead of `cluster_alias` in OCP details.

Fixes https://github.com/project-koku/koku-ui/issues/411