### PR TITLE
Modified table to lazily load expandable rows

### DIFF
--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -116,10 +116,16 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           ],
           isOpen: false,
           item,
+          tableItem: {
+            groupById,
+            index,
+            item,
+            query,
+          },
         },
         {
           parent: index * 2,
-          cells: [this.getTableItem(item, groupById, query, index)],
+          cells: [<div key={`${index * 2}-child`}>{t('loading')}</div>],
         }
       );
     });
@@ -260,8 +266,23 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private handleOnCollapse = (event, rowId, isOpen) => {
+    const { t } = this.props;
     const { rows } = this.state;
+    const {
+      tableItem: { item, groupById, query, index },
+    } = rows[rowId];
+
+    if (isOpen) {
+      rows[rowId + 1].cells = [
+        this.getTableItem(item, groupById, query, index),
+      ];
+    } else {
+      rows[rowId + 1].cells = [
+        <div key={`${index * 2}-child`}>{t('loading')}</div>,
+      ];
+    }
     rows[rowId].isOpen = isOpen;
+
     this.setState({
       rows,
     });


### PR DESCRIPTION
Modified table to lazily load expandable rows. There is a significant performance improvement loading rows only after the row toggle has been clicked. 

Fixes https://github.com/project-koku/koku-ui/issues/469