### PR TITLE
Remove custom VictoryPoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@babel/core": "^7.2.2",
     "@fortawesome/free-solid-svg-icons": "^5.1.0",
     "@patternfly/patternfly": "1.0.193",
-    "@patternfly/react-charts": "2.1.2",
+    "@patternfly/react-charts": "2.1.3",
     "@patternfly/react-core": "2.1.5",
     "@patternfly/react-icons": "3.0.0",
     "@patternfly/react-styles": "2.3.2",

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -16,7 +16,6 @@ import {
   getTooltipLabel,
 } from 'components/charts/commonChart/chartUtils';
 import { getDateRange } from 'components/charts/commonChart/chartUtils';
-import VictoryPoint from 'components/victory/victoryPoint';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
 import React from 'react';
@@ -398,7 +397,6 @@ class HistoricalUsageChart extends React.Component<
         <ChartLegend
           colorScale={datum.colorScale}
           data={datum.data}
-          dataComponent={<VictoryPoint />}
           events={[
             {
               target: 'data',

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -16,7 +16,6 @@ import {
   getTooltipContent,
   getTooltipLabel,
 } from 'components/charts/commonChart/chartUtils';
-import VictoryPoint from 'components/victory/victoryPoint';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
 import React from 'react';
@@ -310,7 +309,6 @@ class UsageChart extends React.Component<UsageChartProps, State> {
           colorScale={datum.colorScale}
           containerComponent={<ChartContainer responsive={false} />}
           data={datum.data}
-          dataComponent={<VictoryPoint />}
           events={[
             {
               target: 'data',

--- a/yarn.lock
+++ b/yarn.lock
@@ -888,9 +888,9 @@
   version "1.0.193"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-1.0.193.tgz#a1b6b1a2f677ec93e41fe4f5048ce23f50346535"
 
-"@patternfly/react-charts@2.1.2":
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-2.1.2.tgz#d10a9443ef29da50ef1c4d3f3cb23af483dc8af3"
+"@patternfly/react-charts@2.1.3":
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-2.1.3.tgz#a69f452c6f4f423788f62cb7a2872fbc18723423"
   dependencies:
     "@patternfly/react-styles" "^2.3.4"
   optionalDependencies:


### PR DESCRIPTION
Remove custom VictoryPoint in favor of the ChartPoint component I created for PF4. This ChartPoint (responsible for dashed lines in the legend) component is now used in ChartLegend by default.

Fixes https://github.com/project-koku/koku-ui/issues/531