### PR TITLE
fix(onboarding): check for failure message in errors

### DIFF
--- a/src/pages/onboardingModal/final/loader.tsx
+++ b/src/pages/onboardingModal/final/loader.tsx
@@ -61,8 +61,13 @@ class Loader extends React.Component<Props> {
     if (this.props.apiErrors) {
       const err = this.props.apiErrors;
       let errorMessage: string = null;
-      if (err.response && err.response.data && err.response.data.Error) {
+      if (err.response && err.response.data) {
         errorMessage = err.response.data.Error;
+        if (!errorMessage && err.response.data.errors !== undefined) {
+          errorMessage = err.response.data.errors
+            .map(er => er.detail)
+            .join(', ');
+        }
       } else if (err.message) {
         errorMessage = err.message;
       }


### PR DESCRIPTION
fixes #542 

//cc @lcouzens 

@chambridge How does the response look when there is a failure on the server side? is it always similar to this?:

```json
{
  "errors": [
   { 
     "details": "....",
    },
   { 
     "details": "....",
    }
  ]
}
```

Thanks.