### PR TITLE
API change for 'order_by'

### DIFF
--- a/src/pages/awsDetails/awsDetails.tsx
+++ b/src/pages/awsDetails/awsDetails.tsx
@@ -303,7 +303,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
       group_by: {
         [groupByKey]: '*',
       },
-      order_by: { total: 'desc' },
+      order_by: { cost: 'desc' },
     };
     if (groupBy.indexOf('tag:') !== -1) {
       newQuery.group_by.account = '*';


### PR DESCRIPTION
Recent API change requires 'order_by' to use 'cost' instead of 'total'. 

Fixes https://github.com/project-koku/koku-ui/issues/560