### PR TITLE
Modify tabs to use lazy loading

### DIFF
--- a/src/pages/awsDashboard/awsDashboardWidget.tsx
+++ b/src/pages/awsDashboard/awsDashboardWidget.tsx
@@ -113,8 +113,8 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
     });
   };
 
-  private renderTab = (tabData: TabData) => {
-    const { tabs, topItems } = this.props;
+  private getTabs = (tabData: TabData) => {
+    const { tabs } = this.props;
 
     const currentTab = getIdKeyForTab(tabData.id as AwsDashboardTab);
 
@@ -124,21 +124,33 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
         key={`${currentTab}-items`}
         report={tabs}
       >
-        {({ items }) =>
-          items.map(tabItem => (
-            <AwsReportSummaryItem
-              key={`${tabItem.id}-item`}
-              formatOptions={topItems.formatOptions}
-              formatValue={formatValue}
-              label={tabItem.label ? tabItem.label.toString() : ''}
-              totalValue={tabs.total.value}
-              units={tabItem.units}
-              value={tabItem.total}
-            />
-          ))
-        }
+        {({ items }) => items.map(tabItem => this.renderTab(tabItem, tabData))}
       </AwsReportSummaryItems>
     );
+  };
+
+  private renderTab = (tabItem, tabData: TabData) => {
+    const { availableTabs, tabs, topItems } = this.props;
+    const { activeTabKey } = this.state;
+
+    const currentTab = getIdKeyForTab(tabData.id as AwsDashboardTab);
+    const activeTab = getIdKeyForTab(availableTabs[activeTabKey]);
+
+    if (activeTab === currentTab) {
+      return (
+        <AwsReportSummaryItem
+          key={`${tabItem.id}-item`}
+          formatOptions={topItems.formatOptions}
+          formatValue={formatValue}
+          label={tabItem.label ? tabItem.label.toString() : ''}
+          totalValue={tabs.total.value}
+          units={tabItem.units}
+          value={tabItem.total}
+        />
+      );
+    } else {
+      return null;
+    }
   };
 
   public render() {
@@ -214,7 +226,7 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
               title={this.getTabTitle(tab)}
             >
               <div className={css(styles.tabs)}>
-                {this.renderTab({ id: tab } as TabData)}
+                {this.getTabs({ id: tab } as TabData)}
               </div>
             </Tab>
           ))}

--- a/src/pages/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/pages/ocpDashboard/ocpDashboardWidget.tsx
@@ -112,8 +112,8 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
     });
   };
 
-  private renderTab = (tabData: TabData) => {
-    const { reportType, tabs, topItems } = this.props;
+  private getTabs = (tabData: TabData) => {
+    const { tabs } = this.props;
 
     const currentTab = getIdKeyForTab(tabData.id as OcpDashboardTab);
 
@@ -123,29 +123,39 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
         key={`${currentTab}-items`}
         report={tabs}
       >
-        {({ items }) =>
-          items.map(tabItem => (
-            <OcpReportSummaryItem
-              key={`${tabItem.id}-item`}
-              formatOptions={topItems.formatOptions}
-              formatValue={formatValue}
-              label={tabItem.label ? tabItem.label.toString() : ''}
-              totalValue={
-                reportType === OcpReportType.charge
-                  ? tabs.total.charge
-                  : tabs.total.usage
-              }
-              units={tabItem.units}
-              value={
-                reportType === OcpReportType.charge
-                  ? tabItem.charge
-                  : tabItem.usage
-              }
-            />
-          ))
-        }
+        {({ items }) => items.map(tabItem => this.renderTab(tabItem, tabData))}
       </OcpReportSummaryItems>
     );
+  };
+
+  private renderTab = (tabItem, tabData: TabData) => {
+    const { availableTabs, reportType, tabs, topItems } = this.props;
+    const { activeTabKey } = this.state;
+
+    const currentTab = getIdKeyForTab(tabData.id as OcpDashboardTab);
+    const activeTab = getIdKeyForTab(availableTabs[activeTabKey]);
+
+    if (activeTab === currentTab) {
+      return (
+        <OcpReportSummaryItem
+          key={`${tabItem.id}-item`}
+          formatOptions={topItems.formatOptions}
+          formatValue={formatValue}
+          label={tabItem.label ? tabItem.label.toString() : ''}
+          totalValue={
+            reportType === OcpReportType.charge
+              ? tabs.total.charge
+              : tabs.total.usage
+          }
+          units={tabItem.units}
+          value={
+            reportType === OcpReportType.charge ? tabItem.charge : tabItem.usage
+          }
+        />
+      );
+    } else {
+      return null;
+    }
   };
 
   public render() {
@@ -251,7 +261,7 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
               title={this.getTabTitle(tab)}
             >
               <div className={css(styles.tabs)}>
-                {this.renderTab({ id: tab } as TabData)}
+                {this.getTabs({ id: tab } as TabData)}
               </div>
             </Tab>
           ))}

--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -98,7 +98,6 @@ class OverviewBase extends React.Component<OverviewProps> {
 
   private getTabs = () => {
     const { awsProviders, ocpProviders } = this.props;
-    const { activeTabKey } = this.state;
     const availableTabs = [];
 
     if (awsProviders && awsProviders.meta && awsProviders.meta.count) {
@@ -108,19 +107,15 @@ class OverviewBase extends React.Component<OverviewProps> {
       availableTabs.push(OverviewTab.ocp);
     }
 
-    return (
-      <Tabs activeKey={activeTabKey} onSelect={this.handleTabClick}>
-        {availableTabs.map((tab, index) => (
-          <Tab
-            eventKey={index}
-            key={`${getIdKeyForTab(tab)}-tab`}
-            title={this.getTabTitle(tab)}
-          >
-            {this.renderTab({ id: tab } as TabData)}
-          </Tab>
-        ))}
-      </Tabs>
-    );
+    return availableTabs.map((tab, index) => (
+      <Tab
+        eventKey={index}
+        key={`${getIdKeyForTab(tab)}-tab`}
+        title={this.getTabTitle(tab)}
+      >
+        {this.renderTab({ id: tab } as TabData, index)}
+      </Tab>
+    ));
   };
 
   private handleTabClick = (event, tabIndex) => {
@@ -129,13 +124,14 @@ class OverviewBase extends React.Component<OverviewProps> {
     });
   };
 
-  private renderTab = (tabData: TabData) => {
+  private renderTab = (tabData: TabData, index: number) => {
+    const { activeTabKey } = this.state;
     const currentTab = getIdKeyForTab(tabData.id as OverviewTab);
 
     if (currentTab === OverviewTab.aws) {
-      return <AwsDashboard />;
+      return activeTabKey === index ? <AwsDashboard /> : null;
     } else {
-      return <OcpDashboard />;
+      return activeTabKey === index ? <OcpDashboard /> : null;
     }
   };
 
@@ -149,6 +145,7 @@ class OverviewBase extends React.Component<OverviewProps> {
       ocpProvidersFetchStatus,
       t,
     } = this.props;
+    const { activeTabKey } = this.state;
 
     const hasAwsMeta = awsProviders && awsProviders.meta;
     const ocpAwsMeta = ocpProviders && ocpProviders.meta;
@@ -182,7 +179,9 @@ class OverviewBase extends React.Component<OverviewProps> {
           {Boolean(awsProvidersError || ocpProvidersError) ? (
             <ErrorState error={awsProvidersError || ocpProvidersError} />
           ) : Boolean(hasProviders) ? (
-            this.getTabs()
+            <Tabs activeKey={activeTabKey} onSelect={this.handleTabClick}>
+              {this.getTabs()}
+            </Tabs>
           ) : Boolean(noProviders) ? (
             <NoProvidersState />
           ) : (


### PR DESCRIPTION
This modifies the tabs to use lazy loading. Currently, both AWS and OCP tabs and sub-tabs are loaded when the overview page is first rendered.

This ensures tabs are not loaded until the user selects a new tab. Thus, child components such as charts and progress bars are updated properly when switching between tabs.

Fixes https://github.com/project-koku/koku-ui/issues/528