### PR TITLE
Refactored charts per high fidelity mocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "typescript": "^2.8.1",
     "url-join": "^4.0.0",
     "url-loader": "^1.0.1",
+    "victory": "^30.1.0",
     "webpack": "^4.5.0",
     "webpack-cli": "^2.0.14",
     "webpack-log": "^2.0.0"

--- a/src/components/commonChart/__snapshots__/chartLegendItem.test.tsx.snap
+++ b/src/components/commonChart/__snapshots__/chartLegendItem.test.tsx.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`range is formated with start and end date 1`] = `"Jan 1 - 15"`;
+exports[`range is formated with start and end date 1`] = `""`;
 
 exports[`range is formated with start and end date for an empty report 1`] = `""`;

--- a/src/components/commonChart/chartUtils.ts
+++ b/src/components/commonChart/chartUtils.ts
@@ -126,11 +126,11 @@ export function getDatumDateRange(datums: ChartDatum[]): [Date, Date] {
   return [start, end];
 }
 
-export function getDateRangeString(
+export function getDateRange(
   datums: ChartDatum[],
   firstOfMonth: boolean = true,
   lastOfMonth: boolean = false
-) {
+): [Date, Date] {
   const [start, end] = getDatumDateRange(datums);
 
   // Show the date range we are trying to cover (i.e., days 1-30/31)
@@ -141,13 +141,44 @@ export function getDateRangeString(
     const lastDate = endOfMonth(start).getDate();
     end.setDate(lastDate);
   }
+  return [start, end];
+}
+
+export function getDateRangeString(
+  datums: ChartDatum[],
+  firstOfMonth: boolean = false,
+  lastOfMonth: boolean = false,
+  current: boolean = false
+) {
+  const [start, end] = getDateRange(datums, firstOfMonth, lastOfMonth);
 
   const monthName = format(start, 'MMM');
   const startDate = getDate(start);
   const endDate = getDate(end);
-  return `${monthName} ${getDate(start)}${
-    startDate !== endDate ? ` - ${endDate}` : ''
-  }`;
+
+  if (current) {
+    return i18next.t(`date.range_current`, {
+      date: getDateString(startDate),
+      month: startDate !== endDate ? monthName : '',
+    });
+  }
+  return i18next.t(`date.range_full`, {
+    endDate: getDateString(endDate),
+    startDate: getDateString(startDate),
+    month: startDate !== endDate ? monthName : '',
+  });
+}
+
+export function getMaxValue(datums: ChartDatum[]) {
+  let max = 0;
+  if (datums && datums.length) {
+    datums.forEach(datum => {
+      if (datum.y > max) {
+        max = datum.y;
+      }
+    });
+  }
+  return max;
 }
 
 export function getTooltipContent(formatValue) {
@@ -191,4 +222,16 @@ function isInt(n) {
 
 function isFloat(n) {
   return Number(n) === n && n % 1 !== 0;
+}
+
+function getDateString(date) {
+  const day = date % 10;
+  if (day === 1) {
+    return i18next.t(`date.first`, { date });
+  } else if (day === 2) {
+    return i18next.t(`date.second`, { date });
+  } else if (day === 3) {
+    return i18next.t(`date.third`, { date });
+  }
+  return i18next.t(`date.tenth`, { date });
 }

--- a/src/components/historicalTrendChart/historicalTrendChart.styles.ts
+++ b/src/components/historicalTrendChart/historicalTrendChart.styles.ts
@@ -1,8 +1,11 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
-  global_primary_color_100,
-  global_primary_color_200,
-  global_success_color_100,
+  global_disabled_color_200,
+  global_FontFamily_sans_serif,
+  global_FontSize_md,
+  global_spacer_lg,
+  global_spacer_sm,
+  global_spacer_xl,
 } from '@patternfly/react-tokens';
 import { VictoryStyleInterface } from 'victory';
 
@@ -21,29 +24,56 @@ export const chartStyles = {
       fontSize: 0,
     },
   } as VictoryStyleInterface,
-  colorScale: [global_success_color_100.value, global_primary_color_100.value],
+  // See: https://github.com/project-koku/koku-ui/issues/241
+  colorScale: [
+    global_disabled_color_200.value,
+    '#A2DA9C',
+    '#88D080',
+    '#6EC664',
+    '#519149',
+    '#3C6C37',
+  ],
+  legend: {
+    labels: {
+      fontFamily: global_FontFamily_sans_serif.value,
+      fontSize: 18,
+    },
+  },
   previousMonth: {
     data: {
       fill: 'none',
-      stroke: global_success_color_100.value,
+      stroke: global_disabled_color_200.value,
     },
   } as VictoryStyleInterface,
   currentMonth: {
     data: {
       fill: 'none',
-      stroke: global_primary_color_200.value,
+      stroke: '#A2DA9C',
     },
   } as VictoryStyleInterface,
 };
 
 export const styles = StyleSheet.create({
-  legendContainer: {
-    paddingTop: '10px',
+  chart: {
+    display: 'inline-block',
+    marginTop: global_spacer_lg.value,
+    width: '65%',
   },
-  reportSummaryTrend: {
+  chartContainer: {
     ':not(foo) svg': {
       overflow: 'visible',
     },
-    textAlign: 'center',
+  },
+  currentLegend: {
+    paddingTop: global_spacer_lg.value,
+  },
+  legend: {
+    display: 'inline-block',
+    fontSize: global_FontSize_md.value,
+    paddingLeft: global_spacer_xl.value,
+    width: '35%',
+  },
+  title: {
+    paddingLeft: global_spacer_sm.value,
   },
 });

--- a/src/components/historicalUsageChart/__snapshots__/historicalUsageChart.test.tsx.snap
+++ b/src/components/historicalUsageChart/__snapshots__/historicalUsageChart.test.tsx.snap
@@ -3,8 +3,8 @@
 exports[`reports are formatted to datums: current month request data 1`] = `
 Array [
   Object {
-    "key": "1-15-18",
-    "name": "1-15-18",
+    "key": "12-15-17",
+    "name": "12-15-17",
     "units": "GB",
     "x": 15,
     "y": 0,
@@ -19,7 +19,7 @@ Array [
     "name": "12-15-17",
     "units": "GB",
     "x": 15,
-    "y": 0,
+    "y": 1,
   },
 ]
 `;
@@ -31,7 +31,7 @@ Array [
     "name": "1-15-18",
     "units": "GB",
     "x": 15,
-    "y": 1,
+    "y": 0,
   },
 ]
 `;
@@ -39,8 +39,8 @@ Array [
 exports[`reports are formatted to datums: previous month usage data 1`] = `
 Array [
   Object {
-    "key": "12-15-17",
-    "name": "12-15-17",
+    "key": "1-15-18",
+    "name": "1-15-18",
     "units": "GB",
     "x": 15,
     "y": 1,
@@ -51,8 +51,8 @@ Array [
 exports[`trend is a daily value: current month data 1`] = `
 Array [
   Object {
-    "key": "1-15-18",
-    "name": "1-15-18",
+    "key": "12-15-17",
+    "name": "12-15-17",
     "units": "GB",
     "x": 15,
     "y": 0,
@@ -63,8 +63,8 @@ Array [
 exports[`trend is a running total: current month data 1`] = `
 Array [
   Object {
-    "key": "1-15-18",
-    "name": "1-15-18",
+    "key": "12-15-17",
+    "name": "12-15-17",
     "units": "GB",
     "x": 15,
     "y": 0,

--- a/src/components/historicalUsageChart/historicalUsageChart.styles.ts
+++ b/src/components/historicalUsageChart/historicalUsageChart.styles.ts
@@ -1,13 +1,10 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
-  global_danger_color_100,
-  global_danger_color_200,
-  global_disabled_color_100,
-  global_disabled_color_200,
-  global_primary_color_100,
-  global_success_color_100,
-  global_warning_color_100,
-  global_warning_color_200,
+  global_FontFamily_sans_serif,
+  global_FontSize_md,
+  global_spacer_lg,
+  global_spacer_sm,
+  global_spacer_xl,
 } from '@patternfly/react-tokens';
 import { VictoryStyleInterface } from 'victory';
 
@@ -26,81 +23,86 @@ export const chartStyles = {
       fontSize: 0,
     },
   } as VictoryStyleInterface,
-  capacityColorScale: [
-    global_disabled_color_200.value,
-    global_disabled_color_100.value,
-  ],
   currentCapacityData: {
     data: {
       fill: 'none',
-      stroke: global_disabled_color_100.value,
+      stroke: '#519149',
     },
   } as VictoryStyleInterface,
+  // See: https://github.com/project-koku/koku-ui/issues/241
+  currentColorScale: ['#A2DA9C', '#88D080', '#6EC664', '#519149', '#3C6C37'],
   currentLimitData: {
     data: {
       fill: 'none',
-      stroke: global_danger_color_200.value,
+      stroke: '#6EC664',
     },
   } as VictoryStyleInterface,
   currentRequestData: {
     data: {
       fill: 'none',
-      stroke: global_warning_color_200.value,
+      stroke: '#88D080',
+      strokeDasharray: '3,3',
     },
   } as VictoryStyleInterface,
   currentUsageData: {
     data: {
       fill: 'none',
-      stroke: global_primary_color_100.value,
+      stroke: '#A2DA9C',
     },
   } as VictoryStyleInterface,
-  limitColorScale: [
-    global_danger_color_100.value,
-    global_danger_color_200.value,
-  ],
+  legend: {
+    labels: {
+      fontFamily: global_FontFamily_sans_serif.value,
+      fontSize: 14,
+    },
+  },
   previousCapacityData: {
     data: {
       fill: 'none',
-      stroke: global_disabled_color_200.value,
+      stroke: '#00659C',
     },
   } as VictoryStyleInterface,
+  // See: https://github.com/project-koku/koku-ui/issues/241
+  previousColorScale: ['#7DC3E8', '#39A5DC', '#007BBA', '#00659C', '#004D76'],
   previousLimitData: {
     data: {
       fill: 'none',
-      stroke: global_danger_color_100.value,
+      stroke: '#007BBA',
     },
   } as VictoryStyleInterface,
   previousRequestData: {
     data: {
       fill: 'none',
-      stroke: global_warning_color_100.value,
+      stroke: '#39A5DC',
+      strokeDasharray: '3,3',
     },
   } as VictoryStyleInterface,
   previousUsageData: {
     data: {
       fill: 'none',
-      stroke: global_success_color_100.value,
+      stroke: '#7DC3E8',
     },
   } as VictoryStyleInterface,
-  usageColorScale: [
-    global_success_color_100.value,
-    global_primary_color_100.value,
-  ],
-  requestColorScale: [
-    global_warning_color_100.value,
-    global_warning_color_200.value,
-  ],
 };
 
 export const styles = StyleSheet.create({
-  legendContainer: {
-    display: 'flex',
-    marginTop: '20px',
+  chart: {
+    display: 'inline-block',
+    marginTop: global_spacer_lg.value,
+    width: '65%',
   },
-  reportSummaryTrend: {
+  chartContainer: {
     ':not(foo) svg': {
       overflow: 'visible',
     },
-    textAlign: 'center',
+  },
+  legend: {
+    display: 'inline-block',
+    fontSize: global_FontSize_md.value,
+    paddingLeft: global_spacer_xl.value,
+    width: '35%',
+  },
+  title: {
+    paddingLeft: global_spacer_sm.value,
   },
 });

--- a/src/components/ocpReportSummary/__snapshots__/ocpReportSummaryDetails.test.tsx.snap
+++ b/src/components/ocpReportSummary/__snapshots__/ocpReportSummaryDetails.test.tsx.snap
@@ -1,58 +1,73 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`defaults value if report is not present 1`] = `
-<div
-  className="css-1saiftj"
->
+<Fragment>
   <div
-    className="css-1a0izfs"
+    className="css-1br38yu"
   >
-    ----
     <div
-      className="css-5bzg50"
+      className="css-qvzirm"
     >
-      <div>
-        label
+      ----
+      <div
+        className="css-5bzg50"
+      >
+        <div>
+          label
+        </div>
       </div>
     </div>
   </div>
-</div>
+  <div
+    className="css-1br38yu"
+  />
+</Fragment>
 `;
 
 exports[`defaults value if report.total is not present 1`] = `
-<div
-  className="css-1saiftj"
->
+<Fragment>
   <div
-    className="css-1a0izfs"
+    className="css-1br38yu"
   >
-    ----
     <div
-      className="css-5bzg50"
+      className="css-qvzirm"
     >
-      <div>
-        label
+      ----
+      <div
+        className="css-5bzg50"
+      >
+        <div>
+          label
+        </div>
       </div>
     </div>
   </div>
-</div>
+  <div
+    className="css-1br38yu"
+  />
+</Fragment>
 `;
 
 exports[`report total is formated 1`] = `
-<div
-  className="css-1saiftj"
->
+<Fragment>
   <div
-    className="css-1a0izfs"
+    className="css-1br38yu"
   >
-    formatedValue
     <div
-      className="css-5bzg50"
+      className="css-qvzirm"
     >
-      <div>
-        label
+      formatedValue
+      <div
+        className="css-5bzg50"
+      >
+        <div>
+          label
+        </div>
       </div>
     </div>
   </div>
-</div>
+  <div
+    className="css-1br38yu"
+  />
+</Fragment>
 `;

--- a/src/components/ocpReportSummary/ocpReportSummaryDetails.styles.ts
+++ b/src/components/ocpReportSummary/ocpReportSummaryDetails.styles.ts
@@ -9,16 +9,8 @@ import {
 } from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
-  reportSummaryDetails: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    marginBottom: global_spacer_md.value,
-  },
-  value: {
-    display: 'flex',
-    color: global_Color_100.var,
-    fontSize: global_FontSize_4xl.value,
-    marginRight: global_spacer_sm.value,
+  requestedValue: {
+    marginLeft: global_spacer_sm.value,
   },
   text: {
     display: 'flex',
@@ -27,5 +19,19 @@ export const styles = StyleSheet.create({
     paddingBottom: 14,
     lineHeight: global_LineHeight_sm.value,
     fontSize: global_FontSize_xs.value,
+  },
+  titleContainer: {
+    display: 'inline-block',
+    marginBottom: global_spacer_md.value,
+    minWidth: '175px',
+    width: '50%',
+  },
+  usageText: {
+    marginRight: global_spacer_sm.value,
+  },
+  value: {
+    display: 'flex',
+    color: global_Color_100.var,
+    fontSize: global_FontSize_4xl.value,
   },
 });

--- a/src/components/ocpReportSummary/ocpReportSummaryDetails.tsx
+++ b/src/components/ocpReportSummary/ocpReportSummaryDetails.tsx
@@ -35,20 +35,24 @@ const OcpReportSummaryDetails: React.SFC<OcpReportSummaryDetailsProps> = ({
     }
   }
   return (
-    <div className={css(styles.reportSummaryDetails)}>
-      <div className={css(styles.value)}>
-        {value}
-        <div className={css(styles.text)}>
-          <div>{label}</div>
+    <>
+      <div className={css(styles.titleContainer)}>
+        <div className={css(styles.value)}>
+          {value}
+          <div className={css(styles.text)}>
+            <div>{label}</div>
+          </div>
         </div>
       </div>
-      {Boolean(reportType !== OcpReportType.charge) && (
-        <div className={css(styles.value)}>
-          {requestValue}
-          <div className={css(styles.text)}>{requestLabel}</div>
-        </div>
-      )}
-    </div>
+      <div className={css(styles.titleContainer)}>
+        {Boolean(reportType !== OcpReportType.charge) && (
+          <div className={css(styles.value, styles.requestedValue)}>
+            {requestValue}
+            <div className={css(styles.text)}>{requestLabel}</div>
+          </div>
+        )}
+      </div>
+    </>
   );
 };
 

--- a/src/components/pieChart/pieChart.styles.ts
+++ b/src/components/pieChart/pieChart.styles.ts
@@ -1,8 +1,13 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import { theme } from '../../styles/theme';
 
+export const chartStyles = {
+  // See: https://github.com/project-koku/koku-ui/issues/241
+  colorScale: ['#7DC3E8', '#39A5DC', '#007BBA', '#00659C', '#004D76'],
+};
+
 export const styles = StyleSheet.create({
-  chartInline: {
+  chartContainer: {
     [theme.page_breakpoint]: {
       display: 'inline-flex',
     },

--- a/src/components/pieChart/pieChart.tsx
+++ b/src/components/pieChart/pieChart.tsx
@@ -1,6 +1,6 @@
 import {
   ChartContainer,
-  // ChartLegend,
+  ChartLegend,
   ChartPie,
   ChartTheme,
 } from '@patternfly/react-charts';
@@ -9,8 +9,8 @@ import { ChartDatum } from 'components/commonChart';
 import { getTooltipLabel } from 'components/commonChart/chartUtils';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
-import { VictoryLegend, VictoryStyleInterface } from 'victory';
-import { styles } from './pieChart.styles';
+import { VictoryStyleInterface } from 'victory';
+import { chartStyles, styles } from './pieChart.styles';
 
 interface PieChartProps {
   data: any;
@@ -130,6 +130,7 @@ class PieChart extends React.Component<PieChartProps, State> {
     if (newData.length) {
       return (
         <ChartPie
+          colorScale={chartStyles.colorScale}
           containerComponent={<ChartContainer responsive={false} />}
           data={newData}
           height={height}
@@ -145,7 +146,8 @@ class PieChart extends React.Component<PieChartProps, State> {
   private getLegend = (datum: PieLegendDatum, width: number) => {
     if (datum && datum.data && datum.data.length) {
       return (
-        <VictoryLegend
+        <ChartLegend
+          colorScale={chartStyles.colorScale}
           containerComponent={<ChartContainer responsive={false} />}
           data={datum.data}
           events={[
@@ -193,7 +195,7 @@ class PieChart extends React.Component<PieChartProps, State> {
 
     return (
       <div ref={this.containerRef}>
-        <div className={css(styles.chartInline)}>
+        <div className={css(styles.chartContainer)}>
           {Boolean(datum && datum.cost && datum.cost.chart) &&
             this.getChart(datum.cost.chart)}
           {this.getLegend(datum && datum.cost ? datum.cost.legend : {}, width)}

--- a/src/components/trendChart/trendChart.styles.ts
+++ b/src/components/trendChart/trendChart.styles.ts
@@ -1,9 +1,9 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
-  global_primary_color_100,
-  global_primary_color_200,
-  global_success_color_100,
-  global_success_color_200,
+  global_disabled_color_200,
+  global_FontFamily_sans_serif,
+  global_FontSize_md,
+  global_spacer_lg,
 } from '@patternfly/react-tokens';
 import { VictoryStyleInterface } from 'victory';
 
@@ -22,25 +22,44 @@ export const chartStyles = {
       fontSize: 0,
     },
   } as VictoryStyleInterface,
-  colorScale: [global_success_color_100.value, global_primary_color_100.value],
+  // See: https://github.com/project-koku/koku-ui/issues/241
+  colorScale: [
+    global_disabled_color_200.value,
+    '#A2DA9C',
+    '#88D080',
+    '#6EC664',
+    '#519149',
+    '#3C6C37',
+  ],
+  legend: {
+    labels: {
+      fontFamily: global_FontFamily_sans_serif.value,
+      fontSize: 12,
+    },
+  },
   previousMonth: {
     data: {
-      fill: global_success_color_200.value,
-      stroke: global_success_color_100.value,
+      fill: 'none',
+      stroke: global_disabled_color_200.value,
     },
   } as VictoryStyleInterface,
   currentMonth: {
     data: {
-      fill: global_primary_color_100.value,
-      stroke: global_primary_color_200.value,
+      fill: 'none',
+      stroke: '#A2DA9C',
     },
   } as VictoryStyleInterface,
 };
 
 export const styles = StyleSheet.create({
-  reportSummaryTrend: {
+  chartContainer: {
     ':not(foo) svg': {
       overflow: 'visible',
     },
+  },
+  legend: {
+    display: 'inline-block',
+    fontSize: global_FontSize_md.value,
+    marginBottom: global_spacer_lg.value,
   },
 });

--- a/src/components/trendChart/trendChart.tsx
+++ b/src/components/trendChart/trendChart.tsx
@@ -1,7 +1,8 @@
 import {
   Chart,
   ChartArea,
-  // ChartLegend,
+  ChartContainer,
+  ChartLegend,
   ChartTheme,
   ChartVoronoiContainer,
 } from '@patternfly/react-charts';
@@ -9,12 +10,13 @@ import { css } from '@patternfly/react-styles';
 import {
   ChartDatum,
   getDateRangeString,
+  getMaxValue,
   getTooltipContent,
   getTooltipLabel,
 } from 'components/commonChart/chartUtils';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
-import { VictoryAxis, VictoryLegend, VictoryStyleInterface } from 'victory';
+import { DomainTuple, VictoryAxis, VictoryStyleInterface } from 'victory';
 import { chartStyles, styles } from './trendChart.styles';
 
 interface TrendChartProps {
@@ -33,13 +35,14 @@ interface TrendChartDatum {
 }
 
 interface TrendNameDatum {
-  name: string;
+  name?: string;
 }
 
 interface TrendLegendDatum {
   colorScale?: string[];
   data?: TrendNameDatum[];
   onClick?: (props) => void;
+  title?: string;
 }
 
 interface Data {
@@ -84,17 +87,23 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   }
 
   private initDatum = () => {
-    const { currentData, previousData } = this.props;
+    const { currentData, previousData, title } = this.props;
 
     const legendData = [];
     if (previousData && previousData.length) {
       legendData.push({
         name: getDateRangeString(previousData, true, true),
+        symbol: {
+          type: 'minus',
+        },
       });
     }
     if (currentData && currentData.length) {
       legendData.push({
-        name: getDateRangeString(currentData),
+        name: getDateRangeString(currentData, true, false, true),
+        symbol: {
+          type: 'minus',
+        },
       });
     }
     const cost = {
@@ -114,6 +123,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         colorScale: chartStyles.colorScale,
         data: legendData,
         onClick: this.handleCostLegendClick,
+        title,
       },
     };
 
@@ -137,7 +147,9 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   };
 
   private handleResize = () => {
-    this.setState({ width: this.containerRef.current.clientWidth });
+    if (this.containerRef.current) {
+      this.setState({ width: this.containerRef.current.clientWidth });
+    }
   };
 
   private getChart = (datum: TrendChartDatum, index: number) => {
@@ -154,13 +166,27 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     }
   };
 
-  private getLegend = (datum: TrendLegendDatum, width: number) => {
-    const { title } = this.props;
+  private getDomain() {
+    const { currentData, previousData } = this.props;
+    const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
 
+    const maxCurrent = currentData ? getMaxValue(currentData) : 0;
+    const maxPrevious = previousData ? getMaxValue(previousData) : 0;
+    const maxValue = Math.max(maxCurrent, maxPrevious);
+    const max = maxValue > 0 ? Math.ceil(maxValue + maxValue * 0.1) : 0;
+
+    if (max > 0) {
+      domain.y = [0, max];
+    }
+    return domain;
+  }
+
+  private getLegend = (datum: TrendLegendDatum, width: number) => {
     if (datum && datum.data && datum.data.length) {
       return (
-        <VictoryLegend
+        <ChartLegend
           colorScale={datum.colorScale}
+          containerComponent={<ChartContainer responsive={false} />}
           data={datum.data}
           events={[
             {
@@ -180,9 +206,11 @@ class TrendChart extends React.Component<TrendChartProps, State> {
               },
             },
           ]}
+          gutter={5}
           height={50}
+          orientation={width > 150 ? 'horizontal' : 'vertical'}
+          style={chartStyles.legend}
           theme={ChartTheme.light.blue}
-          title={title}
           width={width}
         />
       );
@@ -201,25 +229,55 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     );
   };
 
+  private isLegendVisible() {
+    const { datum } = this.state;
+
+    let result = false;
+    if (datum && datum.cost.legend && datum.cost.legend.data) {
+      datum.cost.legend.data.forEach(item => {
+        if (item.name && item.name.trim() !== '') {
+          result = true;
+          return;
+        }
+      });
+    }
+    return result;
+  }
+
   public render() {
     const { height } = this.props;
     const { datum, width } = this.state;
 
     const container = <ChartVoronoiContainer labels={this.getTooltipLabel} />;
+    const legendWidth =
+      styles.legend.minWidth > width / 2
+        ? styles.legendContainer.minWidth
+        : width / 2;
+    const domain = this.getDomain();
 
     return (
-      <div className={css(styles.reportSummaryTrend)} ref={this.containerRef}>
-        <div>
-          <Chart containerComponent={container} height={height} width={width}>
-            {Boolean(datum && datum.cost) &&
-              datum.cost.charts.map((chart, index) => {
-                return this.getChart(chart, index);
-              })}
-            <VictoryAxis style={chartStyles.axis} />
-            <VictoryAxis dependentAxis style={chartStyles.axis} />
-          </Chart>
-        </div>
-        {this.getLegend(datum && datum.cost ? datum.cost.legend : {}, width)}
+      <div className={css(styles.chartContainer)} ref={this.containerRef}>
+        <Chart
+          containerComponent={container}
+          domain={domain}
+          height={height}
+          width={width}
+        >
+          {Boolean(datum && datum.cost) &&
+            datum.cost.charts.map((chart, index) => {
+              return this.getChart(chart, index);
+            })}
+          <VictoryAxis style={chartStyles.axis} />
+          <VictoryAxis dependentAxis style={chartStyles.axis} />
+        </Chart>
+        {Boolean(this.isLegendVisible()) && (
+          <div className={css(styles.legend)}>
+            {Boolean(datum.cost.legend.title) && (
+              <div>{datum.cost.legend.title}</div>
+            )}
+            {this.getLegend(datum.cost.legend, legendWidth)}
+          </div>
+        )}
       </div>
     );
   }

--- a/src/components/usageChart/__snapshots__/usageChart.test.tsx.snap
+++ b/src/components/usageChart/__snapshots__/usageChart.test.tsx.snap
@@ -3,8 +3,8 @@
 exports[`reports are formatted to datums: current month request data 1`] = `
 Array [
   Object {
-    "key": "1-15-18",
-    "name": "1-15-18",
+    "key": "12-15-17",
+    "name": "12-15-17",
     "units": "GB",
     "x": 15,
     "y": 0,
@@ -19,7 +19,7 @@ Array [
     "name": "12-15-17",
     "units": "GB",
     "x": 15,
-    "y": 0,
+    "y": 1,
   },
 ]
 `;
@@ -31,7 +31,7 @@ Array [
     "name": "1-15-18",
     "units": "GB",
     "x": 15,
-    "y": 1,
+    "y": 0,
   },
 ]
 `;
@@ -39,8 +39,8 @@ Array [
 exports[`reports are formatted to datums: previous month usage data 1`] = `
 Array [
   Object {
-    "key": "12-15-17",
-    "name": "12-15-17",
+    "key": "1-15-18",
+    "name": "1-15-18",
     "units": "GB",
     "x": 15,
     "y": 1,
@@ -51,8 +51,8 @@ Array [
 exports[`trend is a daily value: current month data 1`] = `
 Array [
   Object {
-    "key": "1-15-18",
-    "name": "1-15-18",
+    "key": "12-15-17",
+    "name": "12-15-17",
     "units": "GB",
     "x": 15,
     "y": 0,
@@ -63,8 +63,8 @@ Array [
 exports[`trend is a running total: current month data 1`] = `
 Array [
   Object {
-    "key": "1-15-18",
-    "name": "1-15-18",
+    "key": "12-15-17",
+    "name": "12-15-17",
     "units": "GB",
     "x": 15,
     "y": 0,

--- a/src/components/usageChart/usageChart.styles.ts
+++ b/src/components/usageChart/usageChart.styles.ts
@@ -1,9 +1,10 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
-  global_primary_color_100,
-  global_success_color_100,
-  global_warning_color_100,
-  global_warning_color_200,
+  global_disabled_color_100,
+  global_disabled_color_200,
+  global_FontFamily_sans_serif,
+  global_FontSize_md,
+  global_spacer_lg,
 } from '@patternfly/react-tokens';
 import { VictoryStyleInterface } from 'victory';
 
@@ -25,41 +26,55 @@ export const chartStyles = {
   currentRequestData: {
     data: {
       fill: 'none',
-      stroke: global_warning_color_100.value,
+      stroke: '#88D080',
+      strokeDasharray: '3,3',
     },
   } as VictoryStyleInterface,
   currentUsageData: {
     data: {
       fill: 'none',
-      stroke: global_primary_color_100.value,
+      stroke: '#A2DA9C',
     },
   } as VictoryStyleInterface,
+  legend: {
+    labels: {
+      fontFamily: global_FontFamily_sans_serif.value,
+      fontSize: 12,
+    },
+  },
   previousRequestData: {
     data: {
       fill: 'none',
-      stroke: global_warning_color_200.value,
+      stroke: global_disabled_color_200.value,
+      strokeDasharray: '3,3',
     },
   } as VictoryStyleInterface,
   previousUsageData: {
     data: {
       fill: 'none',
-      stroke: global_success_color_100.value,
+      stroke: global_disabled_color_200.value,
     },
   } as VictoryStyleInterface,
-  requestColorScale: [
-    global_warning_color_200.value,
-    global_warning_color_100.value,
-  ],
-  usageColorScale: [
-    global_success_color_100.value,
-    global_primary_color_100.value,
+  // See: https://github.com/project-koku/koku-ui/issues/241
+  currentColorScale: ['#A2DA9C', '#88D080', '#6EC664', '#519149', '#3C6C37'],
+  // TBD: No grey scale, yet
+  previousColorScale: [
+    global_disabled_color_200.value,
+    global_disabled_color_100.value,
   ],
 };
 
 export const styles = StyleSheet.create({
-  reportSummaryTrend: {
+  chartContainer: {
     ':not(foo) svg': {
       overflow: 'visible',
     },
+  },
+  legend: {
+    display: 'inline-block',
+    fontSize: global_FontSize_md.value,
+    marginBottom: global_spacer_lg.value,
+    minWidth: '175px',
+    width: '50%',
   },
 });

--- a/src/components/usageChart/usageChart.test.tsx
+++ b/src/components/usageChart/usageChart.test.tsx
@@ -48,7 +48,6 @@ const props: UsageChartProps = {
   formatDatumOptions: {},
   previousRequestData,
   previousUsageData,
-  title: 'Usage Title',
 };
 
 test('reports are formatted to datums', () => {

--- a/src/components/victory/path-helpers.ts
+++ b/src/components/victory/path-helpers.ts
@@ -1,0 +1,43 @@
+// import pathHelpers from 'victory-core/src/victory-primitives/path-helpers';
+
+// Todo: Move this functionality to PF4 react-charts package
+export default {
+  // Todo: Our jest config fails to process the import in path-helpers
+  // ...pathHelpers,
+  dash(x, y, size) {
+    const baseSize = 1.1 * size;
+    const lineHeight = baseSize - baseSize * 0.3;
+    const x0 = x - baseSize;
+    const y1 = y + lineHeight / 2;
+    const distance = (x + baseSize - x0) * 0.3;
+    const padding = distance / 3;
+    return `M ${x0}, ${y1}
+      h${distance}
+      v-${lineHeight}
+      h-${distance}
+      z
+      M ${x0 + distance + padding}, ${y1}
+      h${distance}
+      v-${lineHeight}
+      h-${distance}
+      z
+      M ${x0 + distance * 2 + padding * 2}, ${y1}
+      h${distance}
+      v-${lineHeight}
+      h-${distance}
+      z`;
+  },
+
+  minus(x, y, size) {
+    const baseSize = 1.1 * size;
+    const lineHeight = baseSize - baseSize * 0.3;
+    const x0 = x - baseSize;
+    const y1 = y + lineHeight / 2;
+    const distance = x + baseSize - x0;
+    return `M ${x0}, ${y1}
+      h${distance}
+      v-${lineHeight}
+      h-${distance}
+      z`;
+  },
+};

--- a/src/components/victory/victoryPoint.tsx
+++ b/src/components/victory/victoryPoint.tsx
@@ -1,0 +1,31 @@
+import PropTypes from 'prop-types';
+import { Point } from 'victory';
+import pathHelpers from './path-helpers';
+
+// Todo: Move this functionality to PF4 react-charts package
+class VictoryPoint extends Point {
+  public static propTypes = {
+    ...Point.propTypes,
+    symbol: PropTypes.oneOfType([
+      PropTypes.oneOf([
+        // Todo: Not importing all due to jest issue
+        // 'circle',
+        // 'diamond',
+        // 'plus',
+        'minus',
+        // 'square',
+        // 'star',
+        // 'triangleDown',
+        // 'triangleUp',
+        'dash',
+      ]),
+      PropTypes.func,
+    ]),
+  };
+
+  public getPath(props) {
+    return pathHelpers[`${props.symbol}`](props.x, props.y, props.size);
+  }
+}
+
+export default VictoryPoint;

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -49,7 +49,21 @@
     "title": "Cloud (AWS) Cost",
     "total_cost": "Total Cost"
   },
+  "chart": {
+    "capacity": "Capacity",
+    "limit": "Limit",
+    "requested": "Requested",
+    "used": "Used"
+  },
   "dashboard": "Dashboard",
+  "date": {
+    "first": "{{date}}st",
+    "range_current": "{{month}} {{date}} - Current",
+    "range_full": "{{month}} {{startDate}} - {{endDate}}",
+    "second": "{{date}}nd",
+    "tenth": "{{date}}th",
+    "third": "{{date}}rd"
+  },
   "export": {
     "aggregate_type": "Select aggregate type",
     "cancel": "Cancel",
@@ -119,12 +133,16 @@
     "charge_detail_label": "Total Charge",
     "charge_title": "OpenShift Total Charge",
     "charge_trend_title": "Month to Month Daily Charge Comparison",
+    "cpu_current_title": "{{date}} - Current",
+    "cpu_previous_title": "{{startDate}} - {{endDate}}",
     "cpu_request_label": "Core-Hours Requested",
     "cpu_requested_label": "{{date}} Requested",
     "cpu_title": "OpenShift CPU Usage & Request",
     "cpu_usage_label": "Core-Hours Used",
     "cpu_used_label": "{{date}} Used",
     "empty_state_title": "Add an AWS Account",
+    "memory_current_title": "{{date}} - Current",
+    "memory_previous_title": "{{startDate}} - {{endDate}}",
     "memory_request_label": "GB-Hours Requested",
     "memory_requested_label": "{{date}} Requested",
     "memory_title": "OpenShift Memory Usage & Request",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -49,7 +49,21 @@
     "title": "Cloud (AWS) Cost",
     "total_cost": "Total Cost"
   },
+  "chart": {
+    "capacity": "Capacity",
+    "limit": "Limit",
+    "requested": "Requested",
+    "used": "Used"
+  },
   "dashboard": "Dashboard",
+  "date": {
+    "first": "{{date}}st",
+    "range_current": "{{month}} {{date}} - Current",
+    "range_full": "{{month}} {{startDate}} - {{endDate}}",
+    "second": "{{date}}nd",
+    "tenth": "{{date}}th",
+    "third": "{{date}}rd"
+  },
   "export": {
     "aggregate_type": "Select aggregate type",
     "cancel": "Cancel",
@@ -119,14 +133,18 @@
     "charge_detail_label": "Total Charge",
     "charge_title": "OpenShift Total Charge",
     "charge_trend_title": "Month to Month Daily Charge Comparison",
+    "cpu_current_title": "{{date}} - Current",
+    "cpu_previous_title": "{{startDate}} - {{endDate}}",
     "cpu_request_label": "Core-Hours Requested",
     "cpu_requested_label": "{{date}} Requested",
     "cpu_title": "OpenShift CPU Usage & Request",
     "cpu_usage_label": "Core-Hours Used",
     "cpu_used_label": "{{date}} Used",
     "empty_state_title": "Add an AWS Account",
+    "memory_current_title": "{{date}} - Current",
+    "memory_previous_title": "{{startDate}} - {{endDate}}",
     "memory_request_label": "GB-Hours Requested",
-    "memory_requested_label": "{{date}} Requested",
+    "memory_requested_label": "Requested",
     "memory_title": "OpenShift Memory Usage & Request",
     "memory_usage_label": "GB-Hours Used",
     "memory_used_label": "{{date}} Used",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -49,7 +49,21 @@
     "title": "Cloud (AWS) Cost",
     "total_cost": "Total Cost"
   },
+  "chart": {
+    "capacity": "Capacity",
+    "limit": "Limit",
+    "requested": "Requested",
+    "used": "Used"
+  },
   "dashboard": "Dashboard",
+  "date": {
+    "first": "{{date}}st",
+    "range_current": "{{month}} {{date}} - Current",
+    "range_full": "{{month}} {{startDate}} - {{endDate}}",
+    "second": "{{date}}nd",
+    "tenth": "{{date}}th",
+    "third": "{{date}}rd"
+  },
   "export": {
     "aggregate_type": "Select aggregate type",
     "cancel": "Cancel",
@@ -119,12 +133,16 @@
     "charge_detail_label": "Total Charge",
     "charge_title": "OpenShift Total Charge",
     "charge_trend_title": "Month to Month Daily Charge Comparison",
+    "cpu_current_title": "{{date}} - Current",
+    "cpu_previous_title": "{{startDate}} - {{endDate}}",
     "cpu_request_label": "Core-Hours Requested",
     "cpu_requested_label": "{{date}} Requested",
     "cpu_title": "OpenShift CPU Usage & Request",
     "cpu_usage_label": "Core-Hours Used",
     "cpu_used_label": "{{date}} Used",
     "empty_state_title": "Add an AWS Account",
+    "memory_current_title": "{{date}} - Current",
+    "memory_previous_title": "{{startDate}} - {{endDate}}",
     "memory_request_label": "GB-Hours Requested",
     "memory_requested_label": "{{date}} Requested",
     "memory_title": "OpenShift Memory Usage & Request",

--- a/src/pages/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/pages/ocpDashboard/ocpDashboardWidget.tsx
@@ -1,9 +1,6 @@
 import { getQuery, OcpQuery, parseQuery } from 'api/ocpQuery';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
-import {
-  getDateRangeString,
-  transformOcpReport,
-} from 'components/commonChart/chartUtils';
+import { transformOcpReport } from 'components/commonChart/chartUtils';
 import { Link } from 'components/link';
 import {
   OcpReportSummary,
@@ -192,19 +189,6 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
         ? transformOcpReport(previous, trend.type, 'date', 'request')
         : undefined;
 
-    const currentRequestLabel = t(trend.currentRequestLabelKey, {
-      date: getDateRangeString(currentRequestData),
-    });
-    const currentUsageLabel = t(trend.currentUsageLabelKey, {
-      date: getDateRangeString(currentUsageData),
-    });
-    const previousRequestLabel = t(trend.previousRequestLabelKey, {
-      date: getDateRangeString(previousRequestData, true, true),
-    });
-    const previousUsageLabel = t(trend.previousUsageLabel, {
-      date: getDateRangeString(previousUsageData, true, true),
-    });
-
     return (
       <OcpReportSummary
         title={title}
@@ -231,15 +215,11 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
         ) : (
           <OcpReportSummaryUsage
             currentRequestData={currentRequestData}
-            currentRequestLabel={currentRequestLabel}
             currentUsageData={currentUsageData}
-            currentUsageLabel={currentUsageLabel}
             formatDatumValue={formatValue}
             formatDatumOptions={trend.formatOptions}
             previousRequestData={previousRequestData}
-            previousRequestLabel={previousRequestLabel}
             previousUsageData={previousUsageData}
-            previousUsageLabel={previousUsageLabel}
           />
         )}
         <Tabs

--- a/src/pages/ocpDetails/detailsItem.tsx
+++ b/src/pages/ocpDetails/detailsItem.tsx
@@ -261,16 +261,8 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
           </GridItem>
         </Grid>
         <HistoricalModal
-          chargeTitle={t('ocp_details.historical.charge_title', {
-            groupBy: parentGroupBy,
-          })}
-          cpuTitle={t('ocp_details.historical.cpu_title', {
-            groupBy: parentGroupBy,
-          })}
           currentQueryString={this.getQueryString(false, true)}
-          memoryTitle={t('ocp_details.historical.memory_title', {
-            groupBy: parentGroupBy,
-          })}
+          groupBy={parentGroupBy}
           isOpen={isHistoricalModalOpen}
           onClose={this.handleHistoricalModalClose}
           previousQueryString={this.getQueryString(false, false)}

--- a/src/pages/ocpDetails/historicalChart.styles.ts
+++ b/src/pages/ocpDetails/historicalChart.styles.ts
@@ -1,16 +1,21 @@
 import { StyleSheet } from '@patternfly/react-styles';
+import {
+  global_spacer_3xl,
+  global_spacer_lg,
+  global_spacer_sm,
+} from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
   chartContainer: {
-    marginLeft: '25px',
+    marginLeft: global_spacer_lg.value,
   },
   chargeChart: {
-    marginTop: '15px',
+    marginTop: global_spacer_sm.value,
   },
   cpuChart: {
-    marginTop: '5px',
+    marginTop: global_spacer_3xl.value,
   },
   memoryChart: {
-    marginTop: '60px',
+    marginTop: global_spacer_3xl.value,
   },
 });

--- a/src/pages/ocpDetails/historicalChart.tsx
+++ b/src/pages/ocpDetails/historicalChart.tsx
@@ -2,7 +2,6 @@ import { css } from '@patternfly/react-styles';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
 import {
   ChartType,
-  getDateRangeString,
   transformOcpReport,
 } from 'components/commonChart/chartUtils';
 import { HistoricalTrendChart } from 'components/historicalTrendChart';
@@ -17,17 +16,9 @@ import { formatValue } from 'utils/formatValue';
 import { styles } from './historicalChart.styles';
 
 interface HistoricalModalOwnProps {
-  chargeTitle?: string;
-  cpuTitle?: string;
   currentQueryString: string;
-  memoryTitle?: string;
+  groupBy: string;
   previousQueryString: string;
-  xAxisChargeLabel?: string;
-  xAxisCpuLabel?: string;
-  xAxisMemoryLabel?: string;
-  yAxisChargeLabel?: string;
-  yAxisCpuLabel?: string;
-  yAxisMemoryLabel?: string;
 }
 
 interface HistoricalModalStateProps {
@@ -118,22 +109,14 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
 
   public render() {
     const {
-      chargeTitle,
-      cpuTitle,
       currentChargeReport,
       currentCpuReport,
       currentMemoryReport,
-      memoryTitle,
+      groupBy,
       previousChargeReport,
       previousCpuReport,
       previousMemoryReport,
       t,
-      xAxisChargeLabel,
-      xAxisCpuLabel,
-      xAxisMemoryLabel,
-      yAxisChargeLabel,
-      yAxisCpuLabel,
-      yAxisMemoryLabel,
     } = this.props;
 
     // Charge data
@@ -200,46 +183,6 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
       'usage'
     );
 
-    // Current labels
-    const currentCpuCapacityLabel = t(
-      'ocp_details.historical.cpu_capacity_label',
-      {
-        date: getDateRangeString(currentChargeData),
-      }
-    );
-    const currentCpuLimitLabel = t('ocp_details.historical.cpu_limit_label', {
-      date: getDateRangeString(currentChargeData),
-    });
-    const currentCpuRequestLabel = t(
-      'ocp_details.historical.cpu_requested_label',
-      {
-        date: getDateRangeString(currentChargeData),
-      }
-    );
-    const currentCpuUsageLabel = t('ocp_details.historical.cpu_usage_label', {
-      date: getDateRangeString(currentChargeData),
-    });
-
-    // Previous labels
-    const previousCpuCapacityLabel = t(
-      'ocp_details.historical.cpu_capacity_label',
-      {
-        date: getDateRangeString(previousChargeData),
-      }
-    );
-    const previousCpuLimitLabel = t('ocp_details.historical.cpu_limit_label', {
-      date: getDateRangeString(previousChargeData),
-    });
-    const previousCpuRequestLabel = t(
-      'ocp_details.historical.cpu_requested_label',
-      {
-        date: getDateRangeString(previousChargeData),
-      }
-    );
-    const previousCpuUsageLabel = t('ocp_details.historical.cpu_usage_label', {
-      date: getDateRangeString(previousChargeData),
-    });
-
     // Memory data
     const currentMemoryCapacityData = transformOcpReport(
       currentMemoryReport,
@@ -290,120 +233,56 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
       'usage'
     );
 
-    // Memory labels
-    const currentMemoryCapacityLabel = t(
-      'ocp_details.historical.memory_capacity_label',
-      {
-        date: getDateRangeString(currentChargeData),
-      }
-    );
-    const currentMemoryLimitLabel = t(
-      'ocp_details.historical.memory_limit_label',
-      {
-        date: getDateRangeString(currentChargeData),
-      }
-    );
-    const currentMemoryRequestLabel = t(
-      'ocp_details.historical.memory_requested_label',
-      {
-        date: getDateRangeString(currentChargeData),
-      }
-    );
-    const currentMemoryUsageLabel = t(
-      'ocp_details.historical.memory_usage_label',
-      {
-        date: getDateRangeString(currentChargeData),
-      }
-    );
-    const previousMemoryCapacityLabel = t(
-      'ocp_details.historical.memory_capacity_label',
-      {
-        date: getDateRangeString(currentChargeData),
-      }
-    );
-    const previousMemoryLimitLabel = t(
-      'ocp_details.historical.memory_limit_label',
-      {
-        date: getDateRangeString(currentChargeData),
-      }
-    );
-    const previousMemoryRequestLabel = t(
-      'ocp_details.historical.memory_requested_label',
-      {
-        date: getDateRangeString(previousChargeData),
-      }
-    );
-    const previousMemoryUsageLabel = t(
-      'ocp_details.historical.memory_usage_label',
-      {
-        date: getDateRangeString(previousChargeData),
-      }
-    );
+    const chartHeight = 145;
 
     return (
       <div className={css(styles.chartContainer)}>
         <div className={css(styles.chargeChart)}>
           <HistoricalTrendChart
-            height={75}
+            height={chartHeight}
             currentData={currentChargeData}
             formatDatumValue={formatValue}
             formatDatumOptions={{}}
             previousData={previousChargeData}
-            title={chargeTitle}
-            xAxisLabel={xAxisChargeLabel}
-            yAxisLabel={yAxisChargeLabel}
+            title={t('ocp_details.historical.charge_title', { groupBy })}
+            xAxisLabel={t('ocp_details.historical.day_of_month_label')}
+            yAxisLabel={t('ocp_details.historical.charge_label')}
           />
         </div>
         <div className={css(styles.cpuChart)}>
           <HistoricalUsageChart
             currentCapacityData={currentCpuCapacityData}
-            currentCapacityLabel={currentCpuCapacityLabel}
             currentLimitData={currentCpuLimitData}
-            currentLimitLabel={currentCpuLimitLabel}
             currentRequestData={currentCpuRequestData}
-            currentRequestLabel={currentCpuRequestLabel}
             currentUsageData={currentCpuUsageData}
-            currentUsageLabel={currentCpuUsageLabel}
             formatDatumValue={formatValue}
             formatDatumOptions={{}}
-            height={75}
+            height={chartHeight}
             previousCapacityData={previousCpuCapacityData}
-            previousCapacityLabel={previousCpuCapacityLabel}
             previousLimitData={previousCpuLimitData}
-            previousLimitLabel={previousCpuLimitLabel}
             previousRequestData={previousCpuRequestData}
-            previousRequestLabel={previousCpuRequestLabel}
             previousUsageData={previousCpuUsageData}
-            previousUsageLabel={previousCpuUsageLabel}
-            title={cpuTitle}
-            xAxisLabel={xAxisCpuLabel}
-            yAxisLabel={yAxisCpuLabel}
+            title={t('ocp_details.historical.cpu_title', { groupBy })}
+            xAxisLabel={t('ocp_details.historical.day_of_month_label')}
+            yAxisLabel={t('ocp_details.historical.cpu_label')}
           />
         </div>
         <div className={css(styles.memoryChart)}>
           <HistoricalUsageChart
             currentCapacityData={currentMemoryCapacityData}
-            currentCapacityLabel={currentMemoryCapacityLabel}
             currentLimitData={currentMemoryLimitData}
-            currentLimitLabel={currentMemoryLimitLabel}
             currentRequestData={currentMemoryRequestData}
-            currentRequestLabel={currentMemoryRequestLabel}
             currentUsageData={currentMemoryUsageData}
-            currentUsageLabel={currentMemoryUsageLabel}
             formatDatumValue={formatValue}
             formatDatumOptions={{}}
-            height={75}
+            height={chartHeight}
             previousCapacityData={previousMemoryCapacityData}
-            previousCapacityLabel={previousMemoryCapacityLabel}
             previousLimitData={previousMemoryLimitData}
-            previousLimitLabel={previousMemoryLimitLabel}
             previousRequestData={previousMemoryRequestData}
-            previousRequestLabel={previousMemoryRequestLabel}
             previousUsageData={previousMemoryUsageData}
-            previousUsageLabel={previousMemoryUsageLabel}
-            title={memoryTitle}
-            xAxisLabel={xAxisMemoryLabel}
-            yAxisLabel={yAxisMemoryLabel}
+            title={t('ocp_details.historical.memory_title', { groupBy })}
+            xAxisLabel={t('ocp_details.historical.day_of_month_label')}
+            yAxisLabel={t('ocp_details.historical.memory_label')}
           />
         </div>
       </div>

--- a/src/pages/ocpDetails/historicalModal.styles.ts
+++ b/src/pages/ocpDetails/historicalModal.styles.ts
@@ -7,8 +7,8 @@ export const styles = StyleSheet.create({
     // Workaround for PatternFly setting Grid color property
     color: global_Color_100.value,
     // Workaround for isLarge not working properly
-    height: '700px',
-    width: '800px',
+    height: '900px',
+    width: '1200px',
   },
 });
 

--- a/src/pages/ocpDetails/historicalModal.tsx
+++ b/src/pages/ocpDetails/historicalModal.tsx
@@ -12,6 +12,7 @@ interface HistoricalModalOwnProps {
   chargeTitle?: string;
   cpuTitle?: string;
   currentQueryString: string;
+  groupBy: string;
   memoryTitle?: string;
   isOpen: boolean;
   onClose(isOpen: boolean);
@@ -34,14 +35,11 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
 
   public render() {
     const {
-      chargeTitle,
-      cpuTitle,
       currentQueryString,
-      memoryTitle,
+      groupBy,
       isOpen,
       previousQueryString,
       title,
-      t,
     } = this.props;
 
     return (
@@ -53,17 +51,9 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
         title={title}
       >
         <HistoricalChart
-          chargeTitle={chargeTitle}
-          cpuTitle={cpuTitle}
           currentQueryString={currentQueryString}
-          memoryTitle={memoryTitle}
+          groupBy={groupBy}
           previousQueryString={previousQueryString}
-          xAxisChargeLabel={t('ocp_details.historical.day_of_month_label')}
-          xAxisCpuLabel={t('ocp_details.historical.day_of_month_label')}
-          xAxisMemoryLabel={t('ocp_details.historical.day_of_month_label')}
-          yAxisChargeLabel={t('ocp_details.historical.charge_label')}
-          yAxisCpuLabel={t('ocp_details.historical.cpu_label')}
-          yAxisMemoryLabel={t('ocp_details.historical.memory_label')}
         />
       </Modal>
     );

--- a/src/store/ocpDashboard/ocpDashboardCommon.ts
+++ b/src/store/ocpDashboard/ocpDashboardCommon.ts
@@ -37,9 +37,11 @@ export interface OcpDashboardWidget {
   };
   trend: {
     currentRequestLabelKey?: string;
+    currentTitleKey?: string;
     currentUsageLabelKey?: string;
     formatOptions: ValueFormatOptions;
     previousRequestLabelKey?: string;
+    previousTitleKey?: string;
     previousUsageLabel?: string;
     titleKey?: string;
     type: ChartType;

--- a/src/store/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/ocpDashboard/ocpDashboardWidgets.ts
@@ -39,11 +39,13 @@ export const cpuWidget: OcpDashboardWidget = {
   },
   trend: {
     currentRequestLabelKey: 'ocp_dashboard.cpu_requested_label',
+    currentTitleKey: 'ocp_dashboard.cpu_current_title',
     currentUsageLabelKey: 'ocp_dashboard.cpu_used_label',
     formatOptions: {
       fractionDigits: 2,
     },
     previousRequestLabelKey: 'ocp_dashboard.cpu_requested_label',
+    previousTitleKey: 'ocp_dashboard.cpu_previous_title',
     previousUsageLabel: 'ocp_dashboard.cpu_used_label',
     type: ChartType.daily,
   },
@@ -67,11 +69,13 @@ export const memoryWidget: OcpDashboardWidget = {
   },
   trend: {
     currentRequestLabelKey: 'ocp_dashboard.memory_requested_label',
+    currentTitleKey: 'ocp_dashboard.memory_current_title',
     currentUsageLabelKey: 'ocp_dashboard.memory_used_label',
     formatOptions: {
       fractionDigits: 2,
     },
     previousRequestLabelKey: 'ocp_dashboard.memory_requested_label',
+    previousTitleKey: 'ocp_dashboard.memory_previous_title',
     previousUsageLabel: 'ocp_dashboard.memory_used_label',
     type: ChartType.daily,
   },

--- a/src/typings/victory.d.ts
+++ b/src/typings/victory.d.ts
@@ -23,4 +23,6 @@ declare module 'victory' {
   export const VictoryVoronoiContainer: React.ComponentClass<
     VictoryVoronoiContainerProps
   >;
+
+  export const Point: React.ComponentClass;
 }


### PR DESCRIPTION
Refactored charts per high fidelity mocks, including:

- Added dashed lines for requested data
- Created a custom Victory legend symbol to match dashed lines
- Modified trend, usage, & historical chart and legend layouts
- Updated colors per the PF4 chart color pallet, including the pie chart

Overview mock: https://redhat.invisionapp.com/share/ENPJQTBXTAC#/screens/336412759
Historical mock: https://redhat.invisionapp.com/share/ENPJQTBXTAC#/screens/337919659

Fixes https://github.com/project-koku/koku-ui/issues/241
Fixes https://github.com/project-koku/koku-ui/issues/397
Fixes https://github.com/project-koku/koku-ui/issues/396
Fixes https://github.com/project-koku/koku-ui/issues/390
Fixes https://github.com/project-koku/koku-ui/issues/387
Fixes https://github.com/project-koku/koku-ui/issues/386

Historical charts:
<img width="1121" alt="screen shot 2019-01-30 at 3 31 58 pm" src="https://user-images.githubusercontent.com/17481322/52061678-e0b90c80-253c-11e9-82da-d187365c2314.png">

OCP Overview charts:
<img width="1390" alt="screen shot 2019-01-30 at 3 33 18 pm" src="https://user-images.githubusercontent.com/17481322/52061707-f0385580-253c-11e9-9aba-d7cc1c015b99.png">

AWS Overview charts:
<img width="1390" alt="screen shot 2019-01-30 at 3 52 17 pm" src="https://user-images.githubusercontent.com/17481322/52061726-faf2ea80-253c-11e9-9b72-79f78b07c000.png">

Pie chart color pallet:
<img width="570" alt="screen shot 2019-01-30 at 3 32 23 pm" src="https://user-images.githubusercontent.com/17481322/52061849-4b6a4800-253d-11e9-9a65-27f445f21165.png">
