### PR TITLE
Match bullet chart colors with legend

### DIFF
--- a/src/components/bulletChart/bulletChart.styles.ts
+++ b/src/components/bulletChart/bulletChart.styles.ts
@@ -12,7 +12,6 @@ export const chartStyles = {
   // See: https://github.com/project-koku/koku-ui/issues/241
   rangeColorScale: [
     '#ededed',
-    '#bee1f4',
     '#d1d1d1',
     '#bbb',
     '#72767b',
@@ -23,7 +22,14 @@ export const chartStyles = {
   thresholdErrorColor: global_danger_color_100.value,
   thresholdErrorWidth: 1,
   // See: https://github.com/project-koku/koku-ui/issues/241
-  valueColorScale: ['#007BBA', '#7DC3E8', '#39A5DC', '#00659C', '#004D76'],
+  valueColorScale: [
+    '#007BBA',
+    '#bee1f4',
+    '#7DC3E8',
+    '#39A5DC',
+    '#00659C',
+    '#004D76',
+  ],
   valueWidth: 9,
 };
 

--- a/src/components/bulletChart/bulletChart.tsx
+++ b/src/components/bulletChart/bulletChart.tsx
@@ -59,11 +59,15 @@ class BulletChart extends React.Component<BulletChartProps, State> {
     const legendData = [];
     for (let i = 0; i < values.length; i++) {
       legendData.push({ name: values[i].legend });
-      legendColorScale.push(chartStyles.valueColorScale[i]);
+      legendColorScale.push(
+        values[i].color ? values[i].color : chartStyles.valueColorScale[i]
+      );
     }
     for (let i = 0; i < ranges.length; i++) {
       legendData.push({ name: ranges[i].legend });
-      legendColorScale.push(chartStyles.rangeColorScale[i]);
+      legendColorScale.push(
+        ranges[i].color ? ranges[i].color : chartStyles.rangeColorScale[i]
+      );
     }
     if (thresholdError) {
       legendData.push({ name: thresholdError.legend });
@@ -101,7 +105,9 @@ class BulletChart extends React.Component<BulletChartProps, State> {
                     labels={[val.tooltip]}
                     style={{
                       data: {
-                        fill: chartStyles.rangeColorScale[index % 4],
+                        fill: val.color
+                          ? val.color
+                          : chartStyles.rangeColorScale[index % 4],
                         width: chartStyles.rangeWidth,
                       },
                     }}
@@ -117,7 +123,9 @@ class BulletChart extends React.Component<BulletChartProps, State> {
                     labels={[val.tooltip]}
                     style={{
                       data: {
-                        fill: chartStyles.valueColorScale[index % 2],
+                        fill: val.color
+                          ? val.color
+                          : chartStyles.valueColorScale[index % 2],
                         width: chartStyles.valueWidth,
                       },
                     }}

--- a/src/pages/ocpDetails/detailsChart.tsx
+++ b/src/pages/ocpDetails/detailsChart.tsx
@@ -2,6 +2,7 @@ import { css } from '@patternfly/react-styles';
 import { getQuery, OcpQuery } from 'api/ocpQuery';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
 import { BulletChart } from 'components/bulletChart';
+import { chartStyles } from 'components/bulletChart/bulletChart.styles';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -80,6 +81,7 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
       };
       datum.ranges = [
         {
+          color: chartStyles.valueColorScale[1], // '#bee1f4'
           legend: t(`ocp_details.bullet.${labelKey}_requests`, {
             value: request,
           }),
@@ -89,6 +91,7 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
           value: Math.trunc(request),
         },
         {
+          color: chartStyles.rangeColorScale[0], // '#ededed'
           legend: t(`ocp_details.bullet.${labelKey}_capacity`, {
             value: datum.capacity,
           }),


### PR DESCRIPTION
This ensures legend colors match the colors used in the bullet chart.

Fixes https://github.com/project-koku/koku-ui/issues/494

![screen shot 2019-02-18 at 2 00 28 pm](https://user-images.githubusercontent.com/17481322/52971479-9e3d5f80-3385-11e9-847a-8a5cafb5f9fc.png)
