### PR TITLE
Replace 'more tags' popover with modal

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -52,6 +52,7 @@
     },
     "show_more": "Show More",
     "tags_label": "Related Tags:",
+    "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Related Tags",
     "title": "AWS Details",
     "total_cost": "Total Cost"
   },
@@ -223,6 +224,7 @@
       "name": "Sort by: Name"
     },
     "tags_label": "Related Tags:",
+    "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Related Tags",
     "title": "OpenShift Details",
     "total_charge": "Total Charge"
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -52,6 +52,7 @@
     },
     "show_more": "Show More",
     "tags_label": "Related Tags:",
+    "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Related Tags",
     "title": "AWS Details",
     "total_cost": "Total Cost"
   },
@@ -223,6 +224,7 @@
       "name": "Sort by: Name"
     },
     "tags_label": "Related Tags:",
+    "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Related Tags",
     "title": "OpenShift Details",
     "total_charge": "Total Charge"
   },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -52,6 +52,7 @@
     },
     "show_more": "Show More",
     "tags_label": "Related Tags:",
+    "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Related Tags",
     "title": "AWS Details",
     "total_cost": "Total Cost"
   },
@@ -223,6 +224,7 @@
       "name": "Sort by: Name"
     },
     "tags_label": "Related Tags:",
+    "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Related Tags",
     "title": "OpenShift Details",
     "total_charge": "Total Charge"
   },

--- a/src/pages/awsDetails/detailsChartModal.tsx
+++ b/src/pages/awsDetails/detailsChartModal.tsx
@@ -50,7 +50,6 @@ class DetailsChartModalBase extends React.Component<DetailsChartModalProps> {
     if (!report) {
       this.props.fetchReport(AwsReportType.cost, queryString);
     }
-    this.setState({});
   }
 
   public componentDidUpdate(prevProps: DetailsChartModalProps) {
@@ -87,29 +86,27 @@ class DetailsChartModalBase extends React.Component<DetailsChartModalProps> {
           localGroupBy,
         })}
       >
-        <div className={styles.modalBody}>
-          <div className={styles.totalCost}>
-            <Title size="lg">
-              {t('aws_details.cost_value', { value: cost })}
-            </Title>
-          </div>
-          <div className={styles.summary}>
-            <AwsReportSummaryItems idKey={localGroupBy as any} report={report}>
-              {({ items }) =>
-                items.map(_item => (
-                  <AwsReportSummaryItem
-                    key={_item.id}
-                    formatOptions={{}}
-                    formatValue={formatValue}
-                    label={_item.label ? _item.label.toString() : ''}
-                    totalValue={report.total.value}
-                    units={_item.units}
-                    value={_item.total}
-                  />
-                ))
-              }
-            </AwsReportSummaryItems>
-          </div>
+        <div className={styles.subTitle}>
+          <Title size="lg">
+            {t('aws_details.cost_value', { value: cost })}
+          </Title>
+        </div>
+        <div className={styles.mainContent}>
+          <AwsReportSummaryItems idKey={localGroupBy as any} report={report}>
+            {({ items }) =>
+              items.map(_item => (
+                <AwsReportSummaryItem
+                  key={_item.id}
+                  formatOptions={{}}
+                  formatValue={formatValue}
+                  label={_item.label ? _item.label.toString() : ''}
+                  totalValue={report.total.value}
+                  units={_item.units}
+                  value={_item.total}
+                />
+              ))
+            }
+          </AwsReportSummaryItems>
         </div>
       </Modal>
     );

--- a/src/pages/awsDetails/detailsTableItem.tsx
+++ b/src/pages/awsDetails/detailsTableItem.tsx
@@ -100,7 +100,12 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
               {Boolean(groupBy === 'account') && (
                 <Form>
                   <FormGroup label={t('aws_details.tags_label')} fieldId="tags">
-                    <DetailsTag id="tags" account={item.label || item.id} />
+                    <DetailsTag
+                      account={item.label || item.id}
+                      groupBy={groupBy}
+                      id="tags"
+                      item={item}
+                    />
                   </FormGroup>
                 </Form>
               )}

--- a/src/pages/awsDetails/detailsTag.styles.ts
+++ b/src/pages/awsDetails/detailsTag.styles.ts
@@ -1,6 +1,5 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_3xl, global_spacer_sm } from '@patternfly/react-tokens';
-import { css } from 'emotion';
 
 export const styles = StyleSheet.create({
   tagsContainer: {
@@ -8,9 +7,3 @@ export const styles = StyleSheet.create({
     marginTop: global_spacer_sm.value,
   },
 });
-
-export const popoverOverride = css`
-  &.pf-c-popover {
-    --pf-c-popover--MaxWidth: 600px;
-  }
-`;

--- a/src/pages/awsDetails/detailsTag.tsx
+++ b/src/pages/awsDetails/detailsTag.tsx
@@ -1,4 +1,3 @@
-import { Popover } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { getQuery } from 'api/awsQuery';
 import { AwsReport, AwsReportType } from 'api/awsReports';
@@ -7,20 +6,25 @@ import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { awsReportsActions, awsReportsSelectors } from 'store/awsReports';
 import { createMapStateToProps, FetchStatus } from 'store/common';
+import { ComputedAwsReportItem } from 'utils/getComputedAwsReportItems';
 import { getTestProps, testIds } from '../../testIds';
-import { popoverOverride, styles } from './detailsTag.styles';
+import { styles } from './detailsTag.styles';
+import { DetailsTagModal } from './detailsTagModal';
 
 interface DetailsTagOwnProps {
   account: string | number;
+  groupBy: string;
   id?: string;
-  queryString?: string;
+  item: ComputedAwsReportItem;
 }
 
 interface DetailsTagState {
+  isDetailsModalOpen: boolean;
   showAll: boolean;
 }
 
 interface DetailsTagStateProps {
+  queryString?: string;
   report?: AwsReport;
   reportFetchStatus?: FetchStatus;
 }
@@ -36,9 +40,16 @@ type DetailsTagProps = DetailsTagOwnProps &
 
 class DetailsTagBase extends React.Component<DetailsTagProps> {
   protected defaultState: DetailsTagState = {
+    isDetailsModalOpen: false,
     showAll: false,
   };
   public state: DetailsTagState = { ...this.defaultState };
+
+  constructor(props: DetailsTagProps) {
+    super(props);
+    this.handleDetailsModalClose = this.handleDetailsModalClose.bind(this);
+    this.handleDetailsModalOpen = this.handleDetailsModalOpen.bind(this);
+  }
 
   public componentDidMount() {
     const { queryString, report } = this.props;
@@ -53,44 +64,19 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
     }
   }
 
-  private handleMoreClicked = (event: React.FormEvent<HTMLAnchorElement>) => {
+  public handleDetailsModalClose = (isOpen: boolean) => {
+    this.setState({ isDetailsModalOpen: isOpen });
+  };
+
+  public handleDetailsModalOpen = event => {
+    this.setState({ isDetailsModalOpen: true });
     event.preventDefault();
     return false;
   };
 
-  private getTagPopover(someTags: any[], allTags: any[]) {
-    const { t } = this.props;
-
-    if (someTags && allTags) {
-      return (
-        <Popover
-          className={popoverOverride}
-          headerContent={<div>{t('aws_details.tags_label')}</div>}
-          position="right"
-          bodyContent={allTags.map((tag, tagIndex) => (
-            <div key={tagIndex}>{tag}</div>
-          ))}
-          size="small"
-        >
-          <a
-            {...getTestProps(testIds.details.tag_lnk)}
-            href="#/"
-            onClick={this.handleMoreClicked}
-          >
-            {t('aws_details.more_tags', {
-              value: allTags.length - someTags.length,
-            })}
-          </a>
-        </Popover>
-      );
-    } else {
-      return null;
-    }
-  }
-
   public render() {
-    const { id, report } = this.props;
-    const { showAll } = this.state;
+    const { account, groupBy, id, item, report, t } = this.props;
+    const { isDetailsModalOpen, showAll } = this.state;
 
     let charCount = 0;
     const maxChars = 50;
@@ -115,8 +101,24 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
       <div className={css(styles.tagsContainer)} id={id}>
         {Boolean(someTags) &&
           someTags.map((tag, tagIndex) => <span key={tagIndex}>{tag}</span>)}
-        {Boolean(someTags.length < allTags.length) &&
-          this.getTagPopover(someTags, allTags)}
+        {Boolean(someTags.length < allTags.length) && (
+          <a
+            {...getTestProps(testIds.details.tag_lnk)}
+            href="#/"
+            onClick={this.handleDetailsModalOpen}
+          >
+            {t('aws_details.more_tags', {
+              value: allTags.length - someTags.length,
+            })}
+          </a>
+        )}
+        <DetailsTagModal
+          account={account}
+          groupBy={groupBy}
+          isOpen={isDetailsModalOpen}
+          item={item}
+          onClose={this.handleDetailsModalClose}
+        />
       </div>
     );
   }
@@ -145,6 +147,7 @@ const mapStateToProps = createMapStateToProps<
     queryString
   );
   return {
+    account,
     queryString,
     report,
     reportFetchStatus,

--- a/src/pages/awsDetails/detailsTagModal.styles.ts
+++ b/src/pages/awsDetails/detailsTagModal.styles.ts
@@ -1,17 +1,15 @@
 import { StyleSheet } from '@patternfly/react-styles';
-import { global_spacer_lg, global_spacer_xl } from '@patternfly/react-tokens';
+import { global_spacer_2xl, global_spacer_lg } from '@patternfly/react-tokens';
 import { css } from 'emotion';
 
 export const styles = StyleSheet.create({
-  mainContent: {
-    marginTop: global_spacer_xl.value,
-  },
   modal: {
     // Workaround for isLarge not working properly
     height: '700px',
     width: '600px',
   },
   subTitle: {
+    marginTop: global_spacer_2xl.value,
     textAlign: 'right',
   },
 });

--- a/src/pages/awsDetails/detailsTagModal.tsx
+++ b/src/pages/awsDetails/detailsTagModal.tsx
@@ -1,0 +1,136 @@
+import { Modal } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import { getQuery } from 'api/awsQuery';
+import { AwsReport, AwsReportType } from 'api/awsReports';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { awsReportsActions, awsReportsSelectors } from 'store/awsReports';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { ComputedAwsReportItem } from 'utils/getComputedAwsReportItems';
+import { modalOverride, styles } from './detailsTagModal.styles';
+
+interface DetailsTagModalOwnProps {
+  account: string | number;
+  groupBy: string;
+  isOpen: boolean;
+  item: ComputedAwsReportItem;
+  onClose(isOpen: boolean);
+}
+
+interface DetailsTagModalStateProps {
+  queryString?: string;
+  report?: AwsReport;
+  reportFetchStatus?: FetchStatus;
+}
+
+interface DetailsTagModalDispatchProps {
+  fetchReport?: typeof awsReportsActions.fetchReport;
+}
+
+type DetailsTagModalProps = DetailsTagModalOwnProps &
+  DetailsTagModalStateProps &
+  DetailsTagModalDispatchProps &
+  InjectedTranslateProps;
+
+class DetailsTagModalBase extends React.Component<DetailsTagModalProps> {
+  constructor(props: DetailsTagModalProps) {
+    super(props);
+    this.handleClose = this.handleClose.bind(this);
+  }
+
+  public componentDidMount() {
+    const { report, queryString } = this.props;
+    if (!report) {
+      this.props.fetchReport(AwsReportType.tag, queryString);
+    }
+  }
+
+  public componentDidUpdate(prevProps: DetailsTagModalProps) {
+    if (prevProps.queryString !== this.props.queryString) {
+      this.props.fetchReport(AwsReportType.tag, this.props.queryString);
+    }
+  }
+
+  private handleClose = () => {
+    this.props.onClose(false);
+  };
+
+  private getTags = () => {
+    const { report } = this.props;
+    const tags = [];
+
+    if (report) {
+      for (const tag of report.data) {
+        for (const val of tag.values) {
+          tags.push(`${(tag as any).key}: ${val}`);
+        }
+      }
+    }
+    return tags;
+  };
+
+  public render() {
+    const { groupBy, isOpen, item, t } = this.props;
+    const tags = this.getTags();
+
+    return (
+      <Modal
+        className={`${modalOverride} ${css(styles.modal)}`}
+        isLarge
+        isOpen={isOpen}
+        onClose={this.handleClose}
+        title={t('aws_details.tags_modal_title', {
+          groupBy,
+          name: item.label,
+        })}
+      >
+        {tags.map((tag, index) => (
+          <div key={`tag-${index}`}>{tag}</div>
+        ))}
+      </Modal>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  DetailsTagModalOwnProps,
+  DetailsTagModalStateProps
+>((state, { account }) => {
+  const queryString = getQuery({
+    filter: {
+      account,
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
+    },
+  });
+  const report = awsReportsSelectors.selectReport(
+    state,
+    AwsReportType.tag,
+    queryString
+  );
+  const reportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
+    state,
+    AwsReportType.tag,
+    queryString
+  );
+  return {
+    queryString,
+    report,
+    reportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: DetailsTagModalDispatchProps = {
+  fetchReport: awsReportsActions.fetchReport,
+};
+
+const DetailsTagModal = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(DetailsTagModalBase)
+);
+
+export { DetailsTagModal, DetailsTagModalBase, DetailsTagModalProps };

--- a/src/pages/ocpDetails/detailsTableItem.tsx
+++ b/src/pages/ocpDetails/detailsTableItem.tsx
@@ -70,7 +70,12 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
                     <DetailsCluster groupBy={groupBy} item={item} />
                   </FormGroup>
                   <FormGroup label={t('ocp_details.tags_label')} fieldId="tags">
-                    <DetailsTag id="tags" project={item.label || item.id} />
+                    <DetailsTag
+                      groupBy={groupBy}
+                      id="tags"
+                      item={item}
+                      project={item.label || item.id}
+                    />
                   </FormGroup>
                 </Form>
               )}

--- a/src/pages/ocpDetails/detailsTag.styles.ts
+++ b/src/pages/ocpDetails/detailsTag.styles.ts
@@ -1,6 +1,5 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_3xl, global_spacer_sm } from '@patternfly/react-tokens';
-import { css } from 'emotion';
 
 export const styles = StyleSheet.create({
   tagsContainer: {
@@ -8,9 +7,3 @@ export const styles = StyleSheet.create({
     marginTop: global_spacer_sm.value,
   },
 });
-
-export const popoverOverride = css`
-  &.pf-c-popover {
-    --pf-c-popover--MaxWidth: 600px;
-  }
-`;

--- a/src/pages/ocpDetails/detailsTagModal.styles.ts
+++ b/src/pages/ocpDetails/detailsTagModal.styles.ts
@@ -1,17 +1,15 @@
 import { StyleSheet } from '@patternfly/react-styles';
-import { global_spacer_lg, global_spacer_xl } from '@patternfly/react-tokens';
+import { global_spacer_2xl, global_spacer_lg } from '@patternfly/react-tokens';
 import { css } from 'emotion';
 
 export const styles = StyleSheet.create({
-  mainContent: {
-    marginTop: global_spacer_xl.value,
-  },
   modal: {
     // Workaround for isLarge not working properly
     height: '700px',
     width: '600px',
   },
   subTitle: {
+    marginTop: global_spacer_2xl.value,
     textAlign: 'right',
   },
 });

--- a/src/pages/ocpDetails/detailsTagModal.tsx
+++ b/src/pages/ocpDetails/detailsTagModal.tsx
@@ -1,0 +1,136 @@
+import { Modal } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import { getQuery } from 'api/ocpQuery';
+import { OcpReport, OcpReportType } from 'api/ocpReports';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { ocpReportsActions, ocpReportsSelectors } from 'store/ocpReports';
+import { ComputedOcpReportItem } from 'utils/getComputedOcpReportItems';
+import { modalOverride, styles } from './detailsTagModal.styles';
+
+interface DetailsTagModalOwnProps {
+  groupBy: string;
+  isOpen: boolean;
+  item: ComputedOcpReportItem;
+  onClose(isOpen: boolean);
+  project: string | number;
+}
+
+interface DetailsTagModalStateProps {
+  queryString?: string;
+  report?: OcpReport;
+  reportFetchStatus?: FetchStatus;
+}
+
+interface DetailsTagModalDispatchProps {
+  fetchReport?: typeof ocpReportsActions.fetchReport;
+}
+
+type DetailsTagModalProps = DetailsTagModalOwnProps &
+  DetailsTagModalStateProps &
+  DetailsTagModalDispatchProps &
+  InjectedTranslateProps;
+
+class DetailsTagModalBase extends React.Component<DetailsTagModalProps> {
+  constructor(props: DetailsTagModalProps) {
+    super(props);
+    this.handleClose = this.handleClose.bind(this);
+  }
+
+  public componentDidMount() {
+    const { report, queryString } = this.props;
+    if (!report) {
+      this.props.fetchReport(OcpReportType.tag, queryString);
+    }
+  }
+
+  public componentDidUpdate(prevProps: DetailsTagModalProps) {
+    if (prevProps.queryString !== this.props.queryString) {
+      this.props.fetchReport(OcpReportType.tag, this.props.queryString);
+    }
+  }
+
+  private handleClose = () => {
+    this.props.onClose(false);
+  };
+
+  private getTags = () => {
+    const { report } = this.props;
+    const tags = [];
+
+    if (report) {
+      for (const tag of report.data) {
+        for (const val of tag.values) {
+          tags.push(`${(tag as any).key}: ${val}`);
+        }
+      }
+    }
+    return tags;
+  };
+
+  public render() {
+    const { groupBy, isOpen, item, t } = this.props;
+    const tags = this.getTags();
+
+    return (
+      <Modal
+        className={`${modalOverride} ${css(styles.modal)}`}
+        isLarge
+        isOpen={isOpen}
+        onClose={this.handleClose}
+        title={t('ocp_details.tags_modal_title', {
+          groupBy,
+          name: item.label,
+        })}
+      >
+        {tags.map((tag, index) => (
+          <div key={`tag-${index}`}>{tag}</div>
+        ))}
+      </Modal>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  DetailsTagModalOwnProps,
+  DetailsTagModalStateProps
+>((state, { project }) => {
+  const queryString = getQuery({
+    filter: {
+      project,
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
+    },
+  });
+  const report = ocpReportsSelectors.selectReport(
+    state,
+    OcpReportType.tag,
+    queryString
+  );
+  const reportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
+    state,
+    OcpReportType.tag,
+    queryString
+  );
+  return {
+    queryString,
+    report,
+    reportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: DetailsTagModalDispatchProps = {
+  fetchReport: ocpReportsActions.fetchReport,
+};
+
+const DetailsTagModal = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(DetailsTagModalBase)
+);
+
+export { DetailsTagModal, DetailsTagModalBase, DetailsTagModalProps };


### PR DESCRIPTION
Replaces the 'more tags' popover with a scrollable modal. This will ensure the popup doesn't appear off the page with too many tags, as shown in the issue below.

Fixes https://github.com/project-koku/koku-ui/issues/481

![screen shot 2019-02-14 at 2 11 34 pm 4](https://user-images.githubusercontent.com/17481322/52811708-c1a19b00-3063-11e9-9d0c-611ea13bc6c9.png)
