### PR TITLE
Added tic labels to charts

### DIFF
--- a/src/components/historicalTrendChart/historicalTrendChart.styles.ts
+++ b/src/components/historicalTrendChart/historicalTrendChart.styles.ts
@@ -10,20 +10,6 @@ import {
 import { VictoryStyleInterface } from 'victory';
 
 export const chartStyles = {
-  axis: {
-    axisLabel: {
-      padding: 15,
-    },
-    grid: {
-      stroke: 'none',
-    },
-    ticks: {
-      stroke: 'none',
-    },
-    tickLabels: {
-      fontSize: 0,
-    },
-  } as VictoryStyleInterface,
   // See: https://github.com/project-koku/koku-ui/issues/241
   colorScale: [
     global_disabled_color_200.value,
@@ -51,13 +37,38 @@ export const chartStyles = {
       stroke: '#A2DA9C',
     },
   } as VictoryStyleInterface,
+  yAxis: {
+    axisLabel: {
+      padding: 15,
+    },
+    grid: {
+      stroke: 'none',
+    },
+    ticks: {
+      stroke: 'none',
+    },
+    tickLabels: {
+      fontSize: 0,
+    },
+  } as VictoryStyleInterface,
+  xAxis: {
+    axisLabel: {
+      padding: 40,
+    },
+    grid: {
+      stroke: 'none',
+    },
+    ticks: {
+      stroke: 'none',
+    },
+  } as VictoryStyleInterface,
 };
 
 export const styles = StyleSheet.create({
   chart: {
     display: 'inline-block',
     marginTop: global_spacer_lg.value,
-    width: '65%',
+    width: '60%',
   },
   chartContainer: {
     ':not(foo) svg': {
@@ -71,7 +82,7 @@ export const styles = StyleSheet.create({
     display: 'inline-block',
     fontSize: global_FontSize_md.value,
     paddingLeft: global_spacer_xl.value,
-    width: '35%',
+    width: '40%',
   },
   title: {
     paddingLeft: global_spacer_sm.value,

--- a/src/components/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/historicalTrendChart/historicalTrendChart.tsx
@@ -13,9 +13,11 @@ import {
   getTooltipContent,
   getTooltipLabel,
 } from 'components/commonChart/chartUtils';
+import getDate from 'date-fns/get_date';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
 import { DomainTuple, VictoryAxis, VictoryStyleInterface } from 'victory';
+import { getDateRange } from '../commonChart/chartUtils';
 import { chartStyles, styles } from './historicalTrendChart.styles';
 
 interface HistoricalTrendChartProps {
@@ -183,6 +185,20 @@ class HistoricalTrendChart extends React.Component<
     return domain;
   }
 
+  private getEndDate() {
+    const { currentData, previousData } = this.props;
+    const previousDate = previousData
+      ? getDate(getDateRange(previousData, true, true)[1])
+      : 0;
+    const currentDate = currentData
+      ? getDate(getDateRange(currentData, true, true)[1])
+      : 0;
+
+    return currentDate > 0 || previousDate > 0
+      ? Math.max(currentDate, previousDate)
+      : 31;
+  }
+
   private getLegend = (datum: HistoricalLegendDatum, width: number) => {
     if (datum && datum.data && datum.data.length) {
       return (
@@ -253,6 +269,9 @@ class HistoricalTrendChart extends React.Component<
     const chartWidth = width * 0.65;
     const legendWidth = width * 0.35;
 
+    const endDate = this.getEndDate();
+    const midDate = Math.floor(endDate / 2);
+
     return (
       <div className={css(styles.chartContainer)} ref={this.containerRef}>
         <div className={css(styles.title)}>{title}</div>
@@ -270,7 +289,7 @@ class HistoricalTrendChart extends React.Component<
             <VictoryAxis
               label={xAxisLabel}
               style={chartStyles.xAxis}
-              tickValues={[1, 15, 31]}
+              tickValues={[1, midDate, endDate]}
             />
             <VictoryAxis
               dependentAxis

--- a/src/components/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/historicalTrendChart/historicalTrendChart.tsx
@@ -267,11 +267,15 @@ class HistoricalTrendChart extends React.Component<
               datum.cost.charts.map((chart, index) => {
                 return this.getChart(chart, index);
               })}
-            <VictoryAxis label={xAxisLabel} style={chartStyles.axis} />
+            <VictoryAxis
+              label={xAxisLabel}
+              style={chartStyles.xAxis}
+              tickValues={[1, 15, 31]}
+            />
             <VictoryAxis
               dependentAxis
               label={yAxisLabel}
-              style={chartStyles.axis}
+              style={chartStyles.yAxis}
             />
           </Chart>
         </div>

--- a/src/components/historicalUsageChart/historicalUsageChart.styles.ts
+++ b/src/components/historicalUsageChart/historicalUsageChart.styles.ts
@@ -9,20 +9,6 @@ import {
 import { VictoryStyleInterface } from 'victory';
 
 export const chartStyles = {
-  axis: {
-    axisLabel: {
-      padding: 15,
-    },
-    grid: {
-      stroke: 'none',
-    },
-    ticks: {
-      stroke: 'none',
-    },
-    tickLabels: {
-      fontSize: 0,
-    },
-  } as VictoryStyleInterface,
   currentCapacityData: {
     data: {
       fill: 'none',
@@ -83,13 +69,38 @@ export const chartStyles = {
       stroke: '#7DC3E8',
     },
   } as VictoryStyleInterface,
+  yAxis: {
+    axisLabel: {
+      padding: 15,
+    },
+    grid: {
+      stroke: 'none',
+    },
+    ticks: {
+      stroke: 'none',
+    },
+    tickLabels: {
+      fontSize: 0,
+    },
+  } as VictoryStyleInterface,
+  xAxis: {
+    axisLabel: {
+      padding: 40,
+    },
+    grid: {
+      stroke: 'none',
+    },
+    ticks: {
+      stroke: 'none',
+    },
+  } as VictoryStyleInterface,
 };
 
 export const styles = StyleSheet.create({
   chart: {
     display: 'inline-block',
     marginTop: global_spacer_lg.value,
-    width: '65%',
+    width: '60%',
   },
   chartContainer: {
     ':not(foo) svg': {
@@ -100,7 +111,7 @@ export const styles = StyleSheet.create({
     display: 'inline-block',
     fontSize: global_FontSize_md.value,
     paddingLeft: global_spacer_xl.value,
-    width: '35%',
+    width: '40%',
   },
   title: {
     paddingLeft: global_spacer_sm.value,

--- a/src/components/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/historicalUsageChart/historicalUsageChart.tsx
@@ -14,10 +14,12 @@ import {
   getTooltipLabel,
 } from 'components/commonChart/chartUtils';
 import VictoryPoint from 'components/victory/victoryPoint';
+import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
 import { DomainTuple, VictoryAxis, VictoryStyleInterface } from 'victory';
+import { getDateRange } from '../commonChart/chartUtils';
 import { chartStyles, styles } from './historicalUsageChart.styles';
 
 interface HistoricalUsageChartProps {
@@ -355,6 +357,39 @@ class HistoricalUsageChart extends React.Component<
     return domain;
   }
 
+  private getEndDate() {
+    const {
+      currentRequestData,
+      currentUsageData,
+      previousRequestData,
+      previousUsageData,
+    } = this.props;
+    const currentRequestDate = currentRequestData
+      ? getDate(getDateRange(currentRequestData, true, true)[1])
+      : 0;
+    const currentUsageDate = currentUsageData
+      ? getDate(getDateRange(currentUsageData, true, true)[1])
+      : 0;
+    const previousRequestDate = previousRequestData
+      ? getDate(getDateRange(previousRequestData, true, true)[1])
+      : 0;
+    const previousUsageDate = previousUsageData
+      ? getDate(getDateRange(previousUsageData, true, true)[1])
+      : 0;
+
+    return currentRequestDate > 0 ||
+      currentUsageDate > 0 ||
+      previousRequestDate > 0 ||
+      previousUsageDate > 0
+      ? Math.max(
+          currentRequestDate,
+          currentUsageDate,
+          previousRequestDate,
+          previousUsageDate
+        )
+      : 31;
+  }
+
   private getLegend = (datum: HistoricalLegendDatum, width: number) => {
     if (datum && datum.data && datum.data.length) {
       return (
@@ -440,6 +475,9 @@ class HistoricalUsageChart extends React.Component<
     const chartWidth = width * 0.65;
     const legendWidth = width * 0.35;
 
+    const endDate = this.getEndDate();
+    const midDate = Math.floor(endDate / 2);
+
     return (
       <div className={css(styles.chartContainer)} ref={this.containerRef}>
         <div className={css(styles.title)}>{title}</div>
@@ -461,7 +499,7 @@ class HistoricalUsageChart extends React.Component<
             <VictoryAxis
               label={xAxisLabel}
               style={chartStyles.xAxis}
-              tickValues={[1, 15, 31]}
+              tickValues={[1, midDate, endDate]}
             />
             <VictoryAxis
               dependentAxis

--- a/src/components/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/historicalUsageChart/historicalUsageChart.tsx
@@ -458,11 +458,15 @@ class HistoricalUsageChart extends React.Component<
               datum.current.charts.map((chart, index) => {
                 return this.getChart(chart, index);
               })}
-            <VictoryAxis label={xAxisLabel} style={chartStyles.axis} />
+            <VictoryAxis
+              label={xAxisLabel}
+              style={chartStyles.xAxis}
+              tickValues={[1, 15, 31]}
+            />
             <VictoryAxis
               dependentAxis
               label={yAxisLabel}
-              style={chartStyles.axis}
+              style={chartStyles.yAxis}
             />
           </Chart>
         </div>

--- a/src/components/trendChart/trendChart.styles.ts
+++ b/src/components/trendChart/trendChart.styles.ts
@@ -8,20 +8,6 @@ import {
 import { VictoryStyleInterface } from 'victory';
 
 export const chartStyles = {
-  axis: {
-    axisLabel: {
-      padding: 15,
-    },
-    grid: {
-      stroke: 'none',
-    },
-    ticks: {
-      stroke: 'none',
-    },
-    tickLabels: {
-      fontSize: 0,
-    },
-  } as VictoryStyleInterface,
   // See: https://github.com/project-koku/koku-ui/issues/241
   colorScale: [
     global_disabled_color_200.value,
@@ -49,6 +35,31 @@ export const chartStyles = {
       stroke: '#A2DA9C',
     },
   } as VictoryStyleInterface,
+  yAxis: {
+    axisLabel: {
+      padding: 15,
+    },
+    grid: {
+      stroke: 'none',
+    },
+    ticks: {
+      stroke: 'none',
+    },
+    tickLabels: {
+      fontSize: 0,
+    },
+  } as VictoryStyleInterface,
+  xAxis: {
+    axisLabel: {
+      padding: 15,
+    },
+    grid: {
+      stroke: 'none',
+    },
+    ticks: {
+      stroke: 'none',
+    },
+  } as VictoryStyleInterface,
 };
 
 export const styles = StyleSheet.create({
@@ -61,5 +72,6 @@ export const styles = StyleSheet.create({
     display: 'inline-block',
     fontSize: global_FontSize_md.value,
     marginBottom: global_spacer_lg.value,
+    marginTop: global_spacer_lg.value,
   },
 });

--- a/src/components/trendChart/trendChart.tsx
+++ b/src/components/trendChart/trendChart.tsx
@@ -14,9 +14,11 @@ import {
   getTooltipContent,
   getTooltipLabel,
 } from 'components/commonChart/chartUtils';
+import getDate from 'date-fns/get_date';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
 import { DomainTuple, VictoryAxis, VictoryStyleInterface } from 'victory';
+import { getDateRange } from '../commonChart/chartUtils';
 import { chartStyles, styles } from './trendChart.styles';
 
 interface TrendChartProps {
@@ -181,6 +183,20 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     return domain;
   }
 
+  private getEndDate() {
+    const { currentData, previousData } = this.props;
+    const previousDate = previousData
+      ? getDate(getDateRange(previousData, true, true)[1])
+      : 0;
+    const currentDate = currentData
+      ? getDate(getDateRange(currentData, true, true)[1])
+      : 0;
+
+    return currentDate > 0 || previousDate > 0
+      ? Math.max(currentDate, previousDate)
+      : 31;
+  }
+
   private getLegend = (datum: TrendLegendDatum, width: number) => {
     if (datum && datum.data && datum.data.length) {
       return (
@@ -255,6 +271,9 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         : width / 2;
     const domain = this.getDomain();
 
+    const endDate = this.getEndDate();
+    const midDate = Math.floor(endDate / 2);
+
     return (
       <div className={css(styles.chartContainer)} ref={this.containerRef}>
         <Chart
@@ -267,7 +286,10 @@ class TrendChart extends React.Component<TrendChartProps, State> {
             datum.cost.charts.map((chart, index) => {
               return this.getChart(chart, index);
             })}
-          <VictoryAxis style={chartStyles.xAxis} tickValues={[1, 15, 31]} />
+          <VictoryAxis
+            style={chartStyles.xAxis}
+            tickValues={[1, midDate, endDate]}
+          />
           <VictoryAxis dependentAxis style={chartStyles.yAxis} />
         </Chart>
         {Boolean(this.isLegendVisible()) && (

--- a/src/components/trendChart/trendChart.tsx
+++ b/src/components/trendChart/trendChart.tsx
@@ -267,8 +267,8 @@ class TrendChart extends React.Component<TrendChartProps, State> {
             datum.cost.charts.map((chart, index) => {
               return this.getChart(chart, index);
             })}
-          <VictoryAxis style={chartStyles.axis} />
-          <VictoryAxis dependentAxis style={chartStyles.axis} />
+          <VictoryAxis style={chartStyles.xAxis} tickValues={[1, 15, 31]} />
+          <VictoryAxis dependentAxis style={chartStyles.yAxis} />
         </Chart>
         {Boolean(this.isLegendVisible()) && (
           <div className={css(styles.legend)}>

--- a/src/components/usageChart/usageChart.styles.ts
+++ b/src/components/usageChart/usageChart.styles.ts
@@ -9,20 +9,6 @@ import {
 import { VictoryStyleInterface } from 'victory';
 
 export const chartStyles = {
-  axis: {
-    axisLabel: {
-      padding: 15,
-    },
-    grid: {
-      stroke: 'none',
-    },
-    ticks: {
-      stroke: 'none',
-    },
-    tickLabels: {
-      fontSize: 0,
-    },
-  } as VictoryStyleInterface,
   currentRequestData: {
     data: {
       fill: 'none',
@@ -62,6 +48,31 @@ export const chartStyles = {
     global_disabled_color_200.value,
     global_disabled_color_100.value,
   ],
+  yAxis: {
+    axisLabel: {
+      padding: 15,
+    },
+    grid: {
+      stroke: 'none',
+    },
+    ticks: {
+      stroke: 'none',
+    },
+    tickLabels: {
+      fontSize: 0,
+    },
+  } as VictoryStyleInterface,
+  xAxis: {
+    axisLabel: {
+      padding: 15,
+    },
+    grid: {
+      stroke: 'none',
+    },
+    ticks: {
+      stroke: 'none',
+    },
+  } as VictoryStyleInterface,
 };
 
 export const styles = StyleSheet.create({
@@ -74,6 +85,7 @@ export const styles = StyleSheet.create({
     display: 'inline-block',
     fontSize: global_FontSize_md.value,
     marginBottom: global_spacer_lg.value,
+    marginTop: global_spacer_lg.value,
     minWidth: '175px',
     width: '50%',
   },

--- a/src/components/usageChart/usageChart.tsx
+++ b/src/components/usageChart/usageChart.tsx
@@ -15,10 +15,12 @@ import {
   getTooltipLabel,
 } from 'components/commonChart/chartUtils';
 import VictoryPoint from 'components/victory/victoryPoint';
+import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
 import { DomainTuple, VictoryAxis, VictoryStyleInterface } from 'victory';
+import { getDateRange } from '../commonChart/chartUtils';
 import { chartStyles, styles } from './usageChart.styles';
 
 interface UsageChartProps {
@@ -266,6 +268,39 @@ class UsageChart extends React.Component<UsageChartProps, State> {
     return domain;
   }
 
+  private getEndDate() {
+    const {
+      currentRequestData,
+      currentUsageData,
+      previousRequestData,
+      previousUsageData,
+    } = this.props;
+    const currentRequestDate = currentRequestData
+      ? getDate(getDateRange(currentRequestData, true, true)[1])
+      : 0;
+    const currentUsageDate = currentUsageData
+      ? getDate(getDateRange(currentUsageData, true, true)[1])
+      : 0;
+    const previousRequestDate = previousRequestData
+      ? getDate(getDateRange(previousRequestData, true, true)[1])
+      : 0;
+    const previousUsageDate = previousUsageData
+      ? getDate(getDateRange(previousUsageData, true, true)[1])
+      : 0;
+
+    return currentRequestDate > 0 ||
+      currentUsageDate > 0 ||
+      previousRequestDate > 0 ||
+      previousUsageDate > 0
+      ? Math.max(
+          currentRequestDate,
+          currentUsageDate,
+          previousRequestDate,
+          previousUsageDate
+        )
+      : 31;
+  }
+
   private getLegend = (datum: UsageLegendDatum, width: number) => {
     if (datum && datum.data && datum.data.length) {
       return (
@@ -354,6 +389,9 @@ class UsageChart extends React.Component<UsageChartProps, State> {
         : width / 2;
     const domain = this.getDomain();
 
+    const endDate = this.getEndDate();
+    const midDate = Math.floor(endDate / 2);
+
     return (
       <div className={css(styles.chartContainer)} ref={this.containerRef}>
         <Chart
@@ -370,7 +408,10 @@ class UsageChart extends React.Component<UsageChartProps, State> {
             datum.current.charts.map((chart, index) => {
               return this.getChart(chart, index);
             })}
-          <VictoryAxis style={chartStyles.xAxis} tickValues={[1, 15, 31]} />
+          <VictoryAxis
+            style={chartStyles.xAxis}
+            tickValues={[1, midDate, endDate]}
+          />
           <VictoryAxis dependentAxis style={chartStyles.yAxis} />
         </Chart>
         {Boolean(this.isPreviousLegendVisible()) && (

--- a/src/components/usageChart/usageChart.tsx
+++ b/src/components/usageChart/usageChart.tsx
@@ -370,8 +370,8 @@ class UsageChart extends React.Component<UsageChartProps, State> {
             datum.current.charts.map((chart, index) => {
               return this.getChart(chart, index);
             })}
-          <VictoryAxis style={chartStyles.axis} />
-          <VictoryAxis dependentAxis style={chartStyles.axis} />
+          <VictoryAxis style={chartStyles.xAxis} tickValues={[1, 15, 31]} />
+          <VictoryAxis dependentAxis style={chartStyles.yAxis} />
         </Chart>
         {Boolean(this.isPreviousLegendVisible()) && (
           <div className={css(styles.legend)}>

--- a/src/pages/ocpDetails/historicalChart.tsx
+++ b/src/pages/ocpDetails/historicalChart.tsx
@@ -233,7 +233,7 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
       'usage'
     );
 
-    const chartHeight = 145;
+    const chartHeight = 140;
 
     return (
       <div className={css(styles.chartContainer)}>

--- a/src/pages/ocpDetails/historicalModal.styles.ts
+++ b/src/pages/ocpDetails/historicalModal.styles.ts
@@ -8,7 +8,7 @@ export const styles = StyleSheet.create({
     color: global_Color_100.value,
     // Workaround for isLarge not working properly
     height: '900px',
-    width: '1200px',
+    width: '1100px',
   },
 });
 


### PR DESCRIPTION
Added a couple tic labels to the chart x-axis. This helps indicate the day of month at a glance (e.g., 1, 15, 31, etc.).

Fixes https://github.com/project-koku/koku-ui/issues/451

Historical charts:
![screen shot 2019-02-04 at 1 49 56 pm](https://user-images.githubusercontent.com/17481322/52229871-f3587c00-2883-11e9-9d59-e9e2cb66a708.png)

OCP charts:
![screen shot 2019-02-04 at 1 50 36 pm](https://user-images.githubusercontent.com/17481322/52229887-fe131100-2883-11e9-9718-92bd66fd35fd.png)

AWS charts:
![screen shot 2019-02-04 at 1 50 27 pm](https://user-images.githubusercontent.com/17481322/52229900-066b4c00-2884-11e9-89a4-c5f174906fd7.png)

