### PR TITLE
Add OCP on AWS tab

### DIFF
--- a/src/api/ocpOnAwsQuery.ts
+++ b/src/api/ocpOnAwsQuery.ts
@@ -1,0 +1,40 @@
+import { parse, stringify } from 'qs';
+
+export interface OcpOnAwsFilters {
+  time_scope_value?: number;
+  time_scope_units?: 'month' | 'day';
+  resolution?: 'daily' | 'monthly';
+  limit?: number;
+  project?: string | number;
+}
+
+type OcpOnAwsGroupByValue = string | string[];
+
+interface OcpOnAwsGroupBys {
+  cluster?: OcpOnAwsGroupByValue;
+  node?: OcpOnAwsGroupByValue;
+  project?: OcpOnAwsGroupByValue;
+}
+
+interface OcpOnAwsOrderBys {
+  cost?: string;
+  cluster?: string;
+  node?: string;
+  project?: string;
+}
+
+export interface OcpOnAwsQuery {
+  delta?: string;
+  filter?: OcpOnAwsFilters;
+  group_by?: OcpOnAwsGroupBys;
+  order_by?: OcpOnAwsOrderBys;
+  key_only?: boolean;
+}
+
+export function getQuery(query: OcpOnAwsQuery) {
+  return stringify(query, { encode: false, indices: false });
+}
+
+export function parseQuery<T = any>(query: string): T {
+  return parse(query, { ignoreQueryPrefix: true });
+}

--- a/src/api/ocpOnAwsReports.test.ts
+++ b/src/api/ocpOnAwsReports.test.ts
@@ -1,0 +1,10 @@
+jest.mock('axios');
+
+import axios from 'axios';
+import { OcpOnAwsReportType, runReport } from './ocpOnAwsReports';
+
+test('api run reports calls axios get', () => {
+  const query = 'filter[resolution]=daily';
+  runReport(OcpOnAwsReportType.cost, query);
+  expect(axios.get).toBeCalledWith(`reports/openshift/charges/?${query}`);
+});

--- a/src/api/ocpOnAwsReports.ts
+++ b/src/api/ocpOnAwsReports.ts
@@ -1,0 +1,109 @@
+import axios from 'axios';
+import { Omit } from 'react-redux';
+
+export interface OcpOnAwsDatum {
+  value: number;
+  units: string;
+}
+
+// Todo: Remove capacity, limit, & request?
+export interface OcpOnAwsReportValue {
+  capacity?: OcpOnAwsDatum;
+  cost?: OcpOnAwsDatum;
+  cluster?: string;
+  cluster_alias?: string;
+  count?: OcpOnAwsDatum;
+  date: string;
+  delta_percent?: number;
+  delta_value?: number;
+  limit?: OcpOnAwsDatum;
+  node?: string;
+  project?: string;
+  request?: OcpOnAwsDatum;
+  usage: OcpOnAwsDatum;
+}
+
+export interface GroupByClusterData
+  extends Omit<OcpOnAwsReportData, 'clusters'> {
+  service: string;
+}
+
+export interface GroupByNodeData extends Omit<OcpOnAwsReportData, 'nodes'> {
+  region: string;
+}
+
+export interface GroupByProjectData
+  extends Omit<OcpOnAwsReportData, 'projects'> {
+  account: string;
+}
+
+export interface OcpOnAwsReportData {
+  clusters?: GroupByClusterData[];
+  date?: string;
+  delta_percent?: number;
+  delta_value?: number;
+  nodes?: GroupByNodeData[];
+  projects?: GroupByProjectData[];
+  values?: OcpOnAwsReportValue[];
+}
+
+export interface OcpOnAwsReport {
+  data: OcpOnAwsReportData[];
+  delta?: {
+    percent: number;
+    value: number;
+  };
+  group_by?: {
+    [group: string]: string[];
+  };
+  order_by?: {
+    [order: string]: string;
+  };
+  filter?: {
+    [filter: string]: any;
+  };
+  total?: {
+    capacity?: OcpOnAwsDatum;
+    cost?: OcpOnAwsDatum;
+    limit?: OcpOnAwsDatum;
+    request?: OcpOnAwsDatum;
+    usage?: OcpOnAwsDatum;
+  };
+}
+
+export const enum OcpOnAwsReportType {
+  cost = 'cost',
+  cpu = 'cpu',
+  instanceType = 'instance_type',
+  memory = 'memory',
+  storage = 'storage',
+  tag = 'tag',
+}
+
+export const ocpOnAwsReportTypePaths: Record<OcpOnAwsReportType, string> = {
+  [OcpOnAwsReportType.cost]: 'reports/openshift/charges/',
+  [OcpOnAwsReportType.cpu]: 'reports/openshift/compute/',
+  [OcpOnAwsReportType.instanceType]:
+    'reports/openshift/infrastructures/aws/instance-types/',
+  [OcpOnAwsReportType.memory]: 'reports/openshift/memory/',
+  [OcpOnAwsReportType.storage]:
+    'reports/openshift/infrastructures/aws/storage/',
+  [OcpOnAwsReportType.tag]: 'tags/openshift/',
+};
+
+export function runReport(reportType: OcpOnAwsReportType, query: string) {
+  const path = ocpOnAwsReportTypePaths[reportType];
+  const insights = (window as any).insights;
+  if (
+    insights &&
+    insights.chrome &&
+    insights.chrome.auth &&
+    insights.chrome.auth.getUser
+  ) {
+    return insights.chrome.auth.getUser().then(() => {
+      return axios.get<OcpOnAwsReport>(`${path}?${query}`);
+    });
+  } else {
+    return axios.get<OcpOnAwsReport>(`${path}?${query}`);
+  }
+}

--- a/src/api/ocpReports.ts
+++ b/src/api/ocpReports.ts
@@ -7,7 +7,6 @@ export interface OcpDatum {
 }
 
 export interface OcpReportValue {
-  app?: string;
   capacity?: OcpDatum;
   cost?: OcpDatum;
   cluster?: string;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -127,11 +127,11 @@ function buildNavigation() {
       id: '',
     },
     {
-      title: 'Cloud Cost',
+      title: 'Aws Details',
       id: 'aws',
     },
     {
-      title: 'OpenShift Charges',
+      title: 'OpenShift Details',
       id: 'ocp',
     },
   ].map(item => ({

--- a/src/components/charts/commonChart/chartUtils.ts
+++ b/src/components/charts/commonChart/chartUtils.ts
@@ -94,6 +94,36 @@ export function transformOcpReport(
   }, []);
 }
 
+export function transformOcpOnAwsReport(
+  report: OcpReport,
+  type: ChartType = ChartType.daily,
+  key: any = 'date',
+  reportItem: any = 'cost'
+): ChartDatum[] {
+  if (!report) {
+    return [];
+  }
+  const items = {
+    report,
+    idKey: key,
+    sortKey: 'id',
+    sortDirection: SortDirection.desc,
+  } as any;
+  const computedItems = getComputedOcpReportItems(items);
+
+  if (type === ChartType.daily) {
+    return computedItems.map(i => createDatum(i[reportItem], i, key));
+  }
+  if (type === ChartType.monthly) {
+    return computedItems.map(i => createDatum(i[reportItem], i, key));
+  }
+
+  return computedItems.reduce<ChartDatum[]>((acc, d) => {
+    const prevValue = acc.length ? acc[acc.length - 1].y : 0;
+    return [...acc, createDatum(prevValue + d[reportItem], d, key)];
+  }, []);
+}
+
 export function createDatum(
   value: number,
   computedItem: ComputedAwsReportItem | ComputedOcpReportItem,

--- a/src/components/reports/ocpOnAwsReportSummary/__snapshots__/ocpOnAwsReportSummaryDetails.test.tsx.snap
+++ b/src/components/reports/ocpOnAwsReportSummary/__snapshots__/ocpOnAwsReportSummaryDetails.test.tsx.snap
@@ -1,0 +1,73 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`defaults value if report is not present 1`] = `
+<Fragment>
+  <div
+    className="css-1br38yu"
+  >
+    <div
+      className="css-qvzirm"
+    >
+      ----
+      <div
+        className="css-5bzg50"
+      >
+        <div>
+          label
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-1br38yu"
+  />
+</Fragment>
+`;
+
+exports[`defaults value if report.total is not present 1`] = `
+<Fragment>
+  <div
+    className="css-1br38yu"
+  >
+    <div
+      className="css-qvzirm"
+    >
+      ----
+      <div
+        className="css-5bzg50"
+      >
+        <div>
+          label
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-1br38yu"
+  />
+</Fragment>
+`;
+
+exports[`report total is formated 1`] = `
+<Fragment>
+  <div
+    className="css-1br38yu"
+  >
+    <div
+      className="css-qvzirm"
+    >
+      formatedValue
+      <div
+        className="css-5bzg50"
+      >
+        <div>
+          label
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="css-1br38yu"
+  />
+</Fragment>
+`;

--- a/src/components/reports/ocpOnAwsReportSummary/__snapshots__/ocpOnAwsReportSummaryItem.test.tsx.snap
+++ b/src/components/reports/ocpOnAwsReportSummary/__snapshots__/ocpOnAwsReportSummaryItem.test.tsx.snap
@@ -1,0 +1,45 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`gets percentage from value and total value: Progress Bar Value 1`] = `10`;
+
+exports[`gets percentage from value and total value: Rendered Label 1`] = `
+<li
+  className="css-1e999ct"
+>
+  <Progress
+    className=""
+    id=""
+    label="formatted 100 (10%)"
+    max={100}
+    measureLocation="top"
+    min={0}
+    size="sm"
+    title="Label"
+    value={10}
+    valueText={null}
+    variant="info"
+  />
+</li>
+`;
+
+exports[`sets percent to 0 if totalValue is 0: Progress Bar Value 1`] = `0`;
+
+exports[`sets percent to 0 if totalValue is 0: Rendered label 1`] = `
+<li
+  className="css-1e999ct"
+>
+  <Progress
+    className=""
+    id=""
+    label="formatted 100 (0%)"
+    max={100}
+    measureLocation="top"
+    min={0}
+    size="sm"
+    title="Label"
+    value={0}
+    valueText={null}
+    variant="info"
+  />
+</li>
+`;

--- a/src/components/reports/ocpOnAwsReportSummary/index.ts
+++ b/src/components/reports/ocpOnAwsReportSummary/index.ts
@@ -1,0 +1,7 @@
+export { OcpOnAwsReportSummary } from './ocpOnAwsReportSummary';
+export { OcpOnAwsReportSummaryAlt } from './ocpOnAwsReportSummaryAlt';
+export { OcpOnAwsReportSummaryDetails } from './ocpOnAwsReportSummaryDetails';
+export { OcpOnAwsReportSummaryItem } from './ocpOnAwsReportSummaryItem';
+export { OcpOnAwsReportSummaryItems } from './ocpOnAwsReportSummaryItems';
+export { OcpOnAwsReportSummaryTrend } from './ocpOnAwsReportSummaryTrend';
+export { OcpOnAwsReportSummaryUsage } from './ocpOnAwsReportSummaryUsage';

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummary.styles.ts
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummary.styles.ts
@@ -1,0 +1,13 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_Color_200, global_FontSize_xs } from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  reportSummary: {
+    height: '100%',
+  },
+  subtitle: {
+    fontSize: global_FontSize_xs.value,
+    color: global_Color_200.var,
+    marginBottom: '0',
+  },
+});

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummary.test.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummary.test.tsx
@@ -1,0 +1,44 @@
+import { CardBody, CardFooter } from '@patternfly/react-core';
+import { mount } from 'enzyme';
+import React from 'react';
+import { FetchStatus } from 'store/common';
+import {
+  OcpOnAwsReportSummary,
+  OcpOnAwsReportSummaryProps,
+} from './ocpOnAwsReportSummary';
+
+const props: OcpOnAwsReportSummaryProps = {
+  title: 'report title',
+  status: FetchStatus.complete,
+  t: jest.fn(v => `t(${v})`),
+};
+
+test('on fetch status in progress show loading text', () => {
+  const view = mount(
+    <OcpOnAwsReportSummary {...props} status={FetchStatus.inProgress} />
+  );
+  expect(view.find(CardBody).text()).toEqual('t(loading)...');
+});
+
+test('on fetch status complete display reports', () => {
+  const view = mount(
+    <OcpOnAwsReportSummary {...props}>hello world</OcpOnAwsReportSummary>
+  );
+  expect(view.find(CardBody).text()).toEqual('hello world');
+});
+
+test('show subtitle if given', () => {
+  const view = mount(
+    <OcpOnAwsReportSummary {...props} subTitle={'sub-title'} />
+  );
+  expect(view.find('p').length).toBe(1);
+  expect(view.find('p').text()).toEqual('sub-title');
+});
+
+test('show details link in card footer if given', () => {
+  const view = mount(
+    <OcpOnAwsReportSummary {...props} detailsLink={<a href="#">link</a>} />
+  );
+  expect(view.find(CardFooter).length).toBe(1);
+  expect(view.find(CardFooter).text()).toEqual('link');
+});

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummary.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummary.tsx
@@ -1,0 +1,44 @@
+import {
+  Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
+  Title,
+} from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { FetchStatus } from 'store/common';
+import { styles } from './ocpOnAwsReportSummary.styles';
+
+interface OcpOnAwsReportSummaryProps extends InjectedTranslateProps {
+  title: string;
+  subTitle?: string;
+  children?: React.ReactNode;
+  detailsLink?: React.ReactNode;
+  status: number;
+}
+
+const OcpOnAwsReportSummaryBase: React.SFC<OcpOnAwsReportSummaryProps> = ({
+  title,
+  subTitle,
+  detailsLink,
+  children,
+  status,
+  t,
+}) => (
+  <Card className={css(styles.reportSummary)}>
+    <CardHeader>
+      <Title size="lg">{title}</Title>
+      {Boolean(subTitle) && <p className={css(styles.subtitle)}>{subTitle}</p>}
+    </CardHeader>
+    <CardBody>
+      {status === FetchStatus.inProgress ? `${t('loading')}...` : children}
+    </CardBody>
+    {Boolean(detailsLink) && <CardFooter>{detailsLink}</CardFooter>}
+  </Card>
+);
+
+const OcpOnAwsReportSummary = translate()(OcpOnAwsReportSummaryBase);
+
+export { OcpOnAwsReportSummary, OcpOnAwsReportSummaryProps };

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryAlt.styles.ts
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryAlt.styles.ts
@@ -1,0 +1,28 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import {
+  global_Color_200,
+  global_FontSize_xs,
+  global_spacer_lg,
+} from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  container: {
+    display: 'flex',
+  },
+  cost: {
+    flexGrow: 1,
+    minHeight: '440px',
+  },
+  reportSummary: {
+    height: '100%',
+  },
+  subtitle: {
+    fontSize: global_FontSize_xs.value,
+    color: global_Color_200.var,
+    marginBottom: '0',
+  },
+  tops: {
+    flexGrow: 1,
+    marginTop: global_spacer_lg.value,
+  },
+});

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryAlt.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryAlt.tsx
@@ -1,0 +1,65 @@
+import {
+  Card,
+  CardBody,
+  CardFooter,
+  CardHeader,
+  Grid,
+  GridItem,
+  Title,
+} from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { FetchStatus } from 'store/common';
+import { styles } from './ocpOnAwsReportSummaryAlt.styles';
+
+interface OcpOnAwsReportSummaryAltProps extends InjectedTranslateProps {
+  children?: React.ReactNode;
+  detailsLink?: React.ReactNode;
+  status: number;
+  subTitle?: string;
+  tabs?: React.ReactNode;
+  title: string;
+}
+
+const OcpOnAwsReportSummaryAltBase: React.SFC<
+  OcpOnAwsReportSummaryAltProps
+> = ({ children, detailsLink, status, t, tabs, title, subTitle }) => (
+  <Card className={css(styles.reportSummary)}>
+    <Grid gutter="md">
+      <GridItem lg={5} xl={6}>
+        <div className={css(styles.container)}>
+          <div className={css(styles.cost)}>
+            <CardHeader>
+              <Title size="lg">{title}</Title>
+              {Boolean(subTitle) && (
+                <p className={css(styles.subtitle)}>{subTitle}</p>
+              )}
+            </CardHeader>
+            <CardBody>
+              {status === FetchStatus.inProgress
+                ? `${t('loading')}...`
+                : children}
+            </CardBody>
+          </div>
+        </div>
+      </GridItem>
+      <GridItem lg={7} xl={6}>
+        <div className={css(styles.container)}>
+          <div className={css(styles.tops)}>
+            {status !== FetchStatus.inProgress && (
+              <>
+                {Boolean(tabs) && <CardBody>{tabs}</CardBody>}
+                {Boolean(detailsLink) && <CardFooter>{detailsLink}</CardFooter>}
+              </>
+            )}
+          </div>
+        </div>
+      </GridItem>
+    </Grid>
+  </Card>
+);
+
+const OcpOnAwsReportSummaryAlt = translate()(OcpOnAwsReportSummaryAltBase);
+
+export { OcpOnAwsReportSummaryAlt, OcpOnAwsReportSummaryAltProps };

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryDetails.styles.ts
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryDetails.styles.ts
@@ -1,0 +1,37 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import {
+  global_Color_100,
+  global_FontSize_4xl,
+  global_FontSize_xs,
+  global_LineHeight_sm,
+  global_spacer_md,
+  global_spacer_sm,
+} from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  requestedValue: {
+    marginLeft: global_spacer_sm.value,
+  },
+  text: {
+    display: 'flex',
+    alignItems: 'flex-end',
+    marginLeft: global_spacer_sm.value,
+    paddingBottom: 14,
+    lineHeight: global_LineHeight_sm.value,
+    fontSize: global_FontSize_xs.value,
+  },
+  titleContainer: {
+    display: 'inline-block',
+    marginBottom: global_spacer_md.value,
+    minWidth: '175px',
+    width: '50%',
+  },
+  usageText: {
+    marginRight: global_spacer_sm.value,
+  },
+  value: {
+    display: 'flex',
+    color: global_Color_100.var,
+    fontSize: global_FontSize_4xl.value,
+  },
+});

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryDetails.test.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryDetails.test.tsx
@@ -1,0 +1,41 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+  OcpOnAwsReportSummaryDetails,
+  OcpOnAwsReportSummaryDetailsProps,
+} from './ocpOnAwsReportSummaryDetails';
+
+const props: OcpOnAwsReportSummaryDetailsProps = {
+  report: { data: [], total: { cost: { value: 100, units: 'USD' } } },
+  label: 'label',
+  formatValue: jest.fn(() => 'formatedValue'),
+};
+
+test('report total is formated', () => {
+  const view = shallow(<OcpOnAwsReportSummaryDetails {...props} />);
+  expect(props.formatValue).toBeCalledWith(
+    props.report.total.cost.value,
+    props.report.total.cost.units,
+    props.formatOptions
+  );
+  expect(view).toMatchSnapshot();
+});
+
+test('defaults value if report is not present', () => {
+  const view = shallow(
+    <OcpOnAwsReportSummaryDetails {...props} report={null} />
+  );
+  expect(props.formatValue).not.toBeCalled();
+  expect(view).toMatchSnapshot();
+});
+
+test('defaults value if report.total is not present', () => {
+  const view = shallow(
+    <OcpOnAwsReportSummaryDetails
+      {...props}
+      report={{ ...props.report, total: null }}
+    />
+  );
+  expect(props.formatValue).not.toBeCalled();
+  expect(view).toMatchSnapshot();
+});

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryDetails.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryDetails.tsx
@@ -1,0 +1,90 @@
+import { css } from '@patternfly/react-styles';
+import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import React from 'react';
+import { FormatOptions, ValueFormatter } from 'utils/formatValue';
+import { styles } from './ocpOnAwsReportSummaryDetails.styles';
+
+interface OcpOnAwsReportSummaryDetailsProps {
+  formatValue?: ValueFormatter;
+  formatOptions?: FormatOptions;
+  label: string;
+  report: OcpOnAwsReport;
+  reportType?: OcpOnAwsReportType;
+  requestLabel?: string;
+}
+
+const OcpOnAwsReportSummaryDetails: React.SFC<
+  OcpOnAwsReportSummaryDetailsProps
+> = ({
+  label,
+  formatValue,
+  formatOptions,
+  report,
+  reportType = OcpOnAwsReportType.cost,
+  requestLabel,
+}) => {
+  let value: string | number = '----';
+  let requestValue: string | number = '----';
+
+  const awsReportType =
+    reportType === OcpOnAwsReportType.instanceType ||
+    reportType === OcpOnAwsReportType.storage;
+
+  if (report && report.total) {
+    if (reportType === OcpOnAwsReportType.cost) {
+      const units: string = report.total.cost.units
+        ? report.total.cost.units
+        : 'USD';
+      value = formatValue(
+        report.total.cost.value ? report.total.cost.value : 0,
+        units,
+        formatOptions
+      );
+    } else if (awsReportType) {
+      const units: string = report.total.usage
+        ? report.total.usage.units
+        : 'USD';
+      value = formatValue(
+        report.total.usage.value ? report.total.usage.value : 0,
+        units,
+        formatOptions
+      );
+    } else {
+      const units: string = report.total.usage.units
+        ? report.total.usage.units
+        : 'GB';
+      value = formatValue(
+        report.total.usage.value ? report.total.usage.value : 0,
+        units,
+        formatOptions
+      );
+      requestValue = formatValue(
+        report.total.request.value ? report.total.request.value : 0,
+        units,
+        formatOptions
+      );
+    }
+  }
+  return (
+    <>
+      <div className={css(styles.titleContainer)}>
+        <div className={css(styles.value)}>
+          {value}
+          <div className={css(styles.text)}>
+            <div>{label}</div>
+          </div>
+        </div>
+      </div>
+      <div className={css(styles.titleContainer)}>
+        {Boolean(reportType !== OcpOnAwsReportType.cost && !awsReportType) && (
+          <div className={css(styles.value, styles.requestedValue)}>
+            {requestValue}
+            <div className={css(styles.text)}>{requestLabel}</div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+};
+
+export { OcpOnAwsReportSummaryDetails, OcpOnAwsReportSummaryDetailsProps };

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItem.styles.ts
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItem.styles.ts
@@ -1,0 +1,15 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_md } from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  reportSummaryItem: {
+    ':not(:last-child)': {
+      marginBottom: global_spacer_md.value,
+    },
+  },
+  test: {
+    ':not(foo) svg': {
+      overflow: 'visible',
+    },
+  },
+});

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItem.test.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItem.test.tsx
@@ -1,0 +1,48 @@
+import { Progress } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import { shallow } from 'enzyme';
+import React from 'react';
+import {
+  OcpOnAwsReportSummaryItem,
+  OcpOnAwsReportSummaryItemProps,
+} from './ocpOnAwsReportSummaryItem';
+import { styles } from './ocpOnAwsReportSummaryItem.styles';
+
+const props: OcpOnAwsReportSummaryItemProps = {
+  label: 'Label',
+  totalValue: 1000,
+  value: 100,
+  units: 'units',
+  formatValue: jest.fn(v => `formatted ${v}`),
+  formatOptions: {},
+};
+
+// Temporarily disabled formatValue test until PF4 progress bar supports custom labels
+xtest('formats value', () => {
+  shallow(<OcpOnAwsReportSummaryItem {...props} />);
+  expect(props.formatValue).toBeCalledWith(
+    props.value,
+    props.units,
+    props.formatOptions
+  );
+});
+
+test('gets percentage from value and total value', () => {
+  const view = shallow(<OcpOnAwsReportSummaryItem {...props} />);
+  expect(view.find(Progress).props().value).toMatchSnapshot(
+    'Progress Bar Value'
+  );
+  expect(view.find(`.${css(styles.reportSummaryItem)}`)).toMatchSnapshot(
+    'Rendered Label'
+  );
+});
+
+test('sets percent to 0 if totalValue is 0', () => {
+  const view = shallow(<OcpOnAwsReportSummaryItem {...props} totalValue={0} />);
+  expect(view.find(Progress).props().value).toMatchSnapshot(
+    'Progress Bar Value'
+  );
+  expect(view.find(`.${css(styles.reportSummaryItem)}`)).toMatchSnapshot(
+    'Rendered label'
+  );
+});

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItem.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItem.tsx
@@ -1,0 +1,48 @@
+import { Progress, ProgressSize } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import React from 'react';
+import { FormatOptions, ValueFormatter } from 'utils/formatValue';
+import { styles } from './ocpOnAwsReportSummaryItem.styles';
+
+interface OcpOnAwsReportSummaryItemProps {
+  label: string;
+  units: string;
+  value: number;
+  totalValue: number;
+  formatValue: ValueFormatter;
+  formatOptions?: FormatOptions;
+}
+
+const OcpOnAwsReportSummaryItem: React.SFC<OcpOnAwsReportSummaryItemProps> = ({
+  label,
+  value,
+  totalValue,
+  formatValue,
+  units,
+  formatOptions,
+}) => {
+  const percent = !totalValue ? 0 : (value / totalValue) * 100;
+  const percentVal = Number(percent.toFixed(2));
+  const percentLabel = `${formatValue(
+    value,
+    units,
+    formatOptions
+  )} (${percentVal}%)`;
+
+  return (
+    <li className={css(styles.reportSummaryItem)}>
+      <Progress
+        label={percentLabel}
+        value={percentVal}
+        title={label}
+        size={ProgressSize.sm}
+      />
+    </li>
+  );
+};
+
+OcpOnAwsReportSummaryItem.defaultProps = {
+  formatValue: v => v,
+};
+
+export { OcpOnAwsReportSummaryItem, OcpOnAwsReportSummaryItemProps };

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItems.test.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItems.test.tsx
@@ -1,0 +1,39 @@
+import { shallow } from 'enzyme';
+import React from 'react';
+import * as utils from 'utils/getComputedOcpOnAwsReportItems';
+import {
+  OcpOnAwsReportSummaryItems,
+  OcpOnAwsReportSummaryItemsProps,
+} from './ocpOnAwsReportSummaryItems';
+
+jest.spyOn(utils, 'getComputedOcpOnAwsReportItems');
+
+const props: OcpOnAwsReportSummaryItemsProps = {
+  report: { data: [] },
+  idKey: 'date',
+  labelKey: 'account',
+  children: jest.fn(() => null),
+};
+
+test('computes report items', () => {
+  shallow(<OcpOnAwsReportSummaryItems {...props} />);
+  expect(utils.getComputedOcpOnAwsReportItems).toBeCalledWith({
+    report: props.report,
+    idKey: props.idKey,
+    labelKey: props.labelKey,
+  });
+  expect(props.children).toBeCalledWith({ items: [] });
+});
+
+test('returns null if a report is not present', () => {
+  shallow(<OcpOnAwsReportSummaryItems {...props} report={null} />);
+  expect(utils.getComputedOcpOnAwsReportItems).not.toBeCalled();
+  expect(props.children).not.toBeCalled();
+});
+
+test('does not update if the report is unchanged', () => {
+  const view = shallow(<OcpOnAwsReportSummaryItems {...props} />);
+  view.setProps(props as any);
+  expect(utils.getComputedOcpOnAwsReportItems).toHaveBeenCalledTimes(1);
+  expect(props.children).toHaveBeenCalledTimes(1);
+});

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItems.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItems.tsx
@@ -1,0 +1,67 @@
+import React from 'react';
+import {
+  ComputedOcpOnAwsReportItem,
+  getComputedOcpOnAwsReportItems,
+  GetComputedOcpOnAwsReportItemsParams,
+} from 'utils/getComputedOcpOnAwsReportItems';
+
+interface OcpOnAwsReportSummaryItemsRenderProps {
+  items: ComputedOcpOnAwsReportItem[];
+}
+
+interface OcpOnAwsReportSummaryItemsProps
+  extends GetComputedOcpOnAwsReportItemsParams {
+  children?(props: OcpOnAwsReportSummaryItemsRenderProps): React.ReactNode;
+}
+
+class OcpOnAwsReportSummaryItems extends React.Component<
+  OcpOnAwsReportSummaryItemsProps
+> {
+  public shouldComponentUpdate(nextProps: OcpOnAwsReportSummaryItemsProps) {
+    return nextProps.report !== this.props.report;
+  }
+
+  private getItems() {
+    const { report, idKey, labelKey } = this.props;
+
+    const computedItems = getComputedOcpOnAwsReportItems({
+      report,
+      idKey,
+      labelKey,
+    });
+
+    const otherIndex = computedItems.findIndex(i => {
+      const id = i.id;
+      if (id && id !== null) {
+        return id.toString().includes('Other');
+      }
+    });
+
+    if (otherIndex !== -1) {
+      return [
+        ...computedItems.slice(0, otherIndex),
+        ...computedItems.slice(otherIndex + 1),
+        computedItems[otherIndex],
+      ];
+    }
+
+    return computedItems;
+  }
+
+  public render() {
+    const { report, children } = this.props;
+    if (!report) {
+      return null;
+    }
+
+    const items = this.getItems();
+
+    return <ul>{children({ items })}</ul>;
+  }
+}
+
+export {
+  OcpOnAwsReportSummaryItems,
+  OcpOnAwsReportSummaryItemsProps,
+  OcpOnAwsReportSummaryItemsRenderProps,
+};

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryTrend.styles.ts
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryTrend.styles.ts
@@ -1,0 +1,8 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_sm } from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  chart: {
+    marginBottom: global_spacer_sm.value,
+  },
+});

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryTrend.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryTrend.tsx
@@ -1,0 +1,12 @@
+import { css } from '@patternfly/react-styles';
+import { TrendChart, TrendChartProps } from 'components/charts/trendChart';
+import React from 'react';
+import { styles } from './ocpOnAwsReportSummaryTrend.styles';
+
+const OcpOnAwsReportSummaryTrend: React.SFC<TrendChartProps> = props => (
+  <div className={css(styles.chart)}>
+    <TrendChart {...props} />
+  </div>
+);
+
+export { OcpOnAwsReportSummaryTrend };

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryUsage.styles.ts
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryUsage.styles.ts
@@ -1,0 +1,8 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_sm } from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  chart: {
+    marginBottom: global_spacer_sm.value,
+  },
+});

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryUsage.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryUsage.tsx
@@ -1,0 +1,12 @@
+import { css } from '@patternfly/react-styles';
+import { UsageChart, UsageChartProps } from 'components/charts/usageChart';
+import React from 'react';
+import { styles } from './ocpOnAwsReportSummaryTrend.styles';
+
+const OcpOnAwsReportSummaryUsage: React.SFC<UsageChartProps> = props => (
+  <div className={css(styles.chart)}>
+    <UsageChart {...props} />
+  </div>
+);
+
+export { OcpOnAwsReportSummaryUsage };

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -17,7 +17,7 @@
       "regions": "Top Regions",
       "services": "Top Services"
     },
-    "title": "Amazon Web Services",
+    "title": "AWS",
     "trend_group_legend": "$t(months.{{month}}) {{startDate}} - {{endDate}}",
     "widget_subtitle": "$t(months.{{month}}) {{startDate}}",
     "widget_subtitle_plural": "$t(months.{{month}}) {{startDate}} - $t(months.{{month}}) {{endDate}}"
@@ -110,6 +110,12 @@
     "cost": "Group cost by",
     "tag": "Tag Key: {{key}}",
     "top": "Top $t(group_by.values.{{groupBy}}, { 'count': 5 })",
+    "top_values": {
+      "account": "account",
+      "account_plural": "accounts",
+      "cluster": "cluster",
+      "cluster_plural": "clusters"
+    },
     "values": {
       "account": "Account",
       "account_plural": "Accounts",
@@ -187,7 +193,7 @@
       "pods": "Top Pods",
       "projects": "Top Projects"
     },
-    "title": "OpenShit Container Platform",
+    "title": "OpenShift",
     "trend_group_legend": "$t(months.{{month}}) {{startDate}} - {{endDate}}",
     "widget_subtitle": "$t(months.{{month}}) {{startDate}}",
     "widget_subtitle_plural": "$t(months.{{month}}) {{startDate}} - $t(months.{{month}}) {{endDate}}"
@@ -260,6 +266,36 @@
       "results": "{{value}} Results"
     },
     "total_cost": "Total Cost"
+  },
+  "ocp_on_aws_dashboard": {
+    "aws": {
+      "compute_detail_label": "Hrs",
+      "compute_title": "AWS compute instances",
+      "compute_trend_title": "Compute instance (hours), month over month",
+      "storage_detail_label": "GB",
+      "storage_title": "AWS storage services",
+      "storage_trend_title": "Storage usage (GB), month over month",
+      "widget_subtitle": "$t(months.{{month}}) {{startDate}}"
+    },
+    "ocp": {
+      "cost_title": "Total Cost",
+      "cost_trend_title": "Cost comparison ($USD), month over month",
+      "cpu_current_title": "{{date}} - Current",
+      "cpu_previous_title": "{{startDate}} - {{endDate}}",
+      "cpu_request_label": "Core-Hours Requested",
+      "cpu_requested_label": "{{date}} Requested",
+      "cpu_title": "OpenShift CPU usage and request",
+      "cpu_usage_label": "Core-Hours Used",
+      "cpu_used_label": "{{date}} Used",
+      "memory_current_title": "{{date}} - Current",
+      "memory_previous_title": "{{startDate}} - {{endDate}}",
+      "memory_request_label": "GB-Hours Requested",
+      "memory_requested_label": "Requested",
+      "memory_title": "OpenShift memory usage and request",
+      "memory_usage_label": "GB-Hours Used",
+      "memory_used_label": "{{date}} Used",
+      "widget_subtitle": "$t(months.{{month}}) {{startDate}}"
+    }
   },
   "onboarding": {
     "aws_configure": {
@@ -357,8 +393,9 @@
     }
   },
   "overview": {
-    "aws": "Amazon Web Services",
-    "ocp": "OpenShift Container Platform",
+    "aws": "AWS",
+    "ocp": "OpenShift",
+    "ocp_on_aws": "OpenShift on AWS",
     "title": "Cost Management Overview"
   },
   "percent": "{{value}}%",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -17,7 +17,7 @@
       "regions": "Top Regions",
       "services": "Top Services"
     },
-    "title": "Amazon Web Services",
+    "title": "AWS",
     "trend_group_legend": "$t(months.{{month}}) {{startDate}} - {{endDate}}",
     "widget_subtitle": "$t(months.{{month}}) {{startDate}}",
     "widget_subtitle_plural": "$t(months.{{month}}) {{startDate}} - $t(months.{{month}}) {{endDate}}"
@@ -109,7 +109,25 @@
     "all": "All $t(group_by.values.{{groupBy}}, { 'count': 5 })",
     "cost": "Group cost by",
     "tag": "Tag Key: {{key}}",
-    "top": "Top $t(group_by.values.{{groupBy}}, { 'count': 5 })",
+    "top": "Top $t(group_by.top_values.{{groupBy}}, { 'count': 5 })",
+    "top_values": {
+      "account": "account",
+      "account_plural": "accounts",
+      "cluster": "cluster",
+      "cluster_plural": "clusters",
+      "instance_type": "instance type",
+      "instance_type_plural": "instance types",
+      "node": "node",
+      "node_plural": "nodes",
+      "pod": "pod",
+      "pod_plural": "pods",
+      "project": "project",
+      "project_plural": "projects",
+      "region": "region",
+      "region_plural": "regions",
+      "service": "service",
+      "service_plural": "services"
+    },
     "values": {
       "account": "Account",
       "account_plural": "Accounts",
@@ -187,7 +205,7 @@
       "pods": "Top Pods",
       "projects": "Top Projects"
     },
-    "title": "OpenShit Container Platform",
+    "title": "OpenShift",
     "trend_group_legend": "$t(months.{{month}}) {{startDate}} - {{endDate}}",
     "widget_subtitle": "$t(months.{{month}}) {{startDate}}",
     "widget_subtitle_plural": "$t(months.{{month}}) {{startDate}} - $t(months.{{month}}) {{endDate}}"
@@ -260,6 +278,36 @@
       "results": "{{value}} Results"
     },
     "total_cost": "Total Cost"
+  },
+  "ocp_on_aws_dashboard": {
+    "aws": {
+      "compute_detail_label": "Hrs",
+      "compute_title": "AWS compute instances",
+      "compute_trend_title": "Compute instance (hours), month over month",
+      "storage_detail_label": "GB",
+      "storage_title": "AWS storage services",
+      "storage_trend_title": "Storage usage (GB), month over month",
+      "widget_subtitle": "$t(months.{{month}}) {{startDate}}"
+    },
+    "ocp": {
+      "cost_title": "Total Cost",
+      "cost_trend_title": "Cost comparison ($USD), month over month",
+      "cpu_current_title": "{{date}} - Current",
+      "cpu_previous_title": "{{startDate}} - {{endDate}}",
+      "cpu_request_label": "Core-Hours Requested",
+      "cpu_requested_label": "{{date}} Requested",
+      "cpu_title": "OpenShift CPU usage and request",
+      "cpu_usage_label": "Core-Hours Used",
+      "cpu_used_label": "{{date}} Used",
+      "memory_current_title": "{{date}} - Current",
+      "memory_previous_title": "{{startDate}} - {{endDate}}",
+      "memory_request_label": "GB-Hours Requested",
+      "memory_requested_label": "Requested",
+      "memory_title": "OpenShift memory usage and request",
+      "memory_usage_label": "GB-Hours Used",
+      "memory_used_label": "{{date}} Used",
+      "widget_subtitle": "$t(months.{{month}}) {{startDate}}"
+    }
   },
   "onboarding": {
     "aws_configure": {
@@ -357,8 +405,9 @@
     }
   },
   "overview": {
-    "aws": "Amazon Web Services",
-    "ocp": "OpenShift Container Platform",
+    "aws": "AWS",
+    "ocp": "OpenShift",
+    "ocp_on_aws": "OpenShift on AWS",
     "title": "Cost Management Overview"
   },
   "percent": "{{value}}%",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -17,7 +17,7 @@
       "regions": "Top Regions",
       "services": "Top Services"
     },
-    "title": "Amazon Web Services",
+    "title": "AWS",
     "trend_group_legend": "$t(months.{{month}}) {{startDate}} - {{endDate}}",
     "widget_subtitle": "$t(months.{{month}}) {{startDate}}",
     "widget_subtitle_plural": "$t(months.{{month}}) {{startDate}} - $t(months.{{month}}) {{endDate}}"
@@ -110,6 +110,12 @@
     "cost": "Group cost by",
     "tag": "Tag Key: {{key}}",
     "top": "Top $t(group_by.values.{{groupBy}}, { 'count': 5 })",
+    "top_values": {
+      "account": "account",
+      "account_plural": "accounts",
+      "cluster": "cluster",
+      "cluster_plural": "clusters"
+    },
     "values": {
       "account": "Account",
       "account_plural": "Accounts",
@@ -187,7 +193,7 @@
       "pods": "Top Pods",
       "projects": "Top Projects"
     },
-    "title": "OpenShit Container Platform",
+    "title": "OpenShift",
     "trend_group_legend": "$t(months.{{month}}) {{startDate}} - {{endDate}}",
     "widget_subtitle": "$t(months.{{month}}) {{startDate}}",
     "widget_subtitle_plural": "$t(months.{{month}}) {{startDate}} - $t(months.{{month}}) {{endDate}}"
@@ -260,6 +266,36 @@
       "results": "{{value}} Results"
     },
     "total_cost": "Total Cost"
+  },
+  "ocp_on_aws_dashboard": {
+    "aws": {
+      "compute_detail_label": "Hrs",
+      "compute_title": "AWS compute instances",
+      "compute_trend_title": "Compute instance (hours), month over month",
+      "storage_detail_label": "GB",
+      "storage_title": "AWS storage services",
+      "storage_trend_title": "Storage usage (GB), month over month",
+      "widget_subtitle": "$t(months.{{month}}) {{startDate}}"
+    },
+    "ocp": {
+      "cost_title": "Total Cost",
+      "cost_trend_title": "Cost comparison ($USD), month over month",
+      "cpu_current_title": "{{date}} - Current",
+      "cpu_previous_title": "{{startDate}} - {{endDate}}",
+      "cpu_request_label": "Core-Hours Requested",
+      "cpu_requested_label": "{{date}} Requested",
+      "cpu_title": "OpenShift CPU usage and request",
+      "cpu_usage_label": "Core-Hours Used",
+      "cpu_used_label": "{{date}} Used",
+      "memory_current_title": "{{date}} - Current",
+      "memory_previous_title": "{{startDate}} - {{endDate}}",
+      "memory_request_label": "GB-Hours Requested",
+      "memory_requested_label": "Requested",
+      "memory_title": "OpenShift memory usage and request",
+      "memory_usage_label": "GB-Hours Used",
+      "memory_used_label": "{{date}} Used",
+      "widget_subtitle": "$t(months.{{month}}) {{startDate}}"
+    }
   },
   "onboarding": {
     "aws_configure": {
@@ -357,8 +393,9 @@
     }
   },
   "overview": {
-    "aws": "Amazon Web Services",
-    "ocp": "OpenShift Container Platform",
+    "aws": "AWS",
+    "ocp": "OpenShift",
+    "ocp_on_aws": "OpenShift on AWS",
     "title": "Cost Management Overview"
   },
   "percent": "{{value}}%",

--- a/src/pages/ocpOnAwsDashboard/__snapshots__/ocpOnAwsDashboardWidget.test.tsx.snap
+++ b/src/pages/ocpOnAwsDashboard/__snapshots__/ocpOnAwsDashboardWidget.test.tsx.snap
@@ -1,0 +1,51 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`detail label is translated 1`] = `
+Array [
+  "detail label",
+  Object {
+    "context": "label context",
+  },
+]
+`;
+
+exports[`subtitle is translated with date range 1`] = `
+Array [
+  "ocp_on_aws_dashboard.ocp.widget_subtitle",
+  Object {
+    "count": 2,
+    "endDate": "formated date",
+    "month": 1,
+    "startDate": "formated date",
+  },
+]
+`;
+
+exports[`subtitle is translated with single date 1`] = `
+Array [
+  "ocp_on_aws_dashboard.ocp.widget_subtitle",
+  Object {
+    "count": 1,
+    "endDate": "formated date",
+    "month": 1,
+    "startDate": "formated date",
+  },
+]
+`;
+
+exports[`title is translated 1`] = `
+Array [
+  "title",
+  Object {
+    "endDate": "formated date",
+    "month": 1,
+    "startDate": "formated date",
+  },
+]
+`;
+
+exports[`trend title is translated 1`] = `
+Array [
+  "trend title",
+]
+`;

--- a/src/pages/ocpOnAwsDashboard/index.ts
+++ b/src/pages/ocpOnAwsDashboard/index.ts
@@ -1,0 +1,4 @@
+import { hot } from 'react-hot-loader';
+import OcpOnAwsDashboard from './ocpOnAwsDashboard';
+
+export default hot(module)(OcpOnAwsDashboard);

--- a/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboard.tsx
+++ b/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboard.tsx
@@ -1,0 +1,63 @@
+import { Grid, GridItem } from '@patternfly/react-core';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps } from 'store/common';
+import { ocpOnAwsDashboardSelectors } from 'store/ocpOnAwsDashboard';
+import { OcpOnAwsDashboardWidget } from './ocpOnAwsDashboardWidget';
+
+type OcpOnAwsDashboardOwnProps = InjectedTranslateProps;
+
+interface OcpOnAwsDashboardStateProps {
+  widgets: number[];
+}
+
+interface OcpOnAwsDashboardDispatchProps {
+  selectWidgets?: typeof ocpOnAwsDashboardSelectors.selectWidgets;
+}
+
+type OcpOnAwsDashboardProps = OcpOnAwsDashboardOwnProps &
+  OcpOnAwsDashboardStateProps &
+  OcpOnAwsDashboardDispatchProps;
+
+const OcpOnAwsDashboardBase: React.SFC<OcpOnAwsDashboardProps> = ({
+  selectWidgets,
+  t,
+  widgets,
+}) => (
+  <div>
+    <Grid gutter="md">
+      {widgets.map(widgetId => {
+        const widget = selectWidgets[widgetId];
+        return Boolean(widget.isHorizontal) ? (
+          <GridItem sm={12} key={widgetId}>
+            <OcpOnAwsDashboardWidget widgetId={widgetId} />
+          </GridItem>
+        ) : (
+          <GridItem xl={4} lg={6} key={widgetId}>
+            <OcpOnAwsDashboardWidget widgetId={widgetId} />
+          </GridItem>
+        );
+      })}
+    </Grid>
+  </div>
+);
+
+const mapStateToProps = createMapStateToProps<
+  OcpOnAwsDashboardOwnProps,
+  OcpOnAwsDashboardStateProps
+>(state => {
+  return {
+    selectWidgets: ocpOnAwsDashboardSelectors.selectWidgets(state),
+    widgets: ocpOnAwsDashboardSelectors.selectCurrentWidgets(state),
+  };
+});
+
+const OcpOnAwsDashboard = translate()(
+  connect(
+    mapStateToProps,
+    {}
+  )(OcpOnAwsDashboardBase)
+);
+
+export default OcpOnAwsDashboard;

--- a/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.styles.ts
+++ b/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.styles.ts
@@ -1,0 +1,8 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_xl } from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  tabs: {
+    marginTop: global_spacer_xl.value,
+  },
+});

--- a/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.test.tsx
+++ b/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.test.tsx
@@ -1,0 +1,126 @@
+jest
+  .mock('date-fns/start_of_month')
+  .mock('date-fns/get_date')
+  .mock('date-fns/format')
+  .mock('date-fns/get_month');
+
+import { Tabs } from '@patternfly/react-core';
+import { OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import { ChartType } from 'components/charts/commonChart/chartUtils';
+import formatDate from 'date-fns/format';
+import getDate from 'date-fns/get_date';
+import getMonth from 'date-fns/get_month';
+import startOfMonth from 'date-fns/start_of_month';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { FetchStatus } from 'store/common';
+import { OcpOnAwsDashboardTab } from 'store/ocpOnAwsDashboard';
+import { mockDate } from 'testUtils';
+import {
+  getIdKeyForTab,
+  OcpOnAwsDashboardWidgetBase,
+  OcpOnAwsDashboardWidgetProps,
+} from './ocpOnAwsDashboardWidget';
+
+const props: OcpOnAwsDashboardWidgetProps = {
+  widgetId: 1,
+  id: 1,
+  t: jest.fn(v => v),
+  current: { data: [] },
+  previous: { data: [] },
+  tabs: { data: [] },
+  fetchReports: jest.fn(),
+  updateTab: jest.fn(),
+  titleKey: 'title',
+  reportType: OcpOnAwsReportType.cost,
+  trend: {
+    type: ChartType.rolling,
+    titleKey: 'trend title',
+    formatOptions: {},
+  },
+  status: FetchStatus.none,
+  currentQuery: '',
+  previousQuery: '',
+  tabsQuery: '',
+  details: {
+    labelKey: 'detail label',
+    labelKeyContext: 'label context',
+    descriptionKeyRange: 'detail description range',
+    descriptionKeySingle: 'detail description single',
+    formatOptions: {},
+  },
+  topItems: { formatOptions: {} },
+  availableTabs: [OcpOnAwsDashboardTab.projects],
+  currentTab: OcpOnAwsDashboardTab.projects,
+};
+
+const getDateMock = getDate as jest.Mock;
+const formatDateMock = formatDate as jest.Mock;
+const startOfMonthMock = startOfMonth as jest.Mock;
+const getMonthMock = getMonth as jest.Mock;
+
+beforeEach(() => {
+  mockDate();
+  getDateMock.mockReturnValue(1);
+  formatDateMock.mockReturnValue('formated date');
+  startOfMonthMock.mockReturnValue(1);
+  getMonthMock.mockReturnValue(1);
+});
+
+test('reports are fetched on mount', () => {
+  shallow(<OcpOnAwsDashboardWidgetBase {...props} />);
+  expect(props.fetchReports).toBeCalledWith(props.widgetId);
+});
+
+test('title is translated', () => {
+  shallow(<OcpOnAwsDashboardWidgetBase {...props} />);
+  expect(getTranslateCallForKey(props.titleKey)).toMatchSnapshot();
+});
+
+test('detail label is translated', () => {
+  shallow(<OcpOnAwsDashboardWidgetBase {...props} />);
+  expect(getTranslateCallForKey(props.details.labelKey)).toMatchSnapshot();
+});
+
+test('subtitle is translated with single date', () => {
+  shallow(<OcpOnAwsDashboardWidgetBase {...props} />);
+  expect(
+    getTranslateCallForKey('ocp_on_aws_dashboard.ocp.widget_subtitle')
+  ).toMatchSnapshot();
+});
+
+test('subtitle is translated with date range', () => {
+  getDateMock.mockReturnValueOnce(2);
+  shallow(<OcpOnAwsDashboardWidgetBase {...props} />);
+  expect(
+    getTranslateCallForKey('ocp_on_aws_dashboard.ocp.widget_subtitle')
+  ).toMatchSnapshot();
+});
+
+test('trend title is translated', () => {
+  shallow(<OcpOnAwsDashboardWidgetBase {...props} />);
+  expect(getTranslateCallForKey(props.trend.titleKey)).toMatchSnapshot();
+});
+
+test('id key for dashboard tab is the tab name in singular form', () => {
+  [
+    OcpOnAwsDashboardTab.clusters,
+    OcpOnAwsDashboardTab.nodes,
+    OcpOnAwsDashboardTab.projects,
+  ].forEach(value => {
+    expect(getIdKeyForTab(value)).toEqual(value.slice(0, -1));
+  });
+
+  expect(getIdKeyForTab(OcpOnAwsDashboardTab.projects)).toEqual('project');
+});
+
+xtest('change tab triggers updateTab', () => {
+  const tabId = OcpOnAwsDashboardTab.clusters;
+  const view = shallow(<OcpOnAwsDashboardWidgetBase {...props} />);
+  view.find(Tabs).simulate('click', { event: {}, tabIndex: 2 });
+  expect(props.updateTab).toBeCalledWith(props.id, { tabId });
+});
+
+function getTranslateCallForKey(key: string) {
+  return (props.t as jest.Mock).mock.calls.find(([k]) => k === key);
+}

--- a/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
+++ b/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
@@ -1,0 +1,407 @@
+import { Tab, Tabs } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import { getQuery, OcpOnAwsQuery, parseQuery } from 'api/ocpOnAwsQuery';
+import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import { transformOcpOnAwsReport } from 'components/charts/commonChart/chartUtils';
+import { Link } from 'components/link';
+import {
+  OcpOnAwsReportSummary,
+  OcpOnAwsReportSummaryAlt,
+  OcpOnAwsReportSummaryDetails,
+  OcpOnAwsReportSummaryItem,
+  OcpOnAwsReportSummaryItems,
+  OcpOnAwsReportSummaryTrend,
+  OcpOnAwsReportSummaryUsage,
+} from 'components/reports/ocpOnAwsReportSummary';
+import formatDate from 'date-fns/format';
+import getDate from 'date-fns/get_date';
+import getMonth from 'date-fns/get_month';
+import startOfMonth from 'date-fns/start_of_month';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps } from 'store/common';
+import {
+  ocpOnAwsDashboardActions,
+  ocpOnAwsDashboardSelectors,
+  OcpOnAwsDashboardTab,
+  OcpOnAwsDashboardWidget as OcpOnAwsDashboardWidgetStatic,
+} from 'store/ocpOnAwsDashboard';
+import { ocpOnAwsReportsSelectors } from 'store/ocpOnAwsReports';
+import { formatValue } from 'utils/formatValue';
+import { GetComputedOcpOnAwsReportItemsParams } from 'utils/getComputedOcpOnAwsReportItems';
+import { styles } from './ocpOnAwsDashboardWidget.styles';
+
+interface OcpOnAwsDashboardWidgetOwnProps {
+  widgetId: number;
+}
+
+interface OcpOnAwsDashboardWidgetStateProps
+  extends OcpOnAwsDashboardWidgetStatic {
+  currentQuery: string;
+  currentReport: OcpOnAwsReport;
+  currentReportFetchStatus: number;
+  previousQuery: string;
+  previousReport: OcpOnAwsReport;
+  tabsQuery: string;
+  tabsReport: OcpOnAwsReport;
+}
+
+interface OcpOnAwsDashboardWidgetDispatchProps {
+  fetchReports: typeof ocpOnAwsDashboardActions.fetchWidgetReports;
+  updateTab: typeof ocpOnAwsDashboardActions.changeWidgetTab;
+}
+
+type OcpOnAwsDashboardWidgetProps = OcpOnAwsDashboardWidgetOwnProps &
+  OcpOnAwsDashboardWidgetStateProps &
+  OcpOnAwsDashboardWidgetDispatchProps &
+  InjectedTranslateProps;
+
+export const getIdKeyForTab = (
+  tab: OcpOnAwsDashboardTab
+): GetComputedOcpOnAwsReportItemsParams['idKey'] => {
+  switch (tab) {
+    case OcpOnAwsDashboardTab.clusters:
+      return 'cluster';
+    case OcpOnAwsDashboardTab.nodes:
+      return 'node';
+    case OcpOnAwsDashboardTab.projects:
+      return 'project';
+  }
+};
+
+class OcpOnAwsDashboardWidgetBase extends React.Component<
+  OcpOnAwsDashboardWidgetProps
+> {
+  public state = {
+    activeTabKey: 0,
+  };
+
+  public componentDidMount() {
+    const { availableTabs, fetchReports, id, widgetId } = this.props;
+    if (availableTabs) {
+      this.props.updateTab(id, availableTabs[0]);
+    }
+    fetchReports(widgetId);
+  }
+
+  private buildDetailsLink = () => {
+    const { currentQuery } = this.props;
+    const groupBy = parseQuery<OcpOnAwsQuery>(currentQuery).group_by;
+    return `/ocp?${getQuery({
+      group_by: groupBy,
+      order_by: { cost: 'desc' },
+    })}`;
+  };
+
+  private handleTabClick = (event, tabIndex) => {
+    const { availableTabs, id } = this.props;
+    const tab = availableTabs[tabIndex];
+
+    this.props.updateTab(id, tab);
+    this.setState({
+      activeTabKey: tabIndex,
+    });
+  };
+
+  private getChart = (height: number) => {
+    const { currentReport, previousReport, reportType, t, trend } = this.props;
+
+    const reportItem =
+      reportType === OcpOnAwsReportType.cost ? 'cost' : 'usage';
+    const currentUsageData = transformOcpOnAwsReport(
+      currentReport,
+      trend.type,
+      'date',
+      reportItem
+    );
+    const previousUsageData = transformOcpOnAwsReport(
+      previousReport,
+      trend.type,
+      'date',
+      reportItem
+    );
+    const currentRequestData =
+      reportType !== OcpOnAwsReportType.cost
+        ? transformOcpOnAwsReport(currentReport, trend.type, 'date', 'request')
+        : undefined;
+    const previousRequestData =
+      reportType !== OcpOnAwsReportType.cost
+        ? transformOcpOnAwsReport(previousReport, trend.type, 'date', 'request')
+        : undefined;
+
+    return (
+      <>
+        {Boolean(
+          reportType === OcpOnAwsReportType.cost ||
+            reportType === OcpOnAwsReportType.instanceType ||
+            reportType === OcpOnAwsReportType.storage
+        ) ? (
+          <OcpOnAwsReportSummaryTrend
+            currentData={currentUsageData}
+            formatDatumValue={formatValue}
+            formatDatumOptions={trend.formatOptions}
+            height={height}
+            previousData={previousUsageData}
+            title={t(trend.titleKey)}
+          />
+        ) : (
+          <OcpOnAwsReportSummaryUsage
+            currentRequestData={currentRequestData}
+            currentUsageData={currentUsageData}
+            formatDatumValue={formatValue}
+            formatDatumOptions={trend.formatOptions}
+            height={height}
+            previousRequestData={previousRequestData}
+            previousUsageData={previousUsageData}
+          />
+        )}
+      </>
+    );
+  };
+
+  private getDetails = () => {
+    const { currentReport, details, reportType } = this.props;
+    return (
+      <OcpOnAwsReportSummaryDetails
+        formatOptions={details.formatOptions}
+        formatValue={formatValue}
+        label={this.getDetailsLabel()}
+        report={currentReport}
+        reportType={reportType}
+        requestLabel={this.getRequestLabel()}
+      />
+    );
+  };
+
+  private getDetailsLabel = () => {
+    const { details, t } = this.props;
+    return t(details.labelKey, { context: details.labelKeyContext });
+  };
+
+  private getDetailsLink = () => {
+    const { currentTab, reportType } = this.props;
+    return (
+      reportType === OcpOnAwsReportType.cost && (
+        <Link to={this.buildDetailsLink()}>
+          {this.getDetailsLinkTitle(currentTab)}
+        </Link>
+      )
+    );
+  };
+
+  private getDetailsLinkTitle = (tab: OcpOnAwsDashboardTab) => {
+    const { t } = this.props;
+    const key = getIdKeyForTab(tab) || '';
+
+    return t('group_by.all', { groupBy: key });
+  };
+
+  private getHorizontalLayout = () => {
+    const { currentReportFetchStatus } = this.props;
+    return (
+      <OcpOnAwsReportSummaryAlt
+        detailsLink={this.getDetailsLink()}
+        status={currentReportFetchStatus}
+        subTitle={this.getSubTitle()}
+        tabs={this.getTabs()}
+        title={this.getTitle()}
+      >
+        {this.getDetails()}
+        {this.getChart(180)}
+      </OcpOnAwsReportSummaryAlt>
+    );
+  };
+
+  private getRequestLabel = () => {
+    const { details, t } = this.props;
+    return t(details.requestLabelKey, { context: details.labelKeyContext });
+  };
+
+  private getSubTitle = () => {
+    const { t } = this.props;
+
+    const today = new Date();
+    const month = getMonth(today);
+    const endDate = formatDate(today, 'Do');
+    const startDate = formatDate(startOfMonth(today), 'Do');
+
+    return t('ocp_on_aws_dashboard.ocp.widget_subtitle', {
+      endDate,
+      month,
+      startDate,
+      count: getDate(today),
+    });
+  };
+
+  private getTab = (tab: OcpOnAwsDashboardTab, index: number) => {
+    const { tabsReport } = this.props;
+    const currentTab = getIdKeyForTab(tab as OcpOnAwsDashboardTab);
+
+    return (
+      <Tab
+        eventKey={index}
+        key={`${getIdKeyForTab(tab)}-tab`}
+        title={this.getTabTitle(tab)}
+      >
+        <div className={css(styles.tabs)}>
+          <OcpOnAwsReportSummaryItems
+            idKey={currentTab}
+            key={`${currentTab}-items`}
+            report={tabsReport}
+          >
+            {({ items }) =>
+              items.map(reportItem => this.getTabItem(tab, reportItem))
+            }
+          </OcpOnAwsReportSummaryItems>
+        </div>
+      </Tab>
+    );
+  };
+
+  private getTabItem = (tab: OcpOnAwsDashboardTab, reportItem) => {
+    const { availableTabs, reportType, tabsReport, topItems } = this.props;
+    const { activeTabKey } = this.state;
+
+    const currentTab = getIdKeyForTab(tab);
+    const activeTab = getIdKeyForTab(availableTabs[activeTabKey]);
+
+    if (activeTab === currentTab) {
+      return (
+        <OcpOnAwsReportSummaryItem
+          key={`${reportItem.id}-item`}
+          formatOptions={topItems.formatOptions}
+          formatValue={formatValue}
+          label={reportItem.label ? reportItem.label.toString() : ''}
+          totalValue={
+            reportType === OcpOnAwsReportType.cost
+              ? tabsReport.total.cost.value
+              : tabsReport.total.usage.value
+          }
+          units={reportItem.units}
+          value={
+            reportType === OcpOnAwsReportType.cost
+              ? reportItem.cost
+              : reportItem.usage
+          }
+        />
+      );
+    } else {
+      return null;
+    }
+  };
+
+  private getTabs = () => {
+    const { availableTabs } = this.props;
+
+    if (availableTabs) {
+      return (
+        <Tabs
+          isFilled
+          activeKey={this.state.activeTabKey}
+          onSelect={this.handleTabClick}
+        >
+          {availableTabs.map((tab, index) => this.getTab(tab, index))}
+        </Tabs>
+      );
+    } else {
+      return null;
+    }
+  };
+
+  private getTabTitle = (tab: OcpOnAwsDashboardTab) => {
+    const { t } = this.props;
+    const key = getIdKeyForTab(tab) || '';
+
+    return t('group_by.top', { groupBy: key });
+  };
+
+  private getTitle = () => {
+    const { t, titleKey } = this.props;
+
+    const today = new Date();
+    const month = getMonth(today);
+    const endDate = formatDate(today, 'Do');
+    const startDate = formatDate(startOfMonth(today), 'Do');
+
+    return t(titleKey, { endDate, month, startDate });
+  };
+
+  private getVerticalLayout = () => {
+    const { currentReportFetchStatus } = this.props;
+    return (
+      <OcpOnAwsReportSummary
+        detailsLink={this.getDetailsLink()}
+        status={currentReportFetchStatus}
+        subTitle={this.getSubTitle()}
+        title={this.getTitle()}
+      >
+        {this.getDetails()}
+        {this.getChart(75)}
+        {this.getTabs()}
+      </OcpOnAwsReportSummary>
+    );
+  };
+
+  public render() {
+    const { isHorizontal = false } = this.props;
+    return Boolean(isHorizontal)
+      ? this.getHorizontalLayout()
+      : this.getVerticalLayout();
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  OcpOnAwsDashboardWidgetOwnProps,
+  OcpOnAwsDashboardWidgetStateProps
+>((state, { widgetId }) => {
+  const widget = ocpOnAwsDashboardSelectors.selectWidget(state, widgetId);
+  const queries = ocpOnAwsDashboardSelectors.selectWidgetQueries(
+    state,
+    widgetId
+  );
+  return {
+    ...widget,
+    currentQuery: queries.current,
+    previousQuery: queries.previous,
+    tabsQuery: queries.tabs,
+    currentReport: ocpOnAwsReportsSelectors.selectReport(
+      state,
+      widget.reportType,
+      queries.current
+    ),
+    currentReportFetchStatus: ocpOnAwsReportsSelectors.selectReportFetchStatus(
+      state,
+      widget.reportType,
+      queries.current
+    ),
+    previousReport: ocpOnAwsReportsSelectors.selectReport(
+      state,
+      widget.reportType,
+      queries.previous
+    ),
+    tabsReport: ocpOnAwsReportsSelectors.selectReport(
+      state,
+      widget.reportType,
+      queries.tabs
+    ),
+  };
+});
+
+const mapDispatchToProps: OcpOnAwsDashboardWidgetDispatchProps = {
+  fetchReports: ocpOnAwsDashboardActions.fetchWidgetReports,
+  updateTab: ocpOnAwsDashboardActions.changeWidgetTab,
+};
+
+const OcpOnAwsDashboardWidget = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(OcpOnAwsDashboardWidgetBase)
+);
+
+export {
+  OcpOnAwsDashboardWidget,
+  OcpOnAwsDashboardWidgetBase,
+  OcpOnAwsDashboardWidgetProps,
+};

--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -15,6 +15,7 @@ import { LoadingState } from 'components/state/loadingState/loadingState';
 import { NoProvidersState } from 'components/state/noProvidersState/noProvidersState';
 import AwsDashboard from 'pages/awsDashboard/awsDashboard';
 import OcpDashboard from 'pages/ocpDashboard/ocpDashboard';
+import OcpOnAwsDashboard from 'pages/ocpOnAwsDashboard/ocpOnAwsDashboard';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -32,6 +33,7 @@ import { getTestProps, testIds } from 'testIds';
 const enum OverviewTab {
   aws = 'aws',
   ocp = 'ocp',
+  ocpOnAws = 'ocpOnAws',
 }
 
 export const getIdKeyForTab = (tab: OverviewTab) => {
@@ -40,6 +42,8 @@ export const getIdKeyForTab = (tab: OverviewTab) => {
       return 'aws';
     case OverviewTab.ocp:
       return 'ocp';
+    case OverviewTab.ocpOnAws:
+      return 'ocpOnAws';
   }
 };
 
@@ -102,10 +106,14 @@ class OverviewBase extends React.Component<OverviewProps> {
     const { activeTabKey } = this.state;
     const currentTab = getIdKeyForTab(tab);
 
-    if (currentTab === OverviewTab.aws) {
+    if (currentTab === OverviewTab.ocpOnAws) {
+      return activeTabKey === index ? <OcpOnAwsDashboard /> : null;
+    } else if (currentTab === OverviewTab.ocp) {
+      return activeTabKey === index ? <OcpDashboard /> : null;
+    } else if (currentTab === OverviewTab.aws) {
       return activeTabKey === index ? <AwsDashboard /> : null;
     } else {
-      return activeTabKey === index ? <OcpDashboard /> : null;
+      return null;
     }
   };
 
@@ -114,11 +122,20 @@ class OverviewBase extends React.Component<OverviewProps> {
     const { activeTabKey } = this.state;
     const availableTabs = [];
 
-    if (awsProviders && awsProviders.meta && awsProviders.meta.count) {
-      availableTabs.push(OverviewTab.aws);
+    // Todo: How do we check if we have Ocp on Aws?
+    if (
+      awsProviders &&
+      awsProviders.meta &&
+      awsProviders.meta.count &&
+      (ocpProviders && ocpProviders.meta && ocpProviders.meta.count)
+    ) {
+      availableTabs.push(OverviewTab.ocpOnAws);
     }
     if (ocpProviders && ocpProviders.meta && ocpProviders.meta.count) {
       availableTabs.push(OverviewTab.ocp);
+    }
+    if (awsProviders && awsProviders.meta && awsProviders.meta.count) {
+      availableTabs.push(OverviewTab.aws);
     }
 
     return (
@@ -135,6 +152,8 @@ class OverviewBase extends React.Component<OverviewProps> {
       return t('overview.aws');
     } else if (tab === OverviewTab.ocp) {
       return t('overview.ocp');
+    } else if (tab === OverviewTab.ocpOnAws) {
+      return t('overview.ocp_on_aws');
     }
   };
 

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -41,7 +41,7 @@ const routes: AppRoute[] = [
   },
   {
     path: '/ocp',
-    labelKey: 'navigation.ocp_detailsaws_',
+    labelKey: 'navigation.ocp_details',
     component: OcpDetails,
     exact: true,
     icon: MoneyBillIcon,

--- a/src/store/ocpOnAwsDashboard/__snapshots__/ocpOnAwsDashboard.test.ts.snap
+++ b/src/store/ocpOnAwsDashboard/__snapshots__/ocpOnAwsDashboard.test.ts.snap
@@ -1,0 +1,40 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`fetch widget reports 1`] = `
+Array [
+  Array [
+    "cost",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&filter[limit]=5&group_by[project]=*",
+  ],
+  Array [
+    "cost",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily&filter[limit]=5&group_by[project]=*",
+  ],
+  Array [
+    "cost",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[project]=*",
+  ],
+]
+`;
+
+exports[`getGroupByForTab clusters tab 1`] = `
+Object {
+  "cluster": "*",
+}
+`;
+
+exports[`getGroupByForTab nodes tab 1`] = `
+Object {
+  "node": "*",
+}
+`;
+
+exports[`getGroupByForTab pod tab 1`] = `Object {}`;
+
+exports[`getGroupByForTab projects tab 1`] = `
+Object {
+  "project": "*",
+}
+`;
+
+exports[`getGroupByForTab unknown tab 1`] = `Object {}`;

--- a/src/store/ocpOnAwsDashboard/index.ts
+++ b/src/store/ocpOnAwsDashboard/index.ts
@@ -1,0 +1,17 @@
+import * as ocpOnAwsDashboardActions from './ocpOnAwsDashboardActions';
+import {
+  ocpOnAwsDashboardStateKey,
+  OcpOnAwsDashboardTab,
+  OcpOnAwsDashboardWidget,
+} from './ocpOnAwsDashboardCommon';
+import { ocpOnAwsDashboardReducer } from './ocpOnAwsDashboardReducer';
+import * as ocpOnAwsDashboardSelectors from './ocpOnAwsDashboardSelectors';
+
+export {
+  ocpOnAwsDashboardStateKey,
+  ocpOnAwsDashboardReducer,
+  ocpOnAwsDashboardActions,
+  ocpOnAwsDashboardSelectors,
+  OcpOnAwsDashboardTab,
+  OcpOnAwsDashboardWidget,
+};

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboard.test.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboard.test.ts
@@ -1,0 +1,115 @@
+jest.mock('store/ocpOnAwsReports/ocpOnAwsReportsActions');
+
+import { OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import { ChartType } from 'components/charts/commonChart/chartUtils';
+import { createMockStoreCreator } from 'store/mockStore';
+import { ocpOnAwsReportsActions } from 'store/ocpOnAwsReports';
+import * as actions from './ocpOnAwsDashboardActions';
+import {
+  getGroupByForTab,
+  getQueryForWidget,
+  ocpOnAwsDashboardStateKey,
+  OcpOnAwsDashboardTab,
+} from './ocpOnAwsDashboardCommon';
+import { ocpOnAwsDashboardReducer } from './ocpOnAwsDashboardReducer';
+import * as selectors from './ocpOnAwsDashboardSelectors';
+import {
+  computeWidget,
+  costSummaryWidget,
+  cpuWidget,
+  memoryWidget,
+  storageWidget,
+} from './ocpOnAwsDashboardWidgets';
+
+const createOcpOnAwsDashboardStore = createMockStoreCreator({
+  [ocpOnAwsDashboardStateKey]: ocpOnAwsDashboardReducer,
+});
+
+const fetchReportMock = ocpOnAwsReportsActions.fetchReport as jest.Mock;
+
+beforeEach(() => {
+  fetchReportMock.mockReturnValue({ type: '@@test' });
+});
+
+test('default state', () => {
+  const store = createOcpOnAwsDashboardStore();
+  const state = store.getState();
+  expect(selectors.selectCurrentWidgets(state)).toEqual([
+    costSummaryWidget.id,
+    computeWidget.id,
+    storageWidget.id,
+    cpuWidget.id,
+    memoryWidget.id,
+  ]);
+  expect(selectors.selectWidget(state, costSummaryWidget.id)).toEqual(
+    costSummaryWidget
+  );
+});
+
+test('fetch widget reports', () => {
+  const store = createOcpOnAwsDashboardStore();
+  store.dispatch(actions.fetchWidgetReports(costSummaryWidget.id));
+  expect(fetchReportMock.mock.calls).toMatchSnapshot();
+});
+
+test('changeWidgetTab', () => {
+  const store = createOcpOnAwsDashboardStore();
+  store.dispatch(
+    actions.changeWidgetTab(costSummaryWidget.id, OcpOnAwsDashboardTab.projects)
+  );
+  const widget = selectors.selectWidget(store.getState(), costSummaryWidget.id);
+  expect(widget.currentTab).toBe(OcpOnAwsDashboardTab.projects);
+  expect(fetchReportMock).toHaveBeenCalledTimes(3);
+});
+
+describe('getGroupByForTab', () => {
+  test('clusters tab', () => {
+    expect(getGroupByForTab(OcpOnAwsDashboardTab.clusters)).toMatchSnapshot();
+  });
+
+  test('nodes tab', () => {
+    expect(getGroupByForTab(OcpOnAwsDashboardTab.nodes)).toMatchSnapshot();
+  });
+
+  test('pod tab', () => {
+    expect(getGroupByForTab(OcpOnAwsDashboardTab.pods)).toMatchSnapshot();
+  });
+
+  test('projects tab', () => {
+    expect(getGroupByForTab(OcpOnAwsDashboardTab.projects)).toMatchSnapshot();
+  });
+
+  test('unknown tab', () => {
+    expect(getGroupByForTab('unknown' as any)).toMatchSnapshot();
+  });
+});
+
+test('getQueryForWidget', () => {
+  const widget = {
+    id: 1,
+    titleKey: '',
+    reportType: OcpOnAwsReportType.cost,
+    availableTabs: [OcpOnAwsDashboardTab.projects],
+    currentTab: OcpOnAwsDashboardTab.projects,
+    details: { labelKey: '', formatOptions: {} },
+    trend: {
+      titleKey: '',
+      type: ChartType.daily,
+      formatOptions: {},
+    },
+    topItems: {
+      formatOptions: {},
+    },
+  };
+
+  [
+    [
+      undefined,
+      'filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&filter[limit]=5&group_by[project]=*',
+    ],
+    [{}, 'group_by[project]=*'],
+    [{ limit: 5 }, 'filter[limit]=5&group_by[project]=*'],
+  ].forEach(value => {
+    expect(getQueryForWidget(widget, value[0])).toEqual(value[1]);
+  });
+});

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardActions.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardActions.ts
@@ -1,0 +1,36 @@
+import { ThunkAction } from 'store/common';
+import { ocpOnAwsReportsActions } from 'store/ocpOnAwsReports';
+import { createStandardAction } from 'typesafe-actions';
+import { OcpOnAwsDashboardTab } from './ocpOnAwsDashboardCommon';
+import {
+  selectWidget,
+  selectWidgetQueries,
+} from './ocpOnAwsDashboardSelectors';
+
+export const fetchWidgetReports = (id: number): ThunkAction => {
+  return (dispatch, getState) => {
+    const state = getState();
+    const widget = selectWidget(state, id);
+    const { previous, current, tabs } = selectWidgetQueries(state, id);
+    dispatch(ocpOnAwsReportsActions.fetchReport(widget.reportType, current));
+    dispatch(ocpOnAwsReportsActions.fetchReport(widget.reportType, previous));
+    dispatch(ocpOnAwsReportsActions.fetchReport(widget.reportType, tabs));
+  };
+};
+
+export const setWidgetTab = createStandardAction(
+  'ocpOnAwsDashboard/widget/tab'
+)<{
+  id: number;
+  tab: OcpOnAwsDashboardTab;
+}>();
+
+export const changeWidgetTab = (
+  id: number,
+  tab: OcpOnAwsDashboardTab
+): ThunkAction => {
+  return dispatch => {
+    dispatch(setWidgetTab({ id, tab }));
+    dispatch(fetchWidgetReports(id));
+  };
+};

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardCommon.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardCommon.ts
@@ -1,0 +1,82 @@
+import { getQuery, OcpOnAwsFilters, OcpOnAwsQuery } from 'api/ocpOnAwsQuery';
+import { OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import { ChartType } from 'components/charts/commonChart/chartUtils';
+
+export const ocpOnAwsDashboardStateKey = 'ocpOnAwsDashboard';
+export const ocpOnAwsDashboardDefaultFilters: OcpOnAwsFilters = {
+  time_scope_units: 'month',
+  time_scope_value: -1,
+  resolution: 'daily',
+  limit: 5,
+};
+
+interface ValueFormatOptions {
+  fractionDigits?: number;
+}
+
+export const enum OcpOnAwsDashboardTab {
+  nodes = 'nodes',
+  clusters = 'clusters',
+  projects = 'projects',
+}
+
+export interface OcpOnAwsDashboardWidget {
+  id: number;
+  /** i18n key for the title. passed { startDate, endDate, month, time } */
+  titleKey: string;
+  reportType: OcpOnAwsReportType;
+  availableTabs?: OcpOnAwsDashboardTab[];
+  currentTab?: OcpOnAwsDashboardTab;
+  details: {
+    /** i18n label key */
+    labelKey?: string;
+    /** i18n label key context used to support multiple units. */
+    labelKeyContext?: string;
+    formatOptions: ValueFormatOptions;
+    requestLabelKey?: string;
+  };
+  isHorizontal?: boolean;
+  tabsLimit?: number;
+  trend: {
+    currentRequestLabelKey?: string;
+    currentTitleKey?: string;
+    currentUsageLabelKey?: string;
+    formatOptions: ValueFormatOptions;
+    previousRequestLabelKey?: string;
+    previousTitleKey?: string;
+    previousUsageLabel?: string;
+    titleKey?: string;
+    type: ChartType;
+  };
+  topItems?: {
+    formatOptions: {};
+  };
+}
+
+// Todo: cluster, project, node
+export function getGroupByForTab(
+  tab: OcpOnAwsDashboardTab
+): OcpOnAwsQuery['group_by'] {
+  switch (tab) {
+    case OcpOnAwsDashboardTab.projects:
+      return { project: '*' };
+    case OcpOnAwsDashboardTab.clusters:
+      return { cluster: '*' };
+    case OcpOnAwsDashboardTab.nodes:
+      return { node: '*' };
+    default:
+      return {};
+  }
+}
+
+export function getQueryForWidget(
+  widget: OcpOnAwsDashboardWidget,
+  filter: OcpOnAwsFilters = ocpOnAwsDashboardDefaultFilters
+) {
+  const query: OcpOnAwsQuery = {
+    filter,
+    group_by: getGroupByForTab(widget.currentTab),
+  };
+
+  return getQuery(query);
+}

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardReducer.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardReducer.ts
@@ -1,0 +1,55 @@
+import { ActionType, getType } from 'typesafe-actions';
+import { setWidgetTab } from './ocpOnAwsDashboardActions';
+import { OcpOnAwsDashboardWidget } from './ocpOnAwsDashboardCommon';
+import {
+  computeWidget,
+  costSummaryWidget,
+  cpuWidget,
+  memoryWidget,
+  storageWidget,
+} from './ocpOnAwsDashboardWidgets';
+
+export type OcpOnAwsDashboardAction = ActionType<typeof setWidgetTab>;
+
+export type OcpOnAwsDashboardState = Readonly<{
+  widgets: Record<number, OcpOnAwsDashboardWidget>;
+  currentWidgets: number[];
+}>;
+
+export const defaultState: OcpOnAwsDashboardState = {
+  currentWidgets: [
+    costSummaryWidget.id,
+    computeWidget.id,
+    storageWidget.id,
+    cpuWidget.id,
+    memoryWidget.id,
+  ],
+  widgets: {
+    [costSummaryWidget.id]: costSummaryWidget,
+    [computeWidget.id]: computeWidget,
+    [storageWidget.id]: storageWidget,
+    [cpuWidget.id]: cpuWidget,
+    [memoryWidget.id]: memoryWidget,
+  },
+};
+
+export function ocpOnAwsDashboardReducer(
+  state = defaultState,
+  action: OcpOnAwsDashboardAction
+): OcpOnAwsDashboardState {
+  switch (action.type) {
+    case getType(setWidgetTab):
+      return {
+        ...state,
+        widgets: {
+          ...state.widgets,
+          [action.payload.id]: {
+            ...state.widgets[action.payload.id],
+            currentTab: action.payload.tab,
+          },
+        },
+      };
+    default:
+      return state;
+  }
+}

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardSelectors.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardSelectors.ts
@@ -1,0 +1,40 @@
+import { RootState } from 'store/rootReducer';
+import {
+  getQueryForWidget,
+  ocpOnAwsDashboardDefaultFilters,
+  ocpOnAwsDashboardStateKey,
+} from './ocpOnAwsDashboardCommon';
+
+export const selectOcpOnAwsDashboardState = (state: RootState) =>
+  state[ocpOnAwsDashboardStateKey];
+
+export const selectWidgets = (state: RootState) =>
+  selectOcpOnAwsDashboardState(state).widgets;
+
+export const selectWidget = (state: RootState, id: number) =>
+  selectWidgets(state)[id];
+
+export const selectCurrentWidgets = (state: RootState) =>
+  selectOcpOnAwsDashboardState(state).currentWidgets;
+
+export const selectWidgetQueries = (state: RootState, id: number) => {
+  const widget = selectWidget(state, id);
+  const tabsFilter = {
+    ...ocpOnAwsDashboardDefaultFilters,
+  };
+  if (widget.tabsLimit) {
+    tabsFilter.limit = widget.tabsLimit;
+  }
+
+  return {
+    previous: getQueryForWidget(widget, {
+      ...ocpOnAwsDashboardDefaultFilters,
+      time_scope_value: -2,
+    }),
+    current: getQueryForWidget(widget, ocpOnAwsDashboardDefaultFilters),
+    tabs: getQueryForWidget(widget, {
+      ...tabsFilter,
+      resolution: 'monthly',
+    }),
+  };
+};

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardWidgets.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardWidgets.ts
@@ -1,0 +1,124 @@
+import { OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import { ChartType } from 'components/charts/commonChart/chartUtils';
+import {
+  OcpOnAwsDashboardTab,
+  OcpOnAwsDashboardWidget,
+} from './ocpOnAwsDashboardCommon';
+
+let currrentId = 0;
+const getId = () => currrentId++;
+
+export const costSummaryWidget: OcpOnAwsDashboardWidget = {
+  id: getId(),
+  titleKey: 'ocp_on_aws_dashboard.ocp.cost_title',
+  reportType: OcpOnAwsReportType.cost,
+  details: {
+    formatOptions: {
+      fractionDigits: 2,
+    },
+  },
+  isHorizontal: true,
+  trend: {
+    titleKey: 'ocp_on_aws_dashboard.ocp.cost_trend_title',
+    formatOptions: {},
+    type: ChartType.rolling,
+  },
+  tabsLimit: 3,
+  topItems: {
+    formatOptions: {},
+  },
+  availableTabs: [OcpOnAwsDashboardTab.projects, OcpOnAwsDashboardTab.clusters],
+  currentTab: OcpOnAwsDashboardTab.projects,
+};
+
+export const cpuWidget: OcpOnAwsDashboardWidget = {
+  id: getId(),
+  titleKey: 'ocp_on_aws_dashboard.ocp.cpu_title',
+  reportType: OcpOnAwsReportType.cpu,
+  details: {
+    labelKey: 'ocp_on_aws_dashboard.ocp.cpu_usage_label',
+    formatOptions: {
+      fractionDigits: 0,
+    },
+    requestLabelKey: 'ocp_on_aws_dashboard.ocp.cpu_request_label',
+  },
+  trend: {
+    currentRequestLabelKey: 'ocp_on_aws_dashboard.ocp.cpu_requested_label',
+    currentTitleKey: 'ocp_on_aws_dashboard.ocp.cpu_current_title',
+    currentUsageLabelKey: 'ocp_on_aws_dashboard.ocp.cpu_used_label',
+    formatOptions: {
+      fractionDigits: 2,
+    },
+    previousRequestLabelKey: 'ocp_on_aws_dashboard.ocp.cpu_requested_label',
+    previousTitleKey: 'ocp_on_aws_dashboard.ocp.cpu_previous_title',
+    previousUsageLabel: 'ocp_on_aws_dashboard.ocp.cpu_used_label',
+    type: ChartType.daily,
+  },
+  currentTab: OcpOnAwsDashboardTab.projects,
+};
+
+export const memoryWidget: OcpOnAwsDashboardWidget = {
+  id: getId(),
+  titleKey: 'ocp_on_aws_dashboard.ocp.memory_title',
+  reportType: OcpOnAwsReportType.memory,
+  details: {
+    labelKey: 'ocp_on_aws_dashboard.ocp.memory_usage_label',
+    formatOptions: {
+      fractionDigits: 0,
+    },
+    requestLabelKey: 'ocp_on_aws_dashboard.ocp.memory_request_label',
+  },
+  trend: {
+    currentRequestLabelKey: 'ocp_on_aws_dashboard.ocp.memory_requested_label',
+    currentTitleKey: 'ocp_on_aws_dashboard.ocp.memory_current_title',
+    currentUsageLabelKey: 'ocp_on_aws_dashboard.ocp.memory_used_label',
+    formatOptions: {
+      fractionDigits: 2,
+    },
+    previousRequestLabelKey: 'ocp_on_aws_dashboard.ocp.memory_requested_label',
+    previousTitleKey: 'ocp_on_aws_dashboard.ocp.memory_previous_title',
+    previousUsageLabel: 'ocp_on_aws_dashboard.ocp.memory_used_label',
+    type: ChartType.daily,
+  },
+  currentTab: OcpOnAwsDashboardTab.projects,
+};
+
+// AWS widgets
+
+export const computeWidget: OcpOnAwsDashboardWidget = {
+  id: getId(),
+  titleKey: 'ocp_on_aws_dashboard.aws.compute_title',
+  reportType: OcpOnAwsReportType.instanceType,
+  details: {
+    labelKey: 'ocp_on_aws_dashboard.aws.compute_detail_label',
+    formatOptions: {
+      fractionDigits: 0,
+    },
+  },
+  trend: {
+    titleKey: 'ocp_on_aws_dashboard.aws.compute_trend_title',
+    formatOptions: {
+      fractionDigits: 2,
+    },
+    type: ChartType.daily,
+  },
+};
+
+export const storageWidget: OcpOnAwsDashboardWidget = {
+  id: getId(),
+  titleKey: 'ocp_on_aws_dashboard.aws.storage_title',
+  reportType: OcpOnAwsReportType.storage,
+  details: {
+    labelKey: 'ocp_on_aws_dashboard.aws.storage_detail_label',
+    formatOptions: {
+      fractionDigits: 0,
+    },
+  },
+  trend: {
+    titleKey: 'ocp_on_aws_dashboard.aws.storage_trend_title',
+    formatOptions: {
+      fractionDigits: 2,
+    },
+    type: ChartType.daily,
+  },
+};

--- a/src/store/ocpOnAwsReports/index.ts
+++ b/src/store/ocpOnAwsReports/index.ts
@@ -1,0 +1,19 @@
+import * as ocpOnAwsReportsActions from './ocpOnAwsReportsActions';
+import { ocpOnAwsReportsStateKey } from './ocpOnAwsReportsCommon';
+import {
+  OcpOnAwsCachedReport,
+  OcpOnAwsReportsAction,
+  ocpOnAwsReportsReducer,
+  OcpOnAwsReportsState,
+} from './ocpOnAwsReportsReducer';
+import * as ocpOnAwsReportsSelectors from './ocpOnAwsReportsSelectors';
+
+export {
+  ocpOnAwsReportsActions,
+  OcpOnAwsReportsAction,
+  OcpOnAwsCachedReport,
+  ocpOnAwsReportsReducer,
+  ocpOnAwsReportsSelectors,
+  ocpOnAwsReportsStateKey,
+  OcpOnAwsReportsState,
+};

--- a/src/store/ocpOnAwsReports/ocpOnAwsReportsActions.ts
+++ b/src/store/ocpOnAwsReports/ocpOnAwsReportsActions.ts
@@ -1,0 +1,74 @@
+import {
+  OcpOnAwsReport,
+  OcpOnAwsReportType,
+  runReport,
+} from 'api/ocpOnAwsReports';
+import { AxiosError } from 'axios';
+import { ThunkAction } from 'redux-thunk';
+import { FetchStatus } from 'store/common';
+import { RootState } from 'store/rootReducer';
+import { createStandardAction } from 'typesafe-actions';
+import { getReportId } from './ocpOnAwsReportsCommon';
+import {
+  selectReport,
+  selectReportFetchStatus,
+} from './ocpOnAwsReportsSelectors';
+
+const expirationMS = 30 * 60 * 1000; // 30 minutes
+
+interface OcpOnAwsReportActionMeta {
+  reportId: string;
+}
+
+export const fetchOcpOnAwsReportRequest = createStandardAction(
+  'ocpOnAwsReports/request'
+)<OcpOnAwsReportActionMeta>();
+export const fetchOcpOnAwsReportSuccess = createStandardAction(
+  'ocpOnAwsReports/success'
+)<OcpOnAwsReport, OcpOnAwsReportActionMeta>();
+export const fetchOcpOnAwsReportFailure = createStandardAction(
+  'ocpOnAwsReports/failure'
+)<AxiosError, OcpOnAwsReportActionMeta>();
+
+export function fetchReport(
+  reportType: OcpOnAwsReportType,
+  query: string
+): ThunkAction<void, RootState, void, any> {
+  return (dispatch, getState) => {
+    if (!isReportExpired(getState(), reportType, query)) {
+      return;
+    }
+
+    const meta: OcpOnAwsReportActionMeta = {
+      reportId: getReportId(reportType, query),
+    };
+
+    dispatch(fetchOcpOnAwsReportRequest(meta));
+    runReport(reportType, query)
+      .then(res => {
+        dispatch(fetchOcpOnAwsReportSuccess(res.data, meta));
+      })
+      .catch(err => {
+        dispatch(fetchOcpOnAwsReportFailure(err, meta));
+      });
+  };
+}
+
+function isReportExpired(
+  state: RootState,
+  reportType: OcpOnAwsReportType,
+  query: string
+) {
+  const report = selectReport(state, reportType, query);
+  const fetchStatus = selectReportFetchStatus(state, reportType, query);
+  if (fetchStatus === FetchStatus.inProgress) {
+    return false;
+  }
+
+  if (!report) {
+    return true;
+  }
+
+  const now = Date.now();
+  return now > report.timeRequested + expirationMS;
+}

--- a/src/store/ocpOnAwsReports/ocpOnAwsReportsCommon.ts
+++ b/src/store/ocpOnAwsReports/ocpOnAwsReportsCommon.ts
@@ -1,0 +1,7 @@
+import { OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+
+export const ocpOnAwsReportsStateKey = 'ocpOnAwsReports';
+
+export function getReportId(type: OcpOnAwsReportType, query: string) {
+  return `${type}--${query}`;
+}

--- a/src/store/ocpOnAwsReports/ocpOnAwsReportsReducer.ts
+++ b/src/store/ocpOnAwsReports/ocpOnAwsReportsReducer.ts
@@ -1,0 +1,73 @@
+import { OcpOnAwsReport } from 'api/ocpOnAwsReports';
+import { AxiosError } from 'axios';
+import { FetchStatus } from 'store/common';
+import { ActionType, getType } from 'typesafe-actions';
+import {
+  fetchOcpOnAwsReportFailure,
+  fetchOcpOnAwsReportRequest,
+  fetchOcpOnAwsReportSuccess,
+} from './ocpOnAwsReportsActions';
+
+export interface OcpOnAwsCachedReport extends OcpOnAwsReport {
+  timeRequested: number;
+}
+
+export type OcpOnAwsReportsState = Readonly<{
+  byId: Map<string, OcpOnAwsCachedReport>;
+  fetchStatus: Map<string, FetchStatus>;
+  errors: Map<string, AxiosError>;
+}>;
+
+const defaultState: OcpOnAwsReportsState = {
+  byId: new Map(),
+  fetchStatus: new Map(),
+  errors: new Map(),
+};
+
+export type OcpOnAwsReportsAction = ActionType<
+  | typeof fetchOcpOnAwsReportFailure
+  | typeof fetchOcpOnAwsReportRequest
+  | typeof fetchOcpOnAwsReportSuccess
+>;
+
+export function ocpOnAwsReportsReducer(
+  state = defaultState,
+  action: OcpOnAwsReportsAction
+): OcpOnAwsReportsState {
+  switch (action.type) {
+    case getType(fetchOcpOnAwsReportRequest):
+      return {
+        ...state,
+        fetchStatus: new Map(state.fetchStatus).set(
+          action.payload.reportId,
+          FetchStatus.inProgress
+        ),
+      };
+
+    case getType(fetchOcpOnAwsReportSuccess):
+      return {
+        ...state,
+        fetchStatus: new Map(state.fetchStatus).set(
+          action.meta.reportId,
+          FetchStatus.complete
+        ),
+        byId: new Map(state.byId).set(action.meta.reportId, {
+          ...action.payload,
+          timeRequested: Date.now(),
+        }),
+        errors: new Map(state.errors).set(action.meta.reportId, null),
+      };
+
+    case getType(fetchOcpOnAwsReportFailure):
+      return {
+        ...state,
+        fetchStatus: new Map(state.fetchStatus).set(
+          action.meta.reportId,
+          FetchStatus.complete
+        ),
+        errors: new Map(state.errors).set(action.meta.reportId, action.payload),
+      };
+    default:
+      return state;
+  }
+}

--- a/src/store/ocpOnAwsReports/ocpOnAwsReportsSelectors.ts
+++ b/src/store/ocpOnAwsReports/ocpOnAwsReportsSelectors.ts
@@ -1,0 +1,24 @@
+import { OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import { RootState } from 'store/rootReducer';
+import { getReportId, ocpOnAwsReportsStateKey } from './ocpOnAwsReportsCommon';
+
+export const selectReportsState = (state: RootState) =>
+  state[ocpOnAwsReportsStateKey];
+
+export const selectReport = (
+  state: RootState,
+  reportType: OcpOnAwsReportType,
+  query: string
+) => selectReportsState(state).byId.get(getReportId(reportType, query));
+
+export const selectReportFetchStatus = (
+  state: RootState,
+  reportType: OcpOnAwsReportType,
+  query: string
+) => selectReportsState(state).fetchStatus.get(getReportId(reportType, query));
+
+export const selectReportError = (
+  state: RootState,
+  reportType: OcpOnAwsReportType,
+  query: string
+) => selectReportsState(state).errors.get(getReportId(reportType, query));

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -6,6 +6,14 @@ import { awsExportReducer, awsExportStateKey } from './awsExport';
 import { awsReportsReducer, awsReportsStateKey } from './awsReports';
 import { ocpDashboardReducer, ocpDashboardStateKey } from './ocpDashboard';
 import { ocpExportReducer, ocpExportStateKey } from './ocpExport';
+import {
+  ocpOnAwsDashboardReducer,
+  ocpOnAwsDashboardStateKey,
+} from './ocpOnAwsDashboard';
+import {
+  ocpOnAwsReportsReducer,
+  ocpOnAwsReportsStateKey,
+} from './ocpOnAwsReports';
 import { ocpReportsReducer, ocpReportsStateKey } from './ocpReports';
 import { providersReducer, providersStateKey } from './providers';
 import { sessionReducer, sessionStateKey } from './session';
@@ -20,6 +28,8 @@ export const rootReducer = combineReducers({
   [awsReportsStateKey]: awsReportsReducer,
   [ocpDashboardStateKey]: ocpDashboardReducer,
   [ocpExportStateKey]: ocpExportReducer,
+  [ocpOnAwsDashboardStateKey]: ocpOnAwsDashboardReducer,
+  [ocpOnAwsReportsStateKey]: ocpOnAwsReportsReducer,
   [ocpReportsStateKey]: ocpReportsReducer,
   [providersStateKey]: providersReducer,
   [sessionStateKey]: sessionReducer,

--- a/src/utils/getComputedOcpOnAwsReportItems.ts
+++ b/src/utils/getComputedOcpOnAwsReportItems.ts
@@ -1,14 +1,14 @@
-import { OcpQuery } from 'api/ocpQuery';
+import { OcpOnAwsQuery } from 'api/ocpOnAwsQuery';
 import {
-  OcpDatum,
-  OcpReport,
-  OcpReportData,
-  OcpReportValue,
-} from 'api/ocpReports';
+  OcpOnAwsDatum,
+  OcpOnAwsReport,
+  OcpOnAwsReportData,
+  OcpOnAwsReportValue,
+} from 'api/ocpOnAwsReports';
 import { Omit } from 'react-redux';
 import { sort, SortDirection } from './sort';
 
-export interface ComputedOcpReportItem {
+export interface ComputedOcpOnAwsReportItem {
   capacity?: number;
   cost: number;
   deltaPercent: number;
@@ -21,26 +21,26 @@ export interface ComputedOcpReportItem {
   usage?: number;
 }
 
-export interface GetComputedOcpReportItemsParams {
-  report: OcpReport;
+export interface GetComputedOcpOnAwsReportItemsParams {
+  report: OcpOnAwsReport;
   idKey: keyof Omit<
-    OcpReportValue,
+    OcpOnAwsReportValue,
     'cost' | 'usage' | 'count' | 'request' | 'limit' | 'capacity'
   >;
-  sortKey?: keyof ComputedOcpReportItem;
-  labelKey?: keyof OcpReportValue;
+  sortKey?: keyof ComputedOcpOnAwsReportItem;
+  labelKey?: keyof OcpOnAwsReportValue;
   sortDirection?: SortDirection;
 }
 
-export function getComputedOcpReportItems({
+export function getComputedOcpOnAwsReportItems({
   report,
   idKey,
   labelKey = idKey,
   sortKey = 'cost',
   sortDirection = SortDirection.asc,
-}: GetComputedOcpReportItemsParams) {
+}: GetComputedOcpOnAwsReportItemsParams) {
   return sort(
-    getUnsortedComputedOcpReportItems({
+    getUnsortedComputedOcpOnAwsReportItems({
       report,
       idKey,
       labelKey,
@@ -54,18 +54,18 @@ export function getComputedOcpReportItems({
   );
 }
 
-export function getUnsortedComputedOcpReportItems({
+export function getUnsortedComputedOcpOnAwsReportItems({
   report,
   idKey,
   labelKey = idKey,
-}: GetComputedOcpReportItemsParams) {
+}: GetComputedOcpOnAwsReportItemsParams) {
   if (!report) {
     return [];
   }
 
-  const itemMap: Record<string, ComputedOcpReportItem> = {};
+  const itemMap: Record<string, ComputedOcpOnAwsReportItem> = {};
 
-  const visitDataPoint = (dataPoint: OcpReportData) => {
+  const visitDataPoint = (dataPoint: OcpOnAwsReportData) => {
     if (dataPoint.values) {
       dataPoint.values.forEach(value => {
         const capacity = value.capacity ? value.capacity.value : 0;
@@ -75,7 +75,7 @@ export function getUnsortedComputedOcpReportItems({
         if (labelKey === 'cluster' && value.cluster_alias) {
           label = value.cluster_alias;
         } else if (value[labelKey] instanceof Object) {
-          label = (value[labelKey] as OcpDatum).value;
+          label = (value[labelKey] as OcpOnAwsDatum).value;
         } else {
           label = value[labelKey];
         }
@@ -121,8 +121,8 @@ export function getUnsortedComputedOcpReportItems({
 }
 
 export function getIdKeyForGroupBy(
-  groupBy: OcpQuery['group_by'] = {}
-): GetComputedOcpReportItemsParams['idKey'] {
+  groupBy: OcpOnAwsQuery['group_by'] = {}
+): GetComputedOcpOnAwsReportItemsParams['idKey'] {
   if (groupBy.project) {
     return 'project';
   }


### PR DESCRIPTION
This adds the infrastructure needed for the OCP on AWS overview tab. This is basically a copy of OCP with additional AWS cards (i.e., until the APIs support appropriate filtering).

Fixes https://github.com/project-koku/koku-ui/issues/547

<img width="1485" alt="screen shot 2019-03-04 at 7 57 40 pm" src="https://user-images.githubusercontent.com/17481322/53773409-5e639580-3eb8-11e9-8121-4163c35d86bc.png">