### PR TITLE
AWS tags details

### DIFF
--- a/src/api/awsQuery.ts
+++ b/src/api/awsQuery.ts
@@ -28,6 +28,7 @@ export interface AwsQuery {
   filter?: AwsFilters;
   group_by?: AwsGroupBys;
   order_by?: AwsOrderBys;
+  key_only?: boolean;
 }
 
 export function getQuery(query: AwsQuery) {

--- a/src/api/awsQuery.ts
+++ b/src/api/awsQuery.ts
@@ -1,6 +1,7 @@
 import { parse, stringify } from 'qs';
 
 export interface AwsFilters {
+  account?: string | number;
   time_scope_value?: number;
   time_scope_units?: 'month' | 'day';
   resolution?: 'daily' | 'monthly';

--- a/src/api/awsReports.ts
+++ b/src/api/awsReports.ts
@@ -68,12 +68,14 @@ export const enum AwsReportType {
   cost = 'cost',
   storage = 'storage',
   instanceType = 'instance_type',
+  tag = 'tag',
 }
 
 export const awsReportTypePaths: Record<AwsReportType, string> = {
   [AwsReportType.cost]: 'reports/costs/aws/',
   [AwsReportType.storage]: 'reports/inventory/aws/storage/',
   [AwsReportType.instanceType]: 'reports/inventory/aws/instance-type/',
+  [AwsReportType.tag]: 'tags/aws/',
 };
 
 export function runReport(reportType: AwsReportType, query: string) {

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -24,6 +24,7 @@
   },
   "aws_details": {
     "change_column_title": "Month Over Month Change",
+    "cluster_label": "Cluster:",
     "cost_column_subtitle": " (Total {{total}})",
     "cost_column_title": "Cost",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
@@ -39,6 +40,7 @@
     },
     "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
     "increase_since_last_month": "{{value}} increase since last month",
+    "more_tags": ", {{value}} more...",
     "name_column_title": "$t(group_by.values.{{groupBy}}) Names",
     "no_change_since_date": "No change since $t(months.{{month}}) {{date}}",
     "order": {
@@ -46,6 +48,7 @@
       "cost_delta": "Sort by: Cost Delta",
       "name": "Sort by: Name"
     },
+    "tags_label": "Related Tags:",
     "title": "AWS Details",
     "total_cost": "Total Cost"
   },
@@ -208,6 +211,7 @@
     },
     "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
     "increase_since_last_month": "{{value}} increase since last month",
+    "more_tags": ", {{value}} more...",
     "name_column_title": "$t(group_by.values.{{groupBy}}) Names",
     "no_change_since_date": "No change since $t(months.{{month}}) {{date}}",
     "order": {
@@ -215,7 +219,7 @@
       "charge_delta": "Sort by: Charges Delta",
       "name": "Sort by: Name"
     },
-    "tags_label": "Tags",
+    "tags_label": "Related Tags:",
     "title": "OpenShift Details",
     "total_charge": "Total Charge"
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -24,6 +24,7 @@
   },
   "aws_details": {
     "change_column_title": "Month Over Month Change",
+    "cluster_label": "Cluster:",
     "cost_column_subtitle": " (Total {{total}})",
     "cost_column_title": "Cost",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
@@ -39,6 +40,7 @@
     },
     "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
     "increase_since_last_month": "{{value}} increase since last month",
+    "more_tags": ", {{value}} more...",
     "name_column_title": "$t(group_by.values.{{groupBy}}) Names",
     "no_change_since_date": "No change since $t(months.{{month}}) {{date}}",
     "order": {
@@ -46,6 +48,7 @@
       "cost_delta": "Sort by: Cost Delta",
       "name": "Sort by: Name"
     },
+    "tags_label": "Related Tags:",
     "title": "AWS Details",
     "total_cost": "Total Cost"
   },
@@ -175,7 +178,7 @@
     "change_column_title": "Month Over Month Change",
     "charge_column_subtitle": " (Total {{total}})",
     "charge_column_title": "Charges",
-    "cluster_label": "Cluster",
+    "cluster_label": "Cluster:",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
     "export_link": "Export",
@@ -208,6 +211,7 @@
     },
     "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
     "increase_since_last_month": "{{value}} increase since last month",
+    "more_tags": ", {{value}} more...",
     "name_column_title": "$t(group_by.values.{{groupBy}}) Names",
     "no_change_since_date": "No change since $t(months.{{month}}) {{date}}",
     "order": {
@@ -215,7 +219,7 @@
       "charge_delta": "Sort by: Charges Delta",
       "name": "Sort by: Name"
     },
-    "tags_label": "Tags",
+    "tags_label": "Related Tags:",
     "title": "OpenShift Details",
     "total_charge": "Total Charge"
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -24,6 +24,7 @@
   },
   "aws_details": {
     "change_column_title": "Month Over Month Change",
+    "cluster_label": "Cluster:",
     "cost_column_subtitle": " (Total {{total}})",
     "cost_column_title": "Cost",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
@@ -39,6 +40,7 @@
     },
     "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
     "increase_since_last_month": "{{value}} increase since last month",
+    "more_tags": ", {{value}} more...",
     "name_column_title": "$t(group_by.values.{{groupBy}}) Names",
     "no_change_since_date": "No change since $t(months.{{month}}) {{date}}",
     "order": {
@@ -46,6 +48,7 @@
       "cost_delta": "Sort by: Cost Delta",
       "name": "Sort by: Name"
     },
+    "tags_label": "Related Tags:",
     "title": "AWS Details",
     "total_cost": "Total Cost"
   },
@@ -208,6 +211,7 @@
     },
     "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
     "increase_since_last_month": "{{value}} increase since last month",
+    "more_tags": ", {{value}} more...",
     "name_column_title": "$t(group_by.values.{{groupBy}}) Names",
     "no_change_since_date": "No change since $t(months.{{month}}) {{date}}",
     "order": {
@@ -215,7 +219,7 @@
       "charge_delta": "Sort by: Charges Delta",
       "name": "Sort by: Name"
     },
-    "tags_label": "Tags",
+    "tags_label": "Related Tags:",
     "title": "OpenShift Details",
     "total_charge": "Total Charge"
   },

--- a/src/pages/awsDetails/awsDetails.styles.ts
+++ b/src/pages/awsDetails/awsDetails.styles.ts
@@ -49,6 +49,20 @@ export const styles = StyleSheet.create({
     display: 'flex',
     justifyContent: 'flex-end',
   },
+  historicalLinkContainer: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    paddingTop: global_spacer_xl.value,
+  },
+  measureChartContainer: {
+    paddingTop: global_spacer_xl.value,
+  },
+  projectsContainer: {
+    paddingTop: global_spacer_xl.value,
+  },
+  summaryContainer: {
+    marginRight: global_spacer_3xl.value,
+  },
   title: {
     paddingBottom: global_spacer_sm.var,
   },

--- a/src/pages/awsDetails/detailsChart.tsx
+++ b/src/pages/awsDetails/detailsChart.tsx
@@ -12,7 +12,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { formatCurrency, formatValue } from 'utils/formatValue';
 
 interface DetailsChartOwnProps {
-  currentGroupBy: any;
+  groupBy: any;
   queryString: string;
 }
 
@@ -45,13 +45,10 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
       this.props.fetchReport(reportType, this.props.queryString);
     }
   }
+
   public render() {
-    const { currentGroupBy, report } = this.props;
-    const currentData = transformAwsReport(
-      report,
-      ChartType.monthly,
-      currentGroupBy
-    );
+    const { groupBy, report } = this.props;
+    const currentData = transformAwsReport(report, ChartType.monthly, groupBy);
     const legendData = currentData.map(item => ({
       name: item.name.toString() + ' (' + formatCurrency(item.y) + ')',
       symbol: { type: 'square' },
@@ -64,7 +61,7 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
           width={200}
           data={currentData}
           formatDatumValue={formatValue}
-          groupBy={currentGroupBy}
+          groupBy={groupBy}
           legendData={legendData}
         />
       );

--- a/src/pages/awsDetails/detailsTag.styles.ts
+++ b/src/pages/awsDetails/detailsTag.styles.ts
@@ -1,0 +1,16 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_3xl, global_spacer_sm } from '@patternfly/react-tokens';
+import { css } from 'emotion';
+
+export const styles = StyleSheet.create({
+  tagsContainer: {
+    marginRight: global_spacer_3xl.value,
+    marginTop: global_spacer_sm.value,
+  },
+});
+
+export const popoverOverride = css`
+  &.pf-c-popover {
+    --pf-c-popover--MaxWidth: 600px;
+  }
+`;

--- a/src/pages/awsDetails/detailsTag.tsx
+++ b/src/pages/awsDetails/detailsTag.tsx
@@ -1,18 +1,18 @@
 import { Popover } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
-import { getQuery } from 'api/ocpQuery';
-import { OcpReport, OcpReportType } from 'api/ocpReports';
+import { getQuery } from 'api/awsQuery';
+import { AwsReport, AwsReportType } from 'api/awsReports';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
+import { awsReportsActions, awsReportsSelectors } from 'store/awsReports';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { ocpReportsActions, ocpReportsSelectors } from 'store/ocpReports';
 import { getTestProps, testIds } from '../../testIds';
 import { popoverOverride, styles } from './detailsTag.styles';
 
 interface DetailsTagOwnProps {
+  account: string | number;
   id?: string;
-  project: string | number;
   queryString?: string;
 }
 
@@ -21,12 +21,12 @@ interface State {
 }
 
 interface DetailsTagStateProps {
-  report?: OcpReport;
+  report?: AwsReport;
   reportFetchStatus?: FetchStatus;
 }
 
 interface DetailsTagDispatchProps {
-  fetchReport?: typeof ocpReportsActions.fetchReport;
+  fetchReport?: typeof awsReportsActions.fetchReport;
 }
 
 type DetailsTagProps = DetailsTagOwnProps &
@@ -43,13 +43,13 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
   public componentDidMount() {
     const { queryString, report } = this.props;
     if (!report) {
-      this.props.fetchReport(OcpReportType.tag, queryString);
+      this.props.fetchReport(AwsReportType.tag, queryString);
     }
   }
 
   public componentDidUpdate(prevProps: DetailsTagProps) {
     if (prevProps.queryString !== this.props.queryString) {
-      this.props.fetchReport(OcpReportType.tag, this.props.queryString);
+      this.props.fetchReport(AwsReportType.tag, this.props.queryString);
     }
   }
 
@@ -65,7 +65,7 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
       return (
         <Popover
           className={popoverOverride}
-          headerContent={<div>{t('ocp_details.tags_label')}</div>}
+          headerContent={<div>{t('aws_details.tags_label')}</div>}
           position="right"
           bodyContent={allTags.map((tag, tagIndex) => (
             <div key={tagIndex}>{tag}</div>
@@ -77,7 +77,7 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
             href="#/"
             onClick={this.handleMoreClicked}
           >
-            {t('ocp_details.more_tags', {
+            {t('aws_details.more_tags', {
               value: allTags.length - someTags.length,
             })}
           </a>
@@ -125,23 +125,23 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
 const mapStateToProps = createMapStateToProps<
   DetailsTagOwnProps,
   DetailsTagStateProps
->((state, { project }) => {
+>((state, { account }) => {
   const queryString = getQuery({
     filter: {
-      project,
+      account,
       resolution: 'monthly',
       time_scope_units: 'month',
       time_scope_value: -1,
     },
   });
-  const report = ocpReportsSelectors.selectReport(
+  const report = awsReportsSelectors.selectReport(
     state,
-    OcpReportType.tag,
+    AwsReportType.tag,
     queryString
   );
-  const reportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
+  const reportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
     state,
-    OcpReportType.tag,
+    AwsReportType.tag,
     queryString
   );
   return {
@@ -152,7 +152,7 @@ const mapStateToProps = createMapStateToProps<
 });
 
 const mapDispatchToProps: DetailsTagDispatchProps = {
-  fetchReport: ocpReportsActions.fetchReport,
+  fetchReport: awsReportsActions.fetchReport,
 };
 
 const DetailsTag = translate()(

--- a/src/pages/ocpDetails/detailsCluster.tsx
+++ b/src/pages/ocpDetails/detailsCluster.tsx
@@ -1,4 +1,4 @@
-import { FormGroup } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -6,8 +6,10 @@ import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { ocpReportsActions, ocpReportsSelectors } from 'store/ocpReports';
 import { getComputedOcpReportItems } from 'utils/getComputedOcpReportItems';
+import { styles } from './ocpDetails.styles';
 
 interface DetailsClusterOwnProps {
+  id?: string;
   idKey: any;
   label?: string;
   queryString: string;
@@ -53,14 +55,14 @@ class DetailsClusterBase extends React.Component<DetailsClusterProps> {
   }
 
   public render() {
-    const { label } = this.props;
+    const { id } = this.props;
     const items = this.getItems();
     const clusterName = items && items.length ? items[0].label : '';
 
     return (
-      <FormGroup label={label} fieldId="cluster-name">
-        <div>{clusterName}</div>
-      </FormGroup>
+      <div className={css(styles.clusterContainer)} id={id}>
+        {clusterName}
+      </div>
     );
   }
 }

--- a/src/pages/ocpDetails/detailsItem.tsx
+++ b/src/pages/ocpDetails/detailsItem.tsx
@@ -3,6 +3,7 @@ import {
   ButtonType,
   ButtonVariant,
   Form,
+  FormGroup,
   Grid,
   GridItem,
 } from '@patternfly/react-core';
@@ -60,7 +61,7 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
     isHistoricalModalOpen: false,
   };
 
-  private getChargeQueryString(groupBy: string) {
+  private getCostQueryString(groupBy: string) {
     const { item, parentGroupBy, parentQuery } = this.props;
     const newQuery: OcpQuery = {
       ...parentQuery,
@@ -216,17 +217,20 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
           <GridItem lg={12} xl={5}>
             <div className={css(styles.projectsContainer)}>
               {Boolean(parentGroupBy === 'project') && (
-                <Form>
-                  <DetailsCluster
+                <Form isHorizontal>
+                  <FormGroup
                     label={t('ocp_details.cluster_label')}
-                    idKey={'cluster'}
-                    queryString={this.getChargeQueryString('cluster')}
-                  />
-                  <DetailsTag
-                    label={t('ocp_details.tags_label')}
-                    project={item.label || item.id}
-                    onTagClicked={this.handleTagClicked}
-                  />
+                    fieldId="cluster-name"
+                  >
+                    <DetailsCluster
+                      id="cluster-name"
+                      idKey={'cluster'}
+                      queryString={this.getCostQueryString('cluster')}
+                    />
+                  </FormGroup>
+                  <FormGroup label={t('ocp_details.tags_label')} fieldId="tags">
+                    <DetailsTag id="tags" project={item.label || item.id} />
+                  </FormGroup>
                 </Form>
               )}
               {Boolean(
@@ -235,7 +239,7 @@ class DetailsItemBase extends React.Component<DetailsItemProps> {
                 <div className={css(styles.summaryContainer)}>
                   <DetailsSummary
                     idKey={'project'}
-                    queryString={this.getChargeQueryString('project')}
+                    queryString={this.getCostQueryString('project')}
                     title={t('ocp_details.historical.project_title')}
                   />
                 </div>

--- a/src/pages/ocpDetails/detailsTag.styles.ts
+++ b/src/pages/ocpDetails/detailsTag.styles.ts
@@ -1,0 +1,16 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_3xl, global_spacer_sm } from '@patternfly/react-tokens';
+import { css } from 'emotion';
+
+export const styles = StyleSheet.create({
+  tagsContainer: {
+    marginRight: global_spacer_3xl.value,
+    marginTop: global_spacer_sm.value,
+  },
+});
+
+export const popoverOverride = css`
+  &.pf-c-popover {
+    --pf-c-popover--MaxWidth: 600px;
+  }
+`;

--- a/src/pages/ocpDetails/ocpDetails.styles.ts
+++ b/src/pages/ocpDetails/ocpDetails.styles.ts
@@ -45,6 +45,10 @@ export const styles = StyleSheet.create({
     fontSize: global_FontSize_sm.value,
     color: global_Color_200.var,
   },
+  clusterContainer: {
+    marginRight: global_spacer_3xl.value,
+    marginTop: global_spacer_sm.value,
+  },
   content: {
     backgroundColor: global_BackgroundColor_300.var,
     paddingTop: global_spacer_xl.value,
@@ -111,8 +115,9 @@ export const styles = StyleSheet.create({
   summaryContainer: {
     marginRight: global_spacer_3xl.value,
   },
-  tagButton: {
-    paddingBottom: global_spacer_sm.value,
+  tagsContainer: {
+    marginRight: global_spacer_3xl.value,
+    marginTop: global_spacer_sm.value,
   },
 });
 

--- a/src/testIds.ts
+++ b/src/testIds.ts
@@ -4,7 +4,7 @@ export const getTestProps = (id: string) => ({ [testIdProp]: id });
 export const testIds = {
   details: {
     historical_data_btn: 'historical-data-btn',
-    tag_btn: 'tag-btn',
+    tag_lnk: 'tag-lnk',
   },
   export: {
     cancel_btn: 'cancel-btn',

--- a/src/utils/getComputedAwsReportItems.ts
+++ b/src/utils/getComputedAwsReportItems.ts
@@ -20,8 +20,6 @@ export interface GetComputedAwsReportItemsParams {
   sortDirection?: SortDirection;
 }
 
-const groups = ['services', 'accounts', 'instance_types', 'regions'];
-
 export function getComputedAwsReportItems({
   report,
   idKey,
@@ -81,11 +79,11 @@ export function getUnsortedComputedAwsReportItems({
         };
       });
     }
-    groups.forEach(group => {
-      if (dataPoint[group]) {
-        return dataPoint[group].forEach(visitDataPoint);
+    for (const key in dataPoint) {
+      if (dataPoint[key] instanceof Array) {
+        return dataPoint[key].forEach(visitDataPoint);
       }
-    });
+    }
   };
   if (report && report.data) {
     report.data.forEach(visitDataPoint);


### PR DESCRIPTION
Added tags to AWS details page. Also modified the OCP details page to mimic the tag functionality for AWS. The details pages now show a few tags initially, with additional/all tags shown in a popover (per @nlcwong).

See mock: https://redhat.invisionapp.com/share/HEO4ISHAT8Z#/screens/343778744

Notes:
- https://github.com/project-koku/koku-ui/pull/455 should be merged first.
- Depends on https://github.com/project-koku/koku/issues/605 in order for AWS to show tags per account.

Fixes https://github.com/project-koku/koku-ui/issues/444
Fixes https://github.com/project-koku/koku-ui/issues/416

![screen shot 2019-02-05 at 6 48 46 pm](https://user-images.githubusercontent.com/17481322/52314787-25e89e80-2982-11e9-9031-2dd7f5d4b0cd.png)
