### PR TITLE
Loading never times out

### DIFF
--- a/src/pages/awsDetails/awsDetails.tsx
+++ b/src/pages/awsDetails/awsDetails.tsx
@@ -351,13 +351,11 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
       report,
       idKey: getIdKeyForGroupBy(query.group_by),
     });
-    const hasMeta = providers && providers.meta;
-    const hasProviders =
-      hasMeta &&
-      providers.meta.count > 0 &&
-      providersFetchStatus === FetchStatus.complete;
+
+    const isLoading = providersFetchStatus === FetchStatus.inProgress;
     const noProviders =
-      hasMeta &&
+      providers !== undefined &&
+      providers.meta !== undefined &&
       providers.meta.count === 0 &&
       providersFetchStatus === FetchStatus.complete;
 
@@ -366,7 +364,11 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
         {this.getHeader()}
         {Boolean(providersError) ? (
           <ErrorState error={providersError} />
-        ) : Boolean(hasProviders) ? (
+        ) : Boolean(noProviders) ? (
+          <NoProvidersState />
+        ) : Boolean(isLoading) ? (
+          <LoadingState />
+        ) : (
           <div className={css(styles.content)}>
             <div className={css(styles.toolbarContainer)}>
               <div className={toolbarOverride}>
@@ -378,10 +380,6 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
               {this.getDetailsTable()}
             </div>
           </div>
-        ) : Boolean(noProviders) ? (
-          <NoProvidersState />
-        ) : (
-          <LoadingState />
         )}
       </div>
     );

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -351,13 +351,11 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
       report,
       idKey: getIdKeyForGroupBy(query.group_by),
     });
-    const hasMeta = providers && providers.meta;
-    const hasProviders =
-      hasMeta &&
-      providers.meta.count > 0 &&
-      providersFetchStatus === FetchStatus.complete;
+
+    const isLoading = providersFetchStatus === FetchStatus.inProgress;
     const noProviders =
-      hasMeta &&
+      providers !== undefined &&
+      providers.meta !== undefined &&
       providers.meta.count === 0 &&
       providersFetchStatus === FetchStatus.complete;
 
@@ -366,7 +364,11 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
         {this.getHeader()}
         {Boolean(providersError) ? (
           <ErrorState error={providersError} />
-        ) : Boolean(hasProviders) ? (
+        ) : Boolean(noProviders) ? (
+          <NoProvidersState />
+        ) : Boolean(isLoading) ? (
+          <LoadingState />
+        ) : (
           <div className={css(styles.content)}>
             <div className={css(styles.toolbarContainer)}>
               <div className={toolbarOverride}>
@@ -378,10 +380,6 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
               {this.getDetailsTable()}
             </div>
           </div>
-        ) : Boolean(noProviders) ? (
-          <NoProvidersState />
-        ) : (
-          <LoadingState />
         )}
       </div>
     );

--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -147,22 +147,20 @@ class OverviewBase extends React.Component<OverviewProps> {
     } = this.props;
     const { activeTabKey } = this.state;
 
-    const hasAwsMeta = awsProviders && awsProviders.meta;
-    const ocpAwsMeta = ocpProviders && ocpProviders.meta;
-    const hasProviders =
-      hasAwsMeta &&
-      awsProviders.meta.count > 0 &&
-      awsProvidersFetchStatus === FetchStatus.complete &&
-      (ocpAwsMeta &&
-        ocpProviders.meta.count > 0 &&
-        ocpProvidersFetchStatus === FetchStatus.complete);
-    const noProviders =
-      hasAwsMeta &&
+    const isLoading =
+      awsProvidersFetchStatus === FetchStatus.inProgress ||
+      ocpProvidersFetchStatus === FetchStatus.inProgress;
+    const noAwsProviders =
+      awsProviders !== undefined &&
+      awsProviders.meta !== undefined &&
       awsProviders.meta.count === 0 &&
-      awsProvidersFetchStatus === FetchStatus.complete &&
-      (ocpAwsMeta &&
-        ocpProviders.meta.count === 0 &&
-        ocpProvidersFetchStatus === FetchStatus.complete);
+      awsProvidersFetchStatus === FetchStatus.complete;
+    const noOcpProviders =
+      ocpProviders !== undefined &&
+      ocpProviders.meta !== undefined &&
+      ocpProviders.meta.count === 0 &&
+      ocpProvidersFetchStatus === FetchStatus.complete;
+    const noProviders = noAwsProviders && noOcpProviders;
 
     return (
       <>
@@ -178,14 +176,14 @@ class OverviewBase extends React.Component<OverviewProps> {
         >
           {Boolean(awsProvidersError || ocpProvidersError) ? (
             <ErrorState error={awsProvidersError || ocpProvidersError} />
-          ) : Boolean(hasProviders) ? (
+          ) : Boolean(noProviders) ? (
+            <NoProvidersState />
+          ) : Boolean(isLoading) ? (
+            <LoadingState />
+          ) : (
             <Tabs activeKey={activeTabKey} onSelect={this.handleTabClick}>
               {this.getTabs()}
             </Tabs>
-          ) : Boolean(noProviders) ? (
-            <NoProvidersState />
-          ) : (
-            <LoadingState />
           )}
         </section>
       </>


### PR DESCRIPTION
This change ensures empty states are shown as expected when a provider has just been added -- just needed to tweak the logic a bit.

The Overview and AWS/OCP detail pages display empty states as expected.
The AWS tab is not shown in the overview -- for OCP only providers.
The add provider screen is shown for the AWS details page -- for OCP only providers.

Fixes https://github.com/project-koku/koku-ui/issues/533