### PR TITLE
Invalid tabs test

### DIFF
--- a/src/pages/awsDashboard/awsDashboardWidget.test.tsx
+++ b/src/pages/awsDashboard/awsDashboardWidget.test.tsx
@@ -116,13 +116,6 @@ test('id key for dashboard tab is the tab name in singular form', () => {
   );
 });
 
-xtest('change tab triggers updateTab', () => {
-  const tabId = AwsDashboardTab.regions;
-  const view = shallow(<AwsDashboardWidgetBase {...props} />);
-  view.find(Tabs).simulate('click', { event: {}, tabIndex: 2 });
-  expect(props.updateTab).toBeCalledWith(props.id, { tabId });
-});
-
 function getTranslateCallForKey(key: string) {
   return (props.t as jest.Mock).mock.calls.find(([k]) => k === key);
 }

--- a/src/pages/ocpDashboard/ocpDashboardWidget.test.tsx
+++ b/src/pages/ocpDashboard/ocpDashboardWidget.test.tsx
@@ -114,13 +114,6 @@ test('id key for dashboard tab is the tab name in singular form', () => {
   expect(getIdKeyForTab(OcpDashboardTab.projects)).toEqual('project');
 });
 
-xtest('change tab triggers updateTab', () => {
-  const tabId = OcpDashboardTab.clusters;
-  const view = shallow(<OcpDashboardWidgetBase {...props} />);
-  view.find(Tabs).simulate('click', { event: {}, tabIndex: 2 });
-  expect(props.updateTab).toBeCalledWith(props.id, { tabId });
-});
-
 function getTranslateCallForKey(key: string) {
   return (props.t as jest.Mock).mock.calls.find(([k]) => k === key);
 }


### PR DESCRIPTION
This test had previously simulated a change event in our custom tabs component. However, the test no longer functions properly after replacing our custom tabs with PF4 tabs. Both @boaz0 and I attempted to refactor it, but we agreed the test should be removed for technical reasons.

For more details, please see: https://github.com/project-koku/koku-ui/issues/551