### PR TITLE
Changes to work under the cloud.redhat.com setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,16 +23,8 @@ User interface for Koku based on Patternfly [![Patternfly][pf-logo]][patternfly]
 From the `insights-proxy` project directory run the following command to interact with the deployed environment:
 
 ```
-bash scripts/run.sh
-```
-
-To run the koku-ui against a local koku server run the following command:
-
-```
 SPANDX_CONFIG=/path/to/koku-ui/config/spandx.config.js bash /path/to/insights-proxy/scripts/run.sh
 ```
-_Note:_ The local koku server must mirror the API path used in the `config/spandx.config.js`. You may also need to alter the port for the `localKoku` variable if you are not using the default port. From openshift you may need to use `port-forwarding`.
-
 
 #### Start Development Server
 
@@ -46,7 +38,7 @@ As a convenience `start:dev` has been provided to work behind the proxy.
 yarn start:dev
 ```
 
-Point your browser to the [Overview page](https://prod.foo.redhat.com:1337/insights/platform/cost-management/)
+Point your browser to the [Overview page](https://ci.foo.redhat.com:1337/hcm/cost-management/)
 
 ### Building
 ```

--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -1,10 +1,14 @@
-/* global exports */
-const localhost =
-  process.env.PLATFORM === 'linux' ? 'localhost' : 'host.docker.internal';
-const localKoku = 'http://' + localhost + ':8000';
-
-exports.routes = {
-  '/r/insights/platform/cost-management/': {
-    host: localKoku,
+/*global module*/
+module.exports = {
+  routes: {
+    '/apps/cost-management': {
+      host: 'http://host.docker.internal:8002',
+    },
+    '/hcm/cost-management': {
+      host: 'http://host.docker.internal:8002',
+    },
+    '/apps/chrome': {
+      host: 'https://ci.cloud.paas.upshift.redhat.com',
+    },
   },
 };

--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -1,11 +1,14 @@
 /*global module*/
+const localhost =
+  process.env.PLATFORM === 'linux' ? 'localhost' : 'host.docker.internal';
+
 module.exports = {
   routes: {
     '/apps/cost-management': {
-      host: 'http://host.docker.internal:8002',
+      host: `http://${localhost}:8002`,
     },
     '/hcm/cost-management': {
-      host: 'http://host.docker.internal:8002',
+      host: `http://${localhost}:8002`,
     },
     '/apps/chrome': {
       host: 'https://ci.cloud.paas.upshift.redhat.com',

--- a/config/spandx.config.local.js
+++ b/config/spandx.config.local.js
@@ -1,0 +1,10 @@
+/* global exports */
+const localhost =
+  process.env.PLATFORM === 'linux' ? 'localhost' : 'host.docker.internal';
+const localKoku = 'http://' + localhost + ':8000';
+
+exports.routes = {
+  '/r/insights/platform/cost-management/': {
+    host: localKoku,
+  },
+};

--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -18,7 +18,7 @@ export interface PagedResponse<D = any> {
 }
 
 export function initApi({ version }: { version: string }) {
-  axios.defaults.baseURL = `/r/insights/platform/cost-management/${version}/`;
+  axios.defaults.baseURL = `/api/cost-management/${version}/`;
   axios.interceptors.request.use(authInterceptor);
 }
 

--- a/src/index.html
+++ b/src/index.html
@@ -2,10 +2,10 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Red Hat Insights | Cost Management </title>
-    <esi:include src="/@@insights/static/chrome/snippets/head.html" />
+    <title>Red Hat Cloud Software Services | Cost Management </title>
+    <esi:include src="/@@env/chrome/snippets/head.html" />
   </head>
   <body>
-    <esi:include src="/@@insights/static/chrome/snippets/body.html"/>
+    <esi:include src="/@@env/chrome/snippets/body.html"/>
   </body>
 </html>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -7,8 +7,12 @@ import { BrowserRouter } from 'react-router-dom';
 import App from './app';
 import { configureStore } from './store';
 
-const appPublicPath: string =
-  process.env.APP_PUBLIC_PATH || 'insights/platform/cost-management';
+const pathName = window.location.pathname.split('/');
+pathName.shift();
+
+if (pathName[0] === 'beta') {
+  pathName.shift();
+}
 
 initApi({
   version: 'v1',
@@ -23,7 +27,7 @@ const store = configureStore({
 
 render(
   <Provider store={store}>
-    <BrowserRouter basename={appPublicPath}>
+    <BrowserRouter basename={`${pathName[0]}/${pathName[1]}`}>
       <App />
     </BrowserRouter>
   </Provider>,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -18,15 +18,17 @@ const appEnv = process.env.APP_ENV;
 const fileRegEx = /\.(png|woff|woff2|eot|ttf|svg|gif|jpe?g|png)(\?[a-z0-9=.]+)?$/;
 const srcDir = path.resolve(__dirname, './src');
 const distDir = path.resolve(__dirname, './public/');
-let insightsDeployment = 'insights';
+let deploymentEnv = 'apps';
+let release = '';
 const betaBranch =
   gitBranch === 'master' ||
   gitBranch === 'qa-beta' ||
   gitBranch === 'prod-beta';
 if (!appEnv && betaBranch) {
-  insightsDeployment = 'insightsbeta';
+  deploymentEnv = 'beta/apps';
+  release = 'beta';
 }
-const publicPath = `/${insightsDeployment}/platform/cost-management/`;
+const publicPath = `/${deploymentEnv}/cost-management/`;
 
 log.info(`appEnv=${appEnv}`);
 log.info(`gitBranch=${gitBranch}`);
@@ -70,7 +72,12 @@ module.exports = env => {
               options: {
                 plugins: [
                   // See https://github.com/babel/babel/issues/8049
-                  ['@babel/plugin-syntax-typescript', { isTSX: true }],
+                  [
+                    '@babel/plugin-syntax-typescript',
+                    {
+                      isTSX: true,
+                    },
+                  ],
                   [
                     '@babel/plugin-syntax-decorators',
                     {
@@ -127,8 +134,8 @@ module.exports = env => {
       }),
       new HtmlReplaceWebpackPlugin([
         {
-          pattern: '@@insights',
-          replacement: insightsDeployment,
+          pattern: '@@env',
+          replacement: deploymentEnv,
         },
       ]),
       new MiniCssExtractPlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -888,15 +888,15 @@
   version "1.0.222"
   resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-1.0.222.tgz#e04947f8c52a6260ff7566fbf74ede74c5a06423"
 
-"@patternfly/patternfly@1.0.227":
-  version "1.0.227"
-  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-1.0.227.tgz#6a45e466dda72285906beefb3f329ad8fbd9f70a"
+"@patternfly/patternfly@1.0.234":
+  version "1.0.234"
+  resolved "https://registry.yarnpkg.com/@patternfly/patternfly/-/patternfly-1.0.234.tgz#be68469f61aed0b1a7cb1a8fe8393939c828c77b"
 
-"@patternfly/react-charts@2.1.8":
-  version "2.1.8"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-2.1.8.tgz#c48e1fd3de3061d01c99e7f1f9523072806d547d"
+"@patternfly/react-charts@2.1.10":
+  version "2.1.10"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-charts/-/react-charts-2.1.10.tgz#42c9900c8b83143c799ac85a901cbf13858ee518"
   dependencies:
-    "@patternfly/react-styles" "^2.3.7"
+    "@patternfly/react-styles" "^2.3.9"
   optionalDependencies:
     "@types/victory" "^0.9.19"
     hoist-non-react-statics "^3.1.0"
@@ -941,22 +941,21 @@
     focus-trap-react "^4.0.1"
     tippy.js "^3.4.1"
 
-"@patternfly/react-core@^2.5.2":
-  version "2.5.2"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-2.5.2.tgz#8946e750c0ebfc843498890cd70b2265ceb344ed"
+"@patternfly/react-core@^2.5.7":
+  version "2.5.7"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-core/-/react-core-2.5.7.tgz#c32dca56b3a187b1d60f072c8c5ae25057fc2612"
   dependencies:
-    "@patternfly/react-icons" "^3.2.0"
-    "@patternfly/react-styles" "^2.3.7"
+    "@patternfly/react-icons" "^3.2.1"
+    "@patternfly/react-styles" "^2.3.9"
     "@patternfly/react-tokens" "^2.0.7"
     "@tippy.js/react" "^1.1.1"
     emotion "^9.2.9"
     exenv "^1.2.2"
     focus-trap-react "^4.0.1"
-    tippy.js "^3.4.1"
 
-"@patternfly/react-icons@3.2.0", "@patternfly/react-icons@^3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.2.0.tgz#ad7e121d43d4d2c857a61c89baef81da38716a55"
+"@patternfly/react-icons@3.2.1", "@patternfly/react-icons@^3.2.1":
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.2.1.tgz#497c11ab8432fa9caa0086e25cd1ba4cf1f76870"
 
 "@patternfly/react-icons@^3.0.0", "@patternfly/react-icons@^3.0.2":
   version "3.0.2"
@@ -966,13 +965,9 @@
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.1.1.tgz#3fd9137f19f10a433c642e61f8d9ca3ec43c7e75"
 
-"@patternfly/react-icons@^3.2.1":
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-icons/-/react-icons-3.2.1.tgz#497c11ab8432fa9caa0086e25cd1ba4cf1f76870"
-
-"@patternfly/react-styles@2.3.7", "@patternfly/react-styles@^2.3.7":
-  version "2.3.7"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-2.3.7.tgz#f1831cb5b039e2078db8de59916bde74b788d5e1"
+"@patternfly/react-styles@2.3.9", "@patternfly/react-styles@^2.3.8", "@patternfly/react-styles@^2.3.9":
+  version "2.3.9"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-2.3.9.tgz#d2204cd181120ba352c576b90380f1253da5a0f6"
   dependencies:
     "@babel/helper-plugin-utils" "^7.0.0-beta.48"
     camel-case "^3.0.0"
@@ -1021,31 +1016,14 @@
     relative "^3.0.2"
     resolve-from "^4.0.0"
 
-"@patternfly/react-styles@^2.3.8":
-  version "2.3.9"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-styles/-/react-styles-2.3.9.tgz#d2204cd181120ba352c576b90380f1253da5a0f6"
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.0.0-beta.48"
-    camel-case "^3.0.0"
-    css "^2.2.3"
-    cssom "^0.3.4"
-    cssstyle "^0.3.1"
-    emotion "^9.2.9"
-    emotion-server "^9.2.9"
-    fbjs-scripts "^0.8.3"
-    fs-extra "^6.0.1"
-    jsdom "^11.11.0"
-    relative "^3.0.2"
-    resolve-from "^4.0.0"
-
-"@patternfly/react-table@1.1.3":
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-1.1.3.tgz#f017cbe86c1791cd5812091269fbc4be9427cfa9"
+"@patternfly/react-table@1.2.3":
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/@patternfly/react-table/-/react-table-1.2.3.tgz#e1783c381334ef8b408e459458bea18c80a27147"
   dependencies:
     "@patternfly/patternfly" "1.0.222"
-    "@patternfly/react-core" "^2.5.2"
-    "@patternfly/react-icons" "^3.2.0"
-    "@patternfly/react-styles" "^2.3.7"
+    "@patternfly/react-core" "^2.5.7"
+    "@patternfly/react-icons" "^3.2.1"
+    "@patternfly/react-styles" "^2.3.9"
     exenv "^1.2.2"
     reactabular-table "^8.14.0"
 


### PR DESCRIPTION
FYI - I believe these are the set of changes for the upcoming app format changes to work on cloud.redhat.com.

FYI - @dlabrecq @boaz0 

Run from the insights proxy folder:
`SPANDX_CONFIG=/path/to/koku-ui/config/spandx.config.js bash scripts/run.sh`

then `yarn start:dev`

Point browser to: 
https://ci.foo.redhat.com:1337/apps/cost-management/

This should also work; but doesn't seem to:
https://ci.foo.redhat.com:1337/hcm/cost-management/

Worked of the changes seen here:
https://github.com/RedHatInsights/insights-frontend-starter-app/pull/62/files