### PR TITLE
Historical chart tooltips are cut off

### DIFF
--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -267,7 +267,12 @@ class HistoricalTrendChart extends React.Component<
     const { height, title, xAxisLabel, yAxisLabel } = this.props;
     const { datum } = this.state;
 
-    const container = <ChartVoronoiContainer labels={this.getTooltipLabel} />;
+    const container = (
+      <ChartVoronoiContainer
+        labels={this.getTooltipLabel}
+        voronoiDimension="x"
+      />
+    );
     const domain = this.getDomain();
     const endDate = this.getEndDate();
     const midDate = Math.floor(endDate / 2);

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -470,7 +470,12 @@ class HistoricalUsageChart extends React.Component<
     const { height, title, xAxisLabel, yAxisLabel } = this.props;
     const { datum } = this.state;
 
-    const container = <ChartVoronoiContainer labels={this.getTooltipLabel} />;
+    const container = (
+      <ChartVoronoiContainer
+        labels={this.getTooltipLabel}
+        voronoiDimension="x"
+      />
+    );
     const domain = this.getDomain();
     const endDate = this.getEndDate();
     const midDate = Math.floor(endDate / 2);

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -266,7 +266,12 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     const { height } = this.props;
     const { datum, width } = this.state;
 
-    const container = <ChartVoronoiContainer labels={this.getTooltipLabel} />;
+    const container = (
+      <ChartVoronoiContainer
+        labels={this.getTooltipLabel}
+        voronoiDimension="x"
+      />
+    );
     const legendWidth =
       chartStyles.legend.minWidth > width / 2
         ? chartStyles.legend.minWidth

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -382,7 +382,12 @@ class UsageChart extends React.Component<UsageChartProps, State> {
     const { height } = this.props;
     const { datum, width } = this.state;
 
-    const container = <ChartVoronoiContainer labels={this.getTooltipLabel} />;
+    const container = (
+      <ChartVoronoiContainer
+        labels={this.getTooltipLabel}
+        voronoiDimension="x"
+      />
+    );
     const legendWidth =
       chartStyles.legend.minWidth > width / 2
         ? chartStyles.legend.minWidth


### PR DESCRIPTION
This solves an issue where the historical chart tooltips are cut off for the first day or two. There just isn't enough room in the left side margin.

Ideally, we would just set the overflow to visible, which would display the tooltip in its entirety. However, this has the side effect of disabling vertical scrolling. In order to scroll vertically when the window is resized, the chart container cannot overflow. 

Instead, I've modified our PF4 Victory charts to use voronoiDimension='x', which forces the tooltip to be displayed within the chart's x-axis. This also stacks all tooltips for any given point on the x-axis, which is something we planned to do anyway.

Fixes https://github.com/project-koku/koku-ui/issues/606

Example:
![Screen Shot 2019-03-11 at 10 35 00 AM](https://user-images.githubusercontent.com/17481322/54131743-57251600-43e9-11e9-80ac-e4164de5fb5b.png)