### PR TITLE
AWS: Group By Account Tags

### DIFF
--- a/src/api/awsQuery.ts
+++ b/src/api/awsQuery.ts
@@ -28,6 +28,7 @@ export interface AwsQuery {
   filter?: AwsFilters;
   group_by?: AwsGroupBys;
   order_by?: AwsOrderBys;
+  key_only?: boolean;
 }
 
 export function getQuery(query: AwsQuery) {

--- a/src/api/awsReports.ts
+++ b/src/api/awsReports.ts
@@ -68,12 +68,14 @@ export const enum AwsReportType {
   cost = 'cost',
   storage = 'storage',
   instanceType = 'instance_type',
+  tag = 'tag',
 }
 
 export const awsReportTypePaths: Record<AwsReportType, string> = {
   [AwsReportType.cost]: 'reports/costs/aws/',
   [AwsReportType.storage]: 'reports/inventory/aws/storage/',
   [AwsReportType.instanceType]: 'reports/inventory/aws/instance-type/',
+  [AwsReportType.tag]: 'tags/aws/',
 };
 
 export function runReport(reportType: AwsReportType, query: string) {

--- a/src/utils/getComputedAwsReportItems.ts
+++ b/src/utils/getComputedAwsReportItems.ts
@@ -20,8 +20,6 @@ export interface GetComputedAwsReportItemsParams {
   sortDirection?: SortDirection;
 }
 
-const groups = ['services', 'accounts', 'instance_types', 'regions'];
-
 export function getComputedAwsReportItems({
   report,
   idKey,
@@ -81,11 +79,11 @@ export function getUnsortedComputedAwsReportItems({
         };
       });
     }
-    groups.forEach(group => {
-      if (dataPoint[group]) {
-        return dataPoint[group].forEach(visitDataPoint);
+    for (const key in dataPoint) {
+      if (dataPoint[key] instanceof Array) {
+        return dataPoint[key].forEach(visitDataPoint);
       }
-    });
+    }
   };
   if (report && report.data) {
     report.data.forEach(visitDataPoint);


### PR DESCRIPTION
Added group by tags functionality to AWS details page.

Note that the `5dc_key` and `c25_key` tags keys are both on the `hccm-alias` account.

Fixes https://github.com/project-koku/koku-ui/issues/445

![screen shot 2019-02-05 at 11 13 59 am](https://user-images.githubusercontent.com/17481322/52286990-4b9c8600-2937-11e9-8e4a-d395572aa6f4.png)
