### PR TITLE
Fix radio button in export modal

### DIFF
--- a/src/pages/awsDetails/awsDetails.tsx
+++ b/src/pages/awsDetails/awsDetails.tsx
@@ -24,7 +24,7 @@ import { styles, toolbarOverride } from './awsDetails.styles';
 import { DetailsHeader } from './detailsHeader';
 import { DetailsTable } from './detailsTable';
 import { DetailsToolbar } from './detailsToolbar';
-import ExportModal from './exportModal';
+import { ExportModal } from './exportModal';
 
 interface AwsDetailsStateProps {
   providers: Providers;

--- a/src/pages/awsDetails/detailsChart.tsx
+++ b/src/pages/awsDetails/detailsChart.tsx
@@ -179,4 +179,4 @@ const DetailsChart = translate()(
   )(DetailsChartBase)
 );
 
-export { DetailsChart, DetailsChartBase, DetailsChartProps };
+export { DetailsChart, DetailsChartProps };

--- a/src/pages/awsDetails/exportModal.tsx
+++ b/src/pages/awsDetails/exportModal.tsx
@@ -16,12 +16,9 @@ import { ComputedAwsReportItem } from 'utils/getComputedAwsReportItems';
 import { sort, SortDirection } from 'utils/sort';
 import { styles } from './exportModal.styles';
 
-export interface ExportModalProps extends InjectedTranslateProps {
-  closeExportModal?: typeof uiActions.closeExportModal;
+interface ExportModalOwnProps extends InjectedTranslateProps {
   error?: AxiosError;
   export?: string;
-  exportReport?: typeof awsExportActions.exportReport;
-  fetchStatus?: FetchStatus;
   groupBy?: string;
   isAllItems?: boolean;
   isExportModalOpen?: boolean;
@@ -31,9 +28,23 @@ export interface ExportModalProps extends InjectedTranslateProps {
   queryString?: string;
 }
 
+interface ExportModalStateProps {
+  fetchStatus?: FetchStatus;
+}
+
+interface ExportModalDispatchProps {
+  exportReport?: typeof awsExportActions.exportReport;
+  closeExportModal?: typeof uiActions.closeExportModal;
+}
+
 interface ExportModalState {
   resolution: string;
 }
+
+type ExportModalProps = ExportModalOwnProps &
+  ExportModalStateProps &
+  ExportModalDispatchProps &
+  InjectedTranslateProps;
 
 const resolutionOptions: {
   label: string;
@@ -43,7 +54,7 @@ const resolutionOptions: {
   { label: 'Monthly', value: 'monthly' },
 ];
 
-export class ExportModal extends React.Component<
+class ExportModalBase extends React.Component<
   ExportModalProps,
   ExportModalState
 > {
@@ -51,6 +62,11 @@ export class ExportModal extends React.Component<
     resolution: 'daily',
   };
   public state: ExportModalState = { ...this.defaultState };
+
+  constructor(stateProps, dispatchProps) {
+    super(stateProps, dispatchProps);
+    this.handleResolutionChange = this.handleResolutionChange.bind(this);
+  }
 
   public componentDidUpdate(prevProps: ExportModalProps) {
     const { closeExportModal, fetchStatus, isExportModalOpen } = this.props;
@@ -151,7 +167,7 @@ export class ExportModal extends React.Component<
             {resolutionOptions.map((option, index) => (
               <Radio
                 key={index}
-                id="resolution"
+                id={`resolution-${index}`}
                 isValid={option.value !== undefined}
                 label={t(option.label)}
                 value={option.value}
@@ -175,15 +191,28 @@ export class ExportModal extends React.Component<
   }
 }
 
-export default connect(
-  createMapStateToProps(state => ({
+const mapStateToProps = createMapStateToProps<
+  ExportModalOwnProps,
+  ExportModalStateProps
+>(state => {
+  return {
     error: awsExportSelectors.selectExportError(state),
     export: awsExportSelectors.selectExport(state),
     fetchStatus: awsExportSelectors.selectExportFetchStatus(state),
     isExportModalOpen: uiSelectors.selectIsExportModalOpen(state),
-  })),
-  {
-    exportReport: awsExportActions.exportReport,
-    closeExportModal: uiActions.closeExportModal,
-  }
-)(translate()(ExportModal));
+  };
+});
+
+const mapDispatchToProps: ExportModalDispatchProps = {
+  exportReport: awsExportActions.exportReport,
+  closeExportModal: uiActions.closeExportModal,
+};
+
+const ExportModal = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(ExportModalBase)
+);
+
+export { ExportModal, ExportModalProps };

--- a/src/pages/ocpDetails/detailsChart.tsx
+++ b/src/pages/ocpDetails/detailsChart.tsx
@@ -200,4 +200,4 @@ const DetailsChart = translate()(
   )(DetailsChartBase)
 );
 
-export { DetailsChart, DetailsChartBase, DetailsChartProps };
+export { DetailsChart, DetailsChartProps };

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -23,7 +23,7 @@ import {
 import { DetailsHeader } from './detailsHeader';
 import { DetailsTable } from './detailsTable';
 import { DetailsToolbar } from './detailsToolbar';
-import ExportModal from './exportModal';
+import { ExportModal } from './exportModal';
 import { styles, toolbarOverride } from './ocpDetails.styles';
 
 interface OcpDetailsStateProps {


### PR DESCRIPTION
This enables selection by label for the export modal's radio button. 

The underlying fix is to use unique IDs for each radio button; however, I also wanted to refactor the code a bit to ensure the constructor binds the `handleResolutionChange` function properly.

Fixes https://github.com/project-koku/koku-ui/issues/586