### PR TITLE
Bullet chart tooltip orientation

### DIFF
--- a/src/components/charts/bulletChart/bulletChart.tsx
+++ b/src/components/charts/bulletChart/bulletChart.tsx
@@ -97,7 +97,10 @@ class BulletChart extends React.Component<BulletChartProps, State> {
           <span className={css(styles.bulletChartTitle)}>{title}</span>
         )}
         <Chart height={chartStyles.height} width={width}>
-          <ChartGroup horizontal labelComponent={<ChartTooltip />}>
+          <ChartGroup
+            horizontal
+            labelComponent={<ChartTooltip dx={-10} dy={30} orientation="top" />}
+          >
             {Boolean(sortedRanges) &&
               sortedRanges.map((val, index) => {
                 return (


### PR DESCRIPTION
Moves the Bullet chart tooltip orientation to top.

Fixes https://github.com/project-koku/koku-ui/issues/637

<img width="618" alt="Screen Shot 2019-03-22 at 7 45 18 PM" src="https://user-images.githubusercontent.com/17481322/54858432-1ecfe280-4cdb-11e9-99e1-395152561623.png">
