### PR TITLE
OCP Details: Group by tag keys

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -65,6 +65,7 @@
     "charges": "Group charges by",
     "cost": "Group cost by",
     "label": "Group cost by",
+    "tag": "Tag Key: {{key}}",
     "top": "Top $t(group_by.values.{{groupBy}}, { 'count': 5 })",
     "values": {
       "account": "Account",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -65,6 +65,7 @@
     "charges": "Group charges by",
     "cost": "Group cost by",
     "label": "Group cost by",
+    "tag": "Tag Key: {{key}}",
     "top": "Top $t(group_by.values.{{groupBy}}, { 'count': 5 })",
     "values": {
       "account": "Account",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -65,6 +65,7 @@
     "charges": "Group charges by",
     "cost": "Group cost by",
     "label": "Group cost by",
+    "tag": "Tag Key: {{key}}",
     "top": "Top $t(group_by.values.{{groupBy}}, { 'count': 5 })",
     "values": {
       "account": "Account",

--- a/src/pages/awsDetails/groupBy.tsx
+++ b/src/pages/awsDetails/groupBy.tsx
@@ -1,0 +1,153 @@
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+  Title,
+} from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import { AwsQuery } from 'api/awsQuery';
+import { parseQuery } from 'api/awsQuery';
+import { AwsReport } from 'api/awsReports';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { awsReportsActions } from 'store/awsReports';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { GetComputedAwsReportItemsParams } from 'utils/getComputedAwsReportItems';
+import { getIdKeyForGroupBy } from 'utils/getComputedAwsReportItems';
+import { styles } from './awsDetails.styles';
+
+interface GroupByOwnProps {
+  onItemClicked(value: string);
+  queryString?: string;
+}
+
+interface GroupByStateProps {
+  report?: AwsReport;
+  reportFetchStatus?: FetchStatus;
+}
+
+interface GroupByDispatchProps {
+  fetchReport?: typeof awsReportsActions.fetchReport;
+}
+
+interface State {
+  isGroupByOpen: boolean;
+}
+
+type GroupByProps = GroupByOwnProps &
+  GroupByStateProps &
+  GroupByDispatchProps &
+  InjectedTranslateProps;
+
+const groupByOptions: {
+  label: string;
+  value: GetComputedAwsReportItemsParams['idKey'];
+}[] = [
+  { label: 'account', value: 'account' },
+  { label: 'service', value: 'service' },
+  { label: 'region', value: 'region' },
+];
+
+class GroupByBase extends React.Component<GroupByProps> {
+  protected defaultState: State = {
+    isGroupByOpen: false,
+  };
+  public state: State = { ...this.defaultState };
+
+  constructor(stateProps, dispatchProps) {
+    super(stateProps, dispatchProps);
+    this.handleGroupByClick = this.handleGroupByClick.bind(this);
+    this.handleGroupBySelect = this.handleGroupBySelect.bind(this);
+    this.handleGroupByToggle = this.handleGroupByToggle.bind(this);
+  }
+
+  public handleGroupByClick = (event, value) => {
+    const { onItemClicked } = this.props;
+    if (onItemClicked) {
+      onItemClicked(value);
+    }
+  };
+
+  public handleGroupBySelect = event => {
+    this.setState({
+      isGroupByOpen: !this.state.isGroupByOpen,
+    });
+  };
+
+  public handleGroupByToggle = isGroupByOpen => {
+    this.setState({
+      isGroupByOpen,
+    });
+  };
+
+  private getDropDownItems = () => {
+    const { t } = this.props;
+
+    return groupByOptions.map(option => (
+      <DropdownItem
+        component="button"
+        key={option.value}
+        onClick={event => this.handleGroupByClick(event, option.value)}
+      >
+        {t(`group_by.values.${option.label}`)}
+      </DropdownItem>
+    ));
+  };
+
+  private getGroupBy = () => {
+    const queryFromRoute = parseQuery<AwsQuery>(location.search);
+    return getIdKeyForGroupBy(queryFromRoute.group_by);
+  };
+
+  public render() {
+    const { t } = this.props;
+    const { isGroupByOpen } = this.state;
+    const groupBy = this.getGroupBy();
+
+    return (
+      <div>
+        <Title className={css(styles.title)} size="2xl">
+          {t('aws_details.title')}
+        </Title>
+        <div className={css(styles.groupBySelector)}>
+          <label className={css(styles.groupBySelectorLabel)}>
+            {t('group_by.charges')}:
+          </label>
+          <Dropdown
+            onSelect={this.handleGroupBySelect}
+            toggle={
+              <DropdownToggle onToggle={this.handleGroupByToggle}>
+                {t(`group_by.values.${groupBy}`)}
+              </DropdownToggle>
+            }
+            isOpen={isGroupByOpen}
+            dropdownItems={this.getDropDownItems()}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  GroupByOwnProps,
+  GroupByStateProps
+>(state => {
+  return {
+    // TBD...
+  };
+});
+
+const mapDispatchToProps: GroupByDispatchProps = {
+  fetchReport: awsReportsActions.fetchReport,
+};
+
+const GroupBy = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(GroupByBase)
+);
+
+export { GroupBy, GroupByBase, GroupByProps };

--- a/src/pages/ocpDetails/groupBy.tsx
+++ b/src/pages/ocpDetails/groupBy.tsx
@@ -1,0 +1,245 @@
+import {
+  Dropdown,
+  DropdownItem,
+  DropdownToggle,
+  Title,
+} from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import { getQuery, OcpQuery } from 'api/ocpQuery';
+import { parseQuery } from 'api/ocpQuery';
+import { OcpReport, OcpReportType } from 'api/ocpReports';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { ocpReportsActions, ocpReportsSelectors } from 'store/ocpReports';
+import { GetComputedOcpReportItemsParams } from 'utils/getComputedOcpReportItems';
+import { getIdKeyForGroupBy } from 'utils/getComputedOcpReportItems';
+import { styles } from './ocpDetails.styles';
+
+interface GroupByOwnProps {
+  onItemClicked(value: string);
+  queryString?: string;
+}
+
+interface GroupByStateProps {
+  report?: OcpReport;
+  reportFetchStatus?: FetchStatus;
+}
+
+interface GroupByDispatchProps {
+  fetchReport?: typeof ocpReportsActions.fetchReport;
+}
+
+interface State {
+  currentItem?: string;
+  isGroupByOpen: boolean;
+}
+
+type GroupByProps = GroupByOwnProps &
+  GroupByStateProps &
+  GroupByDispatchProps &
+  InjectedTranslateProps;
+
+const groupByOptions: {
+  label: string;
+  value: GetComputedOcpReportItemsParams['idKey'];
+}[] = [
+  { label: 'cluster', value: 'cluster' },
+  { label: 'node', value: 'node' },
+  { label: 'project', value: 'project' },
+];
+
+class GroupByBase extends React.Component<GroupByProps> {
+  protected defaultState: State = {
+    isGroupByOpen: false,
+  };
+  public state: State = { ...this.defaultState };
+
+  constructor(stateProps, dispatchProps) {
+    super(stateProps, dispatchProps);
+    this.handleGroupByClick = this.handleGroupByClick.bind(this);
+    this.handleGroupBySelect = this.handleGroupBySelect.bind(this);
+    this.handleGroupByToggle = this.handleGroupByToggle.bind(this);
+  }
+
+  public componentDidMount() {
+    const { queryString, report } = this.props;
+    if (!report) {
+      this.props.fetchReport(OcpReportType.tag, queryString);
+    }
+    this.setState({
+      currentItem: this.getGroupBy(),
+    });
+  }
+
+  public componentDidUpdate(prevProps: GroupByProps) {
+    if (prevProps.queryString !== this.props.queryString) {
+      this.props.fetchReport(OcpReportType.tag, this.props.queryString);
+    }
+
+    // Reset dropdown item if group_by[tag:xxx]=* is overridden in URL via a tag filter.
+    //
+    // Note: The group_by[tag:app]=hive tag filter overrides group_by[tag:app]=*, applied via the dropdown.
+    // When the group_by[tag:app]=hive tag filter is removed, the remaining dropdown item is no longer be valid.
+    const { currentItem } = this.state;
+    const queryFromRoute = parseQuery<OcpQuery>(location.search);
+    let found = false;
+
+    for (const key in queryFromRoute.group_by) {
+      if (
+        key &&
+        key.indexOf(currentItem) !== -1 &&
+        queryFromRoute.group_by[key] === '*'
+      ) {
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      this.setState({
+        currentItem: this.getGroupBy(),
+      });
+    }
+  }
+
+  public handleGroupByClick = (event, value) => {
+    const { onItemClicked } = this.props;
+    if (onItemClicked) {
+      this.setState({
+        currentItem: value,
+      });
+      onItemClicked(value);
+    }
+  };
+
+  public handleGroupBySelect = event => {
+    this.setState({
+      isGroupByOpen: !this.state.isGroupByOpen,
+    });
+  };
+
+  public handleGroupByToggle = isGroupByOpen => {
+    this.setState({
+      isGroupByOpen,
+    });
+  };
+
+  private getDropDownItems = () => {
+    const { t } = this.props;
+
+    return groupByOptions.map(option => (
+      <DropdownItem
+        component="button"
+        key={option.value}
+        onClick={event => this.handleGroupByClick(event, option.value)}
+      >
+        {t(`group_by.values.${option.label}`)}
+      </DropdownItem>
+    ));
+  };
+
+  private getDropDownTags = () => {
+    const { report, t } = this.props;
+
+    if (report && report.data) {
+      return report.data.map(val => (
+        <DropdownItem
+          component="button"
+          key={`tag:${val}`}
+          onClick={event => this.handleGroupByClick(event, `tag:${val}`)}
+        >
+          {t('group_by.tag', { key: val })}
+        </DropdownItem>
+      ));
+    } else {
+      return [];
+    }
+  };
+
+  private getGroupBy = () => {
+    const queryFromRoute = parseQuery<OcpQuery>(location.search);
+    return getIdKeyForGroupBy(queryFromRoute.group_by);
+  };
+
+  public render() {
+    const { t } = this.props;
+    const { currentItem, isGroupByOpen } = this.state;
+
+    const dropdownItems = [
+      ...this.getDropDownItems(),
+      ...this.getDropDownTags(),
+    ];
+
+    const index = currentItem ? currentItem.indexOf('tag:') : -1;
+    const label =
+      index !== -1
+        ? t('group_by.tag', { key: currentItem.slice(4) })
+        : t(`group_by.values.${currentItem}`);
+
+    return (
+      <div>
+        <Title className={css(styles.title)} size="2xl">
+          {t('ocp_details.title')}
+        </Title>
+        <div className={css(styles.groupBySelector)}>
+          <label className={css(styles.groupBySelectorLabel)}>
+            {t('group_by.charges')}:
+          </label>
+          <Dropdown
+            onSelect={this.handleGroupBySelect}
+            toggle={
+              <DropdownToggle onToggle={this.handleGroupByToggle}>
+                {label}
+              </DropdownToggle>
+            }
+            isOpen={isGroupByOpen}
+            dropdownItems={dropdownItems}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  GroupByOwnProps,
+  GroupByStateProps
+>(state => {
+  const queryString = getQuery({
+    filter: {
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
+    },
+    key_only: true,
+  });
+  const report = ocpReportsSelectors.selectReport(
+    state,
+    OcpReportType.tag,
+    queryString
+  );
+  const reportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
+    state,
+    OcpReportType.tag,
+    queryString
+  );
+  return {
+    queryString,
+    report,
+    reportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: GroupByDispatchProps = {
+  fetchReport: ocpReportsActions.fetchReport,
+};
+
+const GroupBy = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(GroupByBase)
+);
+
+export { GroupBy, GroupByBase, GroupByProps };


### PR DESCRIPTION
Added functionality to group by tag keys in OCP details page. Moved "group by" dropdown to its own component in order to add tag key support.

Note: https://github.com/project-koku/koku-ui/pull/430 and https://github.com/project-koku/koku-ui/pull/425 should be merged first.

Fixes https://github.com/project-koku/koku-ui/issues/400

Mocks:
https://redhat.invisionapp.com/share/HEO4ISHAT8Z#/screens/332238366

Screenshot:
<img width="1209" alt="screen shot 2019-01-22 at 10 22 58 pm" src="https://user-images.githubusercontent.com/17481322/51581583-a5607300-1e96-11e9-9b1c-ab6e823affc2.png">
