### PR TITLE
Update API for OCP on AWS cost card

### DIFF
--- a/src/api/ocpOnAwsReports.test.ts
+++ b/src/api/ocpOnAwsReports.test.ts
@@ -6,5 +6,7 @@ import { OcpOnAwsReportType, runReport } from './ocpOnAwsReports';
 test('api run reports calls axios get', () => {
   const query = 'filter[resolution]=daily';
   runReport(OcpOnAwsReportType.cost, query);
-  expect(axios.get).toBeCalledWith(`reports/openshift/costs/?${query}`);
+  expect(axios.get).toBeCalledWith(
+    `reports/openshift/infrastructures/aws/costs/?${query}`
+  );
 });

--- a/src/api/ocpOnAwsReports.ts
+++ b/src/api/ocpOnAwsReports.ts
@@ -94,7 +94,7 @@ export const enum OcpOnAwsReportType {
 }
 
 export const ocpOnAwsReportTypePaths: Record<OcpOnAwsReportType, string> = {
-  [OcpOnAwsReportType.cost]: 'reports/openshift/costs/',
+  [OcpOnAwsReportType.cost]: 'reports/openshift/infrastructures/aws/costs/',
   [OcpOnAwsReportType.cpu]: 'reports/openshift/compute/',
   [OcpOnAwsReportType.instanceType]:
     'reports/openshift/infrastructures/aws/instance-types/',


### PR DESCRIPTION
This simply updates the OCP on AWS cost card to use the new reports/openshift/infrastructure/aws/costs/ API.

Fixes https://github.com/project-koku/koku-ui/issues/612