### PR TITLE
Incorrect total costs

### DIFF
--- a/src/components/charts/commonChart/chartUtils.ts
+++ b/src/components/charts/commonChart/chartUtils.ts
@@ -15,6 +15,10 @@ import {
   getComputedAwsReportItems,
 } from 'utils/getComputedAwsReportItems';
 import {
+  ComputedOcpOnAwsReportItem,
+  getComputedOcpOnAwsReportItems,
+} from 'utils/getComputedOcpOnAwsReportItems';
+import {
   ComputedOcpReportItem,
   getComputedOcpReportItems,
 } from 'utils/getComputedOcpReportItems';
@@ -109,7 +113,7 @@ export function transformOcpOnAwsReport(
     sortKey: 'id',
     sortDirection: SortDirection.desc,
   } as any;
-  const computedItems = getComputedOcpReportItems(items);
+  const computedItems = getComputedOcpOnAwsReportItems(items);
 
   if (type === ChartType.daily) {
     return computedItems.map(i => createDatum(i[reportItem], i, key));
@@ -126,7 +130,10 @@ export function transformOcpOnAwsReport(
 
 export function createDatum(
   value: number,
-  computedItem: ComputedAwsReportItem | ComputedOcpReportItem,
+  computedItem:
+    | ComputedAwsReportItem
+    | ComputedOcpReportItem
+    | ComputedOcpOnAwsReportItem,
   idKey = 'date'
 ): ChartDatum {
   const xVal = idKey === 'date' ? getDate(computedItem.id) : computedItem.label;

--- a/src/components/reports/awsReportSummary/awsReportSummaryItems.test.tsx
+++ b/src/components/reports/awsReportSummary/awsReportSummaryItems.test.tsx
@@ -13,6 +13,7 @@ const props: AwsReportSummaryItemsProps = {
   idKey: 'date',
   labelKey: 'account',
   children: jest.fn(() => null),
+  t: jest.fn(v => `t(${v})`),
 };
 
 test('computes report items', () => {

--- a/src/components/reports/awsReportSummary/awsReportSummaryItems.tsx
+++ b/src/components/reports/awsReportSummary/awsReportSummaryItems.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
 import {
   ComputedAwsReportItem,
   getComputedAwsReportItems,
@@ -9,11 +10,15 @@ interface AwsReportSummaryItemsRenderProps {
   items: ComputedAwsReportItem[];
 }
 
-interface AwsReportSummaryItemsProps extends GetComputedAwsReportItemsParams {
+interface AwsReportSummaryItemsOwnProps
+  extends GetComputedAwsReportItemsParams {
   children?(props: AwsReportSummaryItemsRenderProps): React.ReactNode;
 }
 
-class AwsReportSummaryItems extends React.Component<
+type AwsReportSummaryItemsProps = AwsReportSummaryItemsOwnProps &
+  InjectedTranslateProps;
+
+class AwsReportSummaryItemsBase extends React.Component<
   AwsReportSummaryItemsProps
 > {
   public shouldComponentUpdate(nextProps: AwsReportSummaryItemsProps) {
@@ -48,16 +53,18 @@ class AwsReportSummaryItems extends React.Component<
   }
 
   public render() {
-    const { report, children } = this.props;
+    const { report, children, t } = this.props;
+
     if (!report) {
-      return null;
+      return `${t('loading')}...`;
+    } else {
+      const items = this.getItems();
+      return <ul>{children({ items })}</ul>;
     }
-
-    const items = this.getItems();
-
-    return <ul>{children({ items })}</ul>;
   }
 }
+
+const AwsReportSummaryItems = translate()(AwsReportSummaryItemsBase);
 
 export {
   AwsReportSummaryItems,

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItems.test.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItems.test.tsx
@@ -13,6 +13,7 @@ const props: OcpOnAwsReportSummaryItemsProps = {
   idKey: 'date',
   labelKey: 'account',
   children: jest.fn(() => null),
+  t: jest.fn(v => `t(${v})`),
 };
 
 test('computes report items', () => {

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItems.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItems.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
 import {
   ComputedOcpOnAwsReportItem,
   getComputedOcpOnAwsReportItems,
@@ -9,12 +10,15 @@ interface OcpOnAwsReportSummaryItemsRenderProps {
   items: ComputedOcpOnAwsReportItem[];
 }
 
-interface OcpOnAwsReportSummaryItemsProps
+interface OcpOnAwsReportSummaryItemsOwnProps
   extends GetComputedOcpOnAwsReportItemsParams {
   children?(props: OcpOnAwsReportSummaryItemsRenderProps): React.ReactNode;
 }
 
-class OcpOnAwsReportSummaryItems extends React.Component<
+type OcpOnAwsReportSummaryItemsProps = OcpOnAwsReportSummaryItemsOwnProps &
+  InjectedTranslateProps;
+
+class OcpOnAwsReportSummaryItemsBase extends React.Component<
   OcpOnAwsReportSummaryItemsProps
 > {
   public shouldComponentUpdate(nextProps: OcpOnAwsReportSummaryItemsProps) {
@@ -49,16 +53,18 @@ class OcpOnAwsReportSummaryItems extends React.Component<
   }
 
   public render() {
-    const { report, children } = this.props;
+    const { report, children, t } = this.props;
+
     if (!report) {
-      return null;
+      return `${t('loading')}...`;
+    } else {
+      const items = this.getItems();
+      return <ul>{children({ items })}</ul>;
     }
-
-    const items = this.getItems();
-
-    return <ul>{children({ items })}</ul>;
   }
 }
+
+const OcpOnAwsReportSummaryItems = translate()(OcpOnAwsReportSummaryItemsBase);
 
 export {
   OcpOnAwsReportSummaryItems,

--- a/src/components/reports/ocpReportSummary/ocpReportSummaryItems.test.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummaryItems.test.tsx
@@ -13,6 +13,7 @@ const props: OcpReportSummaryItemsProps = {
   idKey: 'date',
   labelKey: 'account',
   children: jest.fn(() => null),
+  t: jest.fn(v => `t(${v})`),
 };
 
 test('computes report items', () => {

--- a/src/components/reports/ocpReportSummary/ocpReportSummaryItems.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummaryItems.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
 import {
   ComputedOcpReportItem,
   getComputedOcpReportItems,
@@ -9,11 +10,15 @@ interface OcpReportSummaryItemsRenderProps {
   items: ComputedOcpReportItem[];
 }
 
-interface OcpReportSummaryItemsProps extends GetComputedOcpReportItemsParams {
+interface OcpReportSummaryItemsOwnProps
+  extends GetComputedOcpReportItemsParams {
   children?(props: OcpReportSummaryItemsRenderProps): React.ReactNode;
 }
 
-class OcpReportSummaryItems extends React.Component<
+type OcpReportSummaryItemsProps = OcpReportSummaryItemsOwnProps &
+  InjectedTranslateProps;
+
+class OcpReportSummaryItemsBase extends React.Component<
   OcpReportSummaryItemsProps
 > {
   public shouldComponentUpdate(nextProps: OcpReportSummaryItemsProps) {
@@ -48,16 +53,18 @@ class OcpReportSummaryItems extends React.Component<
   }
 
   public render() {
-    const { report, children } = this.props;
+    const { report, children, t } = this.props;
+
     if (!report) {
-      return null;
+      return `${t('loading')}...`;
+    } else {
+      const items = this.getItems();
+      return <ul>{children({ items })}</ul>;
     }
-
-    const items = this.getItems();
-
-    return <ul>{children({ items })}</ul>;
   }
 }
+
+const OcpReportSummaryItems = translate()(OcpReportSummaryItemsBase);
 
 export {
   OcpReportSummaryItems,

--- a/src/pages/awsDetails/detailsHeader.tsx
+++ b/src/pages/awsDetails/detailsHeader.tsx
@@ -45,12 +45,6 @@ const baseQuery: AwsQuery = {
     time_scope_value: -1,
     resolution: 'monthly',
   },
-  group_by: {
-    account: '*',
-  },
-  order_by: {
-    cost: 'desc',
-  },
 };
 
 const reportType = AwsReportType.cost;

--- a/src/pages/ocpDetails/detailsHeader.tsx
+++ b/src/pages/ocpDetails/detailsHeader.tsx
@@ -47,12 +47,6 @@ const baseQuery: OcpQuery = {
     time_scope_value: -1,
     resolution: 'monthly',
   },
-  group_by: {
-    project: '*',
-  },
-  order_by: {
-    cost: 'desc',
-  },
 };
 
 class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {

--- a/src/pages/ocpOnAwsDetails/detailsHeader.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsHeader.tsx
@@ -50,12 +50,6 @@ const baseQuery: OcpOnAwsQuery = {
     time_scope_value: -1,
     resolution: 'monthly',
   },
-  group_by: {
-    project: '*',
-  },
-  order_by: {
-    cost: 'desc',
-  },
 };
 
 class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {

--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -122,7 +122,6 @@ class OverviewBase extends React.Component<OverviewProps> {
     const { activeTabKey } = this.state;
     const availableTabs = [];
 
-    // Todo: How do we check if we have Ocp on Aws?
     if (
       awsProviders &&
       awsProviders.meta &&

--- a/src/store/awsDashboard/__snapshots__/awsDashboard.test.ts.snap
+++ b/src/store/awsDashboard/__snapshots__/awsDashboard.test.ts.snap
@@ -4,11 +4,11 @@ exports[`fetch widget reports 1`] = `
 Array [
   Array [
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&group_by[service]=*",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily",
   ],
   Array [
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily&group_by[service]=*",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily",
   ],
   Array [
     "cost",

--- a/src/store/awsDashboard/awsDashboard.test.ts
+++ b/src/store/awsDashboard/awsDashboard.test.ts
@@ -9,7 +9,7 @@ import {
   awsDashboardStateKey,
   AwsDashboardTab,
   getGroupByForTab,
-  getQueryForWidget,
+  getQueryForWidgetTabs,
 } from './awsDashboardCommon';
 import { awsDashboardReducer } from './awsDashboardReducer';
 import * as selectors from './awsDashboardSelectors';
@@ -110,6 +110,6 @@ test('getQueryForWidget', () => {
     [{}, 'group_by[account]=*'],
     [{ limit: 5 }, 'filter[limit]=5&group_by[account]=*'],
   ].forEach(value => {
-    expect(getQueryForWidget(widget, value[0])).toEqual(value[1]);
+    expect(getQueryForWidgetTabs(widget, value[0])).toEqual(value[1]);
   });
 });

--- a/src/store/awsDashboard/awsDashboardCommon.ts
+++ b/src/store/awsDashboard/awsDashboardCommon.ts
@@ -74,6 +74,15 @@ export function getGroupByForTab(tab: AwsDashboardTab): AwsQuery['group_by'] {
 }
 
 export function getQueryForWidget(
+  filter: AwsFilters = awsDashboardDefaultFilters
+) {
+  const query: AwsQuery = {
+    filter,
+  };
+  return getQuery(query);
+}
+
+export function getQueryForWidgetTabs(
   widget: AwsDashboardWidget,
   filter: AwsFilters = awsDashboardDefaultFilters
 ) {
@@ -81,6 +90,5 @@ export function getQueryForWidget(
     filter,
     group_by: getGroupByForTab(widget.currentTab),
   };
-
   return getQuery(query);
 }

--- a/src/store/awsDashboard/awsDashboardSelectors.ts
+++ b/src/store/awsDashboard/awsDashboardSelectors.ts
@@ -4,6 +4,7 @@ import {
   awsDashboardStateKey,
   awsDashboardTabFilters,
   getQueryForWidget,
+  getQueryForWidgetTabs,
 } from './awsDashboardCommon';
 
 export const selectAwsDashboardState = (state: RootState) =>
@@ -31,12 +32,12 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
   };
 
   return {
-    previous: getQueryForWidget(widget, {
+    previous: getQueryForWidget({
       ...filter,
       time_scope_value: -2,
     }),
-    current: getQueryForWidget(widget, filter),
-    tabs: getQueryForWidget(widget, {
+    current: getQueryForWidget(filter),
+    tabs: getQueryForWidgetTabs(widget, {
       ...tabsFilter,
       resolution: 'monthly',
     }),

--- a/src/store/ocpDashboard/__snapshots__/ocpDashboard.test.ts.snap
+++ b/src/store/ocpDashboard/__snapshots__/ocpDashboard.test.ts.snap
@@ -4,11 +4,11 @@ exports[`fetch widget reports 1`] = `
 Array [
   Array [
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&group_by[project]=*",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily",
   ],
   Array [
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily&group_by[project]=*",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily",
   ],
   Array [
     "cost",

--- a/src/store/ocpDashboard/ocpDashboard.test.ts
+++ b/src/store/ocpDashboard/ocpDashboard.test.ts
@@ -7,7 +7,7 @@ import { ocpReportsActions } from 'store/ocpReports';
 import * as actions from './ocpDashboardActions';
 import {
   getGroupByForTab,
-  getQueryForWidget,
+  getQueryForWidgetTabs,
   ocpDashboardStateKey,
   OcpDashboardTab,
 } from './ocpDashboardCommon';
@@ -106,6 +106,6 @@ test('getQueryForWidget', () => {
     [{}, 'group_by[project]=*'],
     [{ limit: 5 }, 'filter[limit]=5&group_by[project]=*'],
   ].forEach(value => {
-    expect(getQueryForWidget(widget, value[0])).toEqual(value[1]);
+    expect(getQueryForWidgetTabs(widget, value[0])).toEqual(value[1]);
   });
 });

--- a/src/store/ocpDashboard/ocpDashboardCommon.ts
+++ b/src/store/ocpDashboard/ocpDashboardCommon.ts
@@ -79,6 +79,15 @@ export function getGroupByForTab(tab: OcpDashboardTab): OcpQuery['group_by'] {
 }
 
 export function getQueryForWidget(
+  filter: OcpFilters = ocpDashboardDefaultFilters
+) {
+  const query: OcpQuery = {
+    filter,
+  };
+  return getQuery(query);
+}
+
+export function getQueryForWidgetTabs(
   widget: OcpDashboardWidget,
   filter: OcpFilters = ocpDashboardDefaultFilters
 ) {
@@ -86,6 +95,5 @@ export function getQueryForWidget(
     filter,
     group_by: getGroupByForTab(widget.currentTab),
   };
-
   return getQuery(query);
 }

--- a/src/store/ocpDashboard/ocpDashboardSelectors.ts
+++ b/src/store/ocpDashboard/ocpDashboardSelectors.ts
@@ -1,6 +1,7 @@
 import { RootState } from 'store/rootReducer';
 import {
   getQueryForWidget,
+  getQueryForWidgetTabs,
   ocpDashboardDefaultFilters,
   ocpDashboardStateKey,
   ocpDashboardTabFilters,
@@ -31,12 +32,12 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
   };
 
   return {
-    previous: getQueryForWidget(widget, {
+    previous: getQueryForWidget({
       ...filter,
       time_scope_value: -2,
     }),
-    current: getQueryForWidget(widget, filter),
-    tabs: getQueryForWidget(widget, {
+    current: getQueryForWidget(filter),
+    tabs: getQueryForWidgetTabs(widget, {
       ...tabsFilter,
       resolution: 'monthly',
     }),

--- a/src/store/ocpOnAwsDashboard/__snapshots__/ocpOnAwsDashboard.test.ts.snap
+++ b/src/store/ocpOnAwsDashboard/__snapshots__/ocpOnAwsDashboard.test.ts.snap
@@ -4,11 +4,11 @@ exports[`fetch widget reports 1`] = `
 Array [
   Array [
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&group_by[project]=*",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily",
   ],
   Array [
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily&group_by[project]=*",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily",
   ],
   Array [
     "cost",

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboard.test.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboard.test.ts
@@ -7,7 +7,7 @@ import { ocpOnAwsReportsActions } from 'store/ocpOnAwsReports';
 import * as actions from './ocpOnAwsDashboardActions';
 import {
   getGroupByForTab,
-  getQueryForWidget,
+  getQueryForWidgetTabs,
   ocpOnAwsDashboardStateKey,
   OcpOnAwsDashboardTab,
 } from './ocpOnAwsDashboardCommon';
@@ -110,6 +110,6 @@ test('getQueryForWidget', () => {
     [{}, 'group_by[project]=*'],
     [{ limit: 5 }, 'filter[limit]=5&group_by[project]=*'],
   ].forEach(value => {
-    expect(getQueryForWidget(widget, value[0])).toEqual(value[1]);
+    expect(getQueryForWidgetTabs(widget, value[0])).toEqual(value[1]);
   });
 });

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardCommon.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardCommon.ts
@@ -81,6 +81,15 @@ export function getGroupByForTab(
 }
 
 export function getQueryForWidget(
+  filter: OcpOnAwsFilters = ocpOnAwsDashboardDefaultFilters
+) {
+  const query: OcpOnAwsQuery = {
+    filter,
+  };
+  return getQuery(query);
+}
+
+export function getQueryForWidgetTabs(
   widget: OcpOnAwsDashboardWidget,
   filter: OcpOnAwsFilters = ocpOnAwsDashboardDefaultFilters
 ) {
@@ -88,6 +97,5 @@ export function getQueryForWidget(
     filter,
     group_by: getGroupByForTab(widget.currentTab),
   };
-
   return getQuery(query);
 }

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardSelectors.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardSelectors.ts
@@ -1,6 +1,7 @@
 import { RootState } from 'store/rootReducer';
 import {
   getQueryForWidget,
+  getQueryForWidgetTabs,
   ocpOnAwsDashboardDefaultFilters,
   ocpOnAwsDashboardStateKey,
   ocpOnAwsDashboardTabFilters,
@@ -31,12 +32,12 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
   };
 
   return {
-    previous: getQueryForWidget(widget, {
+    previous: getQueryForWidget({
       ...filter,
       time_scope_value: -2,
     }),
-    current: getQueryForWidget(widget, filter),
-    tabs: getQueryForWidget(widget, {
+    current: getQueryForWidget(filter),
+    tabs: getQueryForWidgetTabs(widget, {
       ...tabsFilter,
       resolution: 'monthly',
     }),


### PR DESCRIPTION
The OCP and OCP on AWS overview / details pages show incorrect total costs.

We're showing an incorrect total cost because 'group by' project is applied to the underlying API request. Similarly, the details page also shows a total cost, based on 'group by' project.

This change ensures 'group by' is applied only to the overview tabs, not the API requests associated with total cost.

Fixes https://github.com/project-koku/koku-ui/issues/632

OCP overview:
![chrome-capture](https://user-images.githubusercontent.com/17481322/54850130-a528fc00-4cbc-11e9-94f1-d640439a833e.gif)

OCP details:
<img width="983" alt="Screen Shot 2019-03-22 at 4 07 18 PM" src="https://user-images.githubusercontent.com/17481322/54850142-ace8a080-4cbc-11e9-900d-0783ed13ccbc.png">
