### PR TITLE
fix(providersModal): show error regarding resource name after arn:aws

### DIFF
--- a/src/pages/providersModal/providersModal.test.tsx
+++ b/src/pages/providersModal/providersModal.test.tsx
@@ -54,9 +54,17 @@ test('Alert is shown when aws bucket has a special char', () => {
   expect(view.find(Alert).props().title).toBe('providers.bucket_error');
 });
 
+test('Alert is not shown when aws resource name is arn:aw', () => {
+  const view = shallow(<ProvidersModal {...props} />);
+  const input = 'arn:aw';
+  getResourceNameInput(view).simulate('change', input);
+  view.update();
+  expect(view.find(Alert).length).toBe(0);
+});
+
 test('Alert is shown when aws resource name does not start with arn:aws:', () => {
   const view = shallow(<ProvidersModal {...props} />);
-  const input = 'arn:aws';
+  const input = 'arn:awd';
   getResourceNameInput(view).simulate('change', input);
   view.update();
   expect(view.find(Alert).length).toBe(1);

--- a/src/pages/providersModal/providersModal.tsx
+++ b/src/pages/providersModal/providersModal.tsx
@@ -51,10 +51,15 @@ const validator = {
     !new RegExp('^[a-zA-Z0-9.\\-_]{0,255}$').test(value)
       ? t('providers.bucket_error')
       : null,
-  resourceName: (value: string, t: TranslationFunction) =>
-    !new RegExp('^arn:aws:').test(value)
-      ? t('providers.resource_name_error')
-      : null,
+  resourceName: (value: string, t: TranslationFunction) => {
+    let isValid;
+    if (value.length >= 'arn:aws:'.length) {
+      isValid = value.indexOf('arn:aws:');
+    } else {
+      isValid = 'arn:aws:'.indexOf(value);
+    }
+    return isValid !== 0 ? t('providers.resource_name_error') : null;
+  },
   clusterID: (value: string, t: TranslationFunction) =>
     !new RegExp('^.?').test(value) ? t('providers.name_error') : null,
 };


### PR DESCRIPTION
fixes #422 

It will be easier for me later to take that validation and use it in AWS onboarding process.

The flow is: if the user enters less than "arn:aws:". For example, "arn:a" then a server side error message will appear. Although I can set that the minimal length is 10 and avoid getting this error from server side and be more "user-friendly".

Whatever you like.

//cc @lcouzens 