### PR TITLE
Enable sort by cost while grouping by tags

### DIFF
--- a/src/pages/awsDetails/detailsTable.tsx
+++ b/src/pages/awsDetails/detailsTable.tsx
@@ -369,10 +369,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   private handleOnSort = (event, index, direction) => {
     const { onSort } = this.props;
     const { columns } = this.state;
-    const groupByTagKey = this.getGroupByTagKey();
 
     if (onSort) {
-      const orderBy = columns[index - (groupByTagKey ? 1 : 2)].orderBy;
+      const orderBy = columns[index - 2].orderBy;
       const isSortAscending = direction === SortByDirection.asc;
       onSort(orderBy, isSortAscending);
     }

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -369,10 +369,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   private handleOnSort = (event, index, direction) => {
     const { onSort } = this.props;
     const { columns } = this.state;
-    const groupByTagKey = this.getGroupByTagKey();
 
     if (onSort) {
-      const orderBy = columns[index - (groupByTagKey ? 1 : 2)].orderBy;
+      const orderBy = columns[index - 2].orderBy;
       const isSortAscending = direction === SortByDirection.asc;
       onSort(orderBy, isSortAscending);
     }

--- a/src/pages/ocpOnAwsDetails/detailsTable.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsTable.tsx
@@ -379,10 +379,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   private handleOnSort = (event, index, direction) => {
     const { onSort } = this.props;
     const { columns } = this.state;
-    const groupByTagKey = this.getGroupByTagKey();
 
     if (onSort) {
-      const orderBy = columns[index - (groupByTagKey ? 1 : 2)].orderBy;
+      const orderBy = columns[index - 2].orderBy;
       const isSortAscending = direction === SortByDirection.asc;
       onSort(orderBy, isSortAscending);
     }


### PR DESCRIPTION
Now that we're showing the expanding row column, while grouping by tags, we must adjust the sort functionality to work with the proper number of table columns.

Fixes https://github.com/project-koku/koku-ui/issues/625