### PR TITLE
AWS historical chart widths

### DIFF
--- a/src/components/charts/historicalTrendChart/historicalTrendChart.styles.ts
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.styles.ts
@@ -10,6 +10,7 @@ import {
 import { VictoryStyleInterface } from 'victory';
 
 export const chartStyles = {
+  chartWidth: 600,
   // See: https://github.com/project-koku/koku-ui/issues/241
   colorScale: [
     global_disabled_color_200.value,
@@ -31,6 +32,7 @@ export const chartStyles = {
       fontSize: 14,
     },
   },
+  legendWidth: 170,
   previousMonth: {
     data: {
       fill: 'none',

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -265,14 +265,10 @@ class HistoricalTrendChart extends React.Component<
 
   public render() {
     const { height, title, xAxisLabel, yAxisLabel } = this.props;
-    const { datum, width } = this.state;
+    const { datum } = this.state;
 
     const container = <ChartVoronoiContainer labels={this.getTooltipLabel} />;
     const domain = this.getDomain();
-    const chartWidth = 600;
-    const overallWidth = chartWidth + 40;
-    const legendWidth = width > overallWidth ? width - overallWidth : undefined;
-
     const endDate = this.getEndDate();
     const midDate = Math.floor(endDate / 2);
 
@@ -284,7 +280,7 @@ class HistoricalTrendChart extends React.Component<
             containerComponent={container}
             domain={domain}
             height={height}
-            width={chartWidth}
+            width={chartStyles.chartWidth}
           >
             {Boolean(datum && datum.cost) &&
               datum.cost.charts.map((chart, index) => {
@@ -304,7 +300,7 @@ class HistoricalTrendChart extends React.Component<
         </div>
         {Boolean(this.isLegendVisible()) && (
           <div className={css(styles.legend)}>
-            {this.getLegend(datum.cost.legend, legendWidth)}
+            {this.getLegend(datum.cost.legend, chartStyles.legendWidth)}
           </div>
         )}
       </div>

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.styles.ts
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.styles.ts
@@ -10,6 +10,7 @@ import {
 import { VictoryStyleInterface } from 'victory';
 
 export const chartStyles = {
+  chartWidth: 600,
   currentCapacityData: {
     data: {
       fill: 'none',
@@ -43,6 +44,7 @@ export const chartStyles = {
       fontSize: 14,
     },
   },
+  legendWidth: 170,
   previousCapacityData: {
     data: {
       fill: 'none',

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -468,14 +468,10 @@ class HistoricalUsageChart extends React.Component<
 
   public render() {
     const { height, title, xAxisLabel, yAxisLabel } = this.props;
-    const { datum, width } = this.state;
+    const { datum } = this.state;
 
     const container = <ChartVoronoiContainer labels={this.getTooltipLabel} />;
     const domain = this.getDomain();
-    const chartWidth = 600;
-    const overallWidth = chartWidth + 40;
-    const legendWidth = width > overallWidth ? width - overallWidth : undefined;
-
     const endDate = this.getEndDate();
     const midDate = Math.floor(endDate / 2);
 
@@ -487,7 +483,7 @@ class HistoricalUsageChart extends React.Component<
             containerComponent={container}
             domain={domain}
             height={height}
-            width={chartWidth}
+            width={chartStyles.chartWidth}
           >
             {Boolean(datum && datum.previous) &&
               datum.previous.charts.map((chart, index) => {
@@ -515,7 +511,7 @@ class HistoricalUsageChart extends React.Component<
               {Boolean(datum.previous.legend.title) && (
                 <div>{datum.previous.legend.title}</div>
               )}
-              {this.getLegend(datum.previous.legend, legendWidth)}
+              {this.getLegend(datum.previous.legend, chartStyles.legendWidth)}
             </>
           )}
           {Boolean(this.isCurrentLegendVisible()) && (
@@ -523,7 +519,7 @@ class HistoricalUsageChart extends React.Component<
               {Boolean(datum.current.legend.title) && (
                 <div>{datum.current.legend.title}</div>
               )}
-              {this.getLegend(datum.current.legend, legendWidth)}
+              {this.getLegend(datum.current.legend, chartStyles.legendWidth)}
             </div>
           )}
         </div>

--- a/src/components/charts/trendChart/trendChart.styles.ts
+++ b/src/components/charts/trendChart/trendChart.styles.ts
@@ -20,7 +20,7 @@ export const chartStyles = {
   legend: {
     labels: {
       fontFamily: global_FontFamily_sans_serif.value,
-      fontSize: 12,
+      fontSize: 14,
     },
     minWidth: 175,
   },

--- a/src/components/charts/usageChart/usageChart.styles.ts
+++ b/src/components/charts/usageChart/usageChart.styles.ts
@@ -25,7 +25,7 @@ export const chartStyles = {
   legend: {
     labels: {
       fontFamily: global_FontFamily_sans_serif.value,
-      fontSize: 12,
+      fontSize: 14,
     },
     minWidth: 175,
   },

--- a/src/pages/awsDetails/historicalChart.styles.ts
+++ b/src/pages/awsDetails/historicalChart.styles.ts
@@ -5,6 +5,10 @@ import {
   global_spacer_sm,
 } from '@patternfly/react-tokens';
 
+export const chartStyles = {
+  chartHeight: 125,
+};
+
 export const styles = StyleSheet.create({
   chartContainer: {
     marginLeft: global_spacer_lg.value,

--- a/src/pages/awsDetails/historicalChart.tsx
+++ b/src/pages/awsDetails/historicalChart.tsx
@@ -12,7 +12,7 @@ import * as awsReportsActions from 'store/awsReports/awsReportsActions';
 import * as awsReportsSelectors from 'store/awsReports/awsReportsSelectors';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { formatValue } from 'utils/formatValue';
-import { styles } from './historicalChart.styles';
+import { chartStyles, styles } from './historicalChart.styles';
 
 interface HistoricalModalOwnProps {
   currentQueryString: string;
@@ -159,8 +159,6 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
       'total'
     );
 
-    const chartHeight = 125;
-
     return (
       <div className={css(styles.chartContainer)}>
         <div className={css(styles.costChart)}>
@@ -168,7 +166,7 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
             currentData={currentCostData}
             formatDatumValue={formatValue}
             formatDatumOptions={{}}
-            height={chartHeight}
+            height={chartStyles.chartHeight}
             previousData={previousCostData}
             title={t('aws_details.historical.cost_title', { groupBy })}
             xAxisLabel={t('aws_details.historical.day_of_month_label')}
@@ -180,7 +178,7 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
             currentData={currentInstanceData}
             formatDatumValue={formatValue}
             formatDatumOptions={{}}
-            height={chartHeight}
+            height={chartStyles.chartHeight}
             previousData={previousInstanceData}
             title={t('aws_details.historical.instance_title', { groupBy })}
             xAxisLabel={t('aws_details.historical.day_of_month_label')}
@@ -192,7 +190,7 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
             currentData={currentStorageData}
             formatDatumValue={formatValue}
             formatDatumOptions={{}}
-            height={chartHeight}
+            height={chartStyles.chartHeight}
             previousData={previousStorageData}
             title={t('aws_details.historical.storage_title', { groupBy })}
             xAxisLabel={t('aws_details.historical.day_of_month_label')}

--- a/src/pages/ocpDetails/historicalChart.styles.ts
+++ b/src/pages/ocpDetails/historicalChart.styles.ts
@@ -5,6 +5,10 @@ import {
   global_spacer_sm,
 } from '@patternfly/react-tokens';
 
+export const chartStyles = {
+  chartHeight: 130,
+};
+
 export const styles = StyleSheet.create({
   chartContainer: {
     marginLeft: global_spacer_lg.value,

--- a/src/pages/ocpDetails/historicalChart.tsx
+++ b/src/pages/ocpDetails/historicalChart.tsx
@@ -13,7 +13,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import * as ocpReportsActions from 'store/ocpReports/ocpReportsActions';
 import * as ocpReportsSelectors from 'store/ocpReports/ocpReportsSelectors';
 import { formatValue } from 'utils/formatValue';
-import { styles } from './historicalChart.styles';
+import { chartStyles, styles } from './historicalChart.styles';
 
 interface HistoricalModalOwnProps {
   currentQueryString: string;
@@ -233,13 +233,11 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
       'usage'
     );
 
-    const chartHeight = 130;
-
     return (
       <div className={css(styles.chartContainer)}>
         <div className={css(styles.chargeChart)}>
           <HistoricalTrendChart
-            height={chartHeight}
+            height={chartStyles.chartHeight}
             currentData={currentChargeData}
             formatDatumValue={formatValue}
             formatDatumOptions={{}}
@@ -257,7 +255,7 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
             currentUsageData={currentCpuUsageData}
             formatDatumValue={formatValue}
             formatDatumOptions={{}}
-            height={chartHeight}
+            height={chartStyles.chartHeight}
             previousCapacityData={previousCpuCapacityData}
             previousLimitData={previousCpuLimitData}
             previousRequestData={previousCpuRequestData}
@@ -275,7 +273,7 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
             currentUsageData={currentMemoryUsageData}
             formatDatumValue={formatValue}
             formatDatumOptions={{}}
-            height={chartHeight}
+            height={chartStyles.chartHeight}
             previousCapacityData={previousMemoryCapacityData}
             previousLimitData={previousMemoryLimitData}
             previousRequestData={previousMemoryRequestData}


### PR DESCRIPTION
AWS historical charts appear smaller on some screens.

Fixes https://github.com/project-koku/koku-ui/issues/537