### PR TITLE
Add chart legend click to hide/show data

### DIFF
--- a/src/components/bulletChart/bulletChart.tsx
+++ b/src/components/bulletChart/bulletChart.tsx
@@ -29,10 +29,6 @@ class BulletChart extends React.Component<BulletChartProps, State> {
     width: 0,
   };
 
-  private handleResize = () => {
-    this.setState({ width: this.containerRef.current.clientWidth });
-  };
-
   public componentDidMount() {
     const node = this.containerRef.current;
     if (node) {
@@ -44,6 +40,10 @@ class BulletChart extends React.Component<BulletChartProps, State> {
   public componentWillUnmount() {
     window.removeEventListener('resize', this.handleResize);
   }
+
+  private handleResize = () => {
+    this.setState({ width: this.containerRef.current.clientWidth });
+  };
 
   public render() {
     const {

--- a/src/components/commonChart/chartUtils.ts
+++ b/src/components/commonChart/chartUtils.ts
@@ -25,6 +25,7 @@ export interface ChartDatum {
   y: number;
   key: string | number;
   name?: string | number;
+  show?: boolean;
   units: string;
 }
 

--- a/src/components/historicalUsageChart/__snapshots__/historicalUsageChart.test.tsx.snap
+++ b/src/components/historicalUsageChart/__snapshots__/historicalUsageChart.test.tsx.snap
@@ -7,7 +7,7 @@ Array [
     "name": "1-15-18",
     "units": "GB",
     "x": 15,
-    "y": 1,
+    "y": 0,
   },
 ]
 `;
@@ -15,8 +15,8 @@ Array [
 exports[`reports are formatted to datums: current month usage data 1`] = `
 Array [
   Object {
-    "key": "1-15-18",
-    "name": "1-15-18",
+    "key": "12-15-17",
+    "name": "12-15-17",
     "units": "GB",
     "x": 15,
     "y": 0,
@@ -27,8 +27,8 @@ Array [
 exports[`reports are formatted to datums: previous month request data 1`] = `
 Array [
   Object {
-    "key": "12-15-17",
-    "name": "12-15-17",
+    "key": "1-15-18",
+    "name": "1-15-18",
     "units": "GB",
     "x": 15,
     "y": 1,
@@ -43,7 +43,7 @@ Array [
     "name": "12-15-17",
     "units": "GB",
     "x": 15,
-    "y": 0,
+    "y": 1,
   },
 ]
 `;
@@ -51,8 +51,8 @@ Array [
 exports[`trend is a daily value: current month data 1`] = `
 Array [
   Object {
-    "key": "12-15-17",
-    "name": "12-15-17",
+    "key": "1-15-18",
+    "name": "1-15-18",
     "units": "GB",
     "x": 15,
     "y": 0,
@@ -63,8 +63,8 @@ Array [
 exports[`trend is a running total: current month data 1`] = `
 Array [
   Object {
-    "key": "12-15-17",
-    "name": "12-15-17",
+    "key": "1-15-18",
+    "name": "1-15-18",
     "units": "GB",
     "x": 15,
     "y": 0,

--- a/src/components/historicalUsageChart/historicalUsageChart.styles.ts
+++ b/src/components/historicalUsageChart/historicalUsageChart.styles.ts
@@ -33,19 +33,19 @@ export const chartStyles = {
   currentCapacityData: {
     data: {
       fill: 'none',
-      stroke: global_danger_color_200.value,
+      stroke: global_disabled_color_100.value,
     },
   } as VictoryStyleInterface,
   currentLimitData: {
     data: {
       fill: 'none',
-      stroke: global_danger_color_100.value,
+      stroke: global_danger_color_200.value,
     },
   } as VictoryStyleInterface,
   currentRequestData: {
     data: {
       fill: 'none',
-      stroke: global_warning_color_100.value,
+      stroke: global_warning_color_200.value,
     },
   } as VictoryStyleInterface,
   currentUsageData: {
@@ -61,25 +61,25 @@ export const chartStyles = {
   previousCapacityData: {
     data: {
       fill: 'none',
-      stroke: global_disabled_color_100.value,
+      stroke: global_disabled_color_200.value,
     },
   } as VictoryStyleInterface,
   previousLimitData: {
     data: {
       fill: 'none',
-      stroke: global_danger_color_200.value,
+      stroke: global_danger_color_100.value,
     },
   } as VictoryStyleInterface,
   previousRequestData: {
     data: {
       fill: 'none',
-      stroke: global_warning_color_200.value,
+      stroke: global_warning_color_100.value,
     },
   } as VictoryStyleInterface,
   previousUsageData: {
     data: {
       fill: 'none',
-      stroke: global_disabled_color_100.value,
+      stroke: global_success_color_100.value,
     },
   } as VictoryStyleInterface,
   usageColorScale: [

--- a/src/components/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/historicalUsageChart/historicalUsageChart.tsx
@@ -1,7 +1,7 @@
 import {
   Chart,
   ChartArea,
-  ChartLegend,
+  // ChartLegend,
   ChartTheme,
   ChartVoronoiContainer,
 } from '@patternfly/react-charts';
@@ -13,7 +13,7 @@ import {
 } from 'components/commonChart/chartUtils';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
-import { VictoryAxis } from 'victory';
+import { VictoryAxis, VictoryLegend, VictoryStyleInterface } from 'victory';
 import { chartStyles, styles } from './historicalUsageChart.styles';
 
 interface HistoricalUsageChartProps {
@@ -41,7 +41,34 @@ interface HistoricalUsageChartProps {
   yAxisLabel?: string;
 }
 
+interface HistoricalChartDatum {
+  data?: any;
+  show?: boolean;
+  style?: VictoryStyleInterface;
+}
+
+interface HistoricalNameDatum {
+  name: string;
+}
+
+interface HistoricalLegendDatum {
+  colorScale?: string[];
+  data?: HistoricalNameDatum[];
+  onClick?: (props) => void;
+}
+
+interface Data {
+  charts?: HistoricalChartDatum[];
+  legend?: HistoricalLegendDatum;
+}
+
 interface State {
+  datum?: {
+    capacity?: Data;
+    limit?: Data;
+    request?: Data;
+    usage?: Data;
+  };
   width: number;
 }
 
@@ -54,21 +81,289 @@ class HistoricalUsageChart extends React.Component<
     width: 0,
   };
 
-  public shouldComponentUpdate(nextProps: HistoricalUsageChartProps) {
-    if (
-      !nextProps.currentCapacityData ||
-      !nextProps.currentLimitData ||
-      !nextProps.currentRequestData ||
-      !nextProps.currentUsageData ||
-      !nextProps.previousCapacityData ||
-      !nextProps.previousLimitData ||
-      !nextProps.previousRequestData ||
-      !nextProps.previousUsageData
-    ) {
-      return false;
-    }
-    return true;
+  public componentDidMount() {
+    setTimeout(() => {
+      if (this.containerRef.current) {
+        this.setState({ width: this.containerRef.current.clientWidth });
+      }
+      window.addEventListener('resize', this.handleResize);
+    });
+    this.initDatum();
   }
+
+  public componentDidUpdate(prevProps: HistoricalUsageChartProps) {
+    if (
+      prevProps.currentCapacityData !== this.props.currentCapacityData ||
+      prevProps.currentLimitData !== this.props.currentLimitData ||
+      prevProps.currentRequestData !== this.props.currentRequestData ||
+      prevProps.currentUsageData !== this.props.currentUsageData ||
+      prevProps.previousCapacityData !== this.props.previousCapacityData ||
+      prevProps.previousLimitData !== this.props.previousLimitData ||
+      prevProps.previousRequestData !== this.props.previousRequestData ||
+      prevProps.previousUsageData !== this.props.previousUsageData
+    ) {
+      this.initDatum();
+    }
+  }
+
+  public componentWillUnmount() {
+    window.removeEventListener('resize', this.handleResize);
+  }
+
+  private initDatum = () => {
+    const {
+      currentCapacityData,
+      currentCapacityLabel,
+      currentLimitData,
+      currentLimitLabel,
+      currentRequestData,
+      currentRequestLabel,
+      currentUsageData,
+      currentUsageLabel,
+      previousCapacityData,
+      previousCapacityLabel,
+      previousLimitData,
+      previousLimitLabel,
+      previousRequestData,
+      previousRequestLabel,
+      previousUsageData,
+      previousUsageLabel,
+    } = this.props;
+
+    const capacityLegendData = [];
+    if (previousCapacityLabel) {
+      capacityLegendData.push({
+        name: previousCapacityLabel,
+      });
+    }
+    if (currentCapacityLabel) {
+      capacityLegendData.push({
+        name: currentCapacityLabel,
+      });
+    }
+    const capacity = {
+      charts: [
+        {
+          data: previousCapacityData,
+          show: true,
+          style: chartStyles.previousCapacityData,
+        },
+        {
+          data: currentCapacityData,
+          show: true,
+          style: chartStyles.currentCapacityData,
+        },
+      ],
+      legend: {
+        colorScale: chartStyles.capacityColorScale,
+        data: capacityLegendData,
+        onClick: this.handleCapacityLegendClick,
+      },
+    };
+
+    const limitLegendData = [];
+    if (previousLimitLabel) {
+      limitLegendData.push({
+        name: previousLimitLabel,
+      });
+    }
+    if (currentLimitLabel) {
+      limitLegendData.push({
+        name: currentLimitLabel,
+      });
+    }
+    const limit = {
+      charts: [
+        {
+          data: previousLimitData,
+          show: true,
+          style: chartStyles.previousLimitData,
+        },
+        {
+          data: currentLimitData,
+          show: true,
+          style: chartStyles.currentLimitData,
+        },
+      ],
+      legend: {
+        colorScale: chartStyles.limitColorScale,
+        data: limitLegendData,
+        onClick: this.handleLimitLegendClick,
+      },
+    };
+
+    const requestLegendData = [];
+    if (previousRequestLabel) {
+      requestLegendData.push({
+        name: previousRequestLabel,
+      });
+    }
+    if (currentRequestLabel) {
+      requestLegendData.push({
+        name: currentRequestLabel,
+      });
+    }
+    const request = {
+      charts: [
+        {
+          data: previousRequestData,
+          show: true,
+          style: chartStyles.previousRequestData,
+        },
+        {
+          data: currentRequestData,
+          show: true,
+          style: chartStyles.currentRequestData,
+        },
+      ],
+      legend: {
+        colorScale: chartStyles.requestColorScale,
+        data: requestLegendData,
+        onClick: this.handleRequestLegendClick,
+      },
+    };
+
+    const usageLegendData = [];
+    if (previousUsageLabel) {
+      usageLegendData.push({
+        name: previousUsageLabel,
+      });
+    }
+    if (currentUsageLabel) {
+      usageLegendData.push({
+        name: currentUsageLabel,
+      });
+    }
+    const usage = {
+      charts: [
+        {
+          data: previousUsageData,
+          show: true,
+          style: chartStyles.previousUsageData,
+        },
+        {
+          data: currentUsageData,
+          show: true,
+          style: chartStyles.currentUsageData,
+        },
+      ],
+      legend: {
+        colorScale: chartStyles.usageColorScale,
+        data: usageLegendData,
+        onClick: this.handleUsageLegendClick,
+      },
+    };
+
+    this.setState({
+      datum: {
+        capacity,
+        limit,
+        request,
+        usage,
+      },
+    });
+  };
+
+  private handleCapacityLegendClick = props => {
+    const { datum } = this.state;
+    const newDatum = { ...datum };
+
+    if (props.index >= 0 && newDatum.capacity.charts.length) {
+      newDatum.capacity.charts[props.index].show = !newDatum.capacity.charts[
+        props.index
+      ].show;
+      this.setState({ datum: newDatum });
+    }
+  };
+
+  private handleLimitLegendClick = props => {
+    const { datum } = this.state;
+    const newDatum = { ...datum };
+
+    if (props.index >= 0 && newDatum.limit.charts.length) {
+      newDatum.limit.charts[props.index].show = !newDatum.limit.charts[
+        props.index
+      ].show;
+      this.setState({ datum: newDatum });
+    }
+  };
+
+  private handleRequestLegendClick = props => {
+    const { datum } = this.state;
+    const newDatum = { ...datum };
+
+    if (props.index >= 0 && newDatum.request.charts.length) {
+      newDatum.request.charts[props.index].show = !newDatum.request.charts[
+        props.index
+      ].show;
+      this.setState({ datum: newDatum });
+    }
+  };
+
+  private handleResize = () => {
+    this.setState({ width: this.containerRef.current.clientWidth });
+  };
+
+  private handleUsageLegendClick = props => {
+    const { datum } = this.state;
+    const newDatum = { ...datum };
+
+    if (props.index >= 0 && newDatum.usage.charts.length) {
+      newDatum.usage.charts[props.index].show = !newDatum.usage.charts[
+        props.index
+      ].show;
+      this.setState({ datum: newDatum });
+    }
+  };
+
+  private getChart = (datum: HistoricalChartDatum, index: number) => {
+    if (datum.data && datum.data.length && datum.show) {
+      return (
+        <ChartArea
+          data={datum.data}
+          key={`historical-usage-chart-${index}`}
+          style={datum.style}
+        />
+      );
+    } else {
+      return null;
+    }
+  };
+
+  private getLegend = (datum: HistoricalLegendDatum, width: number) => {
+    if (datum && datum.data && datum.data.length) {
+      return (
+        <VictoryLegend
+          colorScale={datum.colorScale}
+          data={datum.data}
+          events={[
+            {
+              target: 'data',
+              eventHandlers: {
+                onClick: () => {
+                  return [
+                    {
+                      target: 'data',
+                      mutation: props => {
+                        datum.onClick(props);
+                        return null;
+                      },
+                    },
+                  ];
+                },
+              },
+            },
+          ]}
+          height={25}
+          orientation="vertical"
+          theme={ChartTheme.light.blue}
+          width={width}
+        />
+      );
+    } else {
+      return null;
+    }
+  };
 
   private getTooltipLabel = (datum: ChartDatum) => {
     const { formatDatumValue, formatDatumOptions } = this.props;
@@ -80,76 +375,10 @@ class HistoricalUsageChart extends React.Component<
     );
   };
 
-  private handleResize = () => {
-    this.setState({ width: this.containerRef.current.clientWidth });
-  };
-
-  public componentDidMount() {
-    setTimeout(() => {
-      this.setState({ width: this.containerRef.current.clientWidth });
-      window.addEventListener('resize', this.handleResize);
-    });
-  }
-
-  public componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
-  }
-
   public render() {
-    const {
-      currentCapacityData,
-      currentCapacityLabel,
-      currentLimitData,
-      currentLimitLabel,
-      currentRequestData,
-      currentRequestLabel,
-      currentUsageData,
-      currentUsageLabel,
-      height,
-      previousCapacityData,
-      previousCapacityLabel,
-      previousLimitData,
-      previousLimitLabel,
-      previousRequestData,
-      previousRequestLabel,
-      previousUsageData,
-      previousUsageLabel,
-      title,
-      xAxisLabel,
-      yAxisLabel,
-    } = this.props;
-    const { width } = this.state;
+    const { height, title, xAxisLabel, yAxisLabel } = this.props;
+    const { datum, width } = this.state;
     const legendWidth = width * 0.25;
-
-    const capacityLegendData = [];
-    const limitLegendData = [];
-    const usageLegendData = [];
-    const requestLegendData = [];
-
-    if (currentUsageData && currentUsageData.length) {
-      usageLegendData.push({ name: currentUsageLabel });
-    }
-    if (previousUsageData && previousUsageData.length) {
-      usageLegendData.push({ name: previousUsageLabel });
-    }
-    if (currentRequestData && currentRequestData.length) {
-      requestLegendData.push({ name: currentRequestLabel });
-    }
-    if (previousRequestData && previousRequestData.length) {
-      requestLegendData.push({ name: previousRequestLabel });
-    }
-    if (currentLimitData && currentLimitData.length) {
-      limitLegendData.push({ name: currentLimitLabel });
-    }
-    if (previousLimitData && previousLimitData.length) {
-      limitLegendData.push({ name: previousLimitLabel });
-    }
-    if (currentCapacityData && currentCapacityData.length) {
-      capacityLegendData.push({ name: currentCapacityLabel });
-    }
-    if (previousCapacityData && previousCapacityData.length) {
-      capacityLegendData.push({ name: previousCapacityLabel });
-    }
 
     const container = <ChartVoronoiContainer labels={this.getTooltipLabel} />;
 
@@ -157,54 +386,22 @@ class HistoricalUsageChart extends React.Component<
       <div className={css(styles.reportSummaryTrend)} ref={this.containerRef}>
         <span className={css(styles.title)}>{title}</span>
         <Chart containerComponent={container} height={height} width={width}>
-          {Boolean(currentCapacityData && currentCapacityData.length) && (
-            <ChartArea
-              style={chartStyles.currentCapacityData}
-              data={currentCapacityData}
-            />
-          )}
-          {Boolean(currentLimitData && currentLimitData.length) && (
-            <ChartArea
-              style={chartStyles.currentRequestData}
-              data={currentLimitData}
-            />
-          )}
-          {Boolean(currentRequestData && currentRequestData.length) && (
-            <ChartArea
-              style={chartStyles.currentRequestData}
-              data={currentRequestData}
-            />
-          )}
-          {Boolean(currentUsageData && currentUsageData.length) && (
-            <ChartArea
-              style={chartStyles.currentUsageData}
-              data={currentUsageData}
-            />
-          )}
-          {Boolean(previousCapacityData && previousCapacityData.length) && (
-            <ChartArea
-              style={chartStyles.previousCapacityData}
-              data={previousCapacityData}
-            />
-          )}
-          {Boolean(previousLimitData && currentLimitData.length) && (
-            <ChartArea
-              style={chartStyles.currentLimitData}
-              data={currentLimitData}
-            />
-          )}
-          {Boolean(previousRequestData && previousRequestData.length) && (
-            <ChartArea
-              style={chartStyles.previousRequestData}
-              data={previousRequestData}
-            />
-          )}
-          {Boolean(previousUsageData && previousUsageData.length) && (
-            <ChartArea
-              style={chartStyles.previousUsageData}
-              data={previousUsageData}
-            />
-          )}
+          {Boolean(datum && datum.capacity) &&
+            datum.capacity.charts.map((chart, index) => {
+              return this.getChart(chart, index);
+            })}
+          {Boolean(datum && datum.limit) &&
+            datum.limit.charts.map((chart, index) => {
+              return this.getChart(chart, index);
+            })}
+          {Boolean(datum && datum.request) &&
+            datum.request.charts.map((chart, index) => {
+              return this.getChart(chart, index);
+            })}
+          {Boolean(datum && datum.usage) &&
+            datum.usage.charts.map((chart, index) => {
+              return this.getChart(chart, index);
+            })}
           <VictoryAxis label={xAxisLabel} style={chartStyles.axis} />
           <VictoryAxis
             dependentAxis
@@ -213,45 +410,21 @@ class HistoricalUsageChart extends React.Component<
           />
         </Chart>
         <div className={css(styles.legendContainer)}>
-          {Boolean(usageLegendData && usageLegendData.length) && (
-            <ChartLegend
-              theme={ChartTheme.light.blue}
-              colorScale={chartStyles.usageColorScale}
-              data={usageLegendData}
-              height={25}
-              orientation="vertical"
-              width={legendWidth}
-            />
+          {this.getLegend(
+            datum && datum.usage ? datum.usage.legend : {},
+            legendWidth
           )}
-          {Boolean(requestLegendData && requestLegendData.length) && (
-            <ChartLegend
-              theme={ChartTheme.light.blue}
-              colorScale={chartStyles.requestColorScale}
-              data={requestLegendData}
-              height={25}
-              orientation="vertical"
-              width={legendWidth}
-            />
+          {this.getLegend(
+            datum && datum.request ? datum.request.legend : {},
+            legendWidth
           )}
-          {Boolean(limitLegendData && limitLegendData.length) && (
-            <ChartLegend
-              theme={ChartTheme.light.blue}
-              colorScale={chartStyles.limitColorScale}
-              data={limitLegendData}
-              height={25}
-              orientation="vertical"
-              width={legendWidth}
-            />
+          {this.getLegend(
+            datum && datum.limit ? datum.limit.legend : {},
+            legendWidth
           )}
-          {Boolean(capacityLegendData && capacityLegendData.length) && (
-            <ChartLegend
-              theme={ChartTheme.light.blue}
-              colorScale={chartStyles.capacityColorScale}
-              data={capacityLegendData}
-              height={25}
-              orientation="vertical"
-              width={legendWidth}
-            />
+          {this.getLegend(
+            datum && datum.capacity ? datum.capacity.legend : {},
+            legendWidth
           )}
         </div>
       </div>

--- a/src/components/usageChart/__snapshots__/usageChart.test.tsx.snap
+++ b/src/components/usageChart/__snapshots__/usageChart.test.tsx.snap
@@ -15,11 +15,11 @@ Array [
 exports[`reports are formatted to datums: current month usage data 1`] = `
 Array [
   Object {
-    "key": "1-15-18",
-    "name": "1-15-18",
+    "key": "12-15-17",
+    "name": "12-15-17",
     "units": "GB",
     "x": 15,
-    "y": 1,
+    "y": 0,
   },
 ]
 `;
@@ -27,11 +27,11 @@ Array [
 exports[`reports are formatted to datums: previous month request data 1`] = `
 Array [
   Object {
-    "key": "12-15-17",
-    "name": "12-15-17",
+    "key": "1-15-18",
+    "name": "1-15-18",
     "units": "GB",
     "x": 15,
-    "y": 0,
+    "y": 1,
   },
 ]
 `;
@@ -51,11 +51,11 @@ Array [
 exports[`trend is a daily value: current month data 1`] = `
 Array [
   Object {
-    "key": "12-15-17",
-    "name": "12-15-17",
+    "key": "1-15-18",
+    "name": "1-15-18",
     "units": "GB",
     "x": 15,
-    "y": 1,
+    "y": 0,
   },
 ]
 `;
@@ -63,11 +63,11 @@ Array [
 exports[`trend is a running total: current month data 1`] = `
 Array [
   Object {
-    "key": "12-15-17",
-    "name": "12-15-17",
+    "key": "1-15-18",
+    "name": "1-15-18",
     "units": "GB",
     "x": 15,
-    "y": 1,
+    "y": 0,
   },
 ]
 `;

--- a/src/components/usageChart/usageChart.styles.ts
+++ b/src/components/usageChart/usageChart.styles.ts
@@ -22,10 +22,6 @@ export const chartStyles = {
       fontSize: 0,
     },
   } as VictoryStyleInterface,
-  currentColorScale: [
-    global_success_color_100.value,
-    global_primary_color_100.value,
-  ],
   currentRequestData: {
     data: {
       fill: 'none',
@@ -38,10 +34,6 @@ export const chartStyles = {
       stroke: global_primary_color_100.value,
     },
   } as VictoryStyleInterface,
-  previousColorScale: [
-    global_warning_color_200.value,
-    global_warning_color_100.value,
-  ],
   previousRequestData: {
     data: {
       fill: 'none',
@@ -54,6 +46,14 @@ export const chartStyles = {
       stroke: global_success_color_100.value,
     },
   } as VictoryStyleInterface,
+  requestColorScale: [
+    global_warning_color_200.value,
+    global_warning_color_100.value,
+  ],
+  usageColorScale: [
+    global_success_color_100.value,
+    global_primary_color_100.value,
+  ],
 };
 
 export const styles = StyleSheet.create({

--- a/src/typings/victory.d.ts
+++ b/src/typings/victory.d.ts
@@ -1,0 +1,26 @@
+import * as React from 'react';
+import * as victory from 'victory';
+
+declare module 'victory' {
+  export interface VictoryLegendProps extends victory.VictoryLegendProps {
+    events?: victory.EventPropTypeInterface<
+      string,
+      victory.StringOrNumberOrCallback
+    >[];
+    title?: string | any[];
+  }
+
+  export interface VictoryVoronoiContainerProps
+    extends victory.VictoryCommonProps,
+      victory.VictoryContainerProps,
+      victory.VictoryLabableProps {
+    voronoiDimension: 'x' | 'y';
+    labels(datum: any): string;
+  }
+
+  export const VictoryLegend: React.ComponentClass<VictoryLegendProps>;
+
+  export const VictoryVoronoiContainer: React.ComponentClass<
+    VictoryVoronoiContainerProps
+  >;
+}


### PR DESCRIPTION
Added chart legend onClick functionality to hide/show individual pieces of data.

This adds a legend toggle to every chart in the Koku UI. For example, the trend and usage charts on the overview page. The history charts shown in the OCP details. And the pie chart for AWS details.

Also fixed some mismatched chart colors.

Fixes https://github.com/project-koku/koku-ui/issues/391

Screenshot of historical charts with several pieces of data turned off, making the data more readable.
![screen shot 2019-01-24 at 1 42 07 pm](https://user-images.githubusercontent.com/17481322/51700876-224a3480-1fde-11e9-83a8-c6e6fc71e036.png)
