### PR TITLE
Harden request errors

### DIFF
--- a/src/pages/awsDashboard/awsDashboardWidget.tsx
+++ b/src/pages/awsDashboard/awsDashboardWidget.tsx
@@ -76,8 +76,8 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
   };
 
   public componentDidMount() {
-    const { availableTabs, fetchReports, id, widgetId } = this.props;
-    this.props.updateTab(id, availableTabs[0]);
+    const { availableTabs, fetchReports, id, updateTab, widgetId } = this.props;
+    updateTab(id, availableTabs[0]);
     fetchReports(widgetId);
   }
 
@@ -91,10 +91,10 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
   };
 
   private handleTabClick = (event, tabIndex) => {
-    const { availableTabs, id } = this.props;
+    const { availableTabs, id, updateTab } = this.props;
     const tab = availableTabs[tabIndex];
 
-    this.props.updateTab(id, tab);
+    updateTab(id, tab);
     this.setState({
       activeTabKey: tabIndex,
     });

--- a/src/pages/awsDetails/detailsChart.tsx
+++ b/src/pages/awsDetails/detailsChart.tsx
@@ -45,21 +45,22 @@ type DetailsChartProps = DetailsChartOwnProps &
   DetailsChartDispatchProps &
   InjectedTranslateProps;
 
+const reportType = AwsReportType.cost;
+
 class DetailsChartBase extends React.Component<DetailsChartProps> {
   public state: DetailsChartState = {
     isDetailsChartModalOpen: false,
   };
 
   public componentDidMount() {
-    const { report, queryString } = this.props;
-    if (!report) {
-      this.props.fetchReport(AwsReportType.cost, queryString);
-    }
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
   }
 
   public componentDidUpdate(prevProps: DetailsChartProps) {
-    if (prevProps.queryString !== this.props.queryString) {
-      this.props.fetchReport(AwsReportType.cost, this.props.queryString);
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportType, queryString);
     }
   }
 
@@ -153,12 +154,12 @@ const mapStateToProps = createMapStateToProps<
   const queryString = getQuery(query);
   const report = awsReportsSelectors.selectReport(
     state,
-    AwsReportType.cost,
+    reportType,
     queryString
   );
   const reportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
     state,
-    AwsReportType.cost,
+    reportType,
     queryString
   );
   return {

--- a/src/pages/awsDetails/detailsChartModal.tsx
+++ b/src/pages/awsDetails/detailsChartModal.tsx
@@ -39,6 +39,8 @@ type DetailsChartModalProps = DetailsChartModalOwnProps &
   DetailsChartModalDispatchProps &
   InjectedTranslateProps;
 
+const reportType = AwsReportType.cost;
+
 class DetailsChartModalBase extends React.Component<DetailsChartModalProps> {
   constructor(props: DetailsChartModalProps) {
     super(props);
@@ -46,15 +48,14 @@ class DetailsChartModalBase extends React.Component<DetailsChartModalProps> {
   }
 
   public componentDidMount() {
-    const { report, queryString } = this.props;
-    if (!report) {
-      this.props.fetchReport(AwsReportType.cost, queryString);
-    }
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
   }
 
   public componentDidUpdate(prevProps: DetailsChartModalProps) {
-    if (prevProps.queryString !== this.props.queryString) {
-      this.props.fetchReport(AwsReportType.cost, this.props.queryString);
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportType, queryString);
     }
   }
 
@@ -130,12 +131,12 @@ const mapStateToProps = createMapStateToProps<
   const queryString = getQuery(query);
   const report = awsReportsSelectors.selectReport(
     state,
-    AwsReportType.cost,
+    reportType,
     queryString
   );
   const reportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
     state,
-    AwsReportType.cost,
+    reportType,
     queryString
   );
   return {
@@ -156,4 +157,4 @@ const DetailsChartModal = translate()(
   )(DetailsChartModalBase)
 );
 
-export { DetailsChartModal, DetailsChartModalBase, DetailsChartModalProps };
+export { DetailsChartModal, DetailsChartModalProps };

--- a/src/pages/awsDetails/detailsHeader.tsx
+++ b/src/pages/awsDetails/detailsHeader.tsx
@@ -20,10 +20,12 @@ interface DetailsHeaderOwnProps {
 }
 
 interface DetailsHeaderStateProps {
+  queryString?: string;
   providers: Providers;
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
   report: AwsReport;
+  reportError?: AxiosError;
   reportFetchStatus: FetchStatus;
 }
 
@@ -35,8 +37,6 @@ type DetailsHeaderProps = DetailsHeaderOwnProps &
   DetailsHeaderStateProps &
   DetailsHeaderDispatchProps &
   InjectedTranslateProps;
-
-const reportType = AwsReportType.cost;
 
 const baseQuery: AwsQuery = {
   delta: 'cost',
@@ -53,18 +53,34 @@ const baseQuery: AwsQuery = {
   },
 };
 
+const reportType = AwsReportType.cost;
+
 class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
+  public componentDidMount() {
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
+  }
+
+  public componentDidUpdate(prevProps: DetailsHeaderProps) {
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportType, queryString);
+    }
+  }
+
   public render() {
     const {
       onGroupByClicked,
       providers,
       providersError,
       report,
+      reportError,
       t,
     } = this.props;
     const today = new Date();
     const showContent =
       report &&
+      !reportError &&
       !providersError &&
       providers &&
       providers.meta &&
@@ -108,6 +124,11 @@ const mapStateToProps = createMapStateToProps<
     reportType,
     queryString
   );
+  const reportError = awsReportsSelectors.selectReportError(
+    state,
+    reportType,
+    queryString
+  );
   const reportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
     state,
     reportType,
@@ -137,6 +158,7 @@ const mapStateToProps = createMapStateToProps<
     providersFetchStatus,
     queryString,
     report,
+    reportError,
     reportFetchStatus,
   };
 });

--- a/src/pages/awsDetails/detailsTable.tsx
+++ b/src/pages/awsDetails/detailsTable.tsx
@@ -406,4 +406,4 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
 const DetailsTable = translate()(connect()(DetailsTableBase));
 
-export { DetailsTable, DetailsTableBase, DetailsTableProps };
+export { DetailsTable, DetailsTableProps };

--- a/src/pages/awsDetails/detailsTableItem.tsx
+++ b/src/pages/awsDetails/detailsTableItem.tsx
@@ -169,4 +169,4 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
 
 const DetailsTableItem = translate()(connect()(DetailsTableItemBase));
 
-export { DetailsTableItem, DetailsTableItemBase, DetailsTableItemProps };
+export { DetailsTableItem, DetailsTableItemProps };

--- a/src/pages/awsDetails/detailsTag.tsx
+++ b/src/pages/awsDetails/detailsTag.tsx
@@ -38,6 +38,8 @@ type DetailsTagProps = DetailsTagOwnProps &
   DetailsTagDispatchProps &
   InjectedTranslateProps;
 
+const reportType = AwsReportType.tag;
+
 class DetailsTagBase extends React.Component<DetailsTagProps> {
   protected defaultState: DetailsTagState = {
     isDetailsModalOpen: false,
@@ -52,15 +54,14 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
   }
 
   public componentDidMount() {
-    const { queryString, report } = this.props;
-    if (!report) {
-      this.props.fetchReport(AwsReportType.tag, queryString);
-    }
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
   }
 
   public componentDidUpdate(prevProps: DetailsTagProps) {
-    if (prevProps.queryString !== this.props.queryString) {
-      this.props.fetchReport(AwsReportType.tag, this.props.queryString);
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportType, queryString);
     }
   }
 
@@ -138,12 +139,12 @@ const mapStateToProps = createMapStateToProps<
   });
   const report = awsReportsSelectors.selectReport(
     state,
-    AwsReportType.tag,
+    reportType,
     queryString
   );
   const reportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
     state,
-    AwsReportType.tag,
+    reportType,
     queryString
   );
   return {
@@ -165,4 +166,4 @@ const DetailsTag = translate()(
   )(DetailsTagBase)
 );
 
-export { DetailsTag, DetailsTagBase, DetailsTagProps };
+export { DetailsTag, DetailsTagProps };

--- a/src/pages/awsDetails/detailsTagModal.tsx
+++ b/src/pages/awsDetails/detailsTagModal.tsx
@@ -33,6 +33,8 @@ type DetailsTagModalProps = DetailsTagModalOwnProps &
   DetailsTagModalDispatchProps &
   InjectedTranslateProps;
 
+const reportType = AwsReportType.tag;
+
 class DetailsTagModalBase extends React.Component<DetailsTagModalProps> {
   constructor(props: DetailsTagModalProps) {
     super(props);
@@ -40,15 +42,14 @@ class DetailsTagModalBase extends React.Component<DetailsTagModalProps> {
   }
 
   public componentDidMount() {
-    const { report, queryString } = this.props;
-    if (!report) {
-      this.props.fetchReport(AwsReportType.tag, queryString);
-    }
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
   }
 
   public componentDidUpdate(prevProps: DetailsTagModalProps) {
-    if (prevProps.queryString !== this.props.queryString) {
-      this.props.fetchReport(AwsReportType.tag, this.props.queryString);
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportType, queryString);
     }
   }
 
@@ -107,12 +108,12 @@ const mapStateToProps = createMapStateToProps<
   });
   const report = awsReportsSelectors.selectReport(
     state,
-    AwsReportType.tag,
+    reportType,
     queryString
   );
   const reportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
     state,
-    AwsReportType.tag,
+    reportType,
     queryString
   );
   return {
@@ -133,4 +134,4 @@ const DetailsTagModal = translate()(
   )(DetailsTagModalBase)
 );
 
-export { DetailsTagModal, DetailsTagModalBase, DetailsTagModalProps };
+export { DetailsTagModal, DetailsTagModalProps };

--- a/src/pages/awsDetails/exportModal.tsx
+++ b/src/pages/awsDetails/exportModal.tsx
@@ -74,7 +74,7 @@ class ExportModalBase extends React.Component<
       this.setState({ ...this.defaultState });
     }
     if (
-      this.props.export !== prevProps.export &&
+      prevProps.export !== this.props.export &&
       fetchStatus === FetchStatus.complete
     ) {
       fileDownload(this.props.export, 'report.csv', 'text/csv');

--- a/src/pages/awsDetails/groupBy.tsx
+++ b/src/pages/awsDetails/groupBy.tsx
@@ -45,6 +45,8 @@ const groupByOptions: {
   { label: 'region', value: 'region' },
 ];
 
+const reportType = AwsReportType.tag;
+
 class GroupByBase extends React.Component<GroupByProps> {
   protected defaultState: GroupByState = {
     isGroupByOpen: false,
@@ -59,18 +61,17 @@ class GroupByBase extends React.Component<GroupByProps> {
   }
 
   public componentDidMount() {
-    const { queryString, report } = this.props;
-    if (!report) {
-      this.props.fetchReport(AwsReportType.tag, queryString);
-    }
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
     this.setState({
       currentItem: this.getGroupBy(),
     });
   }
 
   public componentDidUpdate(prevProps: GroupByProps) {
-    if (prevProps.queryString !== this.props.queryString) {
-      this.props.fetchReport(AwsReportType.tag, this.props.queryString);
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportType, queryString);
       this.setState({ currentItem: this.getGroupBy() });
     }
   }
@@ -197,12 +198,12 @@ const mapStateToProps = createMapStateToProps<
   });
   const report = awsReportsSelectors.selectReport(
     state,
-    AwsReportType.tag,
+    reportType,
     queryString
   );
   const reportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
     state,
-    AwsReportType.tag,
+    reportType,
     queryString
   );
   return {
@@ -223,4 +224,4 @@ const GroupBy = translate()(
   )(GroupByBase)
 );
 
-export { GroupBy, GroupByBase, GroupByProps };
+export { GroupBy, GroupByProps };

--- a/src/pages/awsDetails/historicalChart.tsx
+++ b/src/pages/awsDetails/historicalChart.tsx
@@ -44,64 +44,33 @@ type HistoricalModalProps = HistoricalModalOwnProps &
   HistoricalModalDispatchProps &
   InjectedTranslateProps;
 
+const costReportType = AwsReportType.cost;
+const instanceReportType = AwsReportType.instanceType;
+const storageReportType = AwsReportType.storage;
+
 class HistoricalModalBase extends React.Component<HistoricalModalProps> {
   public componentDidMount() {
-    const {
-      currentCostReport,
-      currentInstanceReport,
-      currentStorageReport,
-      currentQueryString,
-      previousCostReport,
-      previousInstanceReport,
-      previousStorageReport,
-      previousQueryString,
-    } = this.props;
+    const { fetchReport, currentQueryString, previousQueryString } = this.props;
 
-    if (!currentCostReport) {
-      this.props.fetchReport(AwsReportType.cost, currentQueryString);
-    }
-    if (!currentInstanceReport) {
-      this.props.fetchReport(AwsReportType.instanceType, currentQueryString);
-    }
-    if (!currentStorageReport) {
-      this.props.fetchReport(AwsReportType.storage, currentQueryString);
-    }
-    if (!previousCostReport) {
-      this.props.fetchReport(AwsReportType.cost, previousQueryString);
-    }
-    if (!previousInstanceReport) {
-      this.props.fetchReport(AwsReportType.instanceType, previousQueryString);
-    }
-    if (!previousStorageReport) {
-      this.props.fetchReport(AwsReportType.storage, previousQueryString);
-    }
+    fetchReport(costReportType, currentQueryString);
+    fetchReport(instanceReportType, currentQueryString);
+    fetchReport(storageReportType, currentQueryString);
+    fetchReport(costReportType, previousQueryString);
+    fetchReport(instanceReportType, previousQueryString);
+    fetchReport(storageReportType, previousQueryString);
   }
 
   public componentDidUpdate(prevProps: HistoricalModalProps) {
-    if (prevProps.currentQueryString !== this.props.currentQueryString) {
-      this.props.fetchReport(AwsReportType.cost, this.props.currentQueryString);
-      this.props.fetchReport(
-        AwsReportType.instanceType,
-        this.props.currentQueryString
-      );
-      this.props.fetchReport(
-        AwsReportType.storage,
-        this.props.currentQueryString
-      );
+    const { fetchReport, currentQueryString, previousQueryString } = this.props;
+    if (prevProps.currentQueryString !== currentQueryString) {
+      fetchReport(costReportType, currentQueryString);
+      fetchReport(instanceReportType, currentQueryString);
+      fetchReport(storageReportType, currentQueryString);
     }
-    if (prevProps.previousQueryString !== this.props.previousQueryString) {
-      this.props.fetchReport(
-        AwsReportType.cost,
-        this.props.previousQueryString
-      );
-      this.props.fetchReport(
-        AwsReportType.instanceType,
-        this.props.previousQueryString
-      );
-      this.props.fetchReport(
-        AwsReportType.storage,
-        this.props.previousQueryString
-      );
+    if (prevProps.previousQueryString !== previousQueryString) {
+      fetchReport(costReportType, previousQueryString);
+      fetchReport(instanceReportType, previousQueryString);
+      this.props.fetchReport(storageReportType, previousQueryString);
     }
   }
 
@@ -209,64 +178,64 @@ const mapStateToProps = createMapStateToProps<
   // Current report
   const currentCostReport = awsReportsSelectors.selectReport(
     state,
-    AwsReportType.cost,
+    costReportType,
     currentQueryString
   );
   const currentCostReportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
     state,
-    AwsReportType.cost,
+    costReportType,
     currentQueryString
   );
   const currentInstanceReport = awsReportsSelectors.selectReport(
     state,
-    AwsReportType.instanceType,
+    instanceReportType,
     currentQueryString
   );
   const currentInstanceReportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
     state,
-    AwsReportType.instanceType,
+    instanceReportType,
     currentQueryString
   );
   const currentStorageReport = awsReportsSelectors.selectReport(
     state,
-    AwsReportType.storage,
+    storageReportType,
     currentQueryString
   );
   const currentStorageReportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
     state,
-    AwsReportType.storage,
+    storageReportType,
     currentQueryString
   );
 
   // Previous report
   const previousCostReport = awsReportsSelectors.selectReport(
     state,
-    AwsReportType.cost,
+    costReportType,
     previousQueryString
   );
   const previousCostReportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
     state,
-    AwsReportType.cost,
+    costReportType,
     previousQueryString
   );
   const previousInstanceReport = awsReportsSelectors.selectReport(
     state,
-    AwsReportType.instanceType,
+    instanceReportType,
     previousQueryString
   );
   const previousInstanceReportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
     state,
-    AwsReportType.instanceType,
+    instanceReportType,
     previousQueryString
   );
   const previousStorageReport = awsReportsSelectors.selectReport(
     state,
-    AwsReportType.storage,
+    storageReportType,
     previousQueryString
   );
   const previousStorageReportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
     state,
-    AwsReportType.storage,
+    storageReportType,
     previousQueryString
   );
   return {
@@ -296,4 +265,4 @@ const HistoricalChart = translate()(
   )(HistoricalModalBase)
 );
 
-export { HistoricalChart, HistoricalModalBase, HistoricalModalProps };
+export { HistoricalChart, HistoricalModalProps };

--- a/src/pages/ocpDetails/detailsChart.tsx
+++ b/src/pages/ocpDetails/detailsChart.tsx
@@ -41,21 +41,21 @@ type DetailsChartProps = DetailsChartOwnProps &
   DetailsChartDispatchProps &
   InjectedTranslateProps;
 
+const cpuReportType = OcpReportType.cpu;
+const memoryReportType = OcpReportType.memory;
+
 class DetailsChartBase extends React.Component<DetailsChartProps> {
   public componentDidMount() {
-    const { cpuReport, memoryReport, queryString } = this.props;
-    if (!cpuReport) {
-      this.props.fetchReport(OcpReportType.cpu, queryString);
-    }
-    if (!memoryReport) {
-      this.props.fetchReport(OcpReportType.memory, queryString);
-    }
+    const { fetchReport, queryString } = this.props;
+    fetchReport(cpuReportType, queryString);
+    fetchReport(memoryReportType, queryString);
   }
 
   public componentDidUpdate(prevProps: DetailsChartProps) {
+    const { fetchReport, queryString } = this.props;
     if (prevProps.queryString !== this.props.queryString) {
-      this.props.fetchReport(OcpReportType.cpu, this.props.queryString);
-      this.props.fetchReport(OcpReportType.memory, this.props.queryString);
+      fetchReport(cpuReportType, queryString);
+      fetchReport(memoryReportType, queryString);
     }
   }
 
@@ -162,22 +162,22 @@ const mapStateToProps = createMapStateToProps<
   const queryString = getQuery(query);
   const cpuReport = ocpReportsSelectors.selectReport(
     state,
-    OcpReportType.cpu,
+    cpuReportType,
     queryString
   );
   const cpuReportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
     state,
-    OcpReportType.cpu,
+    cpuReportType,
     queryString
   );
   const memoryReport = ocpReportsSelectors.selectReport(
     state,
-    OcpReportType.memory,
+    memoryReportType,
     queryString
   );
   const memoryReportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
     state,
-    OcpReportType.memory,
+    memoryReportType,
     queryString
   );
   return {

--- a/src/pages/ocpDetails/detailsCluster.tsx
+++ b/src/pages/ocpDetails/detailsCluster.tsx
@@ -33,17 +33,18 @@ type DetailsClusterProps = DetailsClusterOwnProps &
   DetailsClusterDispatchProps &
   InjectedTranslateProps;
 
+const reportType = OcpReportType.cost;
+
 class DetailsClusterBase extends React.Component<DetailsClusterProps> {
   public componentDidMount() {
-    const { report, queryString } = this.props;
-    if (!report) {
-      this.props.fetchReport(OcpReportType.cost, queryString);
-    }
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
   }
 
   public componentDidUpdate(prevProps: DetailsClusterProps) {
-    if (prevProps.queryString !== this.props.queryString) {
-      this.props.fetchReport(OcpReportType.cost, this.props.queryString);
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportType, queryString);
     }
   }
 
@@ -84,12 +85,12 @@ const mapStateToProps = createMapStateToProps<
   const queryString = getQuery(query);
   const report = ocpReportsSelectors.selectReport(
     state,
-    OcpReportType.cost,
+    reportType,
     queryString
   );
   const reportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
     state,
-    OcpReportType.cost,
+    reportType,
     queryString
   );
   return {
@@ -111,4 +112,4 @@ const DetailsCluster = translate()(
   )(DetailsClusterBase)
 );
 
-export { DetailsCluster, DetailsClusterBase, DetailsClusterProps };
+export { DetailsCluster, DetailsClusterProps };

--- a/src/pages/ocpDetails/detailsHeader.tsx
+++ b/src/pages/ocpDetails/detailsHeader.tsx
@@ -23,7 +23,9 @@ interface DetailsHeaderStateProps {
   providers: Providers;
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
+  queryString: string;
   report: OcpReport;
+  reportError?: AxiosError;
   reportFetchStatus: FetchStatus;
 }
 
@@ -54,17 +56,31 @@ const baseQuery: OcpQuery = {
 };
 
 class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
+  public componentDidMount() {
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
+  }
+
+  public componentDidUpdate(prevProps: DetailsHeaderProps) {
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportType, queryString);
+    }
+  }
+
   public render() {
     const {
       onGroupByClicked,
       providers,
       providersError,
       report,
+      reportError,
       t,
     } = this.props;
     const today = new Date();
     const showContent =
       report &&
+      !reportError &&
       !providersError &&
       providers &&
       providers.meta &&
@@ -108,6 +124,11 @@ const mapStateToProps = createMapStateToProps<
     reportType,
     queryString
   );
+  const reportError = ocpReportsSelectors.selectReportError(
+    state,
+    reportType,
+    queryString
+  );
   const reportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
     state,
     reportType,
@@ -137,6 +158,7 @@ const mapStateToProps = createMapStateToProps<
     providersFetchStatus,
     queryString,
     report,
+    reportError,
     reportFetchStatus,
   };
 });

--- a/src/pages/ocpDetails/detailsSummary.tsx
+++ b/src/pages/ocpDetails/detailsSummary.tsx
@@ -34,17 +34,18 @@ type DetailsSummaryProps = DetailsSummaryOwnProps &
   DetailsSummaryDispatchProps &
   InjectedTranslateProps;
 
+const reportType = OcpReportType.cost;
+
 class DetailsSummaryBase extends React.Component<DetailsSummaryProps> {
   public componentDidMount() {
-    const { queryString, report } = this.props;
-    if (!report) {
-      this.props.fetchReport(OcpReportType.cost, queryString);
-    }
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
   }
 
   public componentDidUpdate(prevProps: DetailsSummaryProps) {
-    if (prevProps.queryString !== this.props.queryString) {
-      this.props.fetchReport(OcpReportType.cost, this.props.queryString);
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportType, queryString);
     }
   }
 
@@ -95,12 +96,12 @@ const mapStateToProps = createMapStateToProps<
   const queryString = getQuery(query);
   const report = ocpReportsSelectors.selectReport(
     state,
-    OcpReportType.cost,
+    reportType,
     queryString
   );
   const reportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
     state,
-    OcpReportType.cost,
+    reportType,
     queryString
   );
   return {
@@ -121,4 +122,4 @@ const DetailsSummary = translate()(
   )(DetailsSummaryBase)
 );
 
-export { DetailsSummary, DetailsSummaryBase, DetailsSummaryProps };
+export { DetailsSummary, DetailsSummaryProps };

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -406,4 +406,4 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
 const DetailsTable = translate()(connect()(DetailsTableBase));
 
-export { DetailsTable, DetailsTableBase, DetailsTableProps };
+export { DetailsTable, DetailsTableProps };

--- a/src/pages/ocpDetails/detailsTableItem.tsx
+++ b/src/pages/ocpDetails/detailsTableItem.tsx
@@ -117,4 +117,4 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
 
 const DetailsTableItem = translate()(connect()(DetailsTableItemBase));
 
-export { DetailsTableItem, DetailsTableItemBase, DetailsTableItemProps };
+export { DetailsTableItem, DetailsTableItemProps };

--- a/src/pages/ocpDetails/detailsTag.tsx
+++ b/src/pages/ocpDetails/detailsTag.tsx
@@ -38,6 +38,8 @@ type DetailsTagProps = DetailsTagOwnProps &
   DetailsTagDispatchProps &
   InjectedTranslateProps;
 
+const reportType = OcpReportType.tag;
+
 class DetailsTagBase extends React.Component<DetailsTagProps> {
   protected defaultState: DetailsTagState = {
     isDetailsModalOpen: false,
@@ -52,15 +54,14 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
   }
 
   public componentDidMount() {
-    const { queryString, report } = this.props;
-    if (!report) {
-      this.props.fetchReport(OcpReportType.tag, queryString);
-    }
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
   }
 
   public componentDidUpdate(prevProps: DetailsTagProps) {
-    if (prevProps.queryString !== this.props.queryString) {
-      this.props.fetchReport(OcpReportType.tag, this.props.queryString);
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportType, queryString);
     }
   }
 
@@ -138,12 +139,12 @@ const mapStateToProps = createMapStateToProps<
   });
   const report = ocpReportsSelectors.selectReport(
     state,
-    OcpReportType.tag,
+    reportType,
     queryString
   );
   const reportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
     state,
-    OcpReportType.tag,
+    reportType,
     queryString
   );
   return {
@@ -165,4 +166,4 @@ const DetailsTag = translate()(
   )(DetailsTagBase)
 );
 
-export { DetailsTag, DetailsTagBase, DetailsTagProps };
+export { DetailsTag, DetailsTagProps };

--- a/src/pages/ocpDetails/detailsTagModal.tsx
+++ b/src/pages/ocpDetails/detailsTagModal.tsx
@@ -33,6 +33,8 @@ type DetailsTagModalProps = DetailsTagModalOwnProps &
   DetailsTagModalDispatchProps &
   InjectedTranslateProps;
 
+const reportType = OcpReportType.tag;
+
 class DetailsTagModalBase extends React.Component<DetailsTagModalProps> {
   constructor(props: DetailsTagModalProps) {
     super(props);
@@ -40,15 +42,14 @@ class DetailsTagModalBase extends React.Component<DetailsTagModalProps> {
   }
 
   public componentDidMount() {
-    const { report, queryString } = this.props;
-    if (!report) {
-      this.props.fetchReport(OcpReportType.tag, queryString);
-    }
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
   }
 
   public componentDidUpdate(prevProps: DetailsTagModalProps) {
-    if (prevProps.queryString !== this.props.queryString) {
-      this.props.fetchReport(OcpReportType.tag, this.props.queryString);
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportType, queryString);
     }
   }
 
@@ -107,12 +108,12 @@ const mapStateToProps = createMapStateToProps<
   });
   const report = ocpReportsSelectors.selectReport(
     state,
-    OcpReportType.tag,
+    reportType,
     queryString
   );
   const reportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
     state,
-    OcpReportType.tag,
+    reportType,
     queryString
   );
   return {
@@ -133,4 +134,4 @@ const DetailsTagModal = translate()(
   )(DetailsTagModalBase)
 );
 
-export { DetailsTagModal, DetailsTagModalBase, DetailsTagModalProps };
+export { DetailsTagModal, DetailsTagModalProps };

--- a/src/pages/ocpDetails/exportModal.tsx
+++ b/src/pages/ocpDetails/exportModal.tsx
@@ -74,7 +74,7 @@ export class ExportModalBase extends React.Component<
       this.setState({ ...this.defaultState });
     }
     if (
-      this.props.export !== prevProps.export &&
+      prevProps.export !== this.props.export &&
       fetchStatus === FetchStatus.complete
     ) {
       fileDownload(this.props.export, 'report.csv', 'text/csv');

--- a/src/pages/ocpDetails/groupBy.tsx
+++ b/src/pages/ocpDetails/groupBy.tsx
@@ -45,6 +45,8 @@ const groupByOptions: {
   { label: 'project', value: 'project' },
 ];
 
+const reportType = OcpReportType.tag;
+
 class GroupByBase extends React.Component<GroupByProps> {
   protected defaultState: GroupByState = {
     isGroupByOpen: false,
@@ -59,18 +61,17 @@ class GroupByBase extends React.Component<GroupByProps> {
   }
 
   public componentDidMount() {
-    const { queryString, report } = this.props;
-    if (!report) {
-      this.props.fetchReport(OcpReportType.tag, queryString);
-    }
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
     this.setState({
       currentItem: this.getGroupBy(),
     });
   }
 
   public componentDidUpdate(prevProps: GroupByProps) {
-    if (prevProps.queryString !== this.props.queryString) {
-      this.props.fetchReport(OcpReportType.tag, this.props.queryString);
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportType, queryString);
       this.setState({ currentItem: this.getGroupBy() });
     }
   }
@@ -197,12 +198,12 @@ const mapStateToProps = createMapStateToProps<
   });
   const report = ocpReportsSelectors.selectReport(
     state,
-    OcpReportType.tag,
+    reportType,
     queryString
   );
   const reportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
     state,
-    OcpReportType.tag,
+    reportType,
     queryString
   );
   return {
@@ -223,4 +224,4 @@ const GroupBy = translate()(
   )(GroupByBase)
 );
 
-export { GroupBy, GroupByBase, GroupByProps };
+export { GroupBy, GroupByProps };

--- a/src/pages/ocpDetails/historicalChart.tsx
+++ b/src/pages/ocpDetails/historicalChart.tsx
@@ -49,58 +49,34 @@ type HistoricalModalProps = HistoricalModalOwnProps &
   HistoricalModalDispatchProps &
   InjectedTranslateProps;
 
+const cpuReportType = OcpReportType.cpu;
+const costReportType = OcpReportType.cost;
+const memoryReportType = OcpReportType.memory;
+
 class HistoricalModalBase extends React.Component<HistoricalModalProps> {
   public componentDidMount() {
-    const {
-      currentCostReport,
-      currentCpuReport,
-      currentMemoryReport,
-      currentQueryString,
-      previousCostReport,
-      previousCpuReport,
-      previousMemoryReport,
-      previousQueryString,
-    } = this.props;
+    const { fetchReport, currentQueryString, previousQueryString } = this.props;
 
-    if (!currentCostReport) {
-      this.props.fetchReport(OcpReportType.cost, currentQueryString);
-    }
-    if (!currentCpuReport) {
-      this.props.fetchReport(OcpReportType.cpu, currentQueryString);
-    }
-    if (!currentMemoryReport) {
-      this.props.fetchReport(OcpReportType.memory, currentQueryString);
-    }
-    if (!previousCostReport) {
-      this.props.fetchReport(OcpReportType.cost, previousQueryString);
-    }
-    if (!previousCpuReport) {
-      this.props.fetchReport(OcpReportType.cpu, previousQueryString);
-    }
-    if (!previousMemoryReport) {
-      this.props.fetchReport(OcpReportType.memory, previousQueryString);
-    }
+    fetchReport(costReportType, currentQueryString);
+    fetchReport(cpuReportType, currentQueryString);
+    fetchReport(memoryReportType, currentQueryString);
+    fetchReport(costReportType, previousQueryString);
+    fetchReport(cpuReportType, previousQueryString);
+    fetchReport(memoryReportType, previousQueryString);
   }
 
   public componentDidUpdate(prevProps: HistoricalModalProps) {
-    if (prevProps.currentQueryString !== this.props.currentQueryString) {
-      this.props.fetchReport(OcpReportType.cost, this.props.currentQueryString);
-      this.props.fetchReport(OcpReportType.cpu, this.props.currentQueryString);
-      this.props.fetchReport(
-        OcpReportType.memory,
-        this.props.currentQueryString
-      );
+    const { fetchReport, currentQueryString, previousQueryString } = this.props;
+
+    if (prevProps.currentQueryString !== currentQueryString) {
+      fetchReport(costReportType, currentQueryString);
+      fetchReport(cpuReportType, currentQueryString);
+      fetchReport(memoryReportType, currentQueryString);
     }
-    if (prevProps.previousQueryString !== this.props.previousQueryString) {
-      this.props.fetchReport(
-        OcpReportType.cost,
-        this.props.previousQueryString
-      );
-      this.props.fetchReport(OcpReportType.cpu, this.props.previousQueryString);
-      this.props.fetchReport(
-        OcpReportType.memory,
-        this.props.previousQueryString
-      );
+    if (prevProps.previousQueryString !== previousQueryString) {
+      fetchReport(costReportType, previousQueryString);
+      fetchReport(cpuReportType, previousQueryString);
+      fetchReport(memoryReportType, previousQueryString);
     }
   }
 
@@ -292,64 +268,64 @@ const mapStateToProps = createMapStateToProps<
   // Current report
   const currentCostReport = ocpReportsSelectors.selectReport(
     state,
-    OcpReportType.cost,
+    costReportType,
     currentQueryString
   );
   const currentCostReportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
     state,
-    OcpReportType.cost,
+    costReportType,
     currentQueryString
   );
   const currentCpuReport = ocpReportsSelectors.selectReport(
     state,
-    OcpReportType.cpu,
+    cpuReportType,
     currentQueryString
   );
   const currentCpuReportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
     state,
-    OcpReportType.cpu,
+    cpuReportType,
     currentQueryString
   );
   const currentMemoryReport = ocpReportsSelectors.selectReport(
     state,
-    OcpReportType.memory,
+    memoryReportType,
     currentQueryString
   );
   const currentMemoryReportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
     state,
-    OcpReportType.memory,
+    memoryReportType,
     currentQueryString
   );
 
   // Previous report
   const previousCostReport = ocpReportsSelectors.selectReport(
     state,
-    OcpReportType.cost,
+    costReportType,
     previousQueryString
   );
   const previousCostReportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
     state,
-    OcpReportType.cost,
+    costReportType,
     previousQueryString
   );
   const previousCpuReport = ocpReportsSelectors.selectReport(
     state,
-    OcpReportType.cpu,
+    cpuReportType,
     previousQueryString
   );
   const previousCpuReportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
     state,
-    OcpReportType.cpu,
+    cpuReportType,
     previousQueryString
   );
   const previousMemoryReport = ocpReportsSelectors.selectReport(
     state,
-    OcpReportType.memory,
+    memoryReportType,
     previousQueryString
   );
   const previousMemoryReportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
     state,
-    OcpReportType.memory,
+    memoryReportType,
     previousQueryString
   );
   return {
@@ -379,4 +355,4 @@ const HistoricalChart = translate()(
   )(HistoricalModalBase)
 );
 
-export { HistoricalChart, HistoricalModalBase, HistoricalModalProps };
+export { HistoricalChart, HistoricalModalProps };

--- a/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
+++ b/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
@@ -78,9 +78,9 @@ class OcpOnAwsDashboardWidgetBase extends React.Component<
   };
 
   public componentDidMount() {
-    const { availableTabs, fetchReports, id, widgetId } = this.props;
+    const { availableTabs, fetchReports, id, updateTab, widgetId } = this.props;
     if (availableTabs) {
-      this.props.updateTab(id, availableTabs[0]);
+      updateTab(id, availableTabs[0]);
     }
     fetchReports(widgetId);
   }
@@ -95,10 +95,10 @@ class OcpOnAwsDashboardWidgetBase extends React.Component<
   };
 
   private handleTabClick = (event, tabIndex) => {
-    const { availableTabs, id } = this.props;
+    const { availableTabs, id, updateTab } = this.props;
     const tab = availableTabs[tabIndex];
 
-    this.props.updateTab(id, tab);
+    updateTab(id, tab);
     this.setState({
       activeTabKey: tabIndex,
     });

--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -174,6 +174,7 @@ class OverviewBase extends React.Component<OverviewProps> {
       t,
     } = this.props;
 
+    const error = awsProvidersError || ocpProvidersError;
     const isLoading =
       awsProvidersFetchStatus === FetchStatus.inProgress ||
       ocpProvidersFetchStatus === FetchStatus.inProgress;
@@ -201,8 +202,8 @@ class OverviewBase extends React.Component<OverviewProps> {
           className="pf-l-page__main-section pf-c-page__main-section"
           page-type="cost-management-overview"
         >
-          {Boolean(awsProvidersError || ocpProvidersError) ? (
-            <ErrorState error={awsProvidersError || ocpProvidersError} />
+          {Boolean(error) ? (
+            <ErrorState error={error} />
           ) : Boolean(noProviders) ? (
             <NoProvidersState />
           ) : Boolean(isLoading) ? (


### PR DESCRIPTION
When a request encounters a 400 error; for example, the UI continues to invoke the same request repeatedly.

It turns out that a retry limit is not what is needed to resolve this issue. The UI makes a request each time the page is updated and it has yet to obtain a report. We simply need to check if we received an error before making another request.

Now if we encounter a 400 error, the unexpected error state is shown. This avoids hitting the server unnecessarily.

Fixes https://github.com/project-koku/koku-ui/issues/590