### PR TITLE
Refactor group by tags

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -39,7 +39,9 @@
       "region_placeholder": "Filter by Region",
       "region_select": "Region",
       "service_placeholder": "Filter by Service",
-      "service_select": "Service"
+      "service_select": "Service",
+      "tag_placeholder": "Filter by Tag",
+      "tag_select": "Tag"
     },
     "historical": {
       "cost_label": "Cost ($)",
@@ -63,6 +65,7 @@
       "name": "Sort by: Name"
     },
     "show_more": "Show More",
+    "tag_column_title": "Tag Names",
     "tags_label": "Related Tags:",
     "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Related Tags",
     "title": "AWS Details",
@@ -103,6 +106,7 @@
     "heading": "Aggregates of the following {{groupBy}}s will be exported to a .csv file.",
     "monthly": "Monthly",
     "selected": "Selected {{groupBy}}s",
+    "selected_tags": "Selected tags",
     "title": "Export"
   },
   "group_by": {
@@ -224,7 +228,9 @@
       "node_placeholder": "Filter by Node",
       "node_select": "Node",
       "project_placeholder": "Filter by Project",
-      "project_select": "Project"
+      "project_select": "Project",
+      "tag_placeholder": "Filter by Tag",
+      "tag_select": "Tag"
     },
     "historical": {
       "cost_label": "Cost ($)",
@@ -256,6 +262,7 @@
       "cost_delta": "Sort by: Cost Delta",
       "name": "Sort by: Name"
     },
+    "tag_column_title": "Tag Names",
     "tags_label": "Related Tags:",
     "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Related Tags",
     "title": "OpenShift Details",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -39,7 +39,9 @@
       "region_placeholder": "Filter by Region",
       "region_select": "Region",
       "service_placeholder": "Filter by Service",
-      "service_select": "Service"
+      "service_select": "Service",
+      "tag_placeholder": "Filter by Tag",
+      "tag_select": "Tag"
     },
     "historical": {
       "cost_label": "Cost ($)",
@@ -63,6 +65,7 @@
       "name": "Sort by: Name"
     },
     "show_more": "Show More",
+    "tag_column_title": "Tag Names",
     "tags_label": "Related Tags:",
     "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Related Tags",
     "title": "AWS Details",
@@ -103,6 +106,7 @@
     "heading": "Aggregates of the following {{groupBy}}s will be exported to a .csv file.",
     "monthly": "Monthly",
     "selected": "Selected {{groupBy}}s",
+    "selected_tags": "Selected tags",
     "title": "Export"
   },
   "group_by": {
@@ -236,7 +240,9 @@
       "node_placeholder": "Filter by Node",
       "node_select": "Node",
       "project_placeholder": "Filter by Project",
-      "project_select": "Project"
+      "project_select": "Project",
+      "tag_placeholder": "Filter by Tag",
+      "tag_select": "Tag"
     },
     "historical": {
       "cost_label": "Cost ($)",
@@ -268,6 +274,7 @@
       "cost_delta": "Sort by: Cost Delta",
       "name": "Sort by: Name"
     },
+    "tag_column_title": "Tag Names",
     "tags_label": "Related Tags:",
     "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Related Tags",
     "title": "OpenShift Details",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -39,7 +39,9 @@
       "region_placeholder": "Filter by Region",
       "region_select": "Region",
       "service_placeholder": "Filter by Service",
-      "service_select": "Service"
+      "service_select": "Service",
+      "tag_placeholder": "Filter by Tag",
+      "tag_select": "Tag"
     },
     "historical": {
       "cost_label": "Cost ($)",
@@ -63,6 +65,7 @@
       "name": "Sort by: Name"
     },
     "show_more": "Show More",
+    "tag_column_title": "Tag Names",
     "tags_label": "Related Tags:",
     "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Related Tags",
     "title": "AWS Details",
@@ -103,6 +106,7 @@
     "heading": "Aggregates of the following {{groupBy}}s will be exported to a .csv file.",
     "monthly": "Monthly",
     "selected": "Selected {{groupBy}}s",
+    "selected_tags": "Selected tags",
     "title": "Export"
   },
   "group_by": {
@@ -224,7 +228,9 @@
       "node_placeholder": "Filter by Node",
       "node_select": "Node",
       "project_placeholder": "Filter by Project",
-      "project_select": "Project"
+      "project_select": "Project",
+      "tag_placeholder": "Filter by Tag",
+      "tag_select": "Tag"
     },
     "historical": {
       "cost_label": "Cost ($)",
@@ -256,6 +262,7 @@
       "cost_delta": "Sort by: Cost Delta",
       "name": "Sort by: Name"
     },
+    "tag_column_title": "Tag Names",
     "tags_label": "Related Tags:",
     "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Related Tags",
     "title": "OpenShift Details",

--- a/src/pages/awsDetails/awsDetails.styles.ts
+++ b/src/pages/awsDetails/awsDetails.styles.ts
@@ -1,6 +1,5 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
-  global_BackgroundColor_100,
   global_BackgroundColor_300,
   global_BorderRadius_sm,
   global_Color_100,
@@ -11,7 +10,6 @@ import {
   global_FontSize_xs,
   global_FontWeight_normal,
   global_LineHeight_md,
-  global_spacer_md,
   global_spacer_sm,
   global_spacer_xl,
 } from '@patternfly/react-tokens';
@@ -27,40 +25,13 @@ export const styles = StyleSheet.create({
     paddingTop: global_spacer_xl.value,
     height: '100%',
   },
-  header: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    padding: global_spacer_xl.var,
-    backgroundColor: global_BackgroundColor_100.var,
-  },
   tableContainer: {
     marginBottom: global_spacer_xl.value,
     marginLeft: global_spacer_xl.value,
     marginRight: global_spacer_xl.value,
   },
-  title: {
-    paddingBottom: global_spacer_sm.var,
-  },
   toolbarContainer: {
     backgroundColor: global_BackgroundColor_300.value,
-  },
-  total: {
-    display: 'flex',
-    alignItems: 'center',
-  },
-  totalLabel: {},
-  totalValue: {
-    marginTop: 0,
-    marginBottom: 0,
-    marginRight: global_spacer_md.var,
-  },
-  totalLabelUnit: {
-    fontSize: global_FontSize_sm.value,
-    color: global_Color_100.var,
-  },
-  totalLabelDate: {
-    fontSize: global_FontSize_sm.value,
-    color: global_Color_200.var,
   },
 });
 

--- a/src/pages/awsDetails/awsDetails.tsx
+++ b/src/pages/awsDetails/awsDetails.tsx
@@ -1,4 +1,3 @@
-import { Title } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { AwsQuery, getQuery, parseQuery } from 'api/awsQuery';
 import { AwsReport, AwsReportType } from 'api/awsReports';
@@ -16,17 +15,16 @@ import { awsReportsActions, awsReportsSelectors } from 'store/awsReports';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { awsProvidersQuery, providersSelectors } from 'store/providers';
 import { uiActions } from 'store/ui';
-import { formatCurrency } from 'utils/formatValue';
 import {
   ComputedAwsReportItem,
   getIdKeyForGroupBy,
   getUnsortedComputedAwsReportItems,
 } from 'utils/getComputedAwsReportItems';
 import { styles, toolbarOverride } from './awsDetails.styles';
+import { DetailsHeader } from './detailsHeader';
 import { DetailsTable } from './detailsTable';
 import { DetailsToolbar } from './detailsToolbar';
 import ExportModal from './exportModal';
-import { GroupBy } from './groupBy';
 
 interface AwsDetailsStateProps {
   providers: Providers;
@@ -198,45 +196,6 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     return groupByTag;
   };
 
-  private getHeader = () => {
-    const { providers, providersError, report, t } = this.props;
-    const today = new Date();
-    const showContent =
-      report &&
-      !providersError &&
-      providers &&
-      providers.meta &&
-      providers.meta.count > 0;
-
-    return (
-      <header className={css(styles.header)}>
-        <div>
-          <Title className={css(styles.title)} size="2xl">
-            {t('aws_details.title')}
-          </Title>
-          {Boolean(showContent) && (
-            <GroupBy onItemClicked={this.handleGroupByClick} />
-          )}
-        </div>
-        {Boolean(showContent) && (
-          <div className={css(styles.total)}>
-            <Title className={css(styles.totalValue)} size="4xl">
-              {formatCurrency(report.meta.total.cost.value)}
-            </Title>
-            <div className={css(styles.totalLabel)}>
-              <div className={css(styles.totalLabelUnit)}>
-                {t('aws_details.total_cost')}
-              </div>
-              <div className={css(styles.totalLabelDate)}>
-                {t('since_date', { month: today.getMonth(), date: 1 })}
-              </div>
-            </div>
-          </div>
-        )}
-      </header>
-    );
-  };
-
   private getRouteForQuery(query: AwsQuery) {
     return `/aws?${getQuery(query)}`;
   }
@@ -386,7 +345,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 
     return (
       <div className={css(styles.awsDetails)}>
-        {this.getHeader()}
+        <DetailsHeader onGroupByClicked={this.handleGroupByClick} />
         {Boolean(providersError) ? (
           <ErrorState error={providersError} />
         ) : Boolean(noProviders) ? (

--- a/src/pages/awsDetails/detailsHeader.styles.ts
+++ b/src/pages/awsDetails/detailsHeader.styles.ts
@@ -1,0 +1,40 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import {
+  global_BackgroundColor_100,
+  global_Color_100,
+  global_Color_200,
+  global_FontSize_sm,
+  global_spacer_md,
+  global_spacer_sm,
+  global_spacer_xl,
+} from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  cost: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  costLabel: {},
+  costValue: {
+    marginTop: 0,
+    marginBottom: 0,
+    marginRight: global_spacer_md.var,
+  },
+  costLabelUnit: {
+    fontSize: global_FontSize_sm.value,
+    color: global_Color_100.var,
+  },
+  costLabelDate: {
+    fontSize: global_FontSize_sm.value,
+    color: global_Color_200.var,
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: global_spacer_xl.var,
+    backgroundColor: global_BackgroundColor_100.var,
+  },
+  title: {
+    paddingBottom: global_spacer_sm.var,
+  },
+});

--- a/src/pages/awsDetails/detailsHeader.tsx
+++ b/src/pages/awsDetails/detailsHeader.tsx
@@ -1,0 +1,155 @@
+import { Title } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import { AwsQuery, getQuery } from 'api/awsQuery';
+import { AwsReport, AwsReportType } from 'api/awsReports';
+import { Providers, ProviderType } from 'api/providers';
+import { getProvidersQuery } from 'api/providersQuery';
+import { AxiosError } from 'axios';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { awsReportsActions, awsReportsSelectors } from 'store/awsReports';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { awsProvidersQuery, providersSelectors } from 'store/providers';
+import { formatCurrency } from 'utils/formatValue';
+import { styles } from './detailsHeader.styles';
+import { GroupBy } from './groupBy';
+
+interface DetailsHeaderOwnProps {
+  onGroupByClicked(value: string);
+}
+
+interface DetailsHeaderStateProps {
+  providers: Providers;
+  providersError: AxiosError;
+  providersFetchStatus: FetchStatus;
+  report: AwsReport;
+  reportFetchStatus: FetchStatus;
+}
+
+interface DetailsHeaderDispatchProps {
+  fetchReport?: typeof awsReportsActions.fetchReport;
+}
+
+type DetailsHeaderProps = DetailsHeaderOwnProps &
+  DetailsHeaderStateProps &
+  DetailsHeaderDispatchProps &
+  InjectedTranslateProps;
+
+const reportType = AwsReportType.cost;
+
+const baseQuery: AwsQuery = {
+  delta: 'cost',
+  filter: {
+    time_scope_units: 'month',
+    time_scope_value: -1,
+    resolution: 'monthly',
+  },
+  group_by: {
+    account: '*',
+  },
+  order_by: {
+    cost: 'desc',
+  },
+};
+
+class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
+  public render() {
+    const {
+      onGroupByClicked,
+      providers,
+      providersError,
+      report,
+      t,
+    } = this.props;
+    const today = new Date();
+    const showContent =
+      report &&
+      !providersError &&
+      providers &&
+      providers.meta &&
+      providers.meta.count > 0;
+
+    return (
+      <header className={css(styles.header)}>
+        <div>
+          <Title className={css(styles.title)} size="2xl">
+            {t('aws_details.title')}
+          </Title>
+          {Boolean(showContent) && <GroupBy onItemClicked={onGroupByClicked} />}
+        </div>
+        {Boolean(showContent) && (
+          <div className={css(styles.cost)}>
+            <Title className={css(styles.costValue)} size="4xl">
+              {formatCurrency(report.meta.total.cost.value)}
+            </Title>
+            <div className={css(styles.costLabel)}>
+              <div className={css(styles.costLabelUnit)}>
+                {t('aws_details.total_cost')}
+              </div>
+              <div className={css(styles.costLabelDate)}>
+                {t('since_date', { month: today.getMonth(), date: 1 })}
+              </div>
+            </div>
+          </div>
+        )}
+      </header>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  DetailsHeaderOwnProps,
+  DetailsHeaderStateProps
+>((state, props) => {
+  const queryString = getQuery(baseQuery);
+  const report = awsReportsSelectors.selectReport(
+    state,
+    reportType,
+    queryString
+  );
+  const reportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
+    state,
+    reportType,
+    queryString
+  );
+
+  const providersQueryString = getProvidersQuery(awsProvidersQuery);
+  const providers = providersSelectors.selectProviders(
+    state,
+    ProviderType.aws,
+    providersQueryString
+  );
+  const providersError = providersSelectors.selectProvidersError(
+    state,
+    ProviderType.aws,
+    providersQueryString
+  );
+  const providersFetchStatus = providersSelectors.selectProvidersFetchStatus(
+    state,
+    ProviderType.aws,
+    providersQueryString
+  );
+
+  return {
+    providers,
+    providersError,
+    providersFetchStatus,
+    queryString,
+    report,
+    reportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: DetailsHeaderDispatchProps = {
+  fetchReport: awsReportsActions.fetchReport,
+};
+
+const DetailsHeader = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(DetailsHeaderBase)
+);
+
+export { DetailsHeader, DetailsHeaderProps };

--- a/src/pages/awsDetails/detailsTable.styles.ts
+++ b/src/pages/awsDetails/detailsTable.styles.ts
@@ -76,11 +76,3 @@ export const tableOverride = css`
     }
   }
 `;
-
-export const groupByTagOverride = css`
-  &.pf-c-table {
-    tbody td + td + td {
-      text-align: right;
-    }
-  }
-`;

--- a/src/pages/awsDetails/detailsTable.styles.ts
+++ b/src/pages/awsDetails/detailsTable.styles.ts
@@ -76,3 +76,11 @@ export const tableOverride = css`
     }
   }
 `;
+
+export const groupByTagOverride = css`
+  &.pf-c-table {
+    tbody td + td + td {
+      text-align: right;
+    }
+  }
+`;

--- a/src/pages/awsDetails/detailsTable.tsx
+++ b/src/pages/awsDetails/detailsTable.tsx
@@ -24,7 +24,6 @@ import {
 } from 'utils/getComputedAwsReportItems';
 import { ComputedAwsReportItem } from 'utils/getComputedAwsReportItems';
 import {
-  groupByTagOverride,
   monthOverMonthOverride,
   styles,
   tableOverride,
@@ -381,17 +380,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
   public render() {
     const { columns, rows } = this.state;
-    const groupByTagKey = this.getGroupByTagKey();
 
     return (
       <>
         <Table
           aria-label="details-table"
           cells={columns}
-          className={`${tableOverride} ${
-            groupByTagKey ? groupByTagOverride : ''
-          }`}
-          onCollapse={groupByTagKey ? undefined : this.handleOnCollapse}
+          className={tableOverride}
+          onCollapse={this.handleOnCollapse}
           rows={rows}
           sortBy={this.getSortBy()}
           onSelect={this.handleOnSelect}

--- a/src/pages/awsDetails/detailsTable.tsx
+++ b/src/pages/awsDetails/detailsTable.tsx
@@ -24,6 +24,7 @@ import {
 } from 'utils/getComputedAwsReportItems';
 import { ComputedAwsReportItem } from 'utils/getComputedAwsReportItems';
 import {
+  groupByTagOverride,
   monthOverMonthOverride,
   styles,
   tableOverride,
@@ -87,32 +88,48 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     }
 
     const groupById = getIdKeyForGroupBy(query.group_by);
+    const groupByTagKey = this.getGroupByTagKey();
+
     const total = formatCurrency(
       report && report.meta && report.meta.total
         ? report.meta.total.cost.value
         : 0
     );
 
-    const columns = [
-      {
-        orderBy: groupById === 'account' ? 'account_alias' : groupById,
-        title: t('aws_details.name_column_title', { groupBy: groupById }),
-        transforms: [sortable],
-      },
-      {
-        title: t('aws_details.change_column_title'),
-      },
-      {
-        orderBy: 'cost',
-        title: t('aws_details.cost_column_title', { total }),
-        transforms: [sortable],
-      },
-    ];
+    const columns = groupByTagKey
+      ? [
+          {
+            title: t('ocp_details.tag_column_title'),
+          },
+          {
+            title: t('aws_details.change_column_title'),
+          },
+          {
+            orderBy: 'cost',
+            title: t('aws_details.cost_column_title', { total }),
+            transforms: [sortable],
+          },
+        ]
+      : [
+          {
+            orderBy: groupById === 'account' ? 'account_alias' : groupById,
+            title: t('aws_details.name_column_title', { groupBy: groupById }),
+            transforms: [sortable],
+          },
+          {
+            title: t('aws_details.change_column_title'),
+          },
+          {
+            orderBy: 'cost',
+            title: t('aws_details.cost_column_title', { total }),
+            transforms: [sortable],
+          },
+        ];
 
     const rows = [];
     const computedItems = getUnsortedComputedAwsReportItems({
       report,
-      idKey: groupById,
+      idKey: (groupByTagKey as any) || groupById,
     });
 
     computedItems.map((item, index) => {
@@ -129,7 +146,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           isOpen: false,
           item,
           tableItem: {
-            groupById,
+            groupBy: groupByTagKey ? `tag:${groupByTagKey}` : groupById,
             index,
             item,
             query,
@@ -158,6 +175,20 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         <EmptyStateBody>{t('aws_details.empty_state')}</EmptyStateBody>
       </EmptyState>
     );
+  };
+
+  private getGroupByTagKey = () => {
+    const { query } = this.props;
+    let groupByTagKey;
+
+    for (const groupBy of Object.keys(query.group_by)) {
+      const tagIndex = groupBy.indexOf('tag:');
+      if (tagIndex !== -1) {
+        groupByTagKey = groupBy.substring(tagIndex + 4) as any;
+        break;
+      }
+    }
+    return groupByTagKey;
   };
 
   private getMonthOverMonthCost = (
@@ -231,6 +262,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   public getSortBy = () => {
     const { query } = this.props;
     const { columns } = this.state;
+    const groupByTagKey = this.getGroupByTagKey();
 
     let index = -1;
     let direction = 'asc';
@@ -243,7 +275,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             query.order_by[key] === 'asc'
               ? SortByDirection.asc
               : SortByDirection.desc;
-          index = c + 2;
+          index = c + (groupByTagKey ? 1 : 2);
           break;
         }
         c++;
@@ -292,13 +324,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const { t } = this.props;
     const { rows } = this.state;
     const {
-      tableItem: { item, groupById, query, index },
+      tableItem: { item, groupBy, query, index },
     } = rows[rowId];
 
     if (isOpen) {
-      rows[rowId + 1].cells = [
-        this.getTableItem(item, groupById, query, index),
-      ];
+      rows[rowId + 1].cells = [this.getTableItem(item, groupBy, query, index)];
     } else {
       rows[rowId + 1].cells = [
         <div key={`${index * 2}-child`}>{t('loading')}</div>,
@@ -340,9 +370,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   private handleOnSort = (event, index, direction) => {
     const { onSort } = this.props;
     const { columns } = this.state;
+    const groupByTagKey = this.getGroupByTagKey();
 
     if (onSort) {
-      const orderBy = columns[index - 2].orderBy;
+      const orderBy = columns[index - (groupByTagKey ? 1 : 2)].orderBy;
       const isSortAscending = direction === SortByDirection.asc;
       onSort(orderBy, isSortAscending);
     }
@@ -350,14 +381,17 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
   public render() {
     const { columns, rows } = this.state;
+    const groupByTagKey = this.getGroupByTagKey();
 
     return (
       <>
         <Table
           aria-label="details-table"
           cells={columns}
-          className={tableOverride}
-          onCollapse={this.handleOnCollapse}
+          className={`${tableOverride} ${
+            groupByTagKey ? groupByTagOverride : ''
+          }`}
+          onCollapse={groupByTagKey ? undefined : this.handleOnCollapse}
           rows={rows}
           sortBy={this.getSortBy()}
           onSelect={this.handleOnSelect}

--- a/src/pages/awsDetails/detailsTableItem.tsx
+++ b/src/pages/awsDetails/detailsTableItem.tsx
@@ -59,7 +59,7 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
 
   private getDefaultGroupBy() {
     const { groupBy } = this.props;
-    let localGroupBy = '';
+    let localGroupBy = 'account';
 
     switch (groupBy) {
       case 'account':

--- a/src/pages/awsDetails/exportModal.tsx
+++ b/src/pages/awsDetails/exportModal.tsx
@@ -22,7 +22,7 @@ export interface ExportModalProps extends InjectedTranslateProps {
   export?: string;
   exportReport?: typeof awsExportActions.exportReport;
   fetchStatus?: FetchStatus;
-  groupById?: string;
+  groupBy?: string;
   isAllItems?: boolean;
   isExportModalOpen?: boolean;
   isProviderModalOpen?: boolean;
@@ -67,7 +67,7 @@ export class ExportModal extends React.Component<
   }
 
   private getQueryString = () => {
-    const { groupById, isAllItems, items, query } = this.props;
+    const { groupBy, isAllItems, items, query } = this.props;
     const { resolution } = this.state;
 
     const newQuery: AwsQuery = {
@@ -79,10 +79,10 @@ export class ExportModal extends React.Component<
     let queryString = getQuery(newQuery);
 
     if (isAllItems) {
-      queryString += `&group_by[${groupById}]=*`;
+      queryString += `&group_by[${groupBy}]=*`;
     } else {
       for (const item of items) {
-        queryString += `&group_by[${groupById}]=` + item.label;
+        queryString += `&group_by[${groupBy}]=` + item.label;
       }
     }
     return queryString;
@@ -102,7 +102,7 @@ export class ExportModal extends React.Component<
   };
 
   public render() {
-    const { fetchStatus, groupById, items, t } = this.props;
+    const { fetchStatus, groupBy, items, t } = this.props;
     const { resolution } = this.state;
 
     const sortedItems = [...items];
@@ -112,6 +112,12 @@ export class ExportModal extends React.Component<
         direction: SortDirection.asc,
       });
     }
+
+    let selectedLabel = t('export.selected', { groupBy });
+    if (groupBy.indexOf('tag:') !== -1) {
+      selectedLabel = t('export.selected_tags');
+    }
+
     return (
       <Modal
         className={css(styles.modal)}
@@ -139,7 +145,7 @@ export class ExportModal extends React.Component<
           </Button>,
         ]}
       >
-        <h2>{t('export.heading', { groupBy: groupById })}</h2>
+        <h2>{t('export.heading', { groupBy })}</h2>
         <FormGroup label={t('export.aggregate_type')}>
           <React.Fragment>
             {resolutionOptions.map((option, index) => (
@@ -157,7 +163,7 @@ export class ExportModal extends React.Component<
             ))}
           </React.Fragment>
         </FormGroup>
-        <FormGroup label={t('export.selected', { groupBy: groupById })}>
+        <FormGroup label={selectedLabel}>
           <ul>
             {sortedItems.map((groupItem, index) => {
               return <li key={index}>{groupItem.label}</li>;

--- a/src/pages/awsDetails/groupBy.tsx
+++ b/src/pages/awsDetails/groupBy.tsx
@@ -103,7 +103,8 @@ class GroupByBase extends React.Component<GroupByProps> {
     const { report, t } = this.props;
 
     if (report && report.data) {
-      return report.data.map(val => (
+      const data = [...new Set([...report.data])]; // prune duplicates
+      return data.map(val => (
         <DropdownItem
           component="button"
           key={`tag:${val}`}

--- a/src/pages/ocpDetails/detailsHeader.styles.ts
+++ b/src/pages/ocpDetails/detailsHeader.styles.ts
@@ -1,0 +1,40 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import {
+  global_BackgroundColor_100,
+  global_Color_100,
+  global_Color_200,
+  global_FontSize_sm,
+  global_spacer_md,
+  global_spacer_sm,
+  global_spacer_xl,
+} from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  cost: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  costLabel: {},
+  costValue: {
+    marginTop: 0,
+    marginBottom: 0,
+    marginRight: global_spacer_md.var,
+  },
+  costLabelUnit: {
+    fontSize: global_FontSize_sm.value,
+    color: global_Color_100.var,
+  },
+  costLabelDate: {
+    fontSize: global_FontSize_sm.value,
+    color: global_Color_200.var,
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: global_spacer_xl.var,
+    backgroundColor: global_BackgroundColor_100.var,
+  },
+  title: {
+    paddingBottom: global_spacer_sm.var,
+  },
+});

--- a/src/pages/ocpDetails/detailsHeader.tsx
+++ b/src/pages/ocpDetails/detailsHeader.tsx
@@ -1,0 +1,155 @@
+import { Title } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import { getQuery, OcpQuery } from 'api/ocpQuery';
+import { OcpReport, OcpReportType } from 'api/ocpReports';
+import { Providers, ProviderType } from 'api/providers';
+import { getProvidersQuery } from 'api/providersQuery';
+import { AxiosError } from 'axios';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { ocpReportsActions, ocpReportsSelectors } from 'store/ocpReports';
+import { ocpProvidersQuery, providersSelectors } from 'store/providers';
+import { formatCurrency } from 'utils/formatValue';
+import { styles } from './detailsHeader.styles';
+import { GroupBy } from './groupBy';
+
+interface DetailsHeaderOwnProps {
+  onGroupByClicked(value: string);
+}
+
+interface DetailsHeaderStateProps {
+  providers: Providers;
+  providersError: AxiosError;
+  providersFetchStatus: FetchStatus;
+  report: OcpReport;
+  reportFetchStatus: FetchStatus;
+}
+
+interface DetailsHeaderDispatchProps {
+  fetchReport?: typeof ocpReportsActions.fetchReport;
+}
+
+type DetailsHeaderProps = DetailsHeaderOwnProps &
+  DetailsHeaderStateProps &
+  DetailsHeaderDispatchProps &
+  InjectedTranslateProps;
+
+const reportType = OcpReportType.cost;
+
+const baseQuery: OcpQuery = {
+  delta: 'cost',
+  filter: {
+    time_scope_units: 'month',
+    time_scope_value: -1,
+    resolution: 'monthly',
+  },
+  group_by: {
+    project: '*',
+  },
+  order_by: {
+    cost: 'desc',
+  },
+};
+
+class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
+  public render() {
+    const {
+      onGroupByClicked,
+      providers,
+      providersError,
+      report,
+      t,
+    } = this.props;
+    const today = new Date();
+    const showContent =
+      report &&
+      !providersError &&
+      providers &&
+      providers.meta &&
+      providers.meta.count > 0;
+
+    return (
+      <header className={css(styles.header)}>
+        <div>
+          <Title className={css(styles.title)} size="2xl">
+            {t('ocp_details.title')}
+          </Title>
+          {Boolean(showContent) && <GroupBy onItemClicked={onGroupByClicked} />}
+        </div>
+        {Boolean(showContent) && (
+          <div className={css(styles.cost)}>
+            <Title className={css(styles.costValue)} size="4xl">
+              {formatCurrency(report.meta.total.cost.value)}
+            </Title>
+            <div className={css(styles.costLabel)}>
+              <div className={css(styles.costLabelUnit)}>
+                {t('ocp_details.total_cost')}
+              </div>
+              <div className={css(styles.costLabelDate)}>
+                {t('since_date', { month: today.getMonth(), date: 1 })}
+              </div>
+            </div>
+          </div>
+        )}
+      </header>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  DetailsHeaderOwnProps,
+  DetailsHeaderStateProps
+>((state, props) => {
+  const queryString = getQuery(baseQuery);
+  const report = ocpReportsSelectors.selectReport(
+    state,
+    reportType,
+    queryString
+  );
+  const reportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
+    state,
+    reportType,
+    queryString
+  );
+
+  const providersQueryString = getProvidersQuery(ocpProvidersQuery);
+  const providers = providersSelectors.selectProviders(
+    state,
+    ProviderType.ocp,
+    providersQueryString
+  );
+  const providersError = providersSelectors.selectProvidersError(
+    state,
+    ProviderType.ocp,
+    providersQueryString
+  );
+  const providersFetchStatus = providersSelectors.selectProvidersFetchStatus(
+    state,
+    ProviderType.ocp,
+    providersQueryString
+  );
+
+  return {
+    providers,
+    providersError,
+    providersFetchStatus,
+    queryString,
+    report,
+    reportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: DetailsHeaderDispatchProps = {
+  fetchReport: ocpReportsActions.fetchReport,
+};
+
+const DetailsHeader = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(DetailsHeaderBase)
+);
+
+export { DetailsHeader, DetailsHeaderProps };

--- a/src/pages/ocpDetails/detailsTable.styles.ts
+++ b/src/pages/ocpDetails/detailsTable.styles.ts
@@ -81,11 +81,3 @@ export const tableOverride = css`
     }
   }
 `;
-
-export const groupByTagOverride = css`
-  &.pf-c-table {
-    tbody td + td + td {
-      text-align: right;
-    }
-  }
-`;

--- a/src/pages/ocpDetails/detailsTable.styles.ts
+++ b/src/pages/ocpDetails/detailsTable.styles.ts
@@ -62,6 +62,11 @@ export const monthOverMonthOverride = css`
 
 export const tableOverride = css`
   &.pf-c-table {
+    &.tag {
+      tbody td + td + td {
+        text-align: right;
+      }
+    }
     thead th + th {
       .pf-c-button {
         text-align: right;
@@ -73,6 +78,14 @@ export const tableOverride = css`
     }
     td {
       vertical-align: top;
+    }
+  }
+`;
+
+export const groupByTagOverride = css`
+  &.pf-c-table {
+    tbody td + td + td {
+      text-align: right;
     }
   }
 `;

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -24,7 +24,6 @@ import {
 } from 'utils/getComputedOcpReportItems';
 import { ComputedOcpReportItem } from 'utils/getComputedOcpReportItems';
 import {
-  groupByTagOverride,
   monthOverMonthOverride,
   styles,
   tableOverride,
@@ -381,17 +380,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
   public render() {
     const { columns, rows } = this.state;
-    const groupByTagKey = this.getGroupByTagKey();
 
     return (
       <>
         <Table
           aria-label="details-table"
           cells={columns}
-          className={`${tableOverride} ${
-            groupByTagKey ? groupByTagOverride : ''
-          }`}
-          onCollapse={groupByTagKey ? undefined : this.handleOnCollapse}
+          className={tableOverride}
+          onCollapse={this.handleOnCollapse}
           rows={rows}
           sortBy={this.getSortBy()}
           onSelect={this.handleOnSelect}

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -24,6 +24,7 @@ import {
 } from 'utils/getComputedOcpReportItems';
 import { ComputedOcpReportItem } from 'utils/getComputedOcpReportItems';
 import {
+  groupByTagOverride,
   monthOverMonthOverride,
   styles,
   tableOverride,
@@ -87,32 +88,48 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     }
 
     const groupById = getIdKeyForGroupBy(query.group_by);
+    const groupByTagKey = this.getGroupByTagKey();
+
     const total = formatCurrency(
       report && report.meta && report.meta.total
         ? report.meta.total.cost.value
         : 0
     );
 
-    const columns = [
-      {
-        orderBy: groupById,
-        title: t('ocp_details.name_column_title', { groupBy: groupById }),
-        transforms: [sortable],
-      },
-      {
-        title: t('ocp_details.change_column_title'),
-      },
-      {
-        orderBy: 'cost',
-        title: t('ocp_details.cost_column_title', { total }),
-        transforms: [sortable],
-      },
-    ];
+    const columns = groupByTagKey
+      ? [
+          {
+            title: t('ocp_details.tag_column_title'),
+          },
+          {
+            title: t('ocp_details.change_column_title'),
+          },
+          {
+            orderBy: 'cost',
+            title: t('ocp_details.cost_column_title', { total }),
+            transforms: [sortable],
+          },
+        ]
+      : [
+          {
+            orderBy: groupById,
+            title: t('ocp_details.name_column_title', { groupBy: groupById }),
+            transforms: [sortable],
+          },
+          {
+            title: t('ocp_details.change_column_title'),
+          },
+          {
+            orderBy: 'cost',
+            title: t('ocp_details.cost_column_title', { total }),
+            transforms: [sortable],
+          },
+        ];
 
     const rows = [];
     const computedItems = getUnsortedComputedOcpReportItems({
       report,
-      idKey: groupById,
+      idKey: (groupByTagKey as any) || groupById,
     });
 
     computedItems.map((item, index) => {
@@ -129,7 +146,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           isOpen: false,
           item,
           tableItem: {
-            groupById,
+            groupBy: groupByTagKey ? `tag:${groupByTagKey}` : groupById,
             index,
             item,
             query,
@@ -158,6 +175,20 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         <EmptyStateBody>{t('aws_details.empty_state')}</EmptyStateBody>
       </EmptyState>
     );
+  };
+
+  private getGroupByTagKey = () => {
+    const { query } = this.props;
+    let groupByTagKey;
+
+    for (const groupBy of Object.keys(query.group_by)) {
+      const tagIndex = groupBy.indexOf('tag:');
+      if (tagIndex !== -1) {
+        groupByTagKey = groupBy.substring(tagIndex + 4) as any;
+        break;
+      }
+    }
+    return groupByTagKey;
   };
 
   private getMonthOverMonthCost = (
@@ -231,6 +262,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   private getSortBy = () => {
     const { query } = this.props;
     const { columns } = this.state;
+    const groupByTagKey = this.getGroupByTagKey();
 
     let index = -1;
     let direction = 'asc';
@@ -243,7 +275,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             query.order_by[key] === 'asc'
               ? SortByDirection.asc
               : SortByDirection.desc;
-          index = c + 2;
+          index = c + (groupByTagKey ? 1 : 2);
           break;
         }
         c++;
@@ -292,13 +324,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const { t } = this.props;
     const { rows } = this.state;
     const {
-      tableItem: { item, groupById, query, index },
+      tableItem: { item, groupBy, query, index },
     } = rows[rowId];
 
     if (isOpen) {
-      rows[rowId + 1].cells = [
-        this.getTableItem(item, groupById, query, index),
-      ];
+      rows[rowId + 1].cells = [this.getTableItem(item, groupBy, query, index)];
     } else {
       rows[rowId + 1].cells = [
         <div key={`${index * 2}-child`}>{t('loading')}</div>,
@@ -340,9 +370,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   private handleOnSort = (event, index, direction) => {
     const { onSort } = this.props;
     const { columns } = this.state;
+    const groupByTagKey = this.getGroupByTagKey();
 
     if (onSort) {
-      const orderBy = columns[index - 2].orderBy;
+      const orderBy = columns[index - (groupByTagKey ? 1 : 2)].orderBy;
       const isSortAscending = direction === SortByDirection.asc;
       onSort(orderBy, isSortAscending);
     }
@@ -350,14 +381,17 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
   public render() {
     const { columns, rows } = this.state;
+    const groupByTagKey = this.getGroupByTagKey();
 
     return (
       <>
         <Table
           aria-label="details-table"
           cells={columns}
-          className={tableOverride}
-          onCollapse={this.handleOnCollapse}
+          className={`${tableOverride} ${
+            groupByTagKey ? groupByTagOverride : ''
+          }`}
+          onCollapse={groupByTagKey ? undefined : this.handleOnCollapse}
           rows={rows}
           sortBy={this.getSortBy()}
           onSelect={this.handleOnSelect}

--- a/src/pages/ocpDetails/exportModal.tsx
+++ b/src/pages/ocpDetails/exportModal.tsx
@@ -22,7 +22,7 @@ export interface ExportModalProps extends InjectedTranslateProps {
   export?: string;
   exportReport?: typeof ocpExportActions.exportReport;
   fetchStatus?: FetchStatus;
-  groupById?: string;
+  groupBy?: string;
   isAllItems?: boolean;
   isExportModalOpen?: boolean;
   isProviderModalOpen?: boolean;
@@ -67,7 +67,7 @@ export class ExportModal extends React.Component<
   }
 
   private getQueryString = () => {
-    const { groupById, isAllItems, items, query } = this.props;
+    const { groupBy, isAllItems, items, query } = this.props;
     const { resolution } = this.state;
 
     const newQuery: OcpQuery = {
@@ -79,10 +79,10 @@ export class ExportModal extends React.Component<
     let queryString = getQuery(newQuery);
 
     if (isAllItems) {
-      queryString += `&group_by[${groupById}]=*`;
+      queryString += `&group_by[${groupBy}]=*`;
     } else {
       for (const item of items) {
-        queryString += `&group_by[${groupById}]=` + item.label;
+        queryString += `&group_by[${groupBy}]=` + item.label;
       }
     }
     return queryString;
@@ -102,7 +102,7 @@ export class ExportModal extends React.Component<
   };
 
   public render() {
-    const { fetchStatus, groupById, items, t } = this.props;
+    const { fetchStatus, groupBy, items, t } = this.props;
     const { resolution } = this.state;
 
     const sortedItems = [...items];
@@ -112,6 +112,12 @@ export class ExportModal extends React.Component<
         direction: SortDirection.asc,
       });
     }
+
+    let selectedLabel = t('export.selected', { groupBy });
+    if (groupBy.indexOf('tag:') !== -1) {
+      selectedLabel = t('export.selected_tags');
+    }
+
     return (
       <Modal
         className={css(styles.modal)}
@@ -139,7 +145,7 @@ export class ExportModal extends React.Component<
           </Button>,
         ]}
       >
-        <h2>{t('export.heading', { groupBy: groupById })}</h2>
+        <h2>{t('export.heading', { groupBy })}</h2>
         <FormGroup label={t('export.aggregate_type')}>
           <React.Fragment>
             {resolutionOptions.map((option, index) => (
@@ -157,7 +163,7 @@ export class ExportModal extends React.Component<
             ))}
           </React.Fragment>
         </FormGroup>
-        <FormGroup label={t('export.selected', { groupBy: groupById })}>
+        <FormGroup label={selectedLabel}>
           <ul>
             {sortedItems.map((groupItem, index) => {
               return <li key={index}>{groupItem.label}</li>;

--- a/src/pages/ocpDetails/groupBy.tsx
+++ b/src/pages/ocpDetails/groupBy.tsx
@@ -103,7 +103,8 @@ class GroupByBase extends React.Component<GroupByProps> {
     const { report, t } = this.props;
 
     if (report && report.data) {
-      return report.data.map(val => (
+      const data = [...new Set([...report.data])]; // prune duplicates
+      return data.map(val => (
         <DropdownItem
           component="button"
           key={`tag:${val}`}

--- a/src/pages/ocpDetails/ocpDetails.styles.ts
+++ b/src/pages/ocpDetails/ocpDetails.styles.ts
@@ -1,6 +1,5 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
-  global_BackgroundColor_100,
   global_BackgroundColor_300,
   global_BorderRadius_sm,
   global_Color_100,
@@ -11,41 +10,16 @@ import {
   global_FontSize_xs,
   global_FontWeight_normal,
   global_LineHeight_md,
-  global_spacer_md,
   global_spacer_sm,
   global_spacer_xl,
 } from '@patternfly/react-tokens';
 import { css } from 'emotion';
 
 export const styles = StyleSheet.create({
-  cost: {
-    display: 'flex',
-    alignItems: 'center',
-  },
-  costLabel: {},
-  costValue: {
-    marginTop: 0,
-    marginBottom: 0,
-    marginRight: global_spacer_md.var,
-  },
-  costLabelUnit: {
-    fontSize: global_FontSize_sm.value,
-    color: global_Color_100.var,
-  },
-  costLabelDate: {
-    fontSize: global_FontSize_sm.value,
-    color: global_Color_200.var,
-  },
   content: {
     backgroundColor: global_BackgroundColor_300.var,
     paddingTop: global_spacer_xl.value,
     height: '100%',
-  },
-  header: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    padding: global_spacer_xl.var,
-    backgroundColor: global_BackgroundColor_100.var,
   },
   ocpDetails: {
     backgroundColor: global_BackgroundColor_300.var,
@@ -58,9 +32,6 @@ export const styles = StyleSheet.create({
     marginBottom: global_spacer_xl.value,
     marginLeft: global_spacer_xl.value,
     marginRight: global_spacer_xl.value,
-  },
-  title: {
-    paddingBottom: global_spacer_sm.var,
   },
 });
 

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -1,4 +1,3 @@
-import { Title } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { getQuery, OcpQuery, parseQuery } from 'api/ocpQuery';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
@@ -16,16 +15,15 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { ocpReportsActions, ocpReportsSelectors } from 'store/ocpReports';
 import { ocpProvidersQuery, providersSelectors } from 'store/providers';
 import { uiActions } from 'store/ui';
-import { formatCurrency } from 'utils/formatValue';
 import {
   ComputedOcpReportItem,
   getIdKeyForGroupBy,
   getUnsortedComputedOcpReportItems,
 } from 'utils/getComputedOcpReportItems';
+import { DetailsHeader } from './detailsHeader';
 import { DetailsTable } from './detailsTable';
 import { DetailsToolbar } from './detailsToolbar';
 import ExportModal from './exportModal';
-import { GroupBy } from './groupBy';
 import { styles, toolbarOverride } from './ocpDetails.styles';
 
 interface OcpDetailsStateProps {
@@ -198,45 +196,6 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     return groupByTagKey;
   };
 
-  private getHeader = () => {
-    const { providers, providersError, report, t } = this.props;
-    const today = new Date();
-    const showContent =
-      report &&
-      !providersError &&
-      providers &&
-      providers.meta &&
-      providers.meta.count > 0;
-
-    return (
-      <header className={css(styles.header)}>
-        <div>
-          <Title className={css(styles.title)} size="2xl">
-            {t('ocp_details.title')}
-          </Title>
-          {Boolean(showContent) && (
-            <GroupBy onItemClicked={this.handleGroupByClick} />
-          )}
-        </div>
-        {Boolean(showContent) && (
-          <div className={css(styles.cost)}>
-            <Title className={css(styles.costValue)} size="4xl">
-              {formatCurrency(report.meta.total.cost.value)}
-            </Title>
-            <div className={css(styles.costLabel)}>
-              <div className={css(styles.costLabelUnit)}>
-                {t('ocp_details.total_cost')}
-              </div>
-              <div className={css(styles.costLabelDate)}>
-                {t('since_date', { month: today.getMonth(), date: 1 })}
-              </div>
-            </div>
-          </div>
-        )}
-      </header>
-    );
-  };
-
   private getRouteForQuery(query: OcpQuery) {
     return `/ocp?${getQuery(query)}`;
   }
@@ -388,7 +347,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
     return (
       <div className={css(styles.ocpDetails)}>
-        {this.getHeader()}
+        <DetailsHeader onGroupByClicked={this.handleGroupByClick} />
         {Boolean(providersError) ? (
           <ErrorState error={providersError} />
         ) : Boolean(noProviders) ? (

--- a/src/utils/getComputedAwsReportItems.ts
+++ b/src/utils/getComputedAwsReportItems.ts
@@ -56,7 +56,7 @@ export function getUnsortedComputedAwsReportItems({
     return [];
   }
 
-  const itemMap: Record<string, ComputedAwsReportItem> = {};
+  const itemMap: Map<string | number, ComputedAwsReportItem> = new Map();
 
   const visitDataPoint = (dataPoint: AwsReportData) => {
     if (dataPoint.values) {
@@ -72,21 +72,21 @@ export function getUnsortedComputedAwsReportItems({
         if (labelKey === 'account' && value.account_alias) {
           label = value.account_alias;
         }
-        if (!itemMap[id]) {
-          itemMap[id] = {
+        if (!itemMap.get(id)) {
+          itemMap.set(id, {
             deltaPercent: value.delta_percent,
             deltaValue: value.delta_value,
             id,
             total,
             label,
             units: value.usage ? value.usage.units : value.cost.units,
-          };
+          });
           return;
         }
-        itemMap[id] = {
-          ...itemMap[id],
-          total: itemMap[id].total + total,
-        };
+        itemMap.set(id, {
+          ...itemMap.get(id),
+          total: itemMap.get(id).total + total,
+        });
       });
     }
     for (const key in dataPoint) {
@@ -98,7 +98,7 @@ export function getUnsortedComputedAwsReportItems({
   if (report && report.data) {
     report.data.forEach(visitDataPoint);
   }
-  return Object.values(itemMap);
+  return Array.from(itemMap.values());
 }
 
 export function getIdKeyForGroupBy(

--- a/src/utils/getComputedOcpReportItems.ts
+++ b/src/utils/getComputedOcpReportItems.ts
@@ -63,7 +63,7 @@ export function getUnsortedComputedOcpReportItems({
     return [];
   }
 
-  const itemMap: Record<string, ComputedOcpReportItem> = {};
+  const itemMap: Map<string | number, ComputedOcpReportItem> = new Map();
 
   const visitDataPoint = (dataPoint: OcpReportData) => {
     if (dataPoint.values) {
@@ -83,8 +83,8 @@ export function getUnsortedComputedOcpReportItems({
         const request = value.request ? value.request.value : 0;
         const usage = value.usage ? value.usage.value : 0;
         const units = value.usage ? value.usage.units : value.cost.units;
-        if (!itemMap[id]) {
-          itemMap[id] = {
+        if (!itemMap.get(id)) {
+          itemMap.set(id, {
             capacity,
             cost,
             deltaPercent: value.delta_percent,
@@ -95,17 +95,17 @@ export function getUnsortedComputedOcpReportItems({
             request,
             units,
             usage,
-          };
+          });
           return;
         }
-        itemMap[id] = {
-          ...itemMap[id],
-          capacity: itemMap[id].capacity + capacity,
-          cost: itemMap[id].cost + cost,
-          limit: itemMap[id].limit + limit,
-          request: itemMap[id].request + request,
-          usage: itemMap[id].usage + usage,
-        };
+        itemMap.set(id, {
+          ...itemMap.get(id),
+          capacity: itemMap.get(id).capacity + capacity,
+          cost: itemMap.get(id).cost + cost,
+          limit: itemMap.get(id).limit + limit,
+          request: itemMap.get(id).request + request,
+          usage: itemMap.get(id).usage + usage,
+        });
       });
     }
     for (const key in dataPoint) {
@@ -117,7 +117,7 @@ export function getUnsortedComputedOcpReportItems({
   if (report && report.data) {
     report.data.forEach(visitDataPoint);
   }
-  return Object.values(itemMap);
+  return Array.from(itemMap.values());
 }
 
 export function getIdKeyForGroupBy(


### PR DESCRIPTION
Refactored the group by tags functionality for the AWS/OCP detail pages. Ensured the group by feature works with sorting, filtering, .csv export, etc.

Notes:
- Sorting via tag name is not supported: https://github.com/project-koku/koku/issues/714
- The expanding rows are disabled intentionally

Fixes https://github.com/project-koku/koku-ui/issues/582

<img width="1517" alt="Screen Shot 2019-03-08 at 2 12 02 PM" src="https://user-images.githubusercontent.com/17481322/54050181-9286d100-41ac-11e9-8f98-21785e52ba0c.png">


