### PR TITLE
Update OCP on AWS details page margins

### DIFF
--- a/src/pages/ocpOnAwsDetails/detailsSummary.styles.ts
+++ b/src/pages/ocpOnAwsDetails/detailsSummary.styles.ts
@@ -2,7 +2,7 @@ import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
-  projectsProgressBar: {
+  summary: {
     paddingTop: global_spacer_md.value,
   },
 });

--- a/src/pages/ocpOnAwsDetails/detailsSummary.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsSummary.tsx
@@ -58,7 +58,7 @@ class DetailsSummaryBase extends React.Component<DetailsSummaryProps> {
     return (
       <div>
         {t('group_by.top_ocp_on_aws', { groupBy: 'service' })}
-        <div className={css(styles.projectsProgressBar)}>
+        <div className={css(styles.summary)}>
           <OcpOnAwsReportSummaryItems idKey="project" report={report}>
             {({ items }) =>
               items.map(reportItem => (

--- a/src/pages/ocpOnAwsDetails/detailsTableItem.styles.ts
+++ b/src/pages/ocpOnAwsDetails/detailsTableItem.styles.ts
@@ -1,9 +1,5 @@
 import { StyleSheet } from '@patternfly/react-styles';
-import {
-  global_spacer_2xl,
-  global_spacer_3xl,
-  global_spacer_xl,
-} from '@patternfly/react-tokens';
+import { global_spacer_3xl, global_spacer_xl } from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
   clusterContainer: {
@@ -17,13 +13,11 @@ export const styles = StyleSheet.create({
   leftPane: {
     marginRight: global_spacer_3xl.value,
     paddingBottom: global_spacer_xl.value,
-    paddingTop: global_spacer_xl.value,
+    paddingRight: global_spacer_3xl.value,
   },
   rightPane: {
     marginRight: global_spacer_xl.value,
-    marginLeft: global_spacer_2xl.value,
     paddingBottom: global_spacer_xl.value,
-    paddingTop: global_spacer_xl.value,
   },
   tagsContainer: {
     marginBottom: global_spacer_xl.value,


### PR DESCRIPTION
The OCP on AWS details page should match the margins / padding used by the OCP and AWS details pages.

Fixes https://github.com/project-koku/koku-ui/issues/639

<img width="1495" alt="Screen Shot 2019-03-22 at 7 50 12 PM" src="https://user-images.githubusercontent.com/17481322/54858614-3fe50300-4cdc-11e9-8a7a-d071cc67b493.png">
