### PR TITLE
Add empty state to AWS/OCP details table

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -31,6 +31,7 @@
     "cost_value": "Cost: {{value}}",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
+    "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "export_link": "Export",
     "filter": {
       "account_placeholder": "Filter by Account",
@@ -200,6 +201,7 @@
     "cluster_label": "Cluster:",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
+    "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "export_link": "Export",
     "filter": {
       "cluster_placeholder": "Filter by Cluster",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -31,6 +31,7 @@
     "cost_value": "Cost: {{value}}",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
+    "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "export_link": "Export",
     "filter": {
       "account_placeholder": "Filter by Account",
@@ -200,6 +201,7 @@
     "cluster_label": "Cluster:",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
+    "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "export_link": "Export",
     "filter": {
       "cluster_placeholder": "Filter by Cluster",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -31,6 +31,7 @@
     "cost_value": "Cost: {{value}}",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
+    "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "export_link": "Export",
     "filter": {
       "account_placeholder": "Filter by Account",
@@ -200,6 +201,7 @@
     "cluster_label": "Cluster:",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
+    "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "export_link": "Export",
     "filter": {
       "cluster_placeholder": "Filter by Cluster",

--- a/src/pages/awsDetails/detailsTable.styles.ts
+++ b/src/pages/awsDetails/detailsTable.styles.ts
@@ -1,14 +1,24 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
+  global_BackgroundColor_light_100,
   global_danger_color_100,
   global_disabled_color_100,
   global_FontSize_xs,
+  global_spacer_3xl,
   global_spacer_xs,
   global_success_color_100,
 } from '@patternfly/react-tokens';
 import { css } from 'emotion';
 
 export const styles = StyleSheet.create({
+  emptyState: {
+    backgroundColor: global_BackgroundColor_light_100.value,
+    display: 'flex',
+    justifyContent: 'center',
+    paddingTop: global_spacer_3xl.value,
+    height: '35vh',
+    width: '100%',
+  },
   infoArrow: {
     position: 'relative',
   },

--- a/src/pages/awsDetails/detailsTable.tsx
+++ b/src/pages/awsDetails/detailsTable.tsx
@@ -1,3 +1,9 @@
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+} from '@patternfly/react-core';
+import { CalculatorIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import {
   sortable,
@@ -141,44 +147,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     });
   };
 
-  public getSortBy = () => {
-    const { query } = this.props;
-    const { columns } = this.state;
+  private getEmptyState = () => {
+    const { t } = this.props;
 
-    let index = -1;
-    let direction = 'asc';
-
-    for (const key of Object.keys(query.order_by)) {
-      let c = 0;
-      for (const column of columns) {
-        if (column.orderBy === key) {
-          direction =
-            query.order_by[key] === 'asc'
-              ? SortByDirection.asc
-              : SortByDirection.desc;
-          index = c + 2;
-          break;
-        }
-        c++;
-      }
-    }
-    return index > -1 ? { index, direction } : {};
-  };
-
-  private getTableItem = (
-    item: ComputedAwsReportItem,
-    groupBy: string,
-    query: AwsQuery,
-    index: number
-  ) => {
     return (
-      <>
-        <DetailsTableItem
-          groupBy={groupBy}
-          item={item}
-          key={`table-item-${index}`}
-        />
-      </>
+      <EmptyState>
+        <EmptyStateIcon icon={CalculatorIcon} />
+        <EmptyStateBody>{t('aws_details.empty_state')}</EmptyStateBody>
+      </EmptyState>
     );
   };
 
@@ -237,16 +213,57 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
                   value,
                 })
             : Boolean(item.deltaPercent !== null && item.deltaValue < 0)
-              ? Boolean(date < 31)
-                ? t('aws_details.decrease_since_date', { date, month, value })
-                : t('aws_details.decrease_since_last_month', {
-                    date,
-                    month,
-                    value,
-                  })
-              : t('aws_details.no_change_since_date', { date, month })}
+            ? Boolean(date < 31)
+              ? t('aws_details.decrease_since_date', { date, month, value })
+              : t('aws_details.decrease_since_last_month', {
+                  date,
+                  month,
+                  value,
+                })
+            : t('aws_details.no_change_since_date', { date, month })}
         </div>
       </div>
+    );
+  };
+
+  public getSortBy = () => {
+    const { query } = this.props;
+    const { columns } = this.state;
+
+    let index = -1;
+    let direction = 'asc';
+
+    for (const key of Object.keys(query.order_by)) {
+      let c = 0;
+      for (const column of columns) {
+        if (column.orderBy === key) {
+          direction =
+            query.order_by[key] === 'asc'
+              ? SortByDirection.asc
+              : SortByDirection.desc;
+          index = c + 2;
+          break;
+        }
+        c++;
+      }
+    }
+    return index > -1 ? { index, direction } : {};
+  };
+
+  private getTableItem = (
+    item: ComputedAwsReportItem,
+    groupBy: string,
+    query: AwsQuery,
+    index: number
+  ) => {
+    return (
+      <>
+        <DetailsTableItem
+          groupBy={groupBy}
+          item={item}
+          key={`table-item-${index}`}
+        />
+      </>
     );
   };
 
@@ -332,8 +349,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   public render() {
     const { columns, rows } = this.state;
 
-    if (columns && columns.length && rows && rows.length) {
-      return (
+    return (
+      <>
         <Table
           aria-label="details-table"
           cells={columns}
@@ -347,10 +364,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           <TableHeader />
           <TableBody />
         </Table>
-      );
-    } else {
-      return null;
-    }
+        {Boolean(rows.length === 0) && (
+          <div className={css(styles.emptyState)}>{this.getEmptyState()}</div>
+        )}
+      </>
+    );
   }
 }
 

--- a/src/pages/awsDetails/groupBy.tsx
+++ b/src/pages/awsDetails/groupBy.tsx
@@ -120,11 +120,15 @@ class GroupByBase extends React.Component<GroupByProps> {
   private getGroupBy = () => {
     const queryFromRoute = parseQuery<AwsQuery>(location.search);
     let groupBy: string = getIdKeyForGroupBy(queryFromRoute.group_by);
+    const groupByKeys =
+      queryFromRoute && queryFromRoute.group_by
+        ? Object.keys(queryFromRoute.group_by)
+        : [];
 
-    for (const item of Object.keys(queryFromRoute.group_by)) {
-      const index = item.indexOf('tag:');
+    for (const key of groupByKeys) {
+      const index = key.indexOf('tag:');
       if (index !== -1) {
-        groupBy = item;
+        groupBy = key;
         break;
       }
     }

--- a/src/pages/ocpDetails/detailsTable.styles.ts
+++ b/src/pages/ocpDetails/detailsTable.styles.ts
@@ -1,14 +1,24 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
+  global_BackgroundColor_light_100,
   global_danger_color_100,
   global_disabled_color_100,
   global_FontSize_xs,
+  global_spacer_3xl,
   global_spacer_xs,
   global_success_color_100,
 } from '@patternfly/react-tokens';
 import { css } from 'emotion';
 
 export const styles = StyleSheet.create({
+  emptyState: {
+    backgroundColor: global_BackgroundColor_light_100.value,
+    display: 'flex',
+    justifyContent: 'center',
+    paddingTop: global_spacer_3xl.value,
+    height: '35vh',
+    width: '100%',
+  },
   infoArrow: {
     position: 'relative',
   },

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -1,3 +1,9 @@
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+} from '@patternfly/react-core';
+import { CalculatorIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import {
   sortable,
@@ -141,44 +147,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     });
   };
 
-  public getSortBy = () => {
-    const { query } = this.props;
-    const { columns } = this.state;
+  private getEmptyState = () => {
+    const { t } = this.props;
 
-    let index = -1;
-    let direction = 'asc';
-
-    for (const key of Object.keys(query.order_by)) {
-      let c = 0;
-      for (const column of columns) {
-        if (column.orderBy === key) {
-          direction =
-            query.order_by[key] === 'asc'
-              ? SortByDirection.asc
-              : SortByDirection.desc;
-          index = c + 2;
-          break;
-        }
-        c++;
-      }
-    }
-    return index > -1 ? { index, direction } : {};
-  };
-
-  private getTableItem = (
-    item: ComputedOcpReportItem,
-    groupBy: string,
-    query: OcpQuery,
-    index: number
-  ) => {
     return (
-      <>
-        <DetailsTableItem
-          groupBy={groupBy}
-          item={item}
-          key={`table-item-${index}`}
-        />
-      </>
+      <EmptyState>
+        <EmptyStateIcon icon={CalculatorIcon} />
+        <EmptyStateBody>{t('aws_details.empty_state')}</EmptyStateBody>
+      </EmptyState>
     );
   };
 
@@ -237,16 +213,57 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
                   value,
                 })
             : Boolean(item.deltaPercent !== null && item.deltaValue < 0)
-              ? Boolean(date < 31)
-                ? t('ocp_details.decrease_since_date', { date, month, value })
-                : t('ocp_details.decrease_since_last_month', {
-                    date,
-                    month,
-                    value,
-                  })
-              : t('ocp_details.no_change_since_date', { date, month })}
+            ? Boolean(date < 31)
+              ? t('ocp_details.decrease_since_date', { date, month, value })
+              : t('ocp_details.decrease_since_last_month', {
+                  date,
+                  month,
+                  value,
+                })
+            : t('ocp_details.no_change_since_date', { date, month })}
         </div>
       </div>
+    );
+  };
+
+  private getSortBy = () => {
+    const { query } = this.props;
+    const { columns } = this.state;
+
+    let index = -1;
+    let direction = 'asc';
+
+    for (const key of Object.keys(query.order_by)) {
+      let c = 0;
+      for (const column of columns) {
+        if (column.orderBy === key) {
+          direction =
+            query.order_by[key] === 'asc'
+              ? SortByDirection.asc
+              : SortByDirection.desc;
+          index = c + 2;
+          break;
+        }
+        c++;
+      }
+    }
+    return index > -1 ? { index, direction } : {};
+  };
+
+  private getTableItem = (
+    item: ComputedOcpReportItem,
+    groupBy: string,
+    query: OcpQuery,
+    index: number
+  ) => {
+    return (
+      <>
+        <DetailsTableItem
+          groupBy={groupBy}
+          item={item}
+          key={`table-item-${index}`}
+        />
+      </>
     );
   };
 
@@ -332,8 +349,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   public render() {
     const { columns, rows } = this.state;
 
-    if (columns && columns.length && rows && rows.length) {
-      return (
+    return (
+      <>
         <Table
           aria-label="details-table"
           cells={columns}
@@ -347,10 +364,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           <TableHeader />
           <TableBody />
         </Table>
-      );
-    } else {
-      return null;
-    }
+        {Boolean(rows.length === 0) && (
+          <div className={css(styles.emptyState)}>{this.getEmptyState()}</div>
+        )}
+      </>
+    );
   }
 }
 

--- a/src/pages/ocpDetails/groupBy.tsx
+++ b/src/pages/ocpDetails/groupBy.tsx
@@ -120,11 +120,15 @@ class GroupByBase extends React.Component<GroupByProps> {
   private getGroupBy = () => {
     const queryFromRoute = parseQuery<OcpQuery>(location.search);
     let groupBy: string = getIdKeyForGroupBy(queryFromRoute.group_by);
+    const groupByKeys =
+      queryFromRoute && queryFromRoute.group_by
+        ? Object.keys(queryFromRoute.group_by)
+        : [];
 
-    for (const item of Object.keys(queryFromRoute.group_by)) {
-      const index = item.indexOf('tag:');
+    for (const key of groupByKeys) {
+      const index = key.indexOf('tag:');
       if (index !== -1) {
-        groupBy = item;
+        groupBy = key;
         break;
       }
     }


### PR DESCRIPTION
Adds an empty state to the AWS/OCP details table.

Fixes https://github.com/project-koku/koku-ui/issues/389
Fixes https://github.com/project-koku/koku-ui/issues/388

AWS:
<img width="646" alt="screen shot 2019-02-22 at 4 27 33 pm" src="https://user-images.githubusercontent.com/17481322/53273062-f72c3100-36c0-11e9-9bdf-f7d2dac4fbe7.png">

OCP:
<img width="646" alt="screen shot 2019-02-22 at 4 27 49 pm" src="https://user-images.githubusercontent.com/17481322/53273070-fdbaa880-36c0-11e9-8b47-e4e3435c301b.png">

Known PF4 issues:
- PF4 Table: Disable header controls when no rows are available https://github.com/patternfly/patternfly-react/issues/1431
- PF4 Empty State Icon: Allow size to be set https://github.com/patternfly/patternfly-react/issues/1434
- PF4 Table: Provide empty state support https://github.com/patternfly/patternfly-react/issues/1433