### PR TITLE
Replace OCP charges API with costs

### DIFF
--- a/src/api/ocpOnAwsReports.test.ts
+++ b/src/api/ocpOnAwsReports.test.ts
@@ -6,5 +6,5 @@ import { OcpOnAwsReportType, runReport } from './ocpOnAwsReports';
 test('api run reports calls axios get', () => {
   const query = 'filter[resolution]=daily';
   runReport(OcpOnAwsReportType.cost, query);
-  expect(axios.get).toBeCalledWith(`reports/openshift/charges/?${query}`);
+  expect(axios.get).toBeCalledWith(`reports/openshift/costs/?${query}`);
 });

--- a/src/api/ocpOnAwsReports.ts
+++ b/src/api/ocpOnAwsReports.ts
@@ -94,7 +94,7 @@ export const enum OcpOnAwsReportType {
 }
 
 export const ocpOnAwsReportTypePaths: Record<OcpOnAwsReportType, string> = {
-  [OcpOnAwsReportType.cost]: 'reports/openshift/charges/',
+  [OcpOnAwsReportType.cost]: 'reports/openshift/costs/',
   [OcpOnAwsReportType.cpu]: 'reports/openshift/compute/',
   [OcpOnAwsReportType.instanceType]:
     'reports/openshift/infrastructures/aws/instance-types/',

--- a/src/api/ocpReports.test.ts
+++ b/src/api/ocpReports.test.ts
@@ -6,5 +6,5 @@ import { OcpReportType, runReport } from './ocpReports';
 test('api run reports calls axios get', () => {
   const query = 'filter[resolution]=daily';
   runReport(OcpReportType.cost, query);
-  expect(axios.get).toBeCalledWith(`reports/openshift/charges/?${query}`);
+  expect(axios.get).toBeCalledWith(`reports/openshift/costs/?${query}`);
 });

--- a/src/api/ocpReports.ts
+++ b/src/api/ocpReports.ts
@@ -89,7 +89,7 @@ export const enum OcpReportType {
 }
 
 export const ocpReportTypePaths: Record<OcpReportType, string> = {
-  [OcpReportType.cost]: 'reports/openshift/charges/',
+  [OcpReportType.cost]: 'reports/openshift/costs/',
   [OcpReportType.cpu]: 'reports/openshift/compute/',
   [OcpReportType.memory]: 'reports/openshift/memory/',
   [OcpReportType.tag]: 'tags/openshift/',


### PR DESCRIPTION
Replaces `reports/openshift/charges` API with `reports/openshift/costs`

Fixes https://github.com/project-koku/koku-ui/issues/591