### PR TITLE
AWS total cost card missing dollar sign

### DIFF
--- a/src/components/awsReportSummary/__snapshots__/awsReportSummaryDetails.test.tsx.snap
+++ b/src/components/awsReportSummary/__snapshots__/awsReportSummaryDetails.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`defaults value if report.total is not present 1`] = `
   <div
     className="css-1w8hocc"
   >
-    0
+    ----
   </div>
   <div
     className="css-1640ajm"

--- a/src/components/awsReportSummary/awsReportSummaryDetails.tsx
+++ b/src/components/awsReportSummary/awsReportSummaryDetails.tsx
@@ -18,10 +18,13 @@ const AwsReportSummaryDetails: React.SFC<AwsReportSummaryDetailsProps> = ({
   report,
 }) => {
   let value: string | number = '----';
-  if (report) {
-    value = report.total
-      ? formatValue(report.total.value, report.total.units, formatOptions)
-      : 0;
+  if (report && report.total) {
+    const units: string = report.total.units ? report.total.units : 'USD';
+    value = formatValue(
+      report.total.value ? report.total.value : 0,
+      units,
+      formatOptions
+    );
   }
 
   return (

--- a/src/components/ocpReportSummary/ocpReportSummaryDetails.tsx
+++ b/src/components/ocpReportSummary/ocpReportSummaryDetails.tsx
@@ -27,11 +27,23 @@ const OcpReportSummaryDetails: React.SFC<OcpReportSummaryDetailsProps> = ({
   if (report && report.total) {
     if (reportType === OcpReportType.charge) {
       const units: string = report.total.units ? report.total.units : 'USD';
-      value = formatValue(report.total.charge, units, formatOptions);
+      value = formatValue(
+        report.total.charge ? report.total.charge : 0,
+        units,
+        formatOptions
+      );
     } else {
       const units: string = report.total.units ? report.total.units : 'GB';
-      value = formatValue(report.total.usage, units, formatOptions);
-      requestValue = formatValue(report.total.request, units, formatOptions);
+      value = formatValue(
+        report.total.usage ? report.total.usage : 0,
+        units,
+        formatOptions
+      );
+      requestValue = formatValue(
+        report.total.request ? report.total.request : 0,
+        units,
+        formatOptions
+      );
     }
   }
   return (


### PR DESCRIPTION
This ensures a dollar sign is used when there is no total. Also sync'ed default value with OCP card.

Fixes https://github.com/project-koku/koku-ui/issues/448

![screen shot 2019-02-11 at 3 39 35 pm](https://user-images.githubusercontent.com/17481322/52591999-4d70b880-2e13-11e9-908c-f2a3a900786d.png)
