### PR TITLE
Table fix for null region label

### DIFF
--- a/src/pages/awsDetails/detailsTable.tsx
+++ b/src/pages/awsDetails/detailsTable.tsx
@@ -110,7 +110,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       rows.push(
         {
           cells: [
-            item.label,
+            item.label ? item.label : '',
             this.getMonthOverMonthCost(item, index),
             this.getTotalCost(item, index),
           ],

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -110,7 +110,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       rows.push(
         {
           cells: [
-            item.label,
+            item.label ? item.label : '',
             this.getMonthOverMonthCost(item, index),
             this.getTotalCost(item, index),
           ],


### PR DESCRIPTION
It appears that the PF4 table generates a `Cannot read property 'title' of null` error if any cells are null or undefined. This fixes the issue when the region label is null.

See PF4 table issue for more details:
https://github.com/patternfly/patternfly-react/issues/1371