### PR TITLE
Add initial OCP on AWS details page

### DIFF
--- a/src/api/ocpOnAwsExport.ts
+++ b/src/api/ocpOnAwsExport.ts
@@ -1,0 +1,11 @@
+import axios from 'axios';
+import { OcpOnAwsReportType, ocpOnAwsReportTypePaths } from './ocpOnAwsReports';
+
+export function runExport(reportType: OcpOnAwsReportType, query: string) {
+  const path = ocpOnAwsReportTypePaths[reportType];
+  return axios.get<string>(`${path}?${query}`, {
+    headers: {
+      Accept: 'text/csv',
+    },
+  });
+}

--- a/src/api/ocpOnAwsQuery.ts
+++ b/src/api/ocpOnAwsQuery.ts
@@ -13,9 +13,12 @@ export interface OcpOnAwsFilters {
 type OcpOnAwsGroupByValue = string | string[];
 
 interface OcpOnAwsGroupBys {
+  account?: OcpOnAwsGroupByValue;
   cluster?: OcpOnAwsGroupByValue;
   node?: OcpOnAwsGroupByValue;
   project?: OcpOnAwsGroupByValue;
+  region?: OcpOnAwsGroupByValue;
+  service?: OcpOnAwsGroupByValue;
 }
 
 interface OcpOnAwsOrderBys {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -183,8 +183,9 @@
     "December"
   ],
   "navigation": {
-    "aws_details": "AWS Details",
-    "ocp_details": "OpenShift Details",
+    "aws_details": "AWS details",
+    "ocp_details": "OpenShift details",
+    "ocp_on_aws_details": "OpenShift on AWS details",
     "overview": "Overview"
   },
   "navigation_toggle": "navigation toggle",
@@ -321,6 +322,78 @@
       "widget_subtitle": "$t(months.{{month}}) {{startDate}}",
       "widget_subtitle_plural": "$t(months.{{month}}) {{startDate}} - $t(months.{{month}}) {{endDate}}"
     }
+  },
+  "ocp_on_aws_details": {
+    "bullet": {
+      "cpu_capacity": "Capacity - {{value}} Core-Hours",
+      "cpu_label": "CPU",
+      "cpu_limit": "Limit - {{value}} Core-Hours",
+      "cpu_requests": "Requests - {{value}} Core-Hours",
+      "cpu_usage": "Usage - {{value}} Core-Hours",
+      "memory_capacity": "Capacity - {{value}} GB-Hours",
+      "memory_label": "Memory",
+      "memory_limit": "Limit - {{value}} GB-Hours",
+      "memory_requests": "Requests - {{value}} GB-Hours",
+      "memory_usage": "Usage - {{value}} GB-Hours"
+    },
+    "change_column_title": "Month Over Month Change",
+    "cluster_label": "Cluster:",
+    "cost_column_title": "Cost (Total {{total}})",
+    "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
+    "decrease_since_last_month": "{{value}} decrease since last month",
+    "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
+    "export_link": "Export",
+    "filter": {
+      "cluster_placeholder": "Filter by Cluster",
+      "cluster_select": "Cluster",
+      "node_placeholder": "Filter by Node",
+      "node_select": "Node",
+      "project_placeholder": "Filter by Project",
+      "project_select": "Project",
+      "tag_placeholder": "Filter by Tag",
+      "tag_select": "Tag"
+    },
+    "historical": {
+      "cost_label": "Cost ($)",
+      "cost_title": "Month over Month Total $t(group_by.values.{{groupBy}}) Cost",
+      "cpu_capacity_label": "Capacity ({{date}})",
+      "cpu_label": "Core-Hours",
+      "cpu_limit_label": "Limit ({{date}})",
+      "cpu_requested_label": "Requested ({{date}})",
+      "cpu_title": "Month over Month Total $t(group_by.values.{{groupBy}}) CPU Usage, Request, Limit, and Capacity",
+      "cpu_usage_label": "Used ({{date}})",
+      "day_of_month_label": "Day of Month",
+      "memory_capacity_label": "Capacity ({{date}})",
+      "memory_label": "GB-Hours",
+      "memory_limit_label": "Limit ({{date}})",
+      "memory_requested_label": "Requested ({{date}})",
+      "memory_title": "Month over Month Total $t(group_by.values.{{groupBy}}) Memory Usage, Request, Limit, and Capacity",
+      "memory_usage_label": "Used ({{date}})",
+      "modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Historical Data",
+      "project_title": "Top Projects",
+      "view_data": "View Historical Data"
+    },
+    "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
+    "increase_since_last_month": "{{value}} increase since last month",
+    "more_tags": ", {{value}} more...",
+    "name_column_title": "$t(group_by.values.{{groupBy}}) Names",
+    "no_change_since_date": "No change since $t(months.{{month}}) {{date}}",
+    "order": {
+      "cost": "Sort by: Cost",
+      "cost_delta": "Sort by: Cost Delta",
+      "name": "Sort by: Name"
+    },
+    "tag_column_title": "Tag Names",
+    "tags_label": "Related Tags:",
+    "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Related Tags",
+    "title": "OpenShift on AWS details",
+    "toolbar": {
+      "active_filters": "Active Filters:",
+      "clear_filters": "Clear All Filters",
+      "export": "Export",
+      "results": "{{value}} Results"
+    },
+    "total_cost": "Total Cost"
   },
   "onboarding": {
     "aws_configure": {

--- a/src/pages/ocpOnAwsDetails/detailsChart.styles.ts
+++ b/src/pages/ocpOnAwsDetails/detailsChart.styles.ts
@@ -1,0 +1,13 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_xl } from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  cpuBulletContainer: {
+    paddingRight: '2rem',
+  },
+  memoryBulletContainer: {
+    paddingBottom: global_spacer_xl.value,
+    paddingRight: '2rem',
+    paddingTop: global_spacer_xl.value,
+  },
+});

--- a/src/pages/ocpOnAwsDetails/detailsChart.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsChart.tsx
@@ -1,0 +1,214 @@
+import { css } from '@patternfly/react-styles';
+import { getQuery, OcpOnAwsQuery } from 'api/ocpOnAwsQuery';
+import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import { BulletChart } from 'components/charts/bulletChart';
+import { chartStyles } from 'components/charts/bulletChart/bulletChart.styles';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import {
+  ocpOnAwsReportsActions,
+  ocpOnAwsReportsSelectors,
+} from 'store/ocpOnAwsReports';
+import { ComputedOcpOnAwsReportItem } from 'utils/getComputedOcpOnAwsReportItems';
+import { styles } from './detailsChart.styles';
+
+export interface ChartDatum {
+  capacity: number;
+  legend: any[];
+  limit: any;
+  ranges: any[];
+  values: any[];
+}
+
+interface DetailsChartOwnProps {
+  groupBy: string;
+  item: ComputedOcpOnAwsReportItem;
+}
+
+interface DetailsChartStateProps {
+  cpuReport?: OcpOnAwsReport;
+  cpuReportFetchStatus?: FetchStatus;
+  memoryReport?: OcpOnAwsReport;
+  memoryReportFetchStatus?: FetchStatus;
+  queryString?: string;
+}
+
+interface DetailsChartDispatchProps {
+  fetchReport?: typeof ocpOnAwsReportsActions.fetchReport;
+}
+
+type DetailsChartProps = DetailsChartOwnProps &
+  DetailsChartStateProps &
+  DetailsChartDispatchProps &
+  InjectedTranslateProps;
+
+const cpuReportType = OcpOnAwsReportType.cpu;
+const memoryReportType = OcpOnAwsReportType.memory;
+
+class DetailsChartBase extends React.Component<DetailsChartProps> {
+  public componentDidMount() {
+    const { fetchReport, queryString } = this.props;
+    fetchReport(cpuReportType, queryString);
+    fetchReport(memoryReportType, queryString);
+  }
+
+  public componentDidUpdate(prevProps: DetailsChartProps) {
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== this.props.queryString) {
+      fetchReport(cpuReportType, queryString);
+      fetchReport(memoryReportType, queryString);
+    }
+  }
+
+  private getChartDatum(report: OcpOnAwsReport, labelKey: string): ChartDatum {
+    const { t } = this.props;
+    const datum: ChartDatum = {
+      capacity: 0,
+      legend: [],
+      limit: {},
+      ranges: [],
+      values: [],
+    };
+    if (report && report.meta && report.meta.total) {
+      datum.capacity = Math.trunc(report.meta.total.capacity.value);
+      const limit = Math.trunc(report.meta.total.limit.value);
+      const request = Math.trunc(report.meta.total.request.value);
+      const usage = Math.trunc(report.meta.total.usage.value);
+
+      datum.limit = {
+        legend: t(`ocp_on_aws_details.bullet.${labelKey}_limit`, {
+          value: limit,
+        }),
+        tooltip: t(`ocp_on_aws_details.bullet.${labelKey}_limit`, {
+          value: limit,
+        }),
+        value: Math.trunc(limit),
+      };
+      datum.ranges = [
+        {
+          color: chartStyles.valueColorScale[1], // '#bee1f4'
+          legend: t(`ocp_on_aws_details.bullet.${labelKey}_requests`, {
+            value: request,
+          }),
+          tooltip: t(`ocp_on_aws_details.bullet.${labelKey}_requests`, {
+            value: request,
+          }),
+          value: Math.trunc(request),
+        },
+        {
+          color: chartStyles.rangeColorScale[0], // '#ededed'
+          legend: t(`ocp_on_aws_details.bullet.${labelKey}_capacity`, {
+            value: datum.capacity,
+          }),
+          tooltip: t(`ocp_on_aws_details.bullet.${labelKey}_capacity`, {
+            value: datum.capacity,
+          }),
+          value: Math.trunc(datum.capacity),
+        },
+      ];
+      datum.values = [
+        {
+          legend: t(`ocp_on_aws_details.bullet.${labelKey}_usage`, {
+            value: usage,
+          }),
+          tooltip: t(`ocp_on_aws_details.bullet.${labelKey}_usage`, {
+            value: usage,
+          }),
+          value: Math.trunc(usage),
+        },
+      ];
+    }
+    return datum;
+  }
+
+  public render() {
+    const { cpuReport, memoryReport, t } = this.props;
+    const cpuDatum = this.getChartDatum(cpuReport, 'cpu');
+    const memoryDatum = this.getChartDatum(memoryReport, 'memory');
+
+    return (
+      <>
+        {Boolean(cpuDatum && cpuDatum.values.length) && (
+          <div className={css(styles.cpuBulletContainer)}>
+            <BulletChart
+              ranges={cpuDatum.ranges}
+              thresholdError={cpuDatum.limit}
+              title={t('ocp_on_aws_details.bullet.cpu_label')}
+              values={cpuDatum.values}
+            />
+          </div>
+        )}
+        {Boolean(memoryDatum && memoryDatum.values.length) && (
+          <div className={css(styles.memoryBulletContainer)}>
+            <BulletChart
+              ranges={memoryDatum.ranges}
+              thresholdError={memoryDatum.limit}
+              title={t('ocp_on_aws_details.bullet.memory_label')}
+              values={memoryDatum.values}
+            />
+          </div>
+        )}
+      </>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  DetailsChartOwnProps,
+  DetailsChartStateProps
+>((state, { groupBy, item }) => {
+  const query: OcpOnAwsQuery = {
+    filter: {
+      time_scope_units: 'month',
+      time_scope_value: -1,
+      resolution: 'monthly',
+      limit: 5,
+    },
+    group_by: {
+      [groupBy]: item.label || item.id,
+    },
+  };
+  const queryString = getQuery(query);
+  const cpuReport = ocpOnAwsReportsSelectors.selectReport(
+    state,
+    cpuReportType,
+    queryString
+  );
+  const cpuReportFetchStatus = ocpOnAwsReportsSelectors.selectReportFetchStatus(
+    state,
+    cpuReportType,
+    queryString
+  );
+  const memoryReport = ocpOnAwsReportsSelectors.selectReport(
+    state,
+    memoryReportType,
+    queryString
+  );
+  const memoryReportFetchStatus = ocpOnAwsReportsSelectors.selectReportFetchStatus(
+    state,
+    memoryReportType,
+    queryString
+  );
+  return {
+    cpuReport,
+    cpuReportFetchStatus,
+    memoryReport,
+    memoryReportFetchStatus,
+    queryString,
+  };
+});
+
+const mapDispatchToProps: DetailsChartDispatchProps = {
+  fetchReport: ocpOnAwsReportsActions.fetchReport,
+};
+
+const DetailsChart = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(DetailsChartBase)
+);
+
+export { DetailsChart, DetailsChartProps };

--- a/src/pages/ocpOnAwsDetails/detailsCluster.styles.ts
+++ b/src/pages/ocpOnAwsDetails/detailsCluster.styles.ts
@@ -1,0 +1,9 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_3xl, global_spacer_sm } from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  clusterContainer: {
+    marginRight: global_spacer_3xl.value,
+    marginTop: global_spacer_sm.value,
+  },
+});

--- a/src/pages/ocpOnAwsDetails/detailsCluster.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsCluster.tsx
@@ -1,0 +1,118 @@
+import { css } from '@patternfly/react-styles';
+import { getQuery, OcpOnAwsQuery } from 'api/ocpOnAwsQuery';
+import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import {
+  ocpOnAwsReportsActions,
+  ocpOnAwsReportsSelectors,
+} from 'store/ocpOnAwsReports';
+import {
+  ComputedOcpOnAwsReportItem,
+  getComputedOcpOnAwsReportItems,
+} from 'utils/getComputedOcpOnAwsReportItems';
+import { styles } from './detailsCluster.styles';
+
+interface DetailsClusterOwnProps {
+  groupBy: string;
+  item: ComputedOcpOnAwsReportItem;
+}
+
+interface DetailsClusterStateProps {
+  query?: OcpOnAwsQuery;
+  queryString?: string;
+  report?: OcpOnAwsReport;
+  reportFetchStatus?: FetchStatus;
+}
+
+interface DetailsClusterDispatchProps {
+  fetchReport?: typeof ocpOnAwsReportsActions.fetchReport;
+}
+
+type DetailsClusterProps = DetailsClusterOwnProps &
+  DetailsClusterStateProps &
+  DetailsClusterDispatchProps &
+  InjectedTranslateProps;
+
+const reportType = OcpOnAwsReportType.cost;
+
+class DetailsClusterBase extends React.Component<DetailsClusterProps> {
+  public componentDidMount() {
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
+  }
+
+  public componentDidUpdate(prevProps: DetailsClusterProps) {
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportType, queryString);
+    }
+  }
+
+  private getItems() {
+    const { report } = this.props;
+    const computedItems = getComputedOcpOnAwsReportItems({
+      report,
+      idKey: 'cluster',
+    });
+
+    return computedItems;
+  }
+
+  public render() {
+    const items = this.getItems();
+    const clusterName = items && items.length ? items[0].label : '';
+
+    return <div className={css(styles.clusterContainer)}>{clusterName}</div>;
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  DetailsClusterOwnProps,
+  DetailsClusterStateProps
+>((state, { groupBy, item }) => {
+  const query: OcpOnAwsQuery = {
+    filter: {
+      time_scope_units: 'month',
+      time_scope_value: -1,
+      resolution: 'monthly',
+      limit: 5,
+    },
+    group_by: {
+      cluster: '*',
+      [groupBy]: item.label || item.id,
+    },
+  };
+  const queryString = getQuery(query);
+  const report = ocpOnAwsReportsSelectors.selectReport(
+    state,
+    reportType,
+    queryString
+  );
+  const reportFetchStatus = ocpOnAwsReportsSelectors.selectReportFetchStatus(
+    state,
+    reportType,
+    queryString
+  );
+  return {
+    report,
+    reportFetchStatus,
+    query,
+    queryString,
+  };
+});
+
+const mapDispatchToProps: DetailsClusterDispatchProps = {
+  fetchReport: ocpOnAwsReportsActions.fetchReport,
+};
+
+const DetailsCluster = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(DetailsClusterBase)
+);
+
+export { DetailsCluster, DetailsClusterProps };

--- a/src/pages/ocpOnAwsDetails/detailsHeader.styles.ts
+++ b/src/pages/ocpOnAwsDetails/detailsHeader.styles.ts
@@ -1,0 +1,40 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import {
+  global_BackgroundColor_100,
+  global_Color_100,
+  global_Color_200,
+  global_FontSize_sm,
+  global_spacer_md,
+  global_spacer_sm,
+  global_spacer_xl,
+} from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  cost: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  costLabel: {},
+  costValue: {
+    marginTop: 0,
+    marginBottom: 0,
+    marginRight: global_spacer_md.var,
+  },
+  costLabelUnit: {
+    fontSize: global_FontSize_sm.value,
+    color: global_Color_100.var,
+  },
+  costLabelDate: {
+    fontSize: global_FontSize_sm.value,
+    color: global_Color_200.var,
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: global_spacer_xl.var,
+    backgroundColor: global_BackgroundColor_100.var,
+  },
+  title: {
+    paddingBottom: global_spacer_sm.var,
+  },
+});

--- a/src/pages/ocpOnAwsDetails/detailsHeader.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsHeader.tsx
@@ -1,0 +1,180 @@
+import { Title } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import { getQuery, OcpOnAwsQuery } from 'api/ocpOnAwsQuery';
+import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import { Providers, ProviderType } from 'api/providers';
+import { getProvidersQuery } from 'api/providersQuery';
+import { AxiosError } from 'axios';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import {
+  ocpOnAwsReportsActions,
+  ocpOnAwsReportsSelectors,
+} from 'store/ocpOnAwsReports';
+import { ocpProvidersQuery, providersSelectors } from 'store/providers';
+import { formatCurrency } from 'utils/formatValue';
+import { styles } from './detailsHeader.styles';
+import { GroupBy } from './groupBy';
+
+interface DetailsHeaderOwnProps {
+  onGroupByClicked(value: string);
+}
+
+interface DetailsHeaderStateProps {
+  providers: Providers;
+  providersError: AxiosError;
+  providersFetchStatus: FetchStatus;
+  queryString: string;
+  report: OcpOnAwsReport;
+  reportError?: AxiosError;
+  reportFetchStatus: FetchStatus;
+}
+
+interface DetailsHeaderDispatchProps {
+  fetchReport?: typeof ocpOnAwsReportsActions.fetchReport;
+}
+
+type DetailsHeaderProps = DetailsHeaderOwnProps &
+  DetailsHeaderStateProps &
+  DetailsHeaderDispatchProps &
+  InjectedTranslateProps;
+
+const reportType = OcpOnAwsReportType.cost;
+
+const baseQuery: OcpOnAwsQuery = {
+  delta: 'cost',
+  filter: {
+    time_scope_units: 'month',
+    time_scope_value: -1,
+    resolution: 'monthly',
+  },
+  group_by: {
+    project: '*',
+  },
+  order_by: {
+    cost: 'desc',
+  },
+};
+
+class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
+  public componentDidMount() {
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
+  }
+
+  public componentDidUpdate(prevProps: DetailsHeaderProps) {
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportType, queryString);
+    }
+  }
+
+  public render() {
+    const {
+      onGroupByClicked,
+      providers,
+      providersError,
+      report,
+      reportError,
+      t,
+    } = this.props;
+    const today = new Date();
+    const showContent =
+      report &&
+      !reportError &&
+      !providersError &&
+      providers &&
+      providers.meta &&
+      providers.meta.count > 0;
+
+    return (
+      <header className={css(styles.header)}>
+        <div>
+          <Title className={css(styles.title)} size="2xl">
+            {t('ocp_on_aws_details.title')}
+          </Title>
+          {Boolean(showContent) && <GroupBy onItemClicked={onGroupByClicked} />}
+        </div>
+        {Boolean(showContent) && (
+          <div className={css(styles.cost)}>
+            <Title className={css(styles.costValue)} size="4xl">
+              {formatCurrency(report.meta.total.cost.value)}
+            </Title>
+            <div className={css(styles.costLabel)}>
+              <div className={css(styles.costLabelUnit)}>
+                {t('ocp_on_aws_details.total_cost')}
+              </div>
+              <div className={css(styles.costLabelDate)}>
+                {t('since_date', { month: today.getMonth(), date: 1 })}
+              </div>
+            </div>
+          </div>
+        )}
+      </header>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  DetailsHeaderOwnProps,
+  DetailsHeaderStateProps
+>((state, props) => {
+  const queryString = getQuery(baseQuery);
+  const report = ocpOnAwsReportsSelectors.selectReport(
+    state,
+    reportType,
+    queryString
+  );
+  const reportError = ocpOnAwsReportsSelectors.selectReportError(
+    state,
+    reportType,
+    queryString
+  );
+  const reportFetchStatus = ocpOnAwsReportsSelectors.selectReportFetchStatus(
+    state,
+    reportType,
+    queryString
+  );
+
+  const providersQueryString = getProvidersQuery(ocpProvidersQuery);
+  const providers = providersSelectors.selectProviders(
+    state,
+    ProviderType.ocp,
+    providersQueryString
+  );
+  const providersError = providersSelectors.selectProvidersError(
+    state,
+    ProviderType.ocp,
+    providersQueryString
+  );
+  const providersFetchStatus = providersSelectors.selectProvidersFetchStatus(
+    state,
+    ProviderType.ocp,
+    providersQueryString
+  );
+
+  return {
+    providers,
+    providersError,
+    providersFetchStatus,
+    queryString,
+    report,
+    reportError,
+    reportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: DetailsHeaderDispatchProps = {
+  fetchReport: ocpOnAwsReportsActions.fetchReport,
+};
+
+const DetailsHeader = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(DetailsHeaderBase)
+);
+
+export { DetailsHeader, DetailsHeaderProps };

--- a/src/pages/ocpOnAwsDetails/detailsSummary.styles.ts
+++ b/src/pages/ocpOnAwsDetails/detailsSummary.styles.ts
@@ -1,0 +1,8 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_md } from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  projectsProgressBar: {
+    paddingTop: global_spacer_md.value,
+  },
+});

--- a/src/pages/ocpOnAwsDetails/detailsSummary.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsSummary.tsx
@@ -1,0 +1,128 @@
+import { css } from '@patternfly/react-styles';
+import { getQuery, OcpOnAwsQuery } from 'api/ocpOnAwsQuery';
+import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import {
+  OcpOnAwsReportSummaryItem,
+  OcpOnAwsReportSummaryItems,
+} from 'components/reports/ocpOnAwsReportSummary';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import {
+  ocpOnAwsReportsActions,
+  ocpOnAwsReportsSelectors,
+} from 'store/ocpOnAwsReports';
+import { formatValue } from 'utils/formatValue';
+import { ComputedOcpOnAwsReportItem } from 'utils/getComputedOcpOnAwsReportItems';
+import { styles } from './detailsSummary.styles';
+
+interface DetailsSummaryOwnProps {
+  groupBy: string;
+  item: ComputedOcpOnAwsReportItem;
+}
+
+interface DetailsSummaryStateProps {
+  queryString?: string;
+  report?: OcpOnAwsReport;
+  reportFetchStatus?: FetchStatus;
+}
+
+interface DetailsSummaryDispatchProps {
+  fetchReport?: typeof ocpOnAwsReportsActions.fetchReport;
+}
+
+type DetailsSummaryProps = DetailsSummaryOwnProps &
+  DetailsSummaryStateProps &
+  DetailsSummaryDispatchProps &
+  InjectedTranslateProps;
+
+const reportType = OcpOnAwsReportType.cost;
+
+class DetailsSummaryBase extends React.Component<DetailsSummaryProps> {
+  public componentDidMount() {
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
+  }
+
+  public componentDidUpdate(prevProps: DetailsSummaryProps) {
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportType, queryString);
+    }
+  }
+
+  public render() {
+    const { report, t } = this.props;
+
+    return (
+      <div>
+        {t('ocp_on_aws_details.historical.project_title')}
+        <div className={css(styles.projectsProgressBar)}>
+          <OcpOnAwsReportSummaryItems idKey="project" report={report}>
+            {({ items }) =>
+              items.map(reportItem => (
+                <OcpOnAwsReportSummaryItem
+                  key={reportItem.id}
+                  formatOptions={{}}
+                  formatValue={formatValue}
+                  label={reportItem.label.toString()}
+                  totalValue={report.meta.total.cost.value}
+                  units={reportItem.units}
+                  value={reportItem.cost}
+                />
+              ))
+            }
+          </OcpOnAwsReportSummaryItems>
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  DetailsSummaryOwnProps,
+  DetailsSummaryStateProps
+>((state, { groupBy, item }) => {
+  const query: OcpOnAwsQuery = {
+    filter: {
+      time_scope_units: 'month',
+      time_scope_value: -1,
+      resolution: 'monthly',
+      limit: 5,
+    },
+    group_by: {
+      project: '*',
+      [groupBy]: item.label || item.id,
+    },
+  };
+  const queryString = getQuery(query);
+  const report = ocpOnAwsReportsSelectors.selectReport(
+    state,
+    reportType,
+    queryString
+  );
+  const reportFetchStatus = ocpOnAwsReportsSelectors.selectReportFetchStatus(
+    state,
+    reportType,
+    queryString
+  );
+  return {
+    report,
+    reportFetchStatus,
+    queryString,
+  };
+});
+
+const mapDispatchToProps: DetailsSummaryDispatchProps = {
+  fetchReport: ocpOnAwsReportsActions.fetchReport,
+};
+
+const DetailsSummary = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(DetailsSummaryBase)
+);
+
+export { DetailsSummary, DetailsSummaryProps };

--- a/src/pages/ocpOnAwsDetails/detailsTable.styles.ts
+++ b/src/pages/ocpOnAwsDetails/detailsTable.styles.ts
@@ -1,0 +1,83 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import {
+  global_BackgroundColor_light_100,
+  global_danger_color_100,
+  global_disabled_color_100,
+  global_FontSize_xs,
+  global_spacer_3xl,
+  global_spacer_xs,
+  global_success_color_100,
+} from '@patternfly/react-tokens';
+import { css } from 'emotion';
+
+export const styles = StyleSheet.create({
+  emptyState: {
+    backgroundColor: global_BackgroundColor_light_100.value,
+    display: 'flex',
+    justifyContent: 'center',
+    paddingTop: global_spacer_3xl.value,
+    height: '35vh',
+    width: '100%',
+  },
+  infoArrow: {
+    position: 'relative',
+  },
+  infoArrowDesc: {
+    bottom: global_spacer_xs.value,
+  },
+  infoDescription: {
+    color: global_disabled_color_100.value,
+    fontSize: global_FontSize_xs.value,
+  },
+});
+
+export const monthOverMonthOverride = css`
+  div {
+    display: block;
+    margin-right: 0;
+    margin-bottom: ${global_spacer_xs.value};
+    &.iconOverride {
+      &.decrease {
+        color: ${global_success_color_100.value};
+      }
+      &.increase {
+        color: ${global_danger_color_100.value};
+      }
+      .fa-sort-asc,
+      .fa-sort-desc {
+        margin-left: 10px;
+      }
+      .fa-sort-asc::before {
+        color: ${global_danger_color_100.value};
+      }
+      .fa-sort-desc::before {
+        color: ${global_success_color_100.value};
+      }
+      span {
+        margin-right: -17px !important;
+      }
+    }
+  }
+`;
+
+export const tableOverride = css`
+  &.pf-c-table {
+    &.tag {
+      tbody td + td + td {
+        text-align: right;
+      }
+    }
+    thead th + th {
+      .pf-c-button {
+        text-align: right;
+      }
+      text-align: right;
+    }
+    tbody td + td + td + td {
+      text-align: right;
+    }
+    td {
+      vertical-align: top;
+    }
+  }
+`;

--- a/src/pages/ocpOnAwsDetails/detailsTable.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsTable.tsx
@@ -1,0 +1,419 @@
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+} from '@patternfly/react-core';
+import { CalculatorIcon } from '@patternfly/react-icons';
+import { css } from '@patternfly/react-styles';
+import {
+  sortable,
+  SortByDirection,
+  Table,
+  TableBody,
+  TableHeader,
+} from '@patternfly/react-table';
+import { getQuery, OcpOnAwsQuery } from 'api/ocpOnAwsQuery';
+import { OcpOnAwsReport } from 'api/ocpOnAwsReports';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { formatCurrency } from 'utils/formatValue';
+import {
+  getIdKeyForGroupBy,
+  getUnsortedComputedOcpOnAwsReportItems,
+} from 'utils/getComputedOcpOnAwsReportItems';
+import { ComputedOcpOnAwsReportItem } from 'utils/getComputedOcpOnAwsReportItems';
+import {
+  monthOverMonthOverride,
+  styles,
+  tableOverride,
+} from './detailsTable.styles';
+import { DetailsTableItem } from './detailsTableItem';
+
+interface DetailsTableOwnProps {
+  onSelected(selectedItems: ComputedOcpOnAwsReportItem[]);
+  onSort(value: string, isSortAscending: boolean);
+  query: OcpOnAwsQuery;
+  report: OcpOnAwsReport;
+}
+
+interface DetailsTableState {
+  columns?: any[];
+  isHistoricalModalOpen?: boolean;
+  rows?: any[];
+}
+
+type DetailsTableProps = DetailsTableOwnProps & InjectedTranslateProps;
+
+class DetailsTableBase extends React.Component<DetailsTableProps> {
+  public state: DetailsTableState = {
+    columns: [],
+    isHistoricalModalOpen: false,
+    rows: [],
+  };
+
+  constructor(props: DetailsTableProps) {
+    super(props);
+    this.handleOnCollapse = this.handleOnCollapse.bind(this);
+    this.handleOnSelect = this.handleOnSelect.bind(this);
+    this.handleOnSort = this.handleOnSort.bind(this);
+  }
+
+  public componentDidMount() {
+    this.initDatum();
+  }
+
+  public componentDidUpdate(prevProps: DetailsTableProps) {
+    const { query, report } = this.props;
+    const currentReport =
+      report && report.data ? JSON.stringify(report.data) : '';
+    const previousReport =
+      prevProps.report && prevProps.report.data
+        ? JSON.stringify(prevProps.report.data)
+        : '';
+
+    if (
+      getQuery(prevProps.query) !== getQuery(query) ||
+      previousReport !== currentReport
+    ) {
+      this.initDatum();
+    }
+  }
+
+  private initDatum = () => {
+    const { query, report, t } = this.props;
+    if (!query || !report) {
+      return;
+    }
+
+    const groupById = getIdKeyForGroupBy(query.group_by);
+    const groupByTagKey = this.getGroupByTagKey();
+
+    const total = formatCurrency(
+      report && report.meta && report.meta.total
+        ? report.meta.total.cost.value
+        : 0
+    );
+
+    const columns = groupByTagKey
+      ? [
+          {
+            title: t('ocp_on_aws_details.tag_column_title'),
+          },
+          {
+            title: t('ocp_on_aws_details.change_column_title'),
+          },
+          {
+            orderBy: 'cost',
+            title: t('ocp_on_aws_details.cost_column_title', { total }),
+            transforms: [sortable],
+          },
+        ]
+      : [
+          {
+            orderBy: groupById,
+            title: t('ocp_on_aws_details.name_column_title', {
+              groupBy: groupById,
+            }),
+            transforms: [sortable],
+          },
+          {
+            title: t('ocp_on_aws_details.change_column_title'),
+          },
+          {
+            orderBy: 'cost',
+            title: t('ocp_on_aws_details.cost_column_title', { total }),
+            transforms: [sortable],
+          },
+        ];
+
+    const rows = [];
+    const computedItems = getUnsortedComputedOcpOnAwsReportItems({
+      report,
+      idKey: (groupByTagKey as any) || groupById,
+    });
+
+    computedItems.map((item, index) => {
+      const label = item && item.label !== null ? item.label : '';
+      const monthOverMonth = this.getMonthOverMonthCost(item, index);
+      const cost = this.getTotalCost(item, index);
+      rows.push(
+        {
+          cells: [
+            { title: <div>{label}</div> },
+            { title: <div>{monthOverMonth}</div> },
+            { title: <div>{cost}</div> },
+          ],
+          isOpen: false,
+          item,
+          tableItem: {
+            groupBy: groupByTagKey ? `tag:${groupByTagKey}` : groupById,
+            index,
+            item,
+            query,
+          },
+        },
+        {
+          parent: index * 2,
+          cells: [<div key={`${index * 2}-child`}>{t('loading')}</div>],
+        }
+      );
+    });
+
+    this.setState({
+      columns,
+      rows,
+      sortBy: {},
+    });
+  };
+
+  private getEmptyState = () => {
+    const { t } = this.props;
+
+    return (
+      <EmptyState>
+        <EmptyStateIcon icon={CalculatorIcon} />
+        <EmptyStateBody>{t('aws_details.empty_state')}</EmptyStateBody>
+      </EmptyState>
+    );
+  };
+
+  private getGroupByTagKey = () => {
+    const { query } = this.props;
+    let groupByTagKey;
+
+    for (const groupBy of Object.keys(query.group_by)) {
+      const tagIndex = groupBy.indexOf('tag:');
+      if (tagIndex !== -1) {
+        groupByTagKey = groupBy.substring(tagIndex + 4) as any;
+        break;
+      }
+    }
+    return groupByTagKey;
+  };
+
+  private getMonthOverMonthCost = (
+    item: ComputedOcpOnAwsReportItem,
+    index: number
+  ) => {
+    const { t } = this.props;
+
+    const today = new Date();
+    const date = today.getDate();
+    const month = (((today.getMonth() - 1) % 12) + 12) % 12;
+    const value = formatCurrency(Math.abs(item.deltaValue));
+    const percentage =
+      item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
+
+    let iconOverride = 'iconOverride';
+    if (item.deltaPercent !== null && item.deltaValue < 0) {
+      iconOverride += ' decrease';
+    }
+    if (item.deltaPercent !== null && item.deltaValue > 0) {
+      iconOverride += ' increase';
+    }
+
+    return (
+      <div className={monthOverMonthOverride}>
+        <div className={iconOverride} key={`month-over-month-cost-${index}`}>
+          {t('percent', { value: percentage })}
+          {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
+            <span
+              className={css('fa fa-sort-asc', styles.infoArrow)}
+              key={`month-over-month-icon-${index}`}
+            />
+          )}
+          {Boolean(item.deltaPercent !== null && item.deltaValue < 0) && (
+            <span
+              className={css(
+                'fa fa-sort-desc',
+                styles.infoArrow,
+                styles.infoArrowDesc
+              )}
+              key={`month-over-month-icon-${index}`}
+            />
+          )}
+        </div>
+        <div
+          className={css(styles.infoDescription)}
+          key={`month-over-month-info-${index}`}
+        >
+          {Boolean(item.deltaPercent !== null && item.deltaValue > 0)
+            ? Boolean(date < 31)
+              ? t('ocp_on_aws_details.increase_since_date', {
+                  date,
+                  month,
+                  value,
+                })
+              : t('ocp_on_aws_details.increase_since_last_month', {
+                  date,
+                  month,
+                  value,
+                })
+            : Boolean(item.deltaPercent !== null && item.deltaValue < 0)
+            ? Boolean(date < 31)
+              ? t('ocp_on_aws_details.decrease_since_date', {
+                  date,
+                  month,
+                  value,
+                })
+              : t('ocp_on_aws_details.decrease_since_last_month', {
+                  date,
+                  month,
+                  value,
+                })
+            : t('ocp_on_aws_details.no_change_since_date', { date, month })}
+        </div>
+      </div>
+    );
+  };
+
+  private getSortBy = () => {
+    const { query } = this.props;
+    const { columns } = this.state;
+    const groupByTagKey = this.getGroupByTagKey();
+
+    let index = -1;
+    let direction = 'asc';
+
+    for (const key of Object.keys(query.order_by)) {
+      let c = 0;
+      for (const column of columns) {
+        if (column.orderBy === key) {
+          direction =
+            query.order_by[key] === 'asc'
+              ? SortByDirection.asc
+              : SortByDirection.desc;
+          index = c + (groupByTagKey ? 1 : 2);
+          break;
+        }
+        c++;
+      }
+    }
+    return index > -1 ? { index, direction } : {};
+  };
+
+  private getTableItem = (
+    item: ComputedOcpOnAwsReportItem,
+    groupBy: string,
+    query: OcpOnAwsQuery,
+    index: number
+  ) => {
+    return (
+      <>
+        <DetailsTableItem
+          groupBy={groupBy}
+          item={item}
+          key={`table-item-${index}`}
+        />
+      </>
+    );
+  };
+
+  private getTotalCost = (item: ComputedOcpOnAwsReportItem, index: number) => {
+    const { report, t } = this.props;
+    const total = report.meta.total.cost.value;
+
+    return (
+      <>
+        {formatCurrency(item.cost)}
+        <div
+          className={css(styles.infoDescription)}
+          key={`total-cost-${index}`}
+        >
+          {t('percent_of_cost', {
+            value: ((item.cost / total) * 100).toFixed(2),
+          })}
+        </div>
+      </>
+    );
+  };
+
+  private handleOnCollapse = (event, rowId, isOpen) => {
+    const { t } = this.props;
+    const { rows } = this.state;
+    const {
+      tableItem: { item, groupBy, query, index },
+    } = rows[rowId];
+
+    if (isOpen) {
+      rows[rowId + 1].cells = [this.getTableItem(item, groupBy, query, index)];
+    } else {
+      rows[rowId + 1].cells = [
+        <div key={`${index * 2}-child`}>{t('loading')}</div>,
+      ];
+    }
+    rows[rowId].isOpen = isOpen;
+
+    this.setState({
+      rows,
+    });
+  };
+
+  private handleOnSelect = (event, isSelected, rowId) => {
+    const { onSelected } = this.props;
+
+    let rows;
+    if (rowId === -1) {
+      rows = this.state.rows.map(row => {
+        row.selected = isSelected;
+        return row;
+      });
+    } else {
+      rows = [...this.state.rows];
+      rows[rowId].selected = isSelected;
+    }
+
+    if (onSelected) {
+      const selectedItems = [];
+      for (const row of rows) {
+        if (row.selected && row.item && !row.parent) {
+          selectedItems.push(row.item);
+        }
+      }
+      onSelected(selectedItems);
+    }
+    this.setState({ rows });
+  };
+
+  private handleOnSort = (event, index, direction) => {
+    const { onSort } = this.props;
+    const { columns } = this.state;
+    const groupByTagKey = this.getGroupByTagKey();
+
+    if (onSort) {
+      const orderBy = columns[index - (groupByTagKey ? 1 : 2)].orderBy;
+      const isSortAscending = direction === SortByDirection.asc;
+      onSort(orderBy, isSortAscending);
+    }
+  };
+
+  public render() {
+    const { columns, rows } = this.state;
+
+    return (
+      <>
+        <Table
+          aria-label="details-table"
+          cells={columns}
+          className={tableOverride}
+          onCollapse={this.handleOnCollapse}
+          rows={rows}
+          sortBy={this.getSortBy()}
+          onSelect={this.handleOnSelect}
+          onSort={this.handleOnSort}
+        >
+          <TableHeader />
+          <TableBody />
+        </Table>
+        {Boolean(rows.length === 0) && (
+          <div className={css(styles.emptyState)}>{this.getEmptyState()}</div>
+        )}
+      </>
+    );
+  }
+}
+
+const DetailsTable = translate()(connect()(DetailsTableBase));
+
+export { DetailsTable, DetailsTableProps };

--- a/src/pages/ocpOnAwsDetails/detailsTableItem.styles.ts
+++ b/src/pages/ocpOnAwsDetails/detailsTableItem.styles.ts
@@ -1,0 +1,20 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_3xl, global_spacer_xl } from '@patternfly/react-tokens';
+// import { css } from 'emotion';
+
+export const styles = StyleSheet.create({
+  historicalLinkContainer: {
+    display: 'flex',
+    justifyContent: 'flex-end',
+    paddingTop: global_spacer_xl.value,
+  },
+  measureChartContainer: {
+    paddingTop: global_spacer_xl.value,
+  },
+  projectsContainer: {
+    paddingTop: global_spacer_xl.value,
+  },
+  summaryContainer: {
+    marginRight: global_spacer_3xl.value,
+  },
+});

--- a/src/pages/ocpOnAwsDetails/detailsTableItem.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsTableItem.tsx
@@ -1,0 +1,123 @@
+import {
+  Button,
+  ButtonType,
+  ButtonVariant,
+  Form,
+  FormGroup,
+  Grid,
+  GridItem,
+} from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { getTestProps, testIds } from 'testIds';
+import { ComputedOcpOnAwsReportItem } from 'utils/getComputedOcpOnAwsReportItems';
+import { DetailsChart } from './detailsChart';
+import { DetailsCluster } from './detailsCluster';
+import { DetailsSummary } from './detailsSummary';
+import { styles } from './detailsTableItem.styles';
+import { DetailsTag } from './detailsTag';
+import { HistoricalModal } from './historicalModal';
+
+interface DetailsTableItemOwnProps {
+  groupBy: string;
+  item: ComputedOcpOnAwsReportItem;
+}
+
+interface DetailsTableItemState {
+  isHistoricalModalOpen: boolean;
+}
+
+type DetailsTableItemProps = DetailsTableItemOwnProps & InjectedTranslateProps;
+
+class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
+  public state: DetailsTableItemState = {
+    isHistoricalModalOpen: false,
+  };
+
+  constructor(props: DetailsTableItemProps) {
+    super(props);
+    this.handleHistoricalModalClose = this.handleHistoricalModalClose.bind(
+      this
+    );
+    this.handleHistoricalModalOpen = this.handleHistoricalModalOpen.bind(this);
+  }
+
+  public handleHistoricalModalClose = (isOpen: boolean) => {
+    this.setState({ isHistoricalModalOpen: isOpen });
+  };
+
+  public handleHistoricalModalOpen = () => {
+    this.setState({ isHistoricalModalOpen: true });
+  };
+
+  public render() {
+    const { item, groupBy, t } = this.props;
+    const { isHistoricalModalOpen } = this.state;
+
+    return (
+      <>
+        <Grid>
+          <GridItem md={12} lg={3}>
+            <div className={css(styles.projectsContainer)}>
+              {Boolean(groupBy === 'project') && (
+                <Form>
+                  <FormGroup
+                    label={t('ocp_on_aws_details.cluster_label')}
+                    fieldId="cluster-name"
+                  >
+                    <DetailsCluster groupBy={groupBy} item={item} />
+                  </FormGroup>
+                  <FormGroup
+                    label={t('ocp_on_aws_details.tags_label')}
+                    fieldId="tags"
+                  >
+                    <DetailsTag
+                      groupBy={groupBy}
+                      id="tags"
+                      item={item}
+                      project={item.label || item.id}
+                    />
+                  </FormGroup>
+                </Form>
+              )}
+              {Boolean(groupBy === 'cluster' || groupBy === 'node') && (
+                <div className={css(styles.summaryContainer)}>
+                  <DetailsSummary groupBy={groupBy} item={item} />
+                </div>
+              )}
+            </div>
+          </GridItem>
+          <GridItem md={12} lg={6}>
+            <div className={css(styles.measureChartContainer)}>
+              <DetailsChart groupBy={groupBy} item={item} />
+            </div>
+          </GridItem>
+          <GridItem md={12} lg={3}>
+            <div className={css(styles.historicalLinkContainer)}>
+              <Button
+                {...getTestProps(testIds.details.historical_data_btn)}
+                onClick={this.handleHistoricalModalOpen}
+                type={ButtonType.button}
+                variant={ButtonVariant.secondary}
+              >
+                {t('ocp_on_aws_details.historical.view_data')}
+              </Button>
+            </div>
+          </GridItem>
+        </Grid>
+        <HistoricalModal
+          groupBy={groupBy}
+          isOpen={isHistoricalModalOpen}
+          item={item}
+          onClose={this.handleHistoricalModalClose}
+        />
+      </>
+    );
+  }
+}
+
+const DetailsTableItem = translate()(connect()(DetailsTableItemBase));
+
+export { DetailsTableItem, DetailsTableItemProps };

--- a/src/pages/ocpOnAwsDetails/detailsTag.styles.ts
+++ b/src/pages/ocpOnAwsDetails/detailsTag.styles.ts
@@ -1,0 +1,9 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_3xl, global_spacer_sm } from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  tagsContainer: {
+    marginRight: global_spacer_3xl.value,
+    marginTop: global_spacer_sm.value,
+  },
+});

--- a/src/pages/ocpOnAwsDetails/detailsTag.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsTag.tsx
@@ -1,0 +1,172 @@
+import { css } from '@patternfly/react-styles';
+import { getQuery } from 'api/ocpOnAwsQuery';
+import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import {
+  ocpOnAwsReportsActions,
+  ocpOnAwsReportsSelectors,
+} from 'store/ocpOnAwsReports';
+import { getTestProps, testIds } from 'testIds';
+import { ComputedOcpOnAwsReportItem } from 'utils/getComputedOcpOnAwsReportItems';
+import { styles } from './detailsTag.styles';
+import { DetailsTagModal } from './detailsTagModal';
+
+interface DetailsTagOwnProps {
+  groupBy: string;
+  id?: string;
+  item: ComputedOcpOnAwsReportItem;
+  project: string | number;
+}
+
+interface DetailsTagState {
+  isDetailsModalOpen: boolean;
+  showAll: boolean;
+}
+
+interface DetailsTagStateProps {
+  queryString?: string;
+  report?: OcpOnAwsReport;
+  reportFetchStatus?: FetchStatus;
+}
+
+interface DetailsTagDispatchProps {
+  fetchReport?: typeof ocpOnAwsReportsActions.fetchReport;
+}
+
+type DetailsTagProps = DetailsTagOwnProps &
+  DetailsTagStateProps &
+  DetailsTagDispatchProps &
+  InjectedTranslateProps;
+
+const reportType = OcpOnAwsReportType.tag;
+
+class DetailsTagBase extends React.Component<DetailsTagProps> {
+  protected defaultState: DetailsTagState = {
+    isDetailsModalOpen: false,
+    showAll: false,
+  };
+  public state: DetailsTagState = { ...this.defaultState };
+
+  constructor(props: DetailsTagProps) {
+    super(props);
+    this.handleDetailsModalClose = this.handleDetailsModalClose.bind(this);
+    this.handleDetailsModalOpen = this.handleDetailsModalOpen.bind(this);
+  }
+
+  public componentDidMount() {
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
+  }
+
+  public componentDidUpdate(prevProps: DetailsTagProps) {
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportType, queryString);
+    }
+  }
+
+  public handleDetailsModalClose = (isOpen: boolean) => {
+    this.setState({ isDetailsModalOpen: isOpen });
+  };
+
+  public handleDetailsModalOpen = event => {
+    this.setState({ isDetailsModalOpen: true });
+    event.preventDefault();
+    return false;
+  };
+
+  public render() {
+    const { groupBy, id, item, project, report, t } = this.props;
+    const { isDetailsModalOpen, showAll } = this.state;
+
+    let charCount = 0;
+    const maxChars = 50;
+    const someTags = [];
+    const allTags = [];
+
+    if (report) {
+      for (const tag of report.data) {
+        for (const val of tag.values) {
+          const prefix = someTags.length > 0 ? ', ' : '';
+          const tagString = `${prefix}${(tag as any).key}: ${val}`;
+          charCount += tagString.length;
+          allTags.push(`${(tag as any).key}: ${val}`);
+          if (charCount <= maxChars || showAll) {
+            someTags.push(tagString);
+          }
+        }
+      }
+    }
+
+    return (
+      <div className={css(styles.tagsContainer)} id={id}>
+        {Boolean(someTags) &&
+          someTags.map((tag, tagIndex) => <span key={tagIndex}>{tag}</span>)}
+        {Boolean(someTags.length < allTags.length) && (
+          <a
+            {...getTestProps(testIds.details.tag_lnk)}
+            href="#/"
+            onClick={this.handleDetailsModalOpen}
+          >
+            {t('ocp_on_aws_details.more_tags', {
+              value: allTags.length - someTags.length,
+            })}
+          </a>
+        )}
+        <DetailsTagModal
+          groupBy={groupBy}
+          isOpen={isDetailsModalOpen}
+          item={item}
+          onClose={this.handleDetailsModalClose}
+          project={project}
+        />
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  DetailsTagOwnProps,
+  DetailsTagStateProps
+>((state, { project }) => {
+  const queryString = getQuery({
+    filter: {
+      project,
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
+    },
+  });
+  const report = ocpOnAwsReportsSelectors.selectReport(
+    state,
+    reportType,
+    queryString
+  );
+  const reportFetchStatus = ocpOnAwsReportsSelectors.selectReportFetchStatus(
+    state,
+    reportType,
+    queryString
+  );
+  return {
+    project,
+    queryString,
+    report,
+    reportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: DetailsTagDispatchProps = {
+  fetchReport: ocpOnAwsReportsActions.fetchReport,
+};
+
+const DetailsTag = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(DetailsTagBase)
+);
+
+export { DetailsTag, DetailsTagProps };

--- a/src/pages/ocpOnAwsDetails/detailsTagModal.styles.ts
+++ b/src/pages/ocpOnAwsDetails/detailsTagModal.styles.ts
@@ -1,0 +1,24 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_2xl, global_spacer_lg } from '@patternfly/react-tokens';
+import { css } from 'emotion';
+
+export const styles = StyleSheet.create({
+  modal: {
+    // Workaround for isLarge not working properly
+    height: '700px',
+    width: '600px',
+  },
+  subTitle: {
+    marginTop: global_spacer_2xl.value,
+    textAlign: 'right',
+  },
+});
+
+export const modalOverride = css`
+  & .pf-c-modal-box__body {
+    margin-top: ${global_spacer_lg.value};
+  }
+  & .pf-c-modal-box__footer {
+    display: none;
+  }
+`;

--- a/src/pages/ocpOnAwsDetails/detailsTagModal.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsTagModal.tsx
@@ -1,0 +1,140 @@
+import { Modal } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import { getQuery } from 'api/ocpOnAwsQuery';
+import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import {
+  ocpOnAwsReportsActions,
+  ocpOnAwsReportsSelectors,
+} from 'store/ocpOnAwsReports';
+import { ComputedOcpOnAwsReportItem } from 'utils/getComputedOcpOnAwsReportItems';
+import { modalOverride, styles } from './detailsTagModal.styles';
+
+interface DetailsTagModalOwnProps {
+  groupBy: string;
+  isOpen: boolean;
+  item: ComputedOcpOnAwsReportItem;
+  onClose(isOpen: boolean);
+  project: string | number;
+}
+
+interface DetailsTagModalStateProps {
+  queryString?: string;
+  report?: OcpOnAwsReport;
+  reportFetchStatus?: FetchStatus;
+}
+
+interface DetailsTagModalDispatchProps {
+  fetchReport?: typeof ocpOnAwsReportsActions.fetchReport;
+}
+
+type DetailsTagModalProps = DetailsTagModalOwnProps &
+  DetailsTagModalStateProps &
+  DetailsTagModalDispatchProps &
+  InjectedTranslateProps;
+
+const reportType = OcpOnAwsReportType.tag;
+
+class DetailsTagModalBase extends React.Component<DetailsTagModalProps> {
+  constructor(props: DetailsTagModalProps) {
+    super(props);
+    this.handleClose = this.handleClose.bind(this);
+  }
+
+  public componentDidMount() {
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
+  }
+
+  public componentDidUpdate(prevProps: DetailsTagModalProps) {
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportType, queryString);
+    }
+  }
+
+  private handleClose = () => {
+    this.props.onClose(false);
+  };
+
+  private getTags = () => {
+    const { report } = this.props;
+    const tags = [];
+
+    if (report) {
+      for (const tag of report.data) {
+        for (const val of tag.values) {
+          tags.push(`${(tag as any).key}: ${val}`);
+        }
+      }
+    }
+    return tags;
+  };
+
+  public render() {
+    const { groupBy, isOpen, item, t } = this.props;
+    const tags = this.getTags();
+
+    return (
+      <Modal
+        className={`${modalOverride} ${css(styles.modal)}`}
+        isLarge
+        isOpen={isOpen}
+        onClose={this.handleClose}
+        title={t('ocp_on_aws_details.tags_modal_title', {
+          groupBy,
+          name: item.label,
+        })}
+      >
+        {tags.map((tag, index) => (
+          <div key={`tag-${index}`}>{tag}</div>
+        ))}
+      </Modal>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  DetailsTagModalOwnProps,
+  DetailsTagModalStateProps
+>((state, { project }) => {
+  const queryString = getQuery({
+    filter: {
+      project,
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
+    },
+  });
+  const report = ocpOnAwsReportsSelectors.selectReport(
+    state,
+    reportType,
+    queryString
+  );
+  const reportFetchStatus = ocpOnAwsReportsSelectors.selectReportFetchStatus(
+    state,
+    reportType,
+    queryString
+  );
+  return {
+    queryString,
+    report,
+    reportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: DetailsTagModalDispatchProps = {
+  fetchReport: ocpOnAwsReportsActions.fetchReport,
+};
+
+const DetailsTagModal = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(DetailsTagModalBase)
+);
+
+export { DetailsTagModal, DetailsTagModalProps };

--- a/src/pages/ocpOnAwsDetails/detailsToolbar.styles.ts
+++ b/src/pages/ocpOnAwsDetails/detailsToolbar.styles.ts
@@ -1,0 +1,18 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_md } from '@patternfly/react-tokens';
+import { css } from 'emotion';
+
+export const styles = StyleSheet.create({
+  export: {
+    marginRight: global_spacer_md.value,
+  },
+  paginationContainer: {
+    width: '100%',
+  },
+});
+
+export const btnOverride = css`
+  &.pf-c-button {
+    --pf-c-button--m-disabled--BackgroundColor: none;
+  }
+`;

--- a/src/pages/ocpOnAwsDetails/detailsToolbar.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsToolbar.tsx
@@ -1,0 +1,254 @@
+import { Button, ButtonVariant } from '@patternfly/react-core';
+import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
+import { css } from '@patternfly/react-styles';
+import { OcpOnAwsQuery } from 'api/ocpOnAwsQuery';
+import { OcpOnAwsReport } from 'api/ocpOnAwsReports';
+import { TextInput } from 'components/textInput';
+import { Filter, Toolbar } from 'patternfly-react';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { isEqual } from 'utils/equal';
+import { btnOverride } from './detailsToolbar.styles';
+import { styles } from './detailsToolbar.styles';
+
+interface DetailsToolbarOwnProps {
+  isExportDisabled: boolean;
+  filterFields: any[];
+  exportText: string;
+  onExportClicked();
+  onFilterAdded(filterType: string, filterValue: string);
+  onFilterRemoved(filterType: string, filterValue: string);
+  pagination?: React.ReactNode;
+  query?: OcpOnAwsQuery;
+  report?: OcpOnAwsReport;
+  resultsTotal: number;
+}
+
+type DetailsToolbarProps = DetailsToolbarOwnProps & InjectedTranslateProps;
+
+export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
+  public state = {
+    activeFilters: [],
+    currentFilterType: this.props.filterFields[0],
+    currentValue: '',
+    currentViewType: 'list',
+    filterCategory: undefined,
+    report: undefined,
+  };
+
+  public componentDidUpdate(prevProps: DetailsToolbarProps, prevState) {
+    const { filterFields, query, report } = this.props;
+    if (report && !isEqual(report, prevProps.report)) {
+      this.addQuery(query);
+    }
+    if (!isEqual(filterFields, prevProps.filterFields)) {
+      this.setState({
+        currentFilterType: this.props.filterFields[0],
+      });
+    }
+  }
+
+  public addQuery = (query: OcpOnAwsQuery) => {
+    const activeFilters = [];
+    Object.keys(query.group_by).forEach(key => {
+      if (query.group_by[key] !== '*') {
+        if (Array.isArray(query.group_by[key])) {
+          query.group_by[key].forEach(value => {
+            const field = (key as any).id || key;
+            const filter = this.getFilter(field, value);
+            activeFilters.push(filter);
+          });
+        } else {
+          const field = (key as any).id || key;
+          const filter = this.getFilter(field, query.group_by[key]);
+          activeFilters.push(filter);
+        }
+      }
+    });
+    this.setState({ activeFilters });
+  };
+
+  public clearFilters = (event: React.FormEvent<HTMLAnchorElement>) => {
+    const { currentFilterType } = this.state;
+    this.setState({ activeFilters: [] });
+    this.props.onFilterRemoved(currentFilterType.id, '');
+    event.preventDefault();
+  };
+
+  // Note: Active filters are set upon page refresh -- don't need to do that here
+  public filterAdded = (field, value) => {
+    const { currentFilterType } = this.state;
+    this.props.onFilterAdded(currentFilterType.id, value);
+  };
+
+  public getFilter = (field, value) => {
+    const { currentFilterType } = this.state;
+    const filterLabel = this.getFilterLabel(field, value);
+    return {
+      field: field.indexOf('tag:') === 0 ? field : currentFilterType.id,
+      label: filterLabel,
+      value,
+    };
+  };
+
+  public getFilterLabel = (field, value) => {
+    let filterText = '';
+    if (field.title) {
+      filterText = field.title;
+    } else {
+      filterText = field;
+    }
+
+    const index = filterText.indexOf('tag:');
+    if (index === 0) {
+      filterText = 'Tag: ' + filterText.slice(4) + ': ';
+    } else {
+      filterText =
+        filterText.charAt(0).toUpperCase() + filterText.slice(1) + ': ';
+    }
+
+    if (value.filterCategory) {
+      filterText += `${value.filterCategory.title ||
+        value.filterCategory}-${value.filterValue.title || value.filterValue}`;
+    } else if (value.title) {
+      filterText += value.title;
+    } else {
+      filterText += value;
+    }
+    return filterText;
+  };
+
+  public handleExportClicked = () => {
+    this.props.onExportClicked();
+  };
+
+  public onValueKeyPress = (e: React.KeyboardEvent) => {
+    const { currentValue, currentFilterType } = this.state;
+    if (e.key === 'Enter' && currentValue && currentValue.length > 0) {
+      this.setState({ currentValue: '' });
+      this.filterAdded(currentFilterType, currentValue);
+      e.stopPropagation();
+      e.preventDefault();
+    }
+  };
+
+  public removeFilter = filter => {
+    const { activeFilters } = this.state;
+
+    const index = activeFilters.indexOf(filter);
+    if (index > -1) {
+      const updated = [
+        ...activeFilters.slice(0, index),
+        ...activeFilters.slice(index + 1),
+      ];
+      this.setState({ activeFilters: updated });
+      this.props.onFilterRemoved(filter.field, filter.value);
+    }
+  };
+
+  public selectFilterType = filterType => {
+    const { currentFilterType } = this.state;
+    if (currentFilterType !== filterType) {
+      this.setState({
+        currentValue: '',
+        currentFilterType: filterType,
+      });
+    }
+  };
+
+  public updateCurrentValue = (currentValue: string) => {
+    this.setState({ currentValue });
+  };
+
+  public renderInput() {
+    const { currentFilterType, currentValue } = this.state;
+    if (!currentFilterType) {
+      return null;
+    }
+    return (
+      <TextInput
+        onChange={this.updateCurrentValue}
+        onKeyPress={this.onValueKeyPress}
+        placeholder={currentFilterType.placeholder}
+        type="text"
+        value={currentValue}
+      />
+    );
+  }
+
+  public render() {
+    const { isExportDisabled, pagination, t } = this.props;
+    const { activeFilters, currentFilterType } = this.state;
+
+    return (
+      <Toolbar>
+        <Filter>
+          <Filter.TypeSelector
+            filterTypes={this.props.filterFields}
+            currentFilterType={currentFilterType}
+            onFilterTypeSelected={this.selectFilterType}
+          />
+          {this.renderInput()}
+        </Filter>
+        <div className="form-group">
+          <Button
+            className={btnOverride}
+            isDisabled={isExportDisabled}
+            onClick={this.handleExportClicked}
+            variant={ButtonVariant.link}
+          >
+            <span className={css(styles.export)}>
+              {t('ocp_on_aws_details.toolbar.export')}
+            </span>
+            <ExternalLinkSquareAltIcon />
+          </Button>
+        </div>
+        {pagination && (
+          <div className={css(styles.paginationContainer)}>
+            <Toolbar.RightContent>{pagination}</Toolbar.RightContent>
+          </div>
+        )}
+        {!activeFilters ||
+          (activeFilters.length === 0 && (
+            <Toolbar.Results>
+              <h5>
+                {t('ocp_on_aws_details.toolbar.results', {
+                  value: this.props.resultsTotal,
+                })}
+              </h5>
+            </Toolbar.Results>
+          ))}
+        {activeFilters && activeFilters.length > 0 && (
+          <Toolbar.Results>
+            <h5>
+              {t('ocp_on_aws_details.toolbar.results', {
+                value: this.props.resultsTotal,
+              })}
+            </h5>
+            <Filter.ActiveLabel>
+              {t('ocp_on_aws_details.toolbar.active_filters')}
+            </Filter.ActiveLabel>
+            <Filter.List>
+              {activeFilters.map((item, index) => (
+                <Filter.Item
+                  key={index}
+                  onRemove={this.removeFilter}
+                  filterData={item}
+                >
+                  {item.label}
+                </Filter.Item>
+              ))}
+            </Filter.List>
+            <a href="#" onClick={this.clearFilters}>
+              {t('ocp_on_aws_details.toolbar.clear_filters')}
+            </a>
+          </Toolbar.Results>
+        )}
+      </Toolbar>
+    );
+  }
+}
+
+const DetailsToolbar = translate()(DetailsToolbarBase);
+
+export { DetailsToolbar };

--- a/src/pages/ocpOnAwsDetails/exportModal.styles.ts
+++ b/src/pages/ocpOnAwsDetails/exportModal.styles.ts
@@ -1,0 +1,20 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import {
+  global_spacer_sm,
+  global_spacer_xl,
+  global_spacer_xs,
+} from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  modal: {
+    h2: {
+      marginBottom: global_spacer_xl.value,
+    },
+    input: {
+      marginRight: global_spacer_xs.var,
+    },
+    ul: {
+      marginLeft: global_spacer_sm.var,
+    },
+  },
+});

--- a/src/pages/ocpOnAwsDetails/exportModal.tsx
+++ b/src/pages/ocpOnAwsDetails/exportModal.tsx
@@ -1,0 +1,221 @@
+import { Button, ButtonVariant, Modal, Radio } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import { getQuery, OcpOnAwsQuery } from 'api/ocpOnAwsQuery';
+import { OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import { AxiosError } from 'axios';
+import { FormGroup } from 'components/formGroup';
+import fileDownload from 'js-file-download';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import {
+  ocpOnAwsExportActions,
+  ocpOnAwsExportSelectors,
+} from 'store/ocpOnAwsExport';
+import { uiActions, uiSelectors } from 'store/ui';
+import { getTestProps, testIds } from 'testIds';
+import { ComputedOcpOnAwsReportItem } from 'utils/getComputedOcpOnAwsReportItems';
+import { sort, SortDirection } from 'utils/sort';
+import { styles } from './exportModal.styles';
+
+export interface ExportModalOwnProps extends InjectedTranslateProps {
+  error?: AxiosError;
+  export?: string;
+  groupBy?: string;
+  isAllItems?: boolean;
+  isExportModalOpen?: boolean;
+  isProviderModalOpen?: boolean;
+  items?: ComputedOcpOnAwsReportItem[];
+  query?: OcpOnAwsQuery;
+  queryString?: string;
+}
+
+interface ExportModalStateProps {
+  fetchStatus?: FetchStatus;
+}
+
+interface ExportModalDispatchProps {
+  exportReport?: typeof ocpOnAwsExportActions.exportReport;
+  closeExportModal?: typeof uiActions.closeExportModal;
+}
+
+interface ExportModalState {
+  resolution: string;
+}
+
+type ExportModalProps = ExportModalOwnProps &
+  ExportModalStateProps &
+  ExportModalDispatchProps &
+  InjectedTranslateProps;
+
+const resolutionOptions: {
+  label: string;
+  value: string;
+}[] = [
+  { label: 'Daily', value: 'daily' },
+  { label: 'Monthly', value: 'monthly' },
+];
+
+export class ExportModalBase extends React.Component<
+  ExportModalProps,
+  ExportModalState
+> {
+  protected defaultState: ExportModalState = {
+    resolution: 'daily',
+  };
+  public state: ExportModalState = { ...this.defaultState };
+
+  constructor(stateProps, dispatchProps) {
+    super(stateProps, dispatchProps);
+    this.handleResolutionChange = this.handleResolutionChange.bind(this);
+  }
+
+  public componentDidUpdate(prevProps: ExportModalProps) {
+    const { closeExportModal, fetchStatus, isExportModalOpen } = this.props;
+    if (isExportModalOpen && !prevProps.isExportModalOpen) {
+      this.setState({ ...this.defaultState });
+    }
+    if (
+      prevProps.export !== this.props.export &&
+      fetchStatus === FetchStatus.complete
+    ) {
+      fileDownload(this.props.export, 'report.csv', 'text/csv');
+      closeExportModal();
+    }
+  }
+
+  private getQueryString = () => {
+    const { groupBy, isAllItems, items, query } = this.props;
+    const { resolution } = this.state;
+
+    const newQuery: OcpOnAwsQuery = {
+      ...JSON.parse(JSON.stringify(query)),
+      group_by: undefined,
+      order_by: undefined,
+    };
+    newQuery.filter.resolution = resolution as any;
+    let queryString = getQuery(newQuery);
+
+    if (isAllItems) {
+      queryString += `&group_by[${groupBy}]=*`;
+    } else {
+      for (const item of items) {
+        queryString += `&group_by[${groupBy}]=` + item.label;
+      }
+    }
+    return queryString;
+  };
+
+  private handleCancel = () => {
+    this.props.closeExportModal();
+  };
+
+  private handleFetchReport = () => {
+    const { exportReport } = this.props;
+    exportReport(OcpOnAwsReportType.cost, this.getQueryString());
+  };
+
+  public handleResolutionChange = (_, event) => {
+    this.setState({ resolution: event.currentTarget.value });
+  };
+
+  public render() {
+    const { fetchStatus, groupBy, items, t } = this.props;
+    const { resolution } = this.state;
+
+    const sortedItems = [...items];
+    if (this.props.isExportModalOpen) {
+      sort(sortedItems, {
+        key: 'id',
+        direction: SortDirection.asc,
+      });
+    }
+
+    let selectedLabel = t('export.selected', { groupBy });
+    if (groupBy.indexOf('tag:') !== -1) {
+      selectedLabel = t('export.selected_tags');
+    }
+
+    return (
+      <Modal
+        className={css(styles.modal)}
+        isLarge
+        isOpen={this.props.isExportModalOpen}
+        onClose={this.handleCancel}
+        title={t('export.title')}
+        actions={[
+          <Button
+            {...getTestProps(testIds.export.cancel_btn)}
+            key="cancel"
+            onClick={this.handleCancel}
+            variant={ButtonVariant.secondary}
+          >
+            {t('export.cancel')}
+          </Button>,
+          <Button
+            {...getTestProps(testIds.export.submit_btn)}
+            isDisabled={fetchStatus === FetchStatus.inProgress}
+            key="confirm"
+            onClick={this.handleFetchReport}
+            variant={ButtonVariant.primary}
+          >
+            {t('export.confirm')}
+          </Button>,
+        ]}
+      >
+        <h2>{t('export.heading', { groupBy })}</h2>
+        <FormGroup label={t('export.aggregate_type')}>
+          <React.Fragment>
+            {resolutionOptions.map((option, index) => (
+              <Radio
+                key={index}
+                id={`resolution-${index}`}
+                isValid={option.value !== undefined}
+                label={t(option.label)}
+                value={option.value}
+                checked={resolution === option.value}
+                name="resolution"
+                onChange={this.handleResolutionChange}
+                aria-label={t(option.label)}
+              />
+            ))}
+          </React.Fragment>
+        </FormGroup>
+        <FormGroup label={selectedLabel}>
+          <ul>
+            {sortedItems.map((groupItem, index) => {
+              return <li key={index}>{groupItem.label}</li>;
+            })}
+          </ul>
+        </FormGroup>
+      </Modal>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  ExportModalOwnProps,
+  ExportModalStateProps
+>(state => {
+  return {
+    error: ocpOnAwsExportSelectors.selectExportError(state),
+    export: ocpOnAwsExportSelectors.selectExport(state),
+    fetchStatus: ocpOnAwsExportSelectors.selectExportFetchStatus(state),
+    isExportModalOpen: uiSelectors.selectIsExportModalOpen(state),
+  };
+});
+
+const mapDispatchToProps: ExportModalDispatchProps = {
+  exportReport: ocpOnAwsExportActions.exportReport,
+  closeExportModal: uiActions.closeExportModal,
+};
+
+const ExportModal = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(ExportModalBase)
+);
+
+export { ExportModal, ExportModalProps };

--- a/src/pages/ocpOnAwsDetails/groupBy.styles.ts
+++ b/src/pages/ocpOnAwsDetails/groupBy.styles.ts
@@ -1,0 +1,13 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_md } from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  groupBySelector: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  groupBySelectorLabel: {
+    marginBottom: 0,
+    marginRight: global_spacer_md.var,
+  },
+});

--- a/src/pages/ocpOnAwsDetails/groupBy.tsx
+++ b/src/pages/ocpOnAwsDetails/groupBy.tsx
@@ -1,0 +1,230 @@
+import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import { getQuery, OcpOnAwsQuery } from 'api/ocpOnAwsQuery';
+import { parseQuery } from 'api/ocpOnAwsQuery';
+import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import {
+  ocpOnAwsReportsActions,
+  ocpOnAwsReportsSelectors,
+} from 'store/ocpOnAwsReports';
+import { GetComputedOcpOnAwsReportItemsParams } from 'utils/getComputedOcpOnAwsReportItems';
+import { getIdKeyForGroupBy } from 'utils/getComputedOcpOnAwsReportItems';
+import { styles } from './groupBy.styles';
+
+interface GroupByOwnProps {
+  onItemClicked(value: string);
+  queryString?: string;
+}
+
+interface GroupByStateProps {
+  report?: OcpOnAwsReport;
+  reportFetchStatus?: FetchStatus;
+}
+
+interface GroupByDispatchProps {
+  fetchReport?: typeof ocpOnAwsReportsActions.fetchReport;
+}
+
+interface GroupByState {
+  currentItem?: string;
+  isGroupByOpen: boolean;
+}
+
+type GroupByProps = GroupByOwnProps &
+  GroupByStateProps &
+  GroupByDispatchProps &
+  InjectedTranslateProps;
+
+const groupByOptions: {
+  label: string;
+  value: GetComputedOcpOnAwsReportItemsParams['idKey'];
+}[] = [
+  { label: 'cluster', value: 'cluster' },
+  { label: 'node', value: 'node' },
+  { label: 'project', value: 'project' },
+];
+
+const reportType = OcpOnAwsReportType.tag;
+
+class GroupByBase extends React.Component<GroupByProps> {
+  protected defaultState: GroupByState = {
+    isGroupByOpen: false,
+  };
+  public state: GroupByState = { ...this.defaultState };
+
+  constructor(stateProps, dispatchProps) {
+    super(stateProps, dispatchProps);
+    this.handleGroupByClick = this.handleGroupByClick.bind(this);
+    this.handleGroupBySelect = this.handleGroupBySelect.bind(this);
+    this.handleGroupByToggle = this.handleGroupByToggle.bind(this);
+  }
+
+  public componentDidMount() {
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
+    this.setState({
+      currentItem: this.getGroupBy(),
+    });
+  }
+
+  public componentDidUpdate(prevProps: GroupByProps) {
+    const { fetchReport, queryString } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportType, queryString);
+      this.setState({ currentItem: this.getGroupBy() });
+    }
+  }
+
+  public handleGroupByClick = (event, value) => {
+    const { onItemClicked } = this.props;
+    if (onItemClicked) {
+      this.setState({
+        currentItem: value,
+      });
+      onItemClicked(value);
+    }
+  };
+
+  private getDropDownItems = () => {
+    const { t } = this.props;
+
+    return groupByOptions.map(option => (
+      <DropdownItem
+        component="button"
+        key={option.value}
+        onClick={event => this.handleGroupByClick(event, option.value)}
+      >
+        {t(`group_by.values.${option.label}`)}
+      </DropdownItem>
+    ));
+  };
+
+  private getDropDownTags = () => {
+    const { report, t } = this.props;
+
+    if (report && report.data) {
+      const data = [...new Set([...report.data])]; // prune duplicates
+      return data.map(val => (
+        <DropdownItem
+          component="button"
+          key={`tag:${val}`}
+          onClick={event => this.handleGroupByClick(event, `tag:${val}`)}
+        >
+          {t('group_by.tag', { key: val })}
+        </DropdownItem>
+      ));
+    } else {
+      return [];
+    }
+  };
+
+  private getGroupBy = () => {
+    const queryFromRoute = parseQuery<OcpOnAwsQuery>(location.search);
+    let groupBy: string = getIdKeyForGroupBy(queryFromRoute.group_by);
+    const groupByKeys =
+      queryFromRoute && queryFromRoute.group_by
+        ? Object.keys(queryFromRoute.group_by)
+        : [];
+
+    for (const key of groupByKeys) {
+      const index = key.indexOf('tag:');
+      if (index !== -1) {
+        groupBy = key;
+        break;
+      }
+    }
+    return groupBy !== 'date' ? groupBy : 'project';
+  };
+
+  private handleGroupBySelect = event => {
+    this.setState({
+      isGroupByOpen: !this.state.isGroupByOpen,
+    });
+  };
+
+  private handleGroupByToggle = isGroupByOpen => {
+    this.setState({
+      isGroupByOpen,
+    });
+  };
+
+  public render() {
+    const { t } = this.props;
+    const { currentItem, isGroupByOpen } = this.state;
+
+    const dropdownItems = [
+      ...this.getDropDownItems(),
+      ...this.getDropDownTags(),
+    ];
+
+    const index = currentItem ? currentItem.indexOf('tag:') : -1;
+    const label =
+      index !== -1
+        ? t('group_by.tag', { key: currentItem.slice(4) })
+        : t(`group_by.values.${currentItem}`);
+
+    return (
+      <div className={css(styles.groupBySelector)}>
+        <label className={css(styles.groupBySelectorLabel)}>
+          {t('group_by.cost')}:
+        </label>
+        <Dropdown
+          onSelect={this.handleGroupBySelect}
+          toggle={
+            <DropdownToggle onToggle={this.handleGroupByToggle}>
+              {label}
+            </DropdownToggle>
+          }
+          isOpen={isGroupByOpen}
+          dropdownItems={dropdownItems}
+        />
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  GroupByOwnProps,
+  GroupByStateProps
+>(state => {
+  const queryString = getQuery({
+    filter: {
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
+    },
+    key_only: true,
+  });
+  const report = ocpOnAwsReportsSelectors.selectReport(
+    state,
+    reportType,
+    queryString
+  );
+  const reportFetchStatus = ocpOnAwsReportsSelectors.selectReportFetchStatus(
+    state,
+    reportType,
+    queryString
+  );
+  return {
+    queryString,
+    report,
+    reportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: GroupByDispatchProps = {
+  fetchReport: ocpOnAwsReportsActions.fetchReport,
+};
+
+const GroupBy = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(GroupByBase)
+);
+
+export { GroupBy, GroupByProps };

--- a/src/pages/ocpOnAwsDetails/historicalChart.styles.ts
+++ b/src/pages/ocpOnAwsDetails/historicalChart.styles.ts
@@ -1,0 +1,25 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import {
+  global_spacer_3xl,
+  global_spacer_lg,
+  global_spacer_sm,
+} from '@patternfly/react-tokens';
+
+export const chartStyles = {
+  chartHeight: 130,
+};
+
+export const styles = StyleSheet.create({
+  chartContainer: {
+    marginLeft: global_spacer_lg.value,
+  },
+  costChart: {
+    marginTop: global_spacer_sm.value,
+  },
+  cpuChart: {
+    marginTop: global_spacer_3xl.value,
+  },
+  memoryChart: {
+    marginTop: global_spacer_3xl.value,
+  },
+});

--- a/src/pages/ocpOnAwsDetails/historicalChart.tsx
+++ b/src/pages/ocpOnAwsDetails/historicalChart.tsx
@@ -1,0 +1,358 @@
+import { css } from '@patternfly/react-styles';
+import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import {
+  ChartType,
+  transformOcpOnAwsReport,
+} from 'components/charts/commonChart/chartUtils';
+import { HistoricalTrendChart } from 'components/charts/historicalTrendChart';
+import { HistoricalUsageChart } from 'components/charts/historicalUsageChart';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import * as ocpOnAwsReportsActions from 'store/ocpOnAwsReports/ocpOnAwsReportsActions';
+import * as ocpOnAwsReportsSelectors from 'store/ocpOnAwsReports/ocpOnAwsReportsSelectors';
+import { formatValue } from 'utils/formatValue';
+import { chartStyles, styles } from './historicalChart.styles';
+
+interface HistoricalModalOwnProps {
+  currentQueryString: string;
+  groupBy: string;
+  previousQueryString: string;
+}
+
+interface HistoricalModalStateProps {
+  currentCostReport?: OcpOnAwsReport;
+  currentCostReportFetchStatus?: FetchStatus;
+  currentCpuReport?: OcpOnAwsReport;
+  currentCpuReportFetchStatus?: FetchStatus;
+  currentLimitReport?: OcpOnAwsReport;
+  currentLimitReportFetchStatus?: FetchStatus;
+  currentMemoryReport?: OcpOnAwsReport;
+  currentMemoryReportFetchStatus?: FetchStatus;
+  previousCostReport?: OcpOnAwsReport;
+  previousCostReportFetchStatus?: FetchStatus;
+  previousCpuReport?: OcpOnAwsReport;
+  previousCpuReportFetchStatus?: FetchStatus;
+  previousLimitReport?: OcpOnAwsReport;
+  previousLimitReportFetchStatus?: FetchStatus;
+  previousMemoryReport?: OcpOnAwsReport;
+  previousMemoryReportFetchStatus?: FetchStatus;
+}
+
+interface HistoricalModalDispatchProps {
+  fetchReport?: typeof ocpOnAwsReportsActions.fetchReport;
+}
+
+type HistoricalModalProps = HistoricalModalOwnProps &
+  HistoricalModalStateProps &
+  HistoricalModalDispatchProps &
+  InjectedTranslateProps;
+
+const cpuReportType = OcpOnAwsReportType.cpu;
+const costReportType = OcpOnAwsReportType.cost;
+const memoryReportType = OcpOnAwsReportType.memory;
+
+class HistoricalModalBase extends React.Component<HistoricalModalProps> {
+  public componentDidMount() {
+    const { fetchReport, currentQueryString, previousQueryString } = this.props;
+
+    fetchReport(costReportType, currentQueryString);
+    fetchReport(cpuReportType, currentQueryString);
+    fetchReport(memoryReportType, currentQueryString);
+    fetchReport(costReportType, previousQueryString);
+    fetchReport(cpuReportType, previousQueryString);
+    fetchReport(memoryReportType, previousQueryString);
+  }
+
+  public componentDidUpdate(prevProps: HistoricalModalProps) {
+    const { fetchReport, currentQueryString, previousQueryString } = this.props;
+
+    if (prevProps.currentQueryString !== currentQueryString) {
+      fetchReport(costReportType, currentQueryString);
+      fetchReport(cpuReportType, currentQueryString);
+      fetchReport(memoryReportType, currentQueryString);
+    }
+    if (prevProps.previousQueryString !== previousQueryString) {
+      fetchReport(costReportType, previousQueryString);
+      fetchReport(cpuReportType, previousQueryString);
+      fetchReport(memoryReportType, previousQueryString);
+    }
+  }
+
+  public render() {
+    const {
+      currentCostReport,
+      currentCpuReport,
+      currentMemoryReport,
+      groupBy,
+      previousCostReport,
+      previousCpuReport,
+      previousMemoryReport,
+      t,
+    } = this.props;
+
+    // Cost data
+    const currentCostData = transformOcpOnAwsReport(
+      currentCostReport,
+      ChartType.rolling,
+      'date',
+      'cost'
+    );
+    const previousCostData = transformOcpOnAwsReport(
+      previousCostReport,
+      ChartType.rolling,
+      'date',
+      'cost'
+    );
+
+    // Cpu data
+    const currentCpuCapacityData = transformOcpOnAwsReport(
+      currentCpuReport,
+      ChartType.daily,
+      'date',
+      'capacity'
+    );
+    const currentCpuLimitData = transformOcpOnAwsReport(
+      currentCpuReport,
+      ChartType.daily,
+      'date',
+      'limit'
+    );
+    const currentCpuRequestData = transformOcpOnAwsReport(
+      currentCpuReport,
+      ChartType.daily,
+      'date',
+      'request'
+    );
+    const currentCpuUsageData = transformOcpOnAwsReport(
+      currentCpuReport,
+      ChartType.daily,
+      'date',
+      'usage'
+    );
+    const previousCpuCapacityData = transformOcpOnAwsReport(
+      previousCpuReport,
+      ChartType.daily,
+      'date',
+      'capacity'
+    );
+    const previousCpuLimitData = transformOcpOnAwsReport(
+      previousCpuReport,
+      ChartType.daily,
+      'date',
+      'limit'
+    );
+    const previousCpuRequestData = transformOcpOnAwsReport(
+      previousCpuReport,
+      ChartType.daily,
+      'date',
+      'request'
+    );
+    const previousCpuUsageData = transformOcpOnAwsReport(
+      previousCpuReport,
+      ChartType.daily,
+      'date',
+      'usage'
+    );
+
+    // Memory data
+    const currentMemoryCapacityData = transformOcpOnAwsReport(
+      currentMemoryReport,
+      ChartType.daily,
+      'date',
+      'capacity'
+    );
+    const currentMemoryLimitData = transformOcpOnAwsReport(
+      currentMemoryReport,
+      ChartType.daily,
+      'date',
+      'limit'
+    );
+    const currentMemoryRequestData = transformOcpOnAwsReport(
+      currentMemoryReport,
+      ChartType.daily,
+      'date',
+      'request'
+    );
+    const currentMemoryUsageData = transformOcpOnAwsReport(
+      currentMemoryReport,
+      ChartType.daily,
+      'date',
+      'usage'
+    );
+    const previousMemoryCapacityData = transformOcpOnAwsReport(
+      previousCpuReport,
+      ChartType.daily,
+      'date',
+      'capacity'
+    );
+    const previousMemoryLimitData = transformOcpOnAwsReport(
+      previousCpuReport,
+      ChartType.daily,
+      'date',
+      'limit'
+    );
+    const previousMemoryRequestData = transformOcpOnAwsReport(
+      previousMemoryReport,
+      ChartType.daily,
+      'date',
+      'request'
+    );
+    const previousMemoryUsageData = transformOcpOnAwsReport(
+      previousMemoryReport,
+      ChartType.daily,
+      'date',
+      'usage'
+    );
+
+    return (
+      <div className={css(styles.chartContainer)}>
+        <div className={css(styles.costChart)}>
+          <HistoricalTrendChart
+            height={chartStyles.chartHeight}
+            currentData={currentCostData}
+            formatDatumValue={formatValue}
+            formatDatumOptions={{}}
+            previousData={previousCostData}
+            title={t('ocp_on_aws_details.historical.cost_title', { groupBy })}
+            xAxisLabel={t('ocp_on_aws_details.historical.day_of_month_label')}
+            yAxisLabel={t('ocp_on_aws_details.historical.cost_label')}
+          />
+        </div>
+        <div className={css(styles.cpuChart)}>
+          <HistoricalUsageChart
+            currentCapacityData={currentCpuCapacityData}
+            currentLimitData={currentCpuLimitData}
+            currentRequestData={currentCpuRequestData}
+            currentUsageData={currentCpuUsageData}
+            formatDatumValue={formatValue}
+            formatDatumOptions={{}}
+            height={chartStyles.chartHeight}
+            previousCapacityData={previousCpuCapacityData}
+            previousLimitData={previousCpuLimitData}
+            previousRequestData={previousCpuRequestData}
+            previousUsageData={previousCpuUsageData}
+            title={t('ocp_on_aws_details.historical.cpu_title', { groupBy })}
+            xAxisLabel={t('ocp_on_aws_details.historical.day_of_month_label')}
+            yAxisLabel={t('ocp_on_aws_details.historical.cpu_label')}
+          />
+        </div>
+        <div className={css(styles.memoryChart)}>
+          <HistoricalUsageChart
+            currentCapacityData={currentMemoryCapacityData}
+            currentLimitData={currentMemoryLimitData}
+            currentRequestData={currentMemoryRequestData}
+            currentUsageData={currentMemoryUsageData}
+            formatDatumValue={formatValue}
+            formatDatumOptions={{}}
+            height={chartStyles.chartHeight}
+            previousCapacityData={previousMemoryCapacityData}
+            previousLimitData={previousMemoryLimitData}
+            previousRequestData={previousMemoryRequestData}
+            previousUsageData={previousMemoryUsageData}
+            title={t('ocp_on_aws_details.historical.memory_title', { groupBy })}
+            xAxisLabel={t('ocp_on_aws_details.historical.day_of_month_label')}
+            yAxisLabel={t('ocp_on_aws_details.historical.memory_label')}
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  HistoricalModalOwnProps,
+  HistoricalModalStateProps
+>((state, { currentQueryString, previousQueryString }) => {
+  // Current report
+  const currentCostReport = ocpOnAwsReportsSelectors.selectReport(
+    state,
+    costReportType,
+    currentQueryString
+  );
+  const currentCostReportFetchStatus = ocpOnAwsReportsSelectors.selectReportFetchStatus(
+    state,
+    costReportType,
+    currentQueryString
+  );
+  const currentCpuReport = ocpOnAwsReportsSelectors.selectReport(
+    state,
+    cpuReportType,
+    currentQueryString
+  );
+  const currentCpuReportFetchStatus = ocpOnAwsReportsSelectors.selectReportFetchStatus(
+    state,
+    cpuReportType,
+    currentQueryString
+  );
+  const currentMemoryReport = ocpOnAwsReportsSelectors.selectReport(
+    state,
+    memoryReportType,
+    currentQueryString
+  );
+  const currentMemoryReportFetchStatus = ocpOnAwsReportsSelectors.selectReportFetchStatus(
+    state,
+    memoryReportType,
+    currentQueryString
+  );
+
+  // Previous report
+  const previousCostReport = ocpOnAwsReportsSelectors.selectReport(
+    state,
+    costReportType,
+    previousQueryString
+  );
+  const previousCostReportFetchStatus = ocpOnAwsReportsSelectors.selectReportFetchStatus(
+    state,
+    costReportType,
+    previousQueryString
+  );
+  const previousCpuReport = ocpOnAwsReportsSelectors.selectReport(
+    state,
+    cpuReportType,
+    previousQueryString
+  );
+  const previousCpuReportFetchStatus = ocpOnAwsReportsSelectors.selectReportFetchStatus(
+    state,
+    cpuReportType,
+    previousQueryString
+  );
+  const previousMemoryReport = ocpOnAwsReportsSelectors.selectReport(
+    state,
+    memoryReportType,
+    previousQueryString
+  );
+  const previousMemoryReportFetchStatus = ocpOnAwsReportsSelectors.selectReportFetchStatus(
+    state,
+    memoryReportType,
+    previousQueryString
+  );
+  return {
+    currentCostReport,
+    currentCostReportFetchStatus,
+    currentCpuReport,
+    currentCpuReportFetchStatus,
+    currentMemoryReport,
+    currentMemoryReportFetchStatus,
+    previousCostReport,
+    previousCostReportFetchStatus,
+    previousCpuReport,
+    previousCpuReportFetchStatus,
+    previousMemoryReport,
+    previousMemoryReportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: HistoricalModalDispatchProps = {
+  fetchReport: ocpOnAwsReportsActions.fetchReport,
+};
+
+const HistoricalChart = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(HistoricalModalBase)
+);
+
+export { HistoricalChart, HistoricalModalProps };

--- a/src/pages/ocpOnAwsDetails/historicalModal.styles.ts
+++ b/src/pages/ocpOnAwsDetails/historicalModal.styles.ts
@@ -1,0 +1,16 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { css } from 'emotion';
+
+export const styles = StyleSheet.create({
+  modal: {
+    // Workaround for isLarge not working properly
+    height: '900px',
+    width: '1100px',
+  },
+});
+
+export const modalOverride = css`
+  & .pf-c-modal-box__footer {
+    display: none;
+  }
+`;

--- a/src/pages/ocpOnAwsDetails/historicalModal.tsx
+++ b/src/pages/ocpOnAwsDetails/historicalModal.tsx
@@ -1,0 +1,122 @@
+import { Modal } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import { getQuery, OcpOnAwsQuery } from 'api/ocpOnAwsQuery';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps } from 'store/common';
+import { ocpOnAwsDashboardSelectors } from 'store/ocpOnAwsDashboard';
+import { ComputedOcpOnAwsReportItem } from 'utils/getComputedOcpOnAwsReportItems';
+import { HistoricalChart } from './historicalChart';
+import { modalOverride, styles } from './historicalModal.styles';
+
+interface HistoricalModalOwnProps {
+  groupBy: string;
+  isOpen: boolean;
+  item: ComputedOcpOnAwsReportItem;
+  onClose(isOpen: boolean);
+}
+
+interface HistoricalModalStateProps {
+  currentQueryString: string;
+  previousQueryString: string;
+  widgets: number[];
+}
+
+type HistoricalModalProps = HistoricalModalOwnProps &
+  HistoricalModalStateProps &
+  InjectedTranslateProps;
+
+class HistoricalModalBase extends React.Component<HistoricalModalProps> {
+  constructor(props: HistoricalModalProps) {
+    super(props);
+    this.handleClose = this.handleClose.bind(this);
+  }
+
+  public componentDidMount() {
+    this.setState({});
+  }
+
+  public shouldComponentUpdate(nextProps: HistoricalModalProps) {
+    const { isOpen, item } = this.props;
+    return nextProps.item !== item || nextProps.isOpen !== isOpen;
+  }
+
+  private handleClose = () => {
+    this.props.onClose(false);
+  };
+
+  public render() {
+    const {
+      currentQueryString,
+      groupBy,
+      isOpen,
+      item,
+      previousQueryString,
+      t,
+    } = this.props;
+
+    return (
+      <Modal
+        className={`${modalOverride} ${css(styles.modal)}`}
+        isLarge
+        isOpen={isOpen}
+        onClose={this.handleClose}
+        title={t('ocp_on_aws_details.historical.modal_title', {
+          groupBy,
+          name: item.label,
+        })}
+      >
+        <HistoricalChart
+          currentQueryString={currentQueryString}
+          groupBy={groupBy}
+          previousQueryString={previousQueryString}
+        />
+      </Modal>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  HistoricalModalOwnProps,
+  HistoricalModalStateProps
+>((state, { groupBy, item }) => {
+  const currentQuery: OcpOnAwsQuery = {
+    filter: {
+      time_scope_units: 'month',
+      time_scope_value: -1,
+      resolution: 'daily',
+      limit: 5,
+    },
+    group_by: {
+      [groupBy]: item.label || item.id,
+    },
+  };
+  const currentQueryString = getQuery(currentQuery);
+  const previousQuery: OcpOnAwsQuery = {
+    filter: {
+      time_scope_units: 'month',
+      time_scope_value: -2,
+      resolution: 'daily',
+      limit: 5,
+    },
+    group_by: {
+      [groupBy]: item.label || item.id,
+    },
+  };
+  const previousQueryString = getQuery(previousQuery);
+  return {
+    currentQueryString,
+    previousQueryString,
+    widgets: ocpOnAwsDashboardSelectors.selectCurrentWidgets(state),
+  };
+});
+
+const HistoricalModal = translate()(
+  connect(
+    mapStateToProps,
+    {}
+  )(HistoricalModalBase)
+);
+
+export { HistoricalModal };

--- a/src/pages/ocpOnAwsDetails/index.ts
+++ b/src/pages/ocpOnAwsDetails/index.ts
@@ -1,0 +1,4 @@
+import { hot } from 'react-hot-loader';
+import OcpOnAwsDetails from './ocpOnAwsDetails';
+
+export default hot(module)(OcpOnAwsDetails);

--- a/src/pages/ocpOnAwsDetails/ocpOnAwsDetails.styles.ts
+++ b/src/pages/ocpOnAwsDetails/ocpOnAwsDetails.styles.ts
@@ -1,0 +1,146 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import {
+  global_BackgroundColor_300,
+  global_BackgroundColor_light_100,
+  global_BorderRadius_sm,
+  global_Color_100,
+  global_Color_200,
+  global_FontSize_lg,
+  global_FontSize_md,
+  global_FontSize_sm,
+  global_FontSize_xs,
+  global_FontWeight_normal,
+  global_LineHeight_md,
+  global_spacer_sm,
+  global_spacer_xl,
+} from '@patternfly/react-tokens';
+import { css } from 'emotion';
+
+export const styles = StyleSheet.create({
+  content: {
+    backgroundColor: global_BackgroundColor_300.value,
+    paddingTop: global_spacer_xl.value,
+    height: '100%',
+  },
+  ocpOnAwsDetails: {
+    backgroundColor: global_BackgroundColor_300.value,
+    minHeight: '100%',
+  },
+  paginationContainer: {
+    backgroundColor: global_BackgroundColor_light_100.value,
+    marginBottom: global_spacer_xl.value,
+    marginLeft: global_spacer_xl.value,
+    marginRight: global_spacer_xl.value,
+  },
+  toolbarContainer: {
+    backgroundColor: global_BackgroundColor_300.value,
+  },
+  tableContainer: {
+    marginLeft: global_spacer_xl.value,
+    marginRight: global_spacer_xl.value,
+  },
+});
+
+export const toolbarOverride = css`
+  margin-left: ${global_spacer_xl.value};
+  margin-right: ${global_spacer_xl.value};
+
+  .pf-c-button {
+    border-radius: 0;
+    padding-left: 0;
+    padding-right: 0;
+    display: inline-flex;
+    align-items: center;
+  }
+
+  .fa-download {
+    color: ${global_Color_100.value};
+    margin-right: ${global_spacer_sm.value};
+    font-size: 1.125rem;
+  }
+
+  .toolbar-pf-actions {
+    display: flex;
+    padding-top: ${global_spacer_sm.value};
+    padding-bottom: ${global_spacer_sm.value};
+  }
+
+  .form-group {
+    border: none;
+  }
+
+  .btn {
+    line-height: 28px;
+  }
+
+  .btn-link {
+    color: ${global_Color_200.value};
+    margin-left: ${global_spacer_sm.value};
+  }
+
+  .btn-link .fa {
+    font-size: ${global_FontSize_lg.value};
+  }
+
+  .pf-m-plain {
+    padding: 0;
+    display: flex;
+    align-items: center;
+  }
+
+  .dropdown .btn {
+    border-radius: ${global_BorderRadius_sm.value};
+    background: transparent;
+    box-shadow: none;
+    border-color: #c7c7c7;
+    font-size: ${global_FontSize_md.value};
+    font-weight: 500;
+    padding-left: ${global_spacer_sm.value};
+    padding-right: ${global_spacer_sm.value};
+  }
+
+  input[type='text'] {
+    border-color: #c7c7c7;
+    border-radius: ${global_BorderRadius_sm.value};
+  }
+
+  /* filter results */
+
+  .toolbar-pf-results {
+    font-size: ${global_FontSize_sm.value};
+    padding: ${global_spacer_sm.value} 0;
+    line-heght: ${global_LineHeight_md.value};
+    font-weight: ${global_FontWeight_normal.value};
+
+    .col-sm-12 {
+      display: flex;
+      align-items: center;
+    }
+
+    h5 {
+      font-size: ${global_FontSize_sm.value};
+      font-weight: ${global_FontWeight_normal.value};
+      line-height: ${global_LineHeight_md.value};
+    }
+
+    .filter-pf-active-label {
+      line-height: ${global_LineHeight_md.value};
+    }
+
+    .list-inline {
+      line-height: ${global_LineHeight_md.value};
+    }
+
+    .label {
+      font-size: ${global_FontSize_xs.value};
+      border-radius: ${global_BorderRadius_sm.value};
+      display: inline-flex;
+      align-items: center;
+    }
+
+    .pf-remove-button {
+      display: inline-flex;
+      font-weight: ${global_FontWeight_normal.value};
+    }
+  }
+`;

--- a/src/pages/ocpOnAwsDetails/ocpOnAwsDetails.tsx
+++ b/src/pages/ocpOnAwsDetails/ocpOnAwsDetails.tsx
@@ -1,0 +1,514 @@
+import { Pagination, PaginationVariant } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import { getQuery, OcpOnAwsQuery, parseQuery } from 'api/ocpOnAwsQuery';
+import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import { Providers, ProviderType } from 'api/providers';
+import { getProvidersQuery } from 'api/providersQuery';
+import { AxiosError } from 'axios';
+import { ErrorState } from 'components/state/errorState/errorState';
+import { LoadingState } from 'components/state/loadingState/loadingState';
+import { NoProvidersState } from 'components/state/noProvidersState/noProvidersState';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { RouteComponentProps } from 'react-router';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import {
+  ocpOnAwsReportsActions,
+  ocpOnAwsReportsSelectors,
+} from 'store/ocpOnAwsReports';
+import { ocpProvidersQuery, providersSelectors } from 'store/providers';
+import { uiActions } from 'store/ui';
+import {
+  ComputedOcpOnAwsReportItem,
+  getIdKeyForGroupBy,
+  getUnsortedComputedOcpOnAwsReportItems,
+} from 'utils/getComputedOcpOnAwsReportItems';
+import { DetailsHeader } from './detailsHeader';
+import { DetailsTable } from './detailsTable';
+import { DetailsToolbar } from './detailsToolbar';
+import { ExportModal } from './exportModal';
+import { styles, toolbarOverride } from './ocpOnAwsDetails.styles';
+
+interface OcpOnAwsDetailsStateProps {
+  providers: Providers;
+  providersError: AxiosError;
+  providersFetchStatus: FetchStatus;
+  query: OcpOnAwsQuery;
+  queryString: string;
+  report: OcpOnAwsReport;
+  reportError: AxiosError;
+  reportFetchStatus: FetchStatus;
+}
+
+interface OcpOnAwsDetailsDispatchProps {
+  fetchReport: typeof ocpOnAwsReportsActions.fetchReport;
+  openExportModal: typeof uiActions.openExportModal;
+}
+
+interface OcpOnAwsDetailsState {
+  columns: any[];
+  rows: any[];
+  selectedItems: ComputedOcpOnAwsReportItem[];
+}
+
+type OcpOnAwsDetailsOwnProps = RouteComponentProps<void> &
+  InjectedTranslateProps;
+
+type OcpOnAwsDetailsProps = OcpOnAwsDetailsStateProps &
+  OcpOnAwsDetailsOwnProps &
+  OcpOnAwsDetailsDispatchProps;
+
+const reportType = OcpOnAwsReportType.cost;
+
+const baseQuery: OcpOnAwsQuery = {
+  delta: 'cost',
+  filter: {
+    limit: 10,
+    offset: 0,
+    resolution: 'monthly',
+    time_scope_units: 'month',
+    time_scope_value: -1,
+  },
+  group_by: {
+    project: '*',
+  },
+  order_by: {
+    cost: 'desc',
+  },
+};
+
+class OcpOnAwsDetails extends React.Component<OcpOnAwsDetailsProps> {
+  protected defaultState: OcpOnAwsDetailsState = {
+    columns: [],
+    rows: [],
+    selectedItems: [],
+  };
+  public state: OcpOnAwsDetailsState = { ...this.defaultState };
+
+  constructor(stateProps, dispatchProps) {
+    super(stateProps, dispatchProps);
+    this.handleExportClicked = this.handleExportClicked.bind(this);
+    this.handleFilterAdded = this.handleFilterAdded.bind(this);
+    this.handleFilterRemoved = this.handleFilterRemoved.bind(this);
+    this.handlePerPageSelect = this.handlePerPageSelect.bind(this);
+    this.handleSelected = this.handleSelected.bind(this);
+    this.handleSetPage = this.handleSetPage.bind(this);
+    this.handleSort = this.handleSort.bind(this);
+  }
+
+  public componentDidMount() {
+    this.updateReport();
+  }
+
+  public componentDidUpdate(
+    prevProps: OcpOnAwsDetailsProps,
+    prevState: OcpOnAwsDetailsState
+  ) {
+    const { location, report, reportError, queryString } = this.props;
+    const { selectedItems } = this.state;
+
+    const newQuery = prevProps.queryString !== queryString;
+    const noReport = !report && !reportError;
+    const noLocation = !location.search;
+    const newItems = prevState.selectedItems !== selectedItems;
+
+    if (newQuery || noReport || noLocation || newItems) {
+      this.updateReport();
+    }
+  }
+
+  private getExportModal = (computedItems: ComputedOcpOnAwsReportItem[]) => {
+    const { selectedItems } = this.state;
+    const { query } = this.props;
+
+    const groupById = getIdKeyForGroupBy(query.group_by);
+    const groupByTagKey = this.getGroupByTagKey();
+
+    return (
+      <ExportModal
+        isAllItems={selectedItems.length === computedItems.length}
+        groupBy={groupByTagKey ? `tag:${groupByTagKey}` : groupById}
+        items={selectedItems}
+        query={query}
+      />
+    );
+  };
+
+  private getFilterFields = (groupById: string): any[] => {
+    const { t } = this.props;
+    if (groupById === 'cluster') {
+      return [
+        {
+          id: 'cluster',
+          title: t('ocp_on_aws_details.filter.cluster_select'),
+          placeholder: t('ocp_on_aws_details.filter.cluster_placeholder'),
+          filterType: 'text',
+        },
+      ];
+    } else if (groupById === 'node') {
+      return [
+        {
+          id: 'node',
+          title: t('ocp_on_aws_details.filter.node_select'),
+          placeholder: t('ocp_on_aws_details.filter.node_placeholder'),
+          filterType: 'text',
+        },
+      ];
+    } else if (groupById === 'project') {
+      return [
+        {
+          id: 'project',
+          title: t('ocp_on_aws_details.filter.project_select'),
+          placeholder: t('ocp_on_aws_details.filter.project_placeholder'),
+          filterType: 'text',
+        },
+      ];
+    } else {
+      // Default for group by project tags
+      return [
+        {
+          id: 'tag',
+          title: t('ocp_on_aws_details.filter.tag_select'),
+          placeholder: t('ocp_on_aws_details.filter.tag_placeholder'),
+          filterType: 'text',
+        },
+      ];
+    }
+    return [];
+  };
+
+  private getGroupByTagKey = () => {
+    const { query } = this.props;
+    let groupByTagKey;
+
+    for (const groupBy of Object.keys(query.group_by)) {
+      const tagIndex = groupBy.indexOf('tag:');
+      if (tagIndex !== -1) {
+        groupByTagKey = groupBy.substring(tagIndex + 4) as any;
+        break;
+      }
+    }
+    return groupByTagKey;
+  };
+
+  private getPagination = (isBottom: boolean = false) => {
+    const { report } = this.props;
+
+    const count = report && report.meta ? report.meta.count : 0;
+    const limit =
+      report && report.meta && report.meta.filter && report.meta.filter.limit
+        ? report.meta.filter.limit
+        : baseQuery.filter.limit;
+    const offset =
+      report && report.meta && report.meta.filter && report.meta.filter.offset
+        ? report.meta.filter.offset
+        : baseQuery.filter.offset;
+    const page = offset / limit + 1;
+
+    return (
+      <Pagination
+        itemCount={count}
+        onPerPageSelect={this.handlePerPageSelect}
+        onSetPage={this.handleSetPage}
+        page={page}
+        perPage={limit}
+        variant={isBottom ? PaginationVariant.bottom : PaginationVariant.top}
+        widgetId="`pagination${isBottom ? '-bottom' : ''}`"
+      />
+    );
+  };
+
+  private getRouteForQuery(query: OcpOnAwsQuery) {
+    return `/ocp-on-aws?${getQuery(query)}`;
+  }
+
+  private getTable = () => {
+    const { query, report } = this.props;
+
+    return (
+      <DetailsTable
+        onSelected={this.handleSelected}
+        onSort={this.handleSort}
+        query={query}
+        report={report}
+      />
+    );
+  };
+
+  private getToolbar = (computedItems: ComputedOcpOnAwsReportItem[]) => {
+    const { selectedItems } = this.state;
+    const { query, report, t } = this.props;
+
+    const groupById = getIdKeyForGroupBy(query.group_by);
+    const groupByTagKey = this.getGroupByTagKey();
+    const filterFields = this.getFilterFields(
+      groupByTagKey ? 'tag' : groupById
+    );
+
+    return (
+      <DetailsToolbar
+        exportText={t('ocp_on_aws_details.export_link')}
+        filterFields={filterFields}
+        isExportDisabled={selectedItems.length === 0}
+        onExportClicked={this.handleExportClicked}
+        onFilterAdded={this.handleFilterAdded}
+        onFilterRemoved={this.handleFilterRemoved}
+        pagination={this.getPagination()}
+        query={query}
+        report={report}
+        resultsTotal={computedItems.length}
+      />
+    );
+  };
+
+  private handleExportClicked = () => {
+    this.props.openExportModal();
+  };
+
+  private handleFilterAdded = (filterType: string, filterValue: string) => {
+    const { history, query } = this.props;
+    const newQuery = { ...JSON.parse(JSON.stringify(query)) };
+
+    const groupByTagKey = this.getGroupByTagKey();
+    const newFilterType =
+      filterType === 'tag' ? `${filterType}:${groupByTagKey}` : filterType;
+
+    if (newQuery.group_by[newFilterType]) {
+      if (newQuery.group_by[newFilterType] === '*') {
+        newQuery.group_by[newFilterType] = filterValue;
+      } else if (!newQuery.group_by[newFilterType].includes(filterValue)) {
+        newQuery.group_by[newFilterType] = [
+          newQuery.group_by[newFilterType],
+          filterValue,
+        ];
+      }
+    } else {
+      newQuery.group_by[filterType] = [filterValue];
+    }
+    const filteredQuery = this.getRouteForQuery(newQuery);
+    history.replace(filteredQuery);
+  };
+
+  private handleFilterRemoved = (filterType: string, filterValue: string) => {
+    const { history, query } = this.props;
+    const newQuery = { ...JSON.parse(JSON.stringify(query)) };
+
+    const groupByTagKey = this.getGroupByTagKey();
+    const newFilterType =
+      filterType === 'tag' ? `${filterType}:${groupByTagKey}` : filterType;
+
+    if (filterValue === '') {
+      newQuery.group_by = {
+        [newFilterType]: '*',
+      };
+    } else if (!Array.isArray(newQuery.group_by[newFilterType])) {
+      newQuery.group_by[newFilterType] = '*';
+    } else {
+      const index = newQuery.group_by[newFilterType].indexOf(filterValue);
+      if (index > -1) {
+        newQuery.group_by[newFilterType] = [
+          ...query.group_by[newFilterType].slice(0, index),
+          ...query.group_by[newFilterType].slice(index + 1),
+        ];
+      }
+    }
+    const filteredQuery = this.getRouteForQuery(newQuery);
+    history.replace(filteredQuery);
+  };
+
+  private handleGroupByClick = groupBy => {
+    const { history, query } = this.props;
+    const groupByKey: keyof OcpOnAwsQuery['group_by'] = groupBy as any;
+    const newQuery = {
+      ...JSON.parse(JSON.stringify(query)),
+      group_by: {
+        [groupByKey]: '*',
+      },
+      order_by: { cost: 'desc' },
+    };
+    history.replace(this.getRouteForQuery(newQuery));
+    this.setState({ selectedItems: [] });
+  };
+
+  private handlePerPageSelect = (_event, perPage) => {
+    const { history, query } = this.props;
+    const newQuery = { ...JSON.parse(JSON.stringify(query)) };
+    newQuery.filter = {
+      ...query.filter,
+      limit: perPage,
+    };
+    const filteredQuery = this.getRouteForQuery(newQuery);
+    history.replace(filteredQuery);
+  };
+
+  private handleSelected = (selectedItems: ComputedOcpOnAwsReportItem[]) => {
+    this.setState({ selectedItems });
+  };
+
+  private handleSetPage = (event, pageNumber) => {
+    const { history, query, report } = this.props;
+
+    const limit =
+      report && report.meta && report.meta.filter && report.meta.filter.limit
+        ? report.meta.filter.limit
+        : baseQuery.filter.limit;
+    const offset = pageNumber * limit - limit;
+
+    const newQuery = { ...JSON.parse(JSON.stringify(query)) };
+    newQuery.filter = {
+      ...query.filter,
+      offset,
+    };
+    const filteredQuery = this.getRouteForQuery(newQuery);
+    history.replace(filteredQuery);
+  };
+
+  private handleSort = (sortType: string, isSortAscending: boolean) => {
+    const { history, query } = this.props;
+    const newQuery = { ...JSON.parse(JSON.stringify(query)) };
+    newQuery.order_by = {};
+    newQuery.order_by[sortType] = isSortAscending ? 'asc' : 'desc';
+    const filteredQuery = this.getRouteForQuery(newQuery);
+    history.replace(filteredQuery);
+  };
+
+  private updateReport = () => {
+    const { query, location, fetchReport, history, queryString } = this.props;
+    if (!location.search) {
+      history.replace(
+        this.getRouteForQuery({
+          group_by: query.group_by,
+          order_by: { cost: 'desc' },
+        })
+      );
+    } else {
+      fetchReport(reportType, queryString);
+    }
+  };
+
+  public render() {
+    const {
+      providers,
+      providersError,
+      providersFetchStatus,
+      query,
+      report,
+      reportError,
+    } = this.props;
+
+    const groupById = getIdKeyForGroupBy(query.group_by);
+    const groupByTagKey = this.getGroupByTagKey();
+
+    const computedItems = getUnsortedComputedOcpOnAwsReportItems({
+      report,
+      idKey: (groupByTagKey as any) || groupById,
+    });
+
+    const error = providersError || reportError;
+    const isLoading = providersFetchStatus === FetchStatus.inProgress;
+    const noProviders =
+      providers !== undefined &&
+      providers.meta !== undefined &&
+      providers.meta.count === 0 &&
+      providersFetchStatus === FetchStatus.complete;
+
+    return (
+      <div className={css(styles.ocpOnAwsDetails)}>
+        <DetailsHeader onGroupByClicked={this.handleGroupByClick} />
+        {Boolean(error) ? (
+          <ErrorState error={error} />
+        ) : Boolean(noProviders) ? (
+          <NoProvidersState />
+        ) : Boolean(isLoading) ? (
+          <LoadingState />
+        ) : (
+          <div className={css(styles.content)}>
+            <div className={css(styles.toolbarContainer)}>
+              <div className={toolbarOverride}>
+                {this.getToolbar(computedItems)}
+                {this.getExportModal(computedItems)}
+              </div>
+            </div>
+            <div className={css(styles.tableContainer)}>{this.getTable()}</div>
+            <div className={css(styles.paginationContainer)}>
+              {this.getPagination(true)}
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  OcpOnAwsDetailsOwnProps,
+  OcpOnAwsDetailsStateProps
+>((state, props) => {
+  const queryFromRoute = parseQuery<OcpOnAwsQuery>(location.search);
+  const query = {
+    delta: 'cost',
+    filter: {
+      ...baseQuery.filter,
+      ...queryFromRoute.filter,
+    },
+    group_by: queryFromRoute.group_by || baseQuery.group_by,
+    order_by: queryFromRoute.order_by || baseQuery.order_by,
+  };
+  const queryString = getQuery(query);
+  const report = ocpOnAwsReportsSelectors.selectReport(
+    state,
+    reportType,
+    queryString
+  );
+  const reportError = ocpOnAwsReportsSelectors.selectReportError(
+    state,
+    reportType,
+    queryString
+  );
+  const reportFetchStatus = ocpOnAwsReportsSelectors.selectReportFetchStatus(
+    state,
+    reportType,
+    queryString
+  );
+
+  const providersQueryString = getProvidersQuery(ocpProvidersQuery);
+  const providers = providersSelectors.selectProviders(
+    state,
+    ProviderType.ocp,
+    providersQueryString
+  );
+  const providersError = providersSelectors.selectProvidersError(
+    state,
+    ProviderType.ocp,
+    providersQueryString
+  );
+  const providersFetchStatus = providersSelectors.selectProvidersFetchStatus(
+    state,
+    ProviderType.ocp,
+    providersQueryString
+  );
+
+  return {
+    providers,
+    providersError,
+    providersFetchStatus,
+    query,
+    queryString,
+    report,
+    reportError,
+    reportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: OcpOnAwsDetailsDispatchProps = {
+  fetchReport: ocpOnAwsReportsActions.fetchReport,
+  openExportModal: uiActions.openExportModal,
+};
+
+export default translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(OcpOnAwsDetails)
+);

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -15,6 +15,10 @@ const OcpDetails = asyncComponent(() =>
   import(/* webpackChunkName: "ocp" */ './pages/ocpDetails')
 );
 
+const OcpOnAwsDetails = asyncComponent(() =>
+  import(/* webpackChunkName: "ocp-on-aws" */ './pages/ocpOnAwsDetails')
+);
+
 const Overview = asyncComponent(() =>
   import(/* webpackChunkName: "home" */ './pages/overview')
 );
@@ -41,8 +45,15 @@ const routes: AppRoute[] = [
   },
   {
     path: '/ocp',
-    labelKey: 'navigation.ocp_details',
+    labelKey: 'navigation.ocp_on_aws_details',
     component: OcpDetails,
+    exact: true,
+    icon: MoneyBillIcon,
+  },
+  {
+    path: '/ocp-on-aws',
+    labelKey: 'navigation.ocp_details',
+    component: OcpOnAwsDetails,
     exact: true,
     icon: MoneyBillIcon,
   },

--- a/src/store/ocpOnAwsDetails/index.ts
+++ b/src/store/ocpOnAwsDetails/index.ts
@@ -1,0 +1,17 @@
+import * as ocpOnAwsDetailsActions from './ocpOnAwsDetailsActions';
+import {
+  ocpOnAwsDetailsStateKey,
+  OcpOnAwsDetailsTab,
+  OcpOnAwsDetailsWidget,
+} from './ocpOnAwsDetailsCommon';
+import { ocpOnAwsDetailsReducer } from './ocpOnAwsDetailsReducer';
+import * as ocpOnAwsDetailsSelectors from './ocpOnAwsDetailsSelectors';
+
+export {
+  ocpOnAwsDetailsStateKey,
+  ocpOnAwsDetailsReducer,
+  ocpOnAwsDetailsActions,
+  ocpOnAwsDetailsSelectors,
+  OcpOnAwsDetailsTab,
+  OcpOnAwsDetailsWidget,
+};

--- a/src/store/ocpOnAwsDetails/ocpOnAwsDetailsActions.ts
+++ b/src/store/ocpOnAwsDetails/ocpOnAwsDetailsActions.ts
@@ -1,0 +1,31 @@
+import { ThunkAction } from 'store/common';
+import { ocpOnAwsReportsActions } from 'store/ocpOnAwsReports';
+import { createStandardAction } from 'typesafe-actions';
+import { OcpOnAwsDetailsTab } from './ocpOnAwsDetailsCommon';
+import { selectWidget, selectWidgetQueries } from './ocpOnAwsDetailsSelectors';
+
+export const fetchWidgetReports = (id: number): ThunkAction => {
+  return (dispatch, getState) => {
+    const state = getState();
+    const widget = selectWidget(state, id);
+    const { previous, current, tabs } = selectWidgetQueries(state, id);
+    dispatch(ocpOnAwsReportsActions.fetchReport(widget.reportType, current));
+    dispatch(ocpOnAwsReportsActions.fetchReport(widget.reportType, previous));
+    dispatch(ocpOnAwsReportsActions.fetchReport(widget.reportType, tabs));
+  };
+};
+
+export const setWidgetTab = createStandardAction('ocpOnAwsDetails/widget/tab')<{
+  id: number;
+  tab: OcpOnAwsDetailsTab;
+}>();
+
+export const changeWidgetTab = (
+  id: number,
+  tab: OcpOnAwsDetailsTab
+): ThunkAction => {
+  return dispatch => {
+    dispatch(setWidgetTab({ id, tab }));
+    dispatch(fetchWidgetReports(id));
+  };
+};

--- a/src/store/ocpOnAwsDetails/ocpOnAwsDetailsCommon.ts
+++ b/src/store/ocpOnAwsDetails/ocpOnAwsDetailsCommon.ts
@@ -1,0 +1,95 @@
+import { getQuery, OcpOnAwsFilters, OcpOnAwsQuery } from 'api/ocpOnAwsQuery';
+import { OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import { ChartType } from 'components/charts/commonChart/chartUtils';
+
+export const ocpOnAwsDetailsStateKey = 'ocpOnAwsDetails';
+export const ocpOnAwsDetailsDefaultFilters: OcpOnAwsFilters = {
+  time_scope_units: 'month',
+  time_scope_value: -1,
+  resolution: 'daily',
+};
+export const ocpOnAwsDetailsTabFilters: OcpOnAwsFilters = {
+  ...ocpOnAwsDetailsDefaultFilters,
+  limit: 3,
+};
+
+interface ValueFormatOptions {
+  fractionDigits?: number;
+}
+
+export const enum OcpOnAwsDetailsTab {
+  accounts = 'accounts',
+  projects = 'projects',
+  regions = 'regions',
+  services = 'services',
+}
+
+export interface OcpOnAwsDetailsWidget {
+  id: number;
+  /** i18n key for the title. passed { startDate, endDate, month, time } */
+  titleKey?: string;
+  reportType: OcpOnAwsReportType;
+  availableTabs?: OcpOnAwsDetailsTab[];
+  currentTab?: OcpOnAwsDetailsTab;
+  details?: {
+    /** i18n label key */
+    labelKey?: string;
+    /** i18n label key context used to support multiple units. */
+    labelKeyContext?: string;
+    formatOptions?: ValueFormatOptions;
+    requestLabelKey?: string;
+  };
+  filter?: {
+    limit?: number;
+    product_family?: string;
+  };
+  isDetailsLink?: boolean;
+  isHorizontal?: boolean;
+  tabsFilter?: {
+    limit?: number;
+    product_family?: string;
+  };
+  trend?: {
+    currentRequestLabelKey?: string;
+    currentTitleKey?: string;
+    currentUsageLabelKey?: string;
+    formatOptions: ValueFormatOptions;
+    previousRequestLabelKey?: string;
+    previousTitleKey?: string;
+    previousUsageLabel?: string;
+    titleKey?: string;
+    type: ChartType;
+  };
+  topItems?: {
+    formatOptions: {};
+  };
+}
+
+export function getGroupByForTab(
+  tab: OcpOnAwsDetailsTab
+): OcpOnAwsQuery['group_by'] {
+  switch (tab) {
+    case OcpOnAwsDetailsTab.accounts:
+      return { account: '*' };
+    case OcpOnAwsDetailsTab.projects:
+      return { project: '*' };
+    case OcpOnAwsDetailsTab.regions:
+      return { region: '*' };
+    case OcpOnAwsDetailsTab.services:
+      return { service: '*' };
+    default:
+      return {};
+  }
+}
+
+export function getQueryForWidget(
+  widget: OcpOnAwsDetailsWidget,
+  filter: OcpOnAwsFilters = ocpOnAwsDetailsDefaultFilters
+) {
+  const query: OcpOnAwsQuery = {
+    filter,
+    group_by: getGroupByForTab(widget.currentTab),
+  };
+
+  return getQuery(query);
+}

--- a/src/store/ocpOnAwsDetails/ocpOnAwsDetailsReducer.ts
+++ b/src/store/ocpOnAwsDetails/ocpOnAwsDetailsReducer.ts
@@ -1,0 +1,39 @@
+import { ActionType, getType } from 'typesafe-actions';
+import { setWidgetTab } from './ocpOnAwsDetailsActions';
+import { OcpOnAwsDetailsWidget } from './ocpOnAwsDetailsCommon';
+import { clusterWidget } from './ocpOnAwsDetailsWidgets';
+
+export type OcpOnAwsDetailsAction = ActionType<typeof setWidgetTab>;
+
+export type OcpOnAwsDetailsState = Readonly<{
+  widgets: Record<number, OcpOnAwsDetailsWidget>;
+  currentWidgets: number[];
+}>;
+
+export const defaultState: OcpOnAwsDetailsState = {
+  currentWidgets: [clusterWidget.id],
+  widgets: {
+    [clusterWidget.id]: clusterWidget,
+  },
+};
+
+export function ocpOnAwsDetailsReducer(
+  state = defaultState,
+  action: OcpOnAwsDetailsAction
+): OcpOnAwsDetailsState {
+  switch (action.type) {
+    case getType(setWidgetTab):
+      return {
+        ...state,
+        widgets: {
+          ...state.widgets,
+          [action.payload.id]: {
+            ...state.widgets[action.payload.id],
+            currentTab: action.payload.tab,
+          },
+        },
+      };
+    default:
+      return state;
+  }
+}

--- a/src/store/ocpOnAwsDetails/ocpOnAwsDetailsSelectors.ts
+++ b/src/store/ocpOnAwsDetails/ocpOnAwsDetailsSelectors.ts
@@ -1,0 +1,44 @@
+import { RootState } from 'store/rootReducer';
+import {
+  getQueryForWidget,
+  ocpOnAwsDetailsDefaultFilters,
+  ocpOnAwsDetailsStateKey,
+  ocpOnAwsDetailsTabFilters,
+} from './ocpOnAwsDetailsCommon';
+
+export const selectOcpOnAwsDetailsState = (state: RootState) =>
+  state[ocpOnAwsDetailsStateKey];
+
+export const selectWidgets = (state: RootState) =>
+  selectOcpOnAwsDetailsState(state).widgets;
+
+export const selectWidget = (state: RootState, id: number) =>
+  selectWidgets(state)[id];
+
+export const selectCurrentWidgets = (state: RootState) =>
+  selectOcpOnAwsDetailsState(state).currentWidgets;
+
+export const selectWidgetQueries = (state: RootState, id: number) => {
+  const widget = selectWidget(state, id);
+
+  const filter = {
+    ...ocpOnAwsDetailsDefaultFilters,
+    ...(widget.filter ? widget.filter : {}),
+  };
+  const tabsFilter = {
+    ...ocpOnAwsDetailsTabFilters,
+    ...(widget.tabsFilter ? widget.tabsFilter : {}),
+  };
+
+  return {
+    previous: getQueryForWidget(widget, {
+      ...filter,
+      time_scope_value: -2,
+    }),
+    current: getQueryForWidget(widget, filter),
+    tabs: getQueryForWidget(widget, {
+      ...tabsFilter,
+      resolution: 'monthly',
+    }),
+  };
+};

--- a/src/store/ocpOnAwsDetails/ocpOnAwsDetailsWidgets.ts
+++ b/src/store/ocpOnAwsDetails/ocpOnAwsDetailsWidgets.ts
@@ -1,0 +1,31 @@
+import { OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import {
+  OcpOnAwsDetailsTab,
+  OcpOnAwsDetailsWidget,
+} from './ocpOnAwsDetailsCommon';
+
+let currrentId = 0;
+const getId = () => currrentId++;
+
+export const clusterWidget: OcpOnAwsDetailsWidget = {
+  id: getId(),
+  reportType: OcpOnAwsReportType.cost,
+  details: {
+    formatOptions: {
+      fractionDigits: 2,
+    },
+  },
+  tabsFilter: {
+    limit: 3,
+  },
+  topItems: {
+    formatOptions: {},
+  },
+  availableTabs: [
+    OcpOnAwsDetailsTab.projects,
+    OcpOnAwsDetailsTab.services,
+    OcpOnAwsDetailsTab.accounts,
+    OcpOnAwsDetailsTab.regions,
+  ],
+  currentTab: OcpOnAwsDetailsTab.projects,
+};

--- a/src/store/ocpOnAwsExport/__snapshots__/ocpOnAwsExport.test.ts.snap
+++ b/src/store/ocpOnAwsExport/__snapshots__/ocpOnAwsExport.test.ts.snap
@@ -1,0 +1,11 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`default state 1`] = `
+Object {
+  "export": null,
+  "exportError": null,
+  "exportFetchStatus": 0,
+}
+`;
+
+exports[`fetch export success 1`] = `"data"`;

--- a/src/store/ocpOnAwsExport/index.ts
+++ b/src/store/ocpOnAwsExport/index.ts
@@ -1,0 +1,17 @@
+import * as ocpOnAwsExportActions from './ocpOnAwsExportActions';
+import {
+  OcpOnAwsExportAction,
+  ocpOnAwsExportReducer,
+  OcpOnAwsExportState,
+  stateKey as ocpOnAwsExportStateKey,
+} from './ocpOnAwsExportReducer';
+import * as ocpOnAwsExportSelectors from './ocpOnAwsExportSelectors';
+
+export {
+  OcpOnAwsExportAction,
+  ocpOnAwsExportActions,
+  ocpOnAwsExportReducer,
+  ocpOnAwsExportSelectors,
+  OcpOnAwsExportState,
+  ocpOnAwsExportStateKey,
+};

--- a/src/store/ocpOnAwsExport/ocpOnAwsExport.test.ts
+++ b/src/store/ocpOnAwsExport/ocpOnAwsExport.test.ts
@@ -1,0 +1,61 @@
+jest.mock('api/ocpOnAwsExport');
+
+import { runExport } from 'api/ocpOnAwsExport';
+import { OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import { FetchStatus } from 'store/common';
+import { createMockStoreCreator } from 'store/mockStore';
+import { wait } from 'testUtils';
+import * as actions from './ocpOnAwsExportActions';
+import { ocpOnAwsExportReducer, stateKey } from './ocpOnAwsExportReducer';
+import * as selectors from './ocpOnAwsExportSelectors';
+
+const createExportStore = createMockStoreCreator({
+  [stateKey]: ocpOnAwsExportReducer,
+});
+
+const runExportMock = runExport as jest.Mock;
+
+const mockExport: string = 'data';
+
+const query = 'query';
+const reportType = OcpOnAwsReportType.cost;
+
+runExportMock.mockResolvedValue({ data: mockExport });
+
+test('default state', () => {
+  const store = createExportStore();
+  expect(selectors.selectExportState(store.getState())).toMatchSnapshot();
+});
+
+test('fetch export success', async () => {
+  const store = createExportStore();
+  store.dispatch(actions.exportReport(reportType, query));
+  expect(runExportMock).toBeCalled();
+  expect(selectors.selectExportFetchStatus(store.getState())).toBe(
+    FetchStatus.inProgress
+  );
+  await wait();
+  const finishedState = store.getState();
+  expect(selectors.selectExport(finishedState)).toMatchSnapshot();
+  expect(selectors.selectExportFetchStatus(finishedState)).toBe(
+    FetchStatus.complete
+  );
+  expect(selectors.selectExportError(finishedState)).toBe(null);
+});
+
+test('fetch export failure', async () => {
+  const store = createExportStore();
+  const error = Symbol('export error');
+  runExportMock.mockRejectedValueOnce(error);
+  store.dispatch(actions.exportReport(reportType, query));
+  expect(runExport).toBeCalled();
+  expect(selectors.selectExportFetchStatus(store.getState())).toBe(
+    FetchStatus.inProgress
+  );
+  await wait();
+  const finishedState = store.getState();
+  expect(selectors.selectExportFetchStatus(finishedState)).toBe(
+    FetchStatus.complete
+  );
+  expect(selectors.selectExportError(finishedState)).toBe(error);
+});

--- a/src/store/ocpOnAwsExport/ocpOnAwsExportActions.ts
+++ b/src/store/ocpOnAwsExport/ocpOnAwsExportActions.ts
@@ -1,0 +1,32 @@
+import { runExport } from 'api/ocpOnAwsExport';
+import { OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import { AxiosError } from 'axios';
+import { ThunkAction } from 'redux-thunk';
+import { RootState } from 'store/rootReducer';
+import { createAsyncAction } from 'typesafe-actions';
+
+export const {
+  request: fetchOcpOnAwsExportRequest,
+  success: fetchOcpOnAwsExportSuccess,
+  failure: fetchOcpOnAwsExportFailure,
+} = createAsyncAction(
+  'ocpOnAwsExport/request',
+  'ocpOnAwsExport/success',
+  'ocpOnAwsExport/failure'
+)<void, string, AxiosError>();
+
+export function exportReport(
+  reportType: OcpOnAwsReportType,
+  query: string
+): ThunkAction<void, RootState, void, any> {
+  return (dispatch, getState) => {
+    dispatch(fetchOcpOnAwsExportRequest());
+    runExport(reportType, query)
+      .then(res => {
+        dispatch(fetchOcpOnAwsExportSuccess(res.data));
+      })
+      .catch(err => {
+        dispatch(fetchOcpOnAwsExportFailure(err));
+      });
+  };
+}

--- a/src/store/ocpOnAwsExport/ocpOnAwsExportReducer.ts
+++ b/src/store/ocpOnAwsExport/ocpOnAwsExportReducer.ts
@@ -1,0 +1,57 @@
+import { AxiosError } from 'axios';
+import { FetchStatus } from 'store/common';
+import { ActionType, getType } from 'typesafe-actions';
+import {
+  fetchOcpOnAwsExportFailure,
+  fetchOcpOnAwsExportRequest,
+  fetchOcpOnAwsExportSuccess,
+} from './ocpOnAwsExportActions';
+
+export type OcpOnAwsExportAction = ActionType<
+  | typeof fetchOcpOnAwsExportFailure
+  | typeof fetchOcpOnAwsExportRequest
+  | typeof fetchOcpOnAwsExportSuccess
+>;
+
+export type OcpOnAwsExportState = Readonly<{
+  export: string;
+  exportError: AxiosError;
+  exportFetchStatus: FetchStatus;
+}>;
+
+export const defaultState: OcpOnAwsExportState = {
+  export: null,
+  exportError: null,
+  exportFetchStatus: FetchStatus.none,
+};
+
+export const stateKey = 'ocpOnAwsExport';
+
+export function ocpOnAwsExportReducer(
+  state = defaultState,
+  action: OcpOnAwsExportAction
+): OcpOnAwsExportState {
+  switch (action.type) {
+    case getType(fetchOcpOnAwsExportRequest):
+      return {
+        ...state,
+        exportFetchStatus: FetchStatus.inProgress,
+      };
+    case getType(fetchOcpOnAwsExportSuccess):
+      return {
+        ...state,
+        export: action.payload,
+        exportError: null,
+        exportFetchStatus: FetchStatus.complete,
+      };
+    case getType(fetchOcpOnAwsExportFailure):
+      return {
+        ...state,
+        export: null,
+        exportError: action.payload,
+        exportFetchStatus: FetchStatus.complete,
+      };
+    default:
+      return state;
+  }
+}

--- a/src/store/ocpOnAwsExport/ocpOnAwsExportSelectors.ts
+++ b/src/store/ocpOnAwsExport/ocpOnAwsExportSelectors.ts
@@ -1,0 +1,13 @@
+import { RootState } from 'store/rootReducer';
+import { stateKey } from './ocpOnAwsExportReducer';
+
+export const selectExportState = (state: RootState) => state[stateKey];
+
+export const selectExport = (state: RootState) =>
+  selectExportState(state).export;
+
+export const selectExportFetchStatus = (state: RootState) =>
+  selectExportState(state).exportFetchStatus;
+
+export const selectExportError = (state: RootState) =>
+  selectExportState(state).exportError;

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -11,6 +11,14 @@ import {
   ocpOnAwsDashboardStateKey,
 } from './ocpOnAwsDashboard';
 import {
+  ocpOnAwsDetailsReducer,
+  ocpOnAwsDetailsStateKey,
+} from './ocpOnAwsDetails';
+import {
+  ocpOnAwsExportReducer,
+  ocpOnAwsExportStateKey,
+} from './ocpOnAwsExport';
+import {
   ocpOnAwsReportsReducer,
   ocpOnAwsReportsStateKey,
 } from './ocpOnAwsReports';
@@ -29,6 +37,9 @@ export const rootReducer = combineReducers({
   [ocpDashboardStateKey]: ocpDashboardReducer,
   [ocpExportStateKey]: ocpExportReducer,
   [ocpOnAwsDashboardStateKey]: ocpOnAwsDashboardReducer,
+  [ocpOnAwsDashboardStateKey]: ocpOnAwsDashboardReducer,
+  [ocpOnAwsDetailsStateKey]: ocpOnAwsDetailsReducer,
+  [ocpOnAwsExportStateKey]: ocpOnAwsExportReducer,
   [ocpOnAwsReportsStateKey]: ocpOnAwsReportsReducer,
   [ocpReportsStateKey]: ocpReportsReducer,
   [providersStateKey]: providersReducer,


### PR DESCRIPTION
This adds the initial OCP on AWS details page. This is basically be a copy of OCP, but points to the OCP on AWS API. Everything works (except sort by name https://github.com/project-koku/koku/issues/741), just need to update the content for the expanding rows next.

Fixes https://github.com/project-koku/koku-ui/issues/616

FYI, I want to get this merged ASAP, so Insights can create a new navigation link for Cost Management and have a page to land on.

Currently, I must replace the OCP details page in order to develop this new page. Finding impossible to override Insights' routing.

See https://github.com/RedHatInsights/insights-chrome/issues/182

![Screen Shot 2019-03-14 at 3 46 39 PM](https://user-images.githubusercontent.com/17481322/54387309-661df980-4671-11e9-8094-b84c5359cddc.png)
