### PR TITLE
fix(providersModal): close the provider modal on success

### DIFF
--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -15,7 +15,6 @@ import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router-dom';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { onboardingActions } from 'store/onboarding';
 import { providersSelectors } from 'store/providers';
 import { uiActions } from 'store/ui';
 import { getTestProps, testIds } from 'testIds';
@@ -188,18 +187,18 @@ class OverviewBase extends React.Component<OverviewProps> {
           {Boolean(providersError)
             ? this.getErrorState()
             : Boolean(
-              providers &&
-              providers.count > 0 &&
-              providersFetchStatus === FetchStatus.complete
-            )
-              ? this.getTabs()
-              : Boolean(
                 providers &&
-                providers.count === 0 &&
-                providersFetchStatus === FetchStatus.complete
+                  providers.count > 0 &&
+                  providersFetchStatus === FetchStatus.complete
               )
-                ? this.getEmptyState()
-                : this.getLoadingState()}
+            ? this.getTabs()
+            : Boolean(
+                providers &&
+                  providers.count === 0 &&
+                  providersFetchStatus === FetchStatus.complete
+              )
+            ? this.getEmptyState()
+            : this.getLoadingState()}
         </section>
       </>
     );
@@ -243,7 +242,7 @@ const Overview = translate()(
   connect(
     mapStateToProps,
     {
-      openProvidersModal: onboardingActions.openModal,
+      openProvidersModal: uiActions.openProvidersModal,
     }
   )(OverviewBase)
 );

--- a/src/pages/providersModal/providersModal.tsx
+++ b/src/pages/providersModal/providersModal.tsx
@@ -19,8 +19,8 @@ import {
 } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { onboardingActions, onboardingSelectors } from 'store/onboarding';
 import { providersActions, providersSelectors } from 'store/providers';
+import { uiActions, uiSelectors } from 'store/ui';
 import { getTestProps, testIds } from 'testIds';
 import AttributeField, { AttributeProps } from './attributeField';
 import { styles } from './providersModal.styles';
@@ -28,8 +28,7 @@ import { styles } from './providersModal.styles';
 export interface Props extends InjectedTranslateProps {
   addProvider?: typeof providersActions.addProvider;
   clearProviderFailure: typeof providersActions.clearProviderFailure;
-  closeProvidersModal?: typeof onboardingActions.closeModal;
-  cancelProvidersModal?: typeof onboardingActions.cancelOnboarding;
+  closeProvidersModal?: typeof uiActions.closeProvidersModal;
   error?: AxiosError;
   fetchStatus?: FetchStatus;
   isProviderModalOpen?: boolean;
@@ -199,7 +198,7 @@ export class ProvidersModal extends React.Component<Props, State> {
         className={css(styles.modal)}
         isLarge
         isOpen={this.props.isProviderModalOpen}
-        onClose={this.props.cancelProvidersModal}
+        onClose={this.handleCancel}
         title={t('providers.add_source')}
         actions={[
           <Button
@@ -274,14 +273,13 @@ export class ProvidersModal extends React.Component<Props, State> {
 
 export default connect(
   createMapStateToProps(state => ({
-    isProviderModalOpen: onboardingSelectors.selectOnboardingModal(state),
+    isProviderModalOpen: uiSelectors.selectIsProvidersModalOpen(state),
     error: providersSelectors.selectAddProviderError(state),
     fetchStatus: providersSelectors.selectAddProviderFetchStatus(state),
   })),
   {
     addProvider: providersActions.addProvider,
     clearProviderFailure: providersActions.clearProviderFailure,
-    closeProvidersModal: onboardingActions.closeModal,
-    cancelProvidersModal: onboardingActions.cancelOnboarding,
+    closeProvidersModal: uiActions.closeProvidersModal,
   }
 )(translate()(ProvidersModal));


### PR DESCRIPTION
closes #492 

Since onboardingModal and providersModal are using different parameters in Redux state to determine whether the modal is shown or not, there was a conflict.

In this patch, I fully reverted that part.

//cc @lcouzens 