### PR TITLE
OCP charge card missing dollar sign

### DIFF
--- a/src/components/historicalUsageChart/__snapshots__/historicalUsageChart.test.tsx.snap
+++ b/src/components/historicalUsageChart/__snapshots__/historicalUsageChart.test.tsx.snap
@@ -5,7 +5,7 @@ Array [
   Object {
     "key": "12-15-17",
     "name": "12-15-17",
-    "units": "GB",
+    "units": "unit",
     "x": 15,
     "y": 0,
   },
@@ -17,7 +17,7 @@ Array [
   Object {
     "key": "12-15-17",
     "name": "12-15-17",
-    "units": "GB",
+    "units": "unit",
     "x": 15,
     "y": 1,
   },
@@ -29,7 +29,7 @@ Array [
   Object {
     "key": "1-15-18",
     "name": "1-15-18",
-    "units": "GB",
+    "units": "unit",
     "x": 15,
     "y": 0,
   },
@@ -41,7 +41,7 @@ Array [
   Object {
     "key": "1-15-18",
     "name": "1-15-18",
-    "units": "GB",
+    "units": "unit",
     "x": 15,
     "y": 1,
   },
@@ -53,7 +53,7 @@ Array [
   Object {
     "key": "12-15-17",
     "name": "12-15-17",
-    "units": "GB",
+    "units": "unit",
     "x": 15,
     "y": 0,
   },
@@ -65,7 +65,7 @@ Array [
   Object {
     "key": "12-15-17",
     "name": "12-15-17",
-    "units": "GB",
+    "units": "unit",
     "x": 15,
     "y": 0,
   },

--- a/src/components/usageChart/__snapshots__/usageChart.test.tsx.snap
+++ b/src/components/usageChart/__snapshots__/usageChart.test.tsx.snap
@@ -5,7 +5,7 @@ Array [
   Object {
     "key": "12-15-17",
     "name": "12-15-17",
-    "units": "GB",
+    "units": "unit",
     "x": 15,
     "y": 0,
   },
@@ -17,7 +17,7 @@ Array [
   Object {
     "key": "12-15-17",
     "name": "12-15-17",
-    "units": "GB",
+    "units": "unit",
     "x": 15,
     "y": 1,
   },
@@ -29,7 +29,7 @@ Array [
   Object {
     "key": "1-15-18",
     "name": "1-15-18",
-    "units": "GB",
+    "units": "unit",
     "x": 15,
     "y": 0,
   },
@@ -41,7 +41,7 @@ Array [
   Object {
     "key": "1-15-18",
     "name": "1-15-18",
-    "units": "GB",
+    "units": "unit",
     "x": 15,
     "y": 1,
   },
@@ -53,7 +53,7 @@ Array [
   Object {
     "key": "12-15-17",
     "name": "12-15-17",
-    "units": "GB",
+    "units": "unit",
     "x": 15,
     "y": 0,
   },
@@ -65,7 +65,7 @@ Array [
   Object {
     "key": "12-15-17",
     "name": "12-15-17",
-    "units": "GB",
+    "units": "unit",
     "x": 15,
     "y": 0,
   },

--- a/src/utils/getComputedOcpReportItems.ts
+++ b/src/utils/getComputedOcpReportItems.ts
@@ -71,6 +71,7 @@ export function getUnsortedComputedOcpReportItems({
         const limit = value.limit;
         const request = value.request;
         const usage = value.usage;
+        const units = value.units ? value.units : usage ? 'GB' : 'USD';
         if (!itemMap[id]) {
           itemMap[id] = {
             app: value.app,
@@ -82,7 +83,7 @@ export function getUnsortedComputedOcpReportItems({
             label,
             limit,
             request,
-            units: value.units || usage ? 'GB' : 'USD',
+            units,
             usage,
           };
           return;


### PR DESCRIPTION
Fixes an issue where the OCP charge card is missing its dollar sign -- units are not being mapped correctly.

Fixes https://github.com/project-koku/koku-ui/issues/440

![screen shot 2019-02-11 at 3 22 24 pm](https://user-images.githubusercontent.com/17481322/52591169-42b52400-2e11-11e9-9a9b-0a11a8e8e442.png)
