### PR TITLE
Remove PF4 Dropdown onClick workaround

### DIFF
--- a/src/pages/awsDetails/awsDetails.tsx
+++ b/src/pages/awsDetails/awsDetails.tsx
@@ -348,7 +348,6 @@ class AwsDetails extends React.Component<Props> {
                 {t('group_by.cost')}:
               </label>
               <Dropdown
-                onClick={event => event.preventDefault()}
                 onSelect={this.handleGroupBySelect}
                 toggle={
                   <DropdownToggle onToggle={this.handleGroupByToggle}>
@@ -358,6 +357,7 @@ class AwsDetails extends React.Component<Props> {
                 isOpen={isGroupByOpen}
                 dropdownItems={groupByOptions.map(option => (
                   <DropdownItem
+                    component="button"
                     key={option.value}
                     onClick={event =>
                       this.handleGroupByItemClick(event, option.value)

--- a/src/pages/awsDetails/detailsToolbar.tsx
+++ b/src/pages/awsDetails/detailsToolbar.tsx
@@ -243,7 +243,6 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
         </Filter>
         <Sort>
           <Dropdown
-            onClick={event => event.preventDefault()}
             onSelect={this.handleSortBySelect}
             toggle={
               <DropdownToggle
@@ -256,6 +255,7 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
             isOpen={isSortByOpen}
             dropdownItems={sortFields.map(option => (
               <DropdownItem
+                component="button"
                 key={option.id}
                 onClick={event => this.updateCurrentSortType(event, option)}
               >

--- a/src/pages/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/ocpDetails/detailsToolbar.tsx
@@ -254,7 +254,6 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
         </Filter>
         <Sort>
           <Dropdown
-            onClick={event => event.preventDefault()}
             onSelect={this.handleSortBySelect}
             toggle={
               <DropdownToggle
@@ -267,6 +266,7 @@ export class DetailsToolbar extends React.Component<DetailsToolbarProps> {
             isOpen={isSortByOpen}
             dropdownItems={sortFields.map(option => (
               <DropdownItem
+                component="button"
                 key={option.id}
                 onClick={event => this.updateCurrentSortType(event, option)}
               >

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -358,7 +358,6 @@ class OcpDetails extends React.Component<Props> {
                 {t('group_by.charges')}:
               </label>
               <Dropdown
-                onClick={event => event.preventDefault()}
                 onSelect={this.handleGroupBySelect}
                 toggle={
                   <DropdownToggle onToggle={this.handleGroupByToggle}>
@@ -368,6 +367,7 @@ class OcpDetails extends React.Component<Props> {
                 isOpen={isGroupByOpen}
                 dropdownItems={groupByOptions.map(option => (
                   <DropdownItem
+                    component="button"
                     key={option.value}
                     onClick={event =>
                       this.handleGroupByItemClick(event, option.value)


### PR DESCRIPTION
This replaces the `onClick` workaround added to the PF4 Dropdown item, which prevents the page from auto-submitting when a menu item is selected. The PF4 fix is to add `component='button'` to the DropdownItem component.

See issue: https://github.com/patternfly/patternfly-react/issues/1194