### PR TITLE
Update bullet chart per high fidelity mock

### DIFF
--- a/src/components/bulletChart/bulletChart.styles.ts
+++ b/src/components/bulletChart/bulletChart.styles.ts
@@ -1,38 +1,30 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
-  c_button_disabled_BackgroundColor,
-  global_Color_dark_100,
-  global_Color_dark_200,
   global_danger_color_100,
-  global_disabled_color_100,
-  global_disabled_color_200,
-  global_primary_color_200,
-  global_primary_color_dark_100,
-  global_primary_color_light_100,
   global_spacer_md,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
 
 export const chartStyles = {
-  height: 95,
+  height: 55,
   itemsPerRow: 2,
   legendHeight: 30,
+  // See: https://github.com/project-koku/koku-ui/issues/241
   rangeColorScale: [
-    c_button_disabled_BackgroundColor.value,
-    global_disabled_color_200.value,
-    global_disabled_color_100.value,
-    global_Color_dark_200.value,
-    global_Color_dark_100.value,
+    '#ededed',
+    '#bee1f4',
+    '#d1d1d1',
+    '#bbb',
+    '#72767b',
+    '#72767b',
+    '#282d33',
   ],
-  rangeWidth: 80,
+  rangeWidth: 40,
   thresholdErrorColor: global_danger_color_100.value,
   thresholdErrorWidth: 1,
-  valueColorScale: [
-    global_primary_color_light_100.value,
-    global_primary_color_dark_100.value,
-    global_primary_color_200.value,
-  ],
-  valueWidth: 30,
+  // See: https://github.com/project-koku/koku-ui/issues/241
+  valueColorScale: ['#007BBA', '#7DC3E8', '#39A5DC', '#00659C', '#004D76'],
+  valueWidth: 9,
 };
 
 export const styles = StyleSheet.create({

--- a/src/components/bulletChart/bulletChart.tsx
+++ b/src/components/bulletChart/bulletChart.tsx
@@ -54,20 +54,15 @@ class BulletChart extends React.Component<BulletChartProps, State> {
       values,
     } = this.props;
     const { width } = this.state;
-    const sortedRanges = ranges.sort((a, b) => b.value - a.value);
-    const sortedValues = values.sort((a, b) => b.value - a.value);
-    const itemsPerRow = legendItemsPerRow
-      ? legendItemsPerRow
-      : chartStyles.itemsPerRow;
 
     const legendColorScale = [];
     const legendData = [];
-    for (let i = 0; i < sortedValues.length; i++) {
-      legendData.push({ name: sortedValues[i].legend });
+    for (let i = 0; i < values.length; i++) {
+      legendData.push({ name: values[i].legend });
       legendColorScale.push(chartStyles.valueColorScale[i]);
     }
-    for (let i = 0; i < sortedRanges.length; i++) {
-      legendData.push({ name: sortedRanges[i].legend });
+    for (let i = 0; i < ranges.length; i++) {
+      legendData.push({ name: ranges[i].legend });
       legendColorScale.push(chartStyles.rangeColorScale[i]);
     }
     if (thresholdError) {
@@ -75,12 +70,18 @@ class BulletChart extends React.Component<BulletChartProps, State> {
       legendColorScale.push(chartStyles.thresholdErrorColor);
     }
 
+    const itemsPerRow = legendItemsPerRow
+      ? legendItemsPerRow
+      : chartStyles.itemsPerRow;
+
     const rows =
       legendData.length / itemsPerRow + (legendData.length % itemsPerRow);
     const legendHeight = rows * chartStyles.legendHeight;
+    const sortedRanges = [...ranges].sort((a, b) => b.value - a.value);
+    const sortedValues = [...values].sort((a, b) => b.value - a.value);
     const maxValue = Math.max(
-      sortedRanges[sortedRanges.length - 1].value,
-      sortedValues[sortedValues.length - 1].value,
+      ...sortedRanges.map(val => val.value),
+      ...sortedValues.map(val => val.value),
       thresholdError.value
     );
 
@@ -137,7 +138,7 @@ class BulletChart extends React.Component<BulletChartProps, State> {
               }}
             />
           )}
-          <VictoryAxis tickValues={[0, maxValue / 2, maxValue]} />
+          <VictoryAxis tickValues={[0, Math.floor(maxValue / 2), maxValue]} />
         </Chart>
         {Boolean(legendData.length) && (
           <div className={css(styles.bulletChartLegend)}>

--- a/src/pages/ocpDetails/detailsChart.tsx
+++ b/src/pages/ocpDetails/detailsChart.tsx
@@ -76,6 +76,15 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
       };
       datum.ranges = [
         {
+          legend: t(`ocp_details.bullet.${labelKey}_requests`, {
+            value: request,
+          }),
+          tooltip: t(`ocp_details.bullet.${labelKey}_requests`, {
+            value: request,
+          }),
+          value: Math.trunc(request),
+        },
+        {
           legend: t(`ocp_details.bullet.${labelKey}_capacity`, {
             value: datum.capacity,
           }),
@@ -90,15 +99,6 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
           legend: t(`ocp_details.bullet.${labelKey}_usage`, { value: usage }),
           tooltip: t(`ocp_details.bullet.${labelKey}_usage`, { value: usage }),
           value: Math.trunc(usage),
-        },
-        {
-          legend: t(`ocp_details.bullet.${labelKey}_requests`, {
-            value: request,
-          }),
-          tooltip: t(`ocp_details.bullet.${labelKey}_requests`, {
-            value: request,
-          }),
-          value: Math.trunc(request),
         },
       ];
     }


### PR DESCRIPTION
Update bullet chart per high fidelity mock.

Mock: https://redhat.invisionapp.com/share/ENPJQTBXTAC#/screens/336165167

Fixes https://github.com/project-koku/koku-ui/issues/464

Example (new):
<img width="583" alt="screen shot 2019-02-08 at 2 18 49 am" src="https://user-images.githubusercontent.com/17481322/52464181-e9ff3600-2b47-11e9-92bc-be0183574802.png">

Old PF3 style:
<img width="576" alt="screen shot 2019-02-08 at 2 12 27 am" src="https://user-images.githubusercontent.com/17481322/52464150-c5a35980-2b47-11e9-953d-925a96e1b7c5.png">
