### PR TITLE
Increase modal width for AWS historical charts

### DIFF
--- a/src/pages/awsDetails/historicalModal.styles.ts
+++ b/src/pages/awsDetails/historicalModal.styles.ts
@@ -5,7 +5,7 @@ export const styles = StyleSheet.create({
   modal: {
     // Workaround for isLarge not working properly
     height: '850px',
-    width: '900px',
+    width: '950px',
   },
 });
 


### PR DESCRIPTION
Increasing the modal width slightly for AWS historical charts. This should keep the legend from wrapping onto the next line.

Fixes https://github.com/project-koku/koku-ui/issues/559