### PR TITLE
Display the "Show More" link

### DIFF
--- a/src/pages/awsDetails/detailsChart.tsx
+++ b/src/pages/awsDetails/detailsChart.tsx
@@ -92,7 +92,7 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
     const otherIndex = computedItems.findIndex(i => {
       const id = i.id;
       if (id && id !== null) {
-        return id.toString().includes('Others');
+        return id.toString().includes('Other');
       }
     });
 


### PR DESCRIPTION
Display the "Show More" link for the "1 Other" edge case. This will ensure the user can see "Other" items in the modal.

Fixes https://github.com/project-koku/koku-ui/issues/489

![screen shot 2019-02-18 at 11 53 00 am](https://user-images.githubusercontent.com/17481322/52965858-cb811200-3373-11e9-9091-1b63f9604ac7.png)
