### PR TITLE
OCP Details: update expanding rows area

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -116,6 +116,7 @@
   "group_by": {
     "all": "All $t(group_by.values.{{groupBy}}, { 'count': 5 })",
     "cost": "Group cost by",
+    "details": "$t(group_by.values.{{groupBy}}, { 'count': 3 })",
     "tag": "Tag Key: {{key}}",
     "top": "Top $t(group_by.top_values.{{groupBy}}, { 'count': 5 })",
     "top_ocp_on_aws": "$t(group_by.top_ocp_on_aws_values.{{groupBy}}, { 'count': 3 })",

--- a/src/pages/ocpDetails/detailsSummary.styles.ts
+++ b/src/pages/ocpDetails/detailsSummary.styles.ts
@@ -2,7 +2,7 @@ import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
-  projectsProgressBar: {
+  summary: {
     paddingTop: global_spacer_md.value,
   },
 });

--- a/src/pages/ocpDetails/detailsSummary.tsx
+++ b/src/pages/ocpDetails/detailsSummary.tsx
@@ -54,8 +54,8 @@ class DetailsSummaryBase extends React.Component<DetailsSummaryProps> {
 
     return (
       <div>
-        {t('ocp_details.historical.project_title')}
-        <div className={css(styles.projectsProgressBar)}>
+        {t('group_by.details', { groupBy: 'project' })}
+        <div className={css(styles.summary)}>
           <OcpReportSummaryItems idKey="project" report={report}>
             {({ items }) =>
               items.map(reportItem => (
@@ -86,7 +86,7 @@ const mapStateToProps = createMapStateToProps<
       time_scope_units: 'month',
       time_scope_value: -1,
       resolution: 'monthly',
-      limit: 5,
+      limit: 3,
     },
     group_by: {
       project: '*',

--- a/src/pages/ocpDetails/detailsTableItem.styles.ts
+++ b/src/pages/ocpDetails/detailsTableItem.styles.ts
@@ -1,20 +1,25 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_3xl, global_spacer_xl } from '@patternfly/react-tokens';
-// import { css } from 'emotion';
 
 export const styles = StyleSheet.create({
-  historicalLinkContainer: {
+  clusterContainer: {
+    marginBottom: global_spacer_xl.value,
+  },
+  historicalContainer: {
     display: 'flex',
     justifyContent: 'flex-end',
     paddingTop: global_spacer_xl.value,
   },
-  measureChartContainer: {
-    paddingTop: global_spacer_xl.value,
-  },
-  projectsContainer: {
-    paddingTop: global_spacer_xl.value,
-  },
-  summaryContainer: {
+  leftPane: {
     marginRight: global_spacer_3xl.value,
+    paddingBottom: global_spacer_xl.value,
+    paddingRight: global_spacer_3xl.value,
+  },
+  rightPane: {
+    marginRight: global_spacer_xl.value,
+    paddingBottom: global_spacer_xl.value,
+  },
+  tagsContainer: {
+    marginBottom: global_spacer_xl.value,
   },
 });

--- a/src/pages/ocpDetails/detailsTableItem.tsx
+++ b/src/pages/ocpDetails/detailsTableItem.tsx
@@ -58,40 +58,8 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
     return (
       <>
         <Grid>
-          <GridItem md={12} lg={3}>
-            <div className={css(styles.projectsContainer)}>
-              {Boolean(groupBy === 'project') && (
-                <Form>
-                  <FormGroup
-                    label={t('ocp_details.cluster_label')}
-                    fieldId="cluster-name"
-                  >
-                    <div>{item.cluster}</div>
-                  </FormGroup>
-                  <FormGroup label={t('ocp_details.tags_label')} fieldId="tags">
-                    <DetailsTag
-                      groupBy={groupBy}
-                      id="tags"
-                      item={item}
-                      project={item.label || item.id}
-                    />
-                  </FormGroup>
-                </Form>
-              )}
-              {Boolean(groupBy === 'cluster' || groupBy === 'node') && (
-                <div className={css(styles.summaryContainer)}>
-                  <DetailsSummary groupBy={groupBy} item={item} />
-                </div>
-              )}
-            </div>
-          </GridItem>
-          <GridItem md={12} lg={6}>
-            <div className={css(styles.measureChartContainer)}>
-              <DetailsChart groupBy={groupBy} item={item} />
-            </div>
-          </GridItem>
-          <GridItem md={12} lg={3}>
-            <div className={css(styles.historicalLinkContainer)}>
+          <GridItem sm={12}>
+            <div className={css(styles.historicalContainer)}>
               <Button
                 {...getTestProps(testIds.details.historical_data_btn)}
                 onClick={this.handleHistoricalModalOpen}
@@ -100,6 +68,47 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
               >
                 {t('ocp_details.historical.view_data')}
               </Button>
+            </div>
+          </GridItem>
+          <GridItem lg={12} xl={6}>
+            <div className={css(styles.leftPane)}>
+              {Boolean(groupBy !== 'cluster') && (
+                <div className={css(styles.clusterContainer)}>
+                  <Form>
+                    <FormGroup
+                      label={t('ocp_details.cluster_label')}
+                      fieldId="cluster-name"
+                    >
+                      <div>{item.cluster}</div>
+                    </FormGroup>
+                  </Form>
+                </div>
+              )}
+              {Boolean(groupBy !== 'project') && (
+                <DetailsSummary groupBy={groupBy} item={item} />
+              )}
+            </div>
+          </GridItem>
+          <GridItem lg={12} xl={6}>
+            <div className={css(styles.rightPane)}>
+              {Boolean(groupBy === 'project') && (
+                <div className={css(styles.tagsContainer)}>
+                  <Form>
+                    <FormGroup
+                      label={t('ocp_details.tags_label')}
+                      fieldId="tags"
+                    >
+                      <DetailsTag
+                        groupBy={groupBy}
+                        id="tags"
+                        item={item}
+                        project={item.label || item.id}
+                      />
+                    </FormGroup>
+                  </Form>
+                </div>
+              )}
+              <DetailsChart groupBy={groupBy} item={item} />
             </div>
           </GridItem>
         </Grid>


### PR DESCRIPTION
Update the expanding rows area, for the OCP details page, per the mock below.

Mock: https://redhat.invisionapp.com/share/HEO4ISHAT8Z#/screens/352926695

Note: Tags are shown only for 'group by' project.

Fixes https://github.com/project-koku/koku-ui/issues/599

Group by cluster:
<img width="1311" alt="Screen Shot 2019-03-22 at 3 40 37 PM" src="https://user-images.githubusercontent.com/17481322/54849287-2b900e80-4cba-11e9-8295-4d8d9bfce9ce.png">

Group by project:
<img width="1388" alt="Screen Shot 2019-03-22 at 3 51 05 PM" src="https://user-images.githubusercontent.com/17481322/54849346-5d08da00-4cba-11e9-85b2-831097437e8f.png">
