### PR TITLE
AWS details progress bars

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@patternfly/react-core": "1.48.0",
     "@patternfly/react-icons": "2.9.7",
     "@patternfly/react-styles": "2.3.0",
-    "@patternfly/react-table": "0.4.18",
+    "@patternfly/react-table": "1.0.7",
     "@patternfly/react-tokens": "1.9.6",
     "@red-hat-insights/insights-frontend-components": "^3.19.4",
     "@types/date-fns": "^2.6.0",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -24,9 +24,11 @@
   },
   "aws_details": {
     "change_column_title": "Month Over Month Change",
+    "chart_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s {{localGroupBy}}s",
     "cluster_label": "Cluster:",
     "cost_column_subtitle": " (Total {{total}})",
     "cost_column_title": "Cost",
+    "cost_value": "Cost: {{value}}",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
     "export_link": "Export",
@@ -48,6 +50,7 @@
       "cost_delta": "Sort by: Cost Delta",
       "name": "Sort by: Name"
     },
+    "show_more": "Show More",
     "tags_label": "Related Tags:",
     "title": "AWS Details",
     "total_cost": "Total Cost"
@@ -206,7 +209,8 @@
       "memory_title": "Month over Month Total $t(group_by.values.{{groupBy}}) Memory Usage, Request, Limit, and Capacity",
       "memory_usage_label": "Used ({{date}})",
       "modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Historical Data",
-      "project_title": "Top Projects"
+      "project_title": "Top Projects",
+      "view_data": "View Historical Data"
     },
     "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
     "increase_since_last_month": "{{value}} increase since last month",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -24,9 +24,11 @@
   },
   "aws_details": {
     "change_column_title": "Month Over Month Change",
+    "chart_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s {{localGroupBy}}s",
     "cluster_label": "Cluster:",
     "cost_column_subtitle": " (Total {{total}})",
     "cost_column_title": "Cost",
+    "cost_value": "Cost: {{value}}",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
     "export_link": "Export",
@@ -48,6 +50,7 @@
       "cost_delta": "Sort by: Cost Delta",
       "name": "Sort by: Name"
     },
+    "show_more": "Show More",
     "tags_label": "Related Tags:",
     "title": "AWS Details",
     "total_cost": "Total Cost"
@@ -206,7 +209,8 @@
       "memory_title": "Month over Month Total $t(group_by.values.{{groupBy}}) Memory Usage, Request, Limit, and Capacity",
       "memory_usage_label": "Used ({{date}})",
       "modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Historical Data",
-      "project_title": "Top Projects"
+      "project_title": "Top Projects",
+      "view_data": "View Historical Data"
     },
     "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
     "increase_since_last_month": "{{value}} increase since last month",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -24,9 +24,11 @@
   },
   "aws_details": {
     "change_column_title": "Month Over Month Change",
+    "chart_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s {{localGroupBy}}s",
     "cluster_label": "Cluster:",
     "cost_column_subtitle": " (Total {{total}})",
     "cost_column_title": "Cost",
+    "cost_value": "Cost: {{value}}",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
     "export_link": "Export",
@@ -48,6 +50,7 @@
       "cost_delta": "Sort by: Cost Delta",
       "name": "Sort by: Name"
     },
+    "show_more": "Show More",
     "tags_label": "Related Tags:",
     "title": "AWS Details",
     "total_cost": "Total Cost"
@@ -206,7 +209,8 @@
       "memory_title": "Month over Month Total $t(group_by.values.{{groupBy}}) Memory Usage, Request, Limit, and Capacity",
       "memory_usage_label": "Used ({{date}})",
       "modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Historical Data",
-      "project_title": "Top Projects"
+      "project_title": "Top Projects",
+      "view_data": "View Historical Data"
     },
     "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
     "increase_since_last_month": "{{value}} increase since last month",

--- a/src/pages/awsDetails/detailsChart.styles.ts
+++ b/src/pages/awsDetails/detailsChart.styles.ts
@@ -1,13 +1,9 @@
 import { StyleSheet } from '@patternfly/react-styles';
-import { global_spacer_xl } from '@patternfly/react-tokens';
+import { global_spacer_md } from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
-  cpuBulletContainer: {
-    paddingRight: '2rem',
-  },
-  memoryBulletContainer: {
-    paddingBottom: global_spacer_xl.value,
-    paddingRight: '2rem',
-    paddingTop: global_spacer_xl.value,
+  showMoreContainer: {
+    marginLeft: '-18px',
+    paddingTop: global_spacer_md.value,
   },
 });

--- a/src/pages/awsDetails/detailsChart.tsx
+++ b/src/pages/awsDetails/detailsChart.tsx
@@ -1,17 +1,16 @@
 import { AwsQuery, getQuery } from 'api/awsQuery';
 import { AwsReport, AwsReportType } from 'api/awsReports';
-import {
-  ChartType,
-  transformAwsReport,
-} from 'components/commonChart/chartUtils';
-import { PieChart } from 'components/pieChart/pieChart';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { awsReportsActions, awsReportsSelectors } from 'store/awsReports';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { formatCurrency, formatValue } from 'utils/formatValue';
+import { formatValue } from 'utils/formatValue';
 import { ComputedAwsReportItem } from 'utils/getComputedAwsReportItems';
+import {
+  AwsReportSummaryItem,
+  AwsReportSummaryItems,
+} from '../../components/awsReportSummary';
 
 interface DetailsChartOwnProps {
   groupBy: string;
@@ -51,29 +50,23 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
   public render() {
     const { localGroupBy, report } = this.props;
 
-    const currentData = transformAwsReport(
-      report,
-      ChartType.monthly,
-      localGroupBy
+    return (
+      <AwsReportSummaryItems idKey={localGroupBy as any} report={report}>
+        {({ items }) =>
+          items.map(item => (
+            <AwsReportSummaryItem
+              key={item.id}
+              formatOptions={{}}
+              formatValue={formatValue}
+              label={item.label ? item.label.toString() : ''}
+              totalValue={(item.total as any).value}
+              units={item.units}
+              value={item.total}
+            />
+          ))
+        }
+      </AwsReportSummaryItems>
     );
-    const legendData = currentData.map(item => ({
-      name: item.name.toString() + ' (' + formatCurrency(item.y) + ')',
-      symbol: { type: 'square' },
-    }));
-
-    if (currentData && currentData.length) {
-      return (
-        <PieChart
-          height={200}
-          width={200}
-          data={currentData}
-          formatDatumValue={formatValue}
-          groupBy={localGroupBy}
-          legendData={legendData}
-        />
-      );
-    }
-    return null;
   }
 }
 

--- a/src/pages/awsDetails/detailsChart.tsx
+++ b/src/pages/awsDetails/detailsChart.tsx
@@ -1,16 +1,24 @@
+import { Button, ButtonType, ButtonVariant } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
 import { AwsQuery, getQuery } from 'api/awsQuery';
 import { AwsReport, AwsReportType } from 'api/awsReports';
+import {
+  AwsReportSummaryItem,
+  AwsReportSummaryItems,
+} from 'components/awsReportSummary';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { awsReportsActions, awsReportsSelectors } from 'store/awsReports';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { formatValue } from 'utils/formatValue';
-import { ComputedAwsReportItem } from 'utils/getComputedAwsReportItems';
 import {
-  AwsReportSummaryItem,
-  AwsReportSummaryItems,
-} from '../../components/awsReportSummary';
+  ComputedAwsReportItem,
+  getComputedAwsReportItems,
+} from 'utils/getComputedAwsReportItems';
+import { getTestProps, testIds } from '../../testIds';
+import { styles } from './detailsChart.styles';
+import { DetailsChartModal } from './detailsChartModal';
 
 interface DetailsChartOwnProps {
   groupBy: string;
@@ -28,12 +36,20 @@ interface DetailsChartDispatchProps {
   fetchReport?: typeof awsReportsActions.fetchReport;
 }
 
+interface DetailsChartState {
+  isDetailsChartModalOpen: boolean;
+}
+
 type DetailsChartProps = DetailsChartOwnProps &
   DetailsChartStateProps &
   DetailsChartDispatchProps &
   InjectedTranslateProps;
 
 class DetailsChartBase extends React.Component<DetailsChartProps> {
+  public state: DetailsChartState = {
+    isDetailsChartModalOpen: false,
+  };
+
   public componentDidMount() {
     const { report, queryString } = this.props;
     if (!report) {
@@ -47,25 +63,76 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
     }
   }
 
+  private handleDetailsChartModalClose = (isOpen: boolean) => {
+    this.setState({ isDetailsChartModalOpen: isOpen });
+  };
+
+  private handleDetailsChartModalOpen = event => {
+    this.setState({ isDetailsChartModalOpen: true });
+    event.preventDefault();
+  };
+
+  private getItems() {
+    const { report, localGroupBy } = this.props;
+
+    const computedItems = getComputedAwsReportItems({
+      report,
+      idKey: localGroupBy as any,
+    });
+
+    return computedItems;
+  }
+
   public render() {
-    const { localGroupBy, report } = this.props;
+    const { item, groupBy, localGroupBy, report, t } = this.props;
+    const { isDetailsChartModalOpen } = this.state;
+
+    const computedItems = this.getItems();
+
+    const otherIndex = computedItems.findIndex(i => {
+      const id = i.id;
+      if (id && id !== null) {
+        return id.toString().includes('Others');
+      }
+    });
 
     return (
-      <AwsReportSummaryItems idKey={localGroupBy as any} report={report}>
-        {({ items }) =>
-          items.map(item => (
-            <AwsReportSummaryItem
-              key={item.id}
-              formatOptions={{}}
-              formatValue={formatValue}
-              label={item.label ? item.label.toString() : ''}
-              totalValue={(item.total as any).value}
-              units={item.units}
-              value={item.total}
+      <>
+        <AwsReportSummaryItems idKey={localGroupBy as any} report={report}>
+          {({ items }) =>
+            items.map(_item => (
+              <AwsReportSummaryItem
+                key={_item.id}
+                formatOptions={{}}
+                formatValue={formatValue}
+                label={_item.label ? _item.label.toString() : ''}
+                totalValue={report.total.value}
+                units={_item.units}
+                value={_item.total}
+              />
+            ))
+          }
+        </AwsReportSummaryItems>
+        {Boolean(otherIndex !== -1) && (
+          <div className={css(styles.showMoreContainer)}>
+            <Button
+              {...getTestProps(testIds.details.show_more_btn)}
+              onClick={this.handleDetailsChartModalOpen}
+              type={ButtonType.button}
+              variant={ButtonVariant.link}
+            >
+              {t('aws_details.show_more')}
+            </Button>
+            <DetailsChartModal
+              groupBy={groupBy}
+              isOpen={isDetailsChartModalOpen}
+              item={item}
+              onClose={this.handleDetailsChartModalClose}
+              localGroupBy={localGroupBy}
             />
-          ))
-        }
-      </AwsReportSummaryItems>
+          </div>
+        )}
+      </>
     );
   }
 }
@@ -79,7 +146,7 @@ const mapStateToProps = createMapStateToProps<
       time_scope_units: 'month',
       time_scope_value: -1,
       resolution: 'monthly',
-      limit: 5,
+      limit: 3,
     },
     group_by: { [groupBy]: item.label, [localGroupBy]: '*' },
   };

--- a/src/pages/awsDetails/detailsChartModal.styles.ts
+++ b/src/pages/awsDetails/detailsChartModal.styles.ts
@@ -1,0 +1,35 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import {
+  global_Color_100,
+  global_spacer_2xl,
+  global_spacer_md,
+  global_spacer_xl,
+} from '@patternfly/react-tokens';
+import { css } from 'emotion';
+
+export const styles = StyleSheet.create({
+  modal: {
+    // Workaround for PatternFly setting Grid color property
+    color: global_Color_100.value,
+    // Workaround for isLarge not working properly
+    height: '700px',
+    width: '600px',
+  },
+  modalBody: {
+    marginBottom: global_spacer_md.value,
+    marginTop: global_spacer_xl.value,
+  },
+  summary: {
+    marginTop: global_spacer_xl.value,
+  },
+  totalCost: {
+    marginTop: global_spacer_2xl.value,
+    textAlign: 'right',
+  },
+});
+
+export const modalOverride = css`
+  & .pf-c-modal-box__footer {
+    display: none;
+  }
+`;

--- a/src/pages/awsDetails/detailsChartModal.tsx
+++ b/src/pages/awsDetails/detailsChartModal.tsx
@@ -1,0 +1,160 @@
+import { Modal, Title } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import { AwsQuery, getQuery } from 'api/awsQuery';
+import { AwsReport, AwsReportType } from 'api/awsReports';
+import {
+  AwsReportSummaryItem,
+  AwsReportSummaryItems,
+} from 'components/awsReportSummary';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { awsReportsActions, awsReportsSelectors } from 'store/awsReports';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { formatValue } from 'utils/formatValue';
+import { formatCurrency } from 'utils/formatValue';
+import { ComputedAwsReportItem } from 'utils/getComputedAwsReportItems';
+import { modalOverride, styles } from './detailsChartModal.styles';
+
+interface DetailsChartModalOwnProps {
+  groupBy: string;
+  item: ComputedAwsReportItem;
+  isOpen: boolean;
+  localGroupBy: string;
+  onClose(isOpen: boolean);
+}
+
+interface DetailsChartModalStateProps {
+  queryString?: string;
+  report?: AwsReport;
+  reportFetchStatus?: FetchStatus;
+}
+
+interface DetailsChartModalDispatchProps {
+  fetchReport?: typeof awsReportsActions.fetchReport;
+}
+
+type DetailsChartModalProps = DetailsChartModalOwnProps &
+  DetailsChartModalStateProps &
+  DetailsChartModalDispatchProps &
+  InjectedTranslateProps;
+
+class DetailsChartModalBase extends React.Component<DetailsChartModalProps> {
+  constructor(props: DetailsChartModalProps) {
+    super(props);
+    this.handleClose = this.handleClose.bind(this);
+  }
+
+  public componentDidMount() {
+    const { report, queryString } = this.props;
+    if (!report) {
+      this.props.fetchReport(AwsReportType.cost, queryString);
+    }
+    this.setState({});
+  }
+
+  public componentDidUpdate(prevProps: DetailsChartModalProps) {
+    if (prevProps.queryString !== this.props.queryString) {
+      this.props.fetchReport(AwsReportType.cost, this.props.queryString);
+    }
+  }
+
+  public shouldComponentUpdate(nextProps: DetailsChartModalProps) {
+    const { isOpen, item } = this.props;
+    return nextProps.item !== item || nextProps.isOpen !== isOpen;
+  }
+
+  private handleClose = () => {
+    this.props.onClose(false);
+  };
+
+  public render() {
+    const { groupBy, isOpen, item, localGroupBy, report, t } = this.props;
+
+    const cost = formatCurrency(
+      report && report.total ? report.total.value : 0
+    );
+
+    return (
+      <Modal
+        className={`${modalOverride} ${css(styles.modal)}`}
+        isLarge
+        isOpen={isOpen}
+        onClose={this.handleClose}
+        title={t('aws_details.chart_modal_title', {
+          groupBy,
+          name: item.label,
+          localGroupBy,
+        })}
+      >
+        <div className={styles.modalBody}>
+          <div className={styles.totalCost}>
+            <Title size="lg">
+              {t('aws_details.cost_value', { value: cost })}
+            </Title>
+          </div>
+          <div className={styles.summary}>
+            <AwsReportSummaryItems idKey={localGroupBy as any} report={report}>
+              {({ items }) =>
+                items.map(_item => (
+                  <AwsReportSummaryItem
+                    key={_item.id}
+                    formatOptions={{}}
+                    formatValue={formatValue}
+                    label={_item.label ? _item.label.toString() : ''}
+                    totalValue={report.total.value}
+                    units={_item.units}
+                    value={_item.total}
+                  />
+                ))
+              }
+            </AwsReportSummaryItems>
+          </div>
+        </div>
+      </Modal>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  DetailsChartModalOwnProps,
+  DetailsChartModalStateProps
+>((state, { groupBy, item, localGroupBy }) => {
+  const query: AwsQuery = {
+    filter: {
+      time_scope_units: 'month',
+      time_scope_value: -1,
+      resolution: 'monthly',
+    },
+    group_by: { [groupBy]: item.label, [localGroupBy]: '*' },
+  };
+  const queryString = getQuery(query);
+  const report = awsReportsSelectors.selectReport(
+    state,
+    AwsReportType.cost,
+    queryString
+  );
+  const reportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
+    state,
+    AwsReportType.cost,
+    queryString
+  );
+  return {
+    queryString,
+    report,
+    reportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: DetailsChartModalDispatchProps = {
+  fetchReport: awsReportsActions.fetchReport,
+};
+
+const DetailsChartModal = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(DetailsChartModalBase)
+);
+
+export { DetailsChartModal, DetailsChartModalBase, DetailsChartModalProps };

--- a/src/pages/awsDetails/detailsTable.tsx
+++ b/src/pages/awsDetails/detailsTable.tsx
@@ -114,9 +114,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       rows.push(
         {
           cells: [
-            <div key={`label-${index}`}>{label}</div>,
-            <div key={`month-over-month-${index}`}>{monthOverMonth}</div>,
-            <div key={`cost-${index}`}>{cost}</div>,
+            { title: <div>{label}</div> },
+            { title: <div>{monthOverMonth}</div> },
+            { title: <div>{cost}</div> },
           ],
           isOpen: false,
           item,

--- a/src/pages/awsDetails/detailsTable.tsx
+++ b/src/pages/awsDetails/detailsTable.tsx
@@ -31,7 +31,7 @@ interface DetailsTableOwnProps {
   report: AwsReport;
 }
 
-interface State {
+interface DetailsTableState {
   columns?: any[];
   isHistoricalModalOpen?: boolean;
   rows?: any[];
@@ -40,7 +40,7 @@ interface State {
 type DetailsTableProps = DetailsTableOwnProps & InjectedTranslateProps;
 
 class DetailsTableBase extends React.Component<DetailsTableProps> {
-  public state: State = {
+  public state: DetailsTableState = {
     columns: [],
     isHistoricalModalOpen: false,
     rows: [],
@@ -81,8 +81,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     }
 
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const total =
-      report && report.total ? formatCurrency(report.total.value) : 0;
+    const total = formatCurrency(
+      report && report.total ? report.total.value : 0
+    );
 
     const columns = [
       {
@@ -107,12 +108,15 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     });
 
     computedItems.map((item, index) => {
+      const label = item && item.label !== null ? item.label : '';
+      const monthOverMonth = this.getMonthOverMonthCost(item, index);
+      const cost = this.getTotalCost(item, index);
       rows.push(
         {
           cells: [
-            item.label ? item.label : '',
-            this.getMonthOverMonthCost(item, index),
-            this.getTotalCost(item, index),
+            <div key={`label-${index}`}>{label}</div>,
+            <div key={`month-over-month-${index}`}>{monthOverMonth}</div>,
+            <div key={`cost-${index}`}>{cost}</div>,
           ],
           isOpen: false,
           item,

--- a/src/pages/awsDetails/detailsTableItem.styles.ts
+++ b/src/pages/awsDetails/detailsTableItem.styles.ts
@@ -1,10 +1,10 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
+  global_FontSize_sm,
   global_spacer_3xl,
   global_spacer_md,
   global_spacer_xl,
 } from '@patternfly/react-tokens';
-// import { css } from 'emotion';
 
 export const styles = StyleSheet.create({
   accountsContainer: {
@@ -15,11 +15,18 @@ export const styles = StyleSheet.create({
     justifyContent: 'flex-end',
     paddingTop: global_spacer_xl.value,
   },
+  innerGroupBySelector: {
+    display: 'flex',
+    alignItems: 'center',
+    fontSize: global_FontSize_sm.value,
+    paddingBottom: global_spacer_xl.value,
+  },
   innerGroupBySelectorLabel: {
     marginBottom: 0,
     marginRight: global_spacer_md.var,
   },
   measureChartContainer: {
+    paddingBottom: global_spacer_xl.value,
     paddingTop: global_spacer_xl.value,
   },
   summaryContainer: {

--- a/src/pages/awsDetails/detailsTableItem.tsx
+++ b/src/pages/awsDetails/detailsTableItem.tsx
@@ -95,10 +95,10 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
     return (
       <>
         <Grid>
-          <GridItem lg={12} xl={4}>
+          <GridItem md={12} lg={3}>
             <div className={css(styles.accountsContainer)}>
               {Boolean(groupBy === 'account') && (
-                <Form isHorizontal>
+                <Form>
                   <FormGroup label={t('aws_details.tags_label')} fieldId="tags">
                     <DetailsTag id="tags" account={item.label || item.id} />
                   </FormGroup>
@@ -109,7 +109,7 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
               )}
             </div>
           </GridItem>
-          <GridItem lg={12} xl={5}>
+          <GridItem md={12} lg={6}>
             <div className={css(styles.measureChartContainer)}>
               <div className={css(styles.innerGroupBySelector)}>
                 <label className={css(styles.innerGroupBySelectorLabel)}>
@@ -137,7 +137,7 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
               />
             </div>
           </GridItem>
-          <GridItem lg={12} xl={3}>
+          <GridItem md={12} lg={3}>
             <div className={css(styles.historicalLinkContainer)}>
               <Button
                 isDisabled

--- a/src/pages/awsDetails/detailsTag.tsx
+++ b/src/pages/awsDetails/detailsTag.tsx
@@ -53,7 +53,7 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
     }
   }
 
-  public handleMoreClicked = (event: React.FormEvent<HTMLAnchorElement>) => {
+  private handleMoreClicked = (event: React.FormEvent<HTMLAnchorElement>) => {
     event.preventDefault();
     return false;
   };

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -31,7 +31,7 @@ interface DetailsTableOwnProps {
   report: OcpReport;
 }
 
-interface State {
+interface DetailsTableState {
   columns?: any[];
   isHistoricalModalOpen?: boolean;
   rows?: any[];
@@ -40,7 +40,7 @@ interface State {
 type DetailsTableProps = DetailsTableOwnProps & InjectedTranslateProps;
 
 class DetailsTableBase extends React.Component<DetailsTableProps> {
-  public state: State = {
+  public state: DetailsTableState = {
     columns: [],
     isHistoricalModalOpen: false,
     rows: [],
@@ -81,8 +81,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     }
 
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const total =
-      report && report.total ? formatCurrency(report.total.charge) : 0;
+    const total = formatCurrency(
+      report && report.total ? report.total.charge : 0
+    );
 
     const columns = [
       {
@@ -107,12 +108,15 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     });
 
     computedItems.map((item, index) => {
+      const label = item && item.label !== null ? item.label : '';
+      const monthOverMonth = this.getMonthOverMonthCost(item, index);
+      const cost = this.getTotalCost(item, index);
       rows.push(
         {
           cells: [
-            item.label ? item.label : '',
-            this.getMonthOverMonthCost(item, index),
-            this.getTotalCost(item, index),
+            <div key={`label-${index}`}>{label}</div>,
+            <div key={`month-over-month-${index}`}>{monthOverMonth}</div>,
+            <div key={`cost-${index}`}>{cost}</div>,
           ],
           isOpen: false,
           item,

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -114,9 +114,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       rows.push(
         {
           cells: [
-            <div key={`label-${index}`}>{label}</div>,
-            <div key={`month-over-month-${index}`}>{monthOverMonth}</div>,
-            <div key={`cost-${index}`}>{cost}</div>,
+            { title: <div>{label}</div> },
+            { title: <div>{monthOverMonth}</div> },
+            { title: <div>{cost}</div> },
           ],
           isOpen: false,
           item,

--- a/src/pages/ocpDetails/detailsTableItem.tsx
+++ b/src/pages/ocpDetails/detailsTableItem.tsx
@@ -59,10 +59,10 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
     return (
       <>
         <Grid>
-          <GridItem lg={12} xl={4}>
+          <GridItem md={12} lg={3}>
             <div className={css(styles.projectsContainer)}>
               {Boolean(groupBy === 'project') && (
-                <Form isHorizontal>
+                <Form>
                   <FormGroup
                     label={t('ocp_details.cluster_label')}
                     fieldId="cluster-name"
@@ -81,12 +81,12 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
               )}
             </div>
           </GridItem>
-          <GridItem lg={12} xl={5}>
+          <GridItem md={12} lg={6}>
             <div className={css(styles.measureChartContainer)}>
               <DetailsChart groupBy={groupBy} item={item} />
             </div>
           </GridItem>
-          <GridItem lg={12} xl={3}>
+          <GridItem md={12} lg={3}>
             <div className={css(styles.historicalLinkContainer)}>
               <Button
                 {...getTestProps(testIds.details.historical_data_btn)}
@@ -94,7 +94,7 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
                 type={ButtonType.button}
                 variant={ButtonVariant.secondary}
               >
-                View Historical Data
+                {t('ocp_details.historical.view_data')}
               </Button>
             </div>
           </GridItem>

--- a/src/pages/ocpDetails/detailsTag.tsx
+++ b/src/pages/ocpDetails/detailsTag.tsx
@@ -53,7 +53,7 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
     }
   }
 
-  public handleMoreClicked = (event: React.FormEvent<HTMLAnchorElement>) => {
+  private handleMoreClicked = (event: React.FormEvent<HTMLAnchorElement>) => {
     event.preventDefault();
     return false;
   };

--- a/src/testIds.ts
+++ b/src/testIds.ts
@@ -5,6 +5,7 @@ export const testIds = {
   details: {
     historical_data_btn: 'historical-data-btn',
     tag_lnk: 'tag-lnk',
+    show_more_btn: 'show-more-btn',
   },
   export: {
     cancel_btn: 'cancel-btn',

--- a/yarn.lock
+++ b/yarn.lock
@@ -299,9 +299,9 @@
   version "1.0.129"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly-next/-/patternfly-next-1.0.129.tgz#6bc752cf7da13984ce4007c6e963cf2a01355e93"
 
-"@patternfly/patternfly@1.0.178":
-  version "1.0.178"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-1.0.178.tgz#5b520cc6da54f54a7b5a0c449101335cfbff5218"
+"@patternfly/patternfly@1.0.184":
+  version "1.0.184"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-1.0.184.tgz#4a27921653d4cbf8272d62f66d9a17db6590d3d6"
 
 "@patternfly/react-charts@1.2.7":
   version "1.2.7"
@@ -335,13 +335,13 @@
   optionalDependencies:
     "@patternfly/react-tokens" "^1.0.0"
 
-"@patternfly/react-core@^1.52.0":
-  version "1.52.0"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-1.52.0.tgz#4ca4e8d800203afdf9c0871e556725f776f6c07c"
+"@patternfly/react-core@^2.1.4":
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-2.1.4.tgz#be16ae1928d694eb1408f585542471abf3c147f9"
   dependencies:
-    "@patternfly/react-icons" "^2.10.6"
-    "@patternfly/react-styles" "^2.3.1"
-    "@patternfly/react-tokens" "^1.10.3"
+    "@patternfly/react-icons" "^3.0.0"
+    "@patternfly/react-styles" "^2.3.2"
+    "@patternfly/react-tokens" "^2.0.0"
     "@tippy.js/react" "^1.1.1"
     emotion "^10.0.6"
     exenv "^1.2.2"
@@ -356,13 +356,13 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-2.0.0.tgz#9e2c44ec366df14b9173ab72b8072827aaf4b188"
 
-"@patternfly/react-icons@^2.10.6":
-  version "2.10.6"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-2.10.6.tgz#496c83e1a54257d3929df58a40e42410af35968d"
-
 "@patternfly/react-icons@^2.4.0":
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-2.4.0.tgz#f90fa68d626fc62266545b21fdedf0967abbc860"
+
+"@patternfly/react-icons@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.0.0.tgz#fe5f79b9b883168c0fc25af1997243759967e6e5"
 
 "@patternfly/react-styles@2.3.0", "@patternfly/react-styles@^2.3.0":
   version "2.3.0"
@@ -396,9 +396,9 @@
     relative "^3.0.2"
     resolve-from "^4.0.0"
 
-"@patternfly/react-styles@^2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-2.3.1.tgz#9bc2edc2feae9d0bf1ffff08d6a41f555cda79f3"
+"@patternfly/react-styles@^2.3.2":
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-2.3.2.tgz#b2dd4d0e202bbdda7ceaceb6beced9c1419d2d87"
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0-beta.48"
     camel-case "^3.0.0"
@@ -413,18 +413,18 @@
     relative "^3.0.2"
     resolve-from "^4.0.0"
 
-"@patternfly/react-table@0.4.18":
-  version "0.4.18"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-0.4.18.tgz#d47854e51cfaa983c3c5264d3d87f1f27c8a7c9c"
+"@patternfly/react-table@1.0.7":
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-1.0.7.tgz#066994d6d1925640ce7a9ab72485c3132616dd38"
   dependencies:
-    "@patternfly/patternfly" "1.0.178"
-    "@patternfly/react-core" "^1.52.0"
-    "@patternfly/react-icons" "^2.10.6"
-    "@patternfly/react-styles" "^2.3.1"
+    "@patternfly/patternfly" "1.0.184"
+    "@patternfly/react-core" "^2.1.4"
+    "@patternfly/react-icons" "^3.0.0"
+    "@patternfly/react-styles" "^2.3.2"
     exenv "^1.2.2"
     reactabular-table "^8.14.0"
   optionalDependencies:
-    "@patternfly/react-tokens" "^1.10.3"
+    "@patternfly/react-tokens" "^2.0.0"
 
 "@patternfly/react-tokens@1.9.6", "@patternfly/react-tokens@^1.9.4", "@patternfly/react-tokens@^1.9.6":
   version "1.9.6"
@@ -434,9 +434,9 @@
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-1.3.0.tgz#5b78e3b900c3209d9c0cbc4b8ea6738b669003d9"
 
-"@patternfly/react-tokens@^1.10.3":
-  version "1.10.3"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-1.10.3.tgz#02e8d06ff6e0a3346b49731e1c481aef9f2e9f43"
+"@patternfly/react-tokens@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-tokens/-/react-tokens-2.0.0.tgz#db44313e884bf2a3eb78aba64f084f0a9dd93625"
 
 "@red-hat-insights/insights-frontend-components@^3.19.4":
   version "3.19.7"


### PR DESCRIPTION
This replaces the pie chart with PF4 progress bars in the AWS details page. There is no mock, but worked with Natalie to create progress bars similar to the overview page. The difference here is that we only display the top 3 and use a scrollable modal to show more.

<img width="1657" alt="screen shot 2019-02-12 at 11 46 32 pm" src="https://user-images.githubusercontent.com/17481322/52687544-7763d100-2f20-11e9-97c2-bb4c616b5090.png">

<img width="1655" alt="screen shot 2019-02-12 at 11 41 23 pm" src="https://user-images.githubusercontent.com/17481322/52687412-c8bf9080-2f1f-11e9-9e50-26dc8d59aeb5.png">
