### PR TITLE
Enable providers request to fetch AWS and OCP counts separately

### DIFF
--- a/src/api/providers.test.ts
+++ b/src/api/providers.test.ts
@@ -24,5 +24,5 @@ test('api add provider calls axios.post', () => {
 test('api get provider calls axios.get', () => {
   const query = getProvidersQuery(awsProvidersQuery);
   fetchProviders(query);
-  expect(axios.get).toBeCalledWith('providers/?page_size=100');
+  expect(axios.get).toBeCalledWith('providers/?type=AWS');
 });

--- a/src/api/providersQuery.ts
+++ b/src/api/providersQuery.ts
@@ -1,12 +1,8 @@
 import { parse, stringify } from 'qs';
 
-export interface ProvidersFilters {
-  type?: 'aws' | 'ocp';
-}
-
 export interface ProvidersQuery {
-  filter?: ProvidersFilters;
   page_size?: number;
+  type?: 'AWS' | 'OCP';
 }
 
 export function getProvidersQuery(query: ProvidersQuery) {

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -142,7 +142,6 @@ function buildNavigation() {
 
 const mapStateToProps = createMapStateToProps<AppOwnProps, AppStateProps>(
   (state, props) => {
-    // Todo: Get AWS providers when API is available -- https://github.com/project-koku/koku/issues/658
     const awsProvidersQueryString = getProvidersQuery(awsProvidersQuery);
     const awsProviders = providersSelectors.selectProviders(
       state,
@@ -155,7 +154,6 @@ const mapStateToProps = createMapStateToProps<AppOwnProps, AppStateProps>(
       awsProvidersQueryString
     );
 
-    // Todo: Get OCP providers when API is available -- https://github.com/project-koku/koku/issues/658
     const ocpProvidersQueryString = getProvidersQuery(ocpProvidersQuery);
     const ocpProviders = providersSelectors.selectProviders(
       state,

--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -187,7 +187,6 @@ const mapStateToProps = createMapStateToProps<
   OverviewOwnProps,
   OverviewStateProps
 >(state => {
-  // Todo: Get AWS providers when API is available -- https://github.com/project-koku/koku/issues/658
   const awsProvidersQueryString = getProvidersQuery(awsProvidersQuery);
   const awsProviders = providersSelectors.selectProviders(
     state,
@@ -205,7 +204,6 @@ const mapStateToProps = createMapStateToProps<
     awsProvidersQueryString
   );
 
-  // Todo: Get OCP providers when API is available -- https://github.com/project-koku/koku/issues/658
   const ocpProvidersQueryString = getProvidersQuery(ocpProvidersQuery);
   const ocpProviders = providersSelectors.selectProviders(
     state,

--- a/src/store/providers/providersCommon.ts
+++ b/src/store/providers/providersCommon.ts
@@ -5,17 +5,11 @@ export const stateKey = 'providers';
 export const addProviderKey = 'add-provider';
 
 export const awsProvidersQuery: ProvidersQuery = {
-  // filter: {
-  //   type: 'aws'
-  // },
-  page_size: 100,
+  type: 'AWS',
 };
 
 export const ocpProvidersQuery: ProvidersQuery = {
-  // filter: {
-  //   type: 'aws'
-  // },
-  page_size: 100,
+  type: 'OCP',
 };
 
 export function getReportId(type: ProviderType, query: string) {


### PR DESCRIPTION
This enables the UI to fetch AWS and OCP provider counts separately.

Note that the providers API now supports a type query parameter -- See: https://github.com/project-koku/koku/issues/658

Fixes https://github.com/project-koku/koku-ui/issues/453
Fixes https://github.com/project-koku/koku-ui/issues/437