### PR TITLE
UI change for time scope API updates.

### DIFF
--- a/src/store/awsReports/awsReportsActions.ts
+++ b/src/store/awsReports/awsReportsActions.ts
@@ -4,6 +4,7 @@ import { ThunkAction } from 'redux-thunk';
 import { FetchStatus } from 'store/common';
 import { RootState } from 'store/rootReducer';
 import { createStandardAction } from 'typesafe-actions';
+import { dropCurrentMonthData } from 'utils/dropCurrentMonthData';
 import { getReportId } from './awsReportsCommon';
 import { selectReport, selectReportFetchStatus } from './awsReportsSelectors';
 
@@ -41,7 +42,8 @@ export function fetchReport(
     dispatch(fetchAwsReportRequest(meta));
     runReport(reportType, query)
       .then(res => {
-        dispatch(fetchAwsReportSuccess(res.data, meta));
+        const repsonseData = dropCurrentMonthData(res, query);
+        dispatch(fetchAwsReportSuccess(repsonseData, meta));
       })
       .catch(err => {
         dispatch(fetchAwsReportFailure(err, meta));

--- a/src/store/ocpOnAwsReports/ocpOnAwsReportsActions.ts
+++ b/src/store/ocpOnAwsReports/ocpOnAwsReportsActions.ts
@@ -8,6 +8,7 @@ import { ThunkAction } from 'redux-thunk';
 import { FetchStatus } from 'store/common';
 import { RootState } from 'store/rootReducer';
 import { createStandardAction } from 'typesafe-actions';
+import { dropCurrentMonthData } from 'utils/dropCurrentMonthData';
 import { getReportId } from './ocpOnAwsReportsCommon';
 import {
   selectReport,
@@ -46,7 +47,8 @@ export function fetchReport(
     dispatch(fetchOcpOnAwsReportRequest(meta));
     runReport(reportType, query)
       .then(res => {
-        dispatch(fetchOcpOnAwsReportSuccess(res.data, meta));
+        const repsonseData = dropCurrentMonthData(res, query);
+        dispatch(fetchOcpOnAwsReportSuccess(repsonseData, meta));
       })
       .catch(err => {
         dispatch(fetchOcpOnAwsReportFailure(err, meta));

--- a/src/store/ocpReports/ocpReportsActions.ts
+++ b/src/store/ocpReports/ocpReportsActions.ts
@@ -4,6 +4,7 @@ import { ThunkAction } from 'redux-thunk';
 import { FetchStatus } from 'store/common';
 import { RootState } from 'store/rootReducer';
 import { createStandardAction } from 'typesafe-actions';
+import { dropCurrentMonthData } from 'utils/dropCurrentMonthData';
 import { getReportId } from './ocpReportsCommon';
 import { selectReport, selectReportFetchStatus } from './ocpReportsSelectors';
 
@@ -43,7 +44,8 @@ export function fetchReport(
       .then(res => {
         // Todo: For testing purposes
         // dispatch(fetchOcpReportSuccess(test as any, meta));
-        dispatch(fetchOcpReportSuccess(res.data, meta));
+        const repsonseData = dropCurrentMonthData(res, query);
+        dispatch(fetchOcpReportSuccess(repsonseData, meta));
       })
       .catch(err => {
         dispatch(fetchOcpReportFailure(err, meta));

--- a/src/utils/dropCurrentMonthData.ts
+++ b/src/utils/dropCurrentMonthData.ts
@@ -1,0 +1,21 @@
+export function dropCurrentMonthData(res, query): any {
+  const repsonseData = res.data;
+  const isLastMonth = query.indexOf('filter[time_scope_value]=-2') >= 0;
+  const isDaily = query.indexOf('filter[resolution]=daily') >= 0;
+  if (isLastMonth && isDaily) {
+    const today = new Date();
+    const thisMonth = today.getMonth() + 1;
+    const thisMonthStr =
+      thisMonth > 9 ? thisMonth.toString() : '0' + thisMonth.toString();
+    const thisYear = today.getFullYear();
+    const thisMonthPrefix = thisYear.toString() + '-' + thisMonthStr;
+    const newData = [];
+    repsonseData.data.forEach(element => {
+      if (element.date && !element.date.startsWith(thisMonthPrefix)) {
+        newData.push(element);
+      }
+    });
+    repsonseData.data = newData;
+  }
+  return repsonseData;
+}


### PR DESCRIPTION
Minimal impact UI update to have the new API which will return 2 months of data to "act" like old API.

Another PR can make performance improvements to alter API calls to use one API call and process the previous and current data from the single 2 months of data call.

Real impact here is on the historical charts previous/current data calls.
<img width="815" alt="image" src="https://user-images.githubusercontent.com/29379759/53894016-54977a80-3ffd-11e9-83e7-2a1f7e671dcd.png">

Associated with: https://github.com/project-koku/koku/pull/679