### PR TITLE
Ensure "others" appears last in top 5

### DIFF
--- a/src/components/awsReportSummary/awsReportSummaryItems.tsx
+++ b/src/components/awsReportSummary/awsReportSummaryItems.tsx
@@ -29,7 +29,12 @@ class AwsReportSummaryItems extends React.Component<
       labelKey,
     });
 
-    const otherIndex = computedItems.findIndex(i => i.id === 'Other');
+    const otherIndex = computedItems.findIndex(i => {
+      const id = i.id;
+      if (id && id !== null) {
+        return id.toString().includes('Other');
+      }
+    });
 
     if (otherIndex !== -1) {
       return [

--- a/src/components/ocpReportSummary/ocpReportSummaryItems.tsx
+++ b/src/components/ocpReportSummary/ocpReportSummaryItems.tsx
@@ -29,7 +29,12 @@ class OcpReportSummaryItems extends React.Component<
       labelKey,
     });
 
-    const otherIndex = computedItems.findIndex(i => i.id === 'Other');
+    const otherIndex = computedItems.findIndex(i => {
+      const id = i.id;
+      if (id && id !== null) {
+        return id.toString().includes('Other');
+      }
+    });
 
     if (otherIndex !== -1) {
       return [


### PR DESCRIPTION
The label returned in the report doesn't contain "Other" only, but something more like "8 Others". The underlying issue was that we were looking for an exact match. 

This change will ensure "Others" appears last in the overview's top 5 as originally intended.

Fixes https://github.com/project-koku/koku-ui/issues/355

<img width="1740" alt="screen shot 2019-02-22 at 2 51 42 pm" src="https://user-images.githubusercontent.com/17481322/53267469-6568f780-36b1-11e9-8ab5-0948a40ed852.png">
