### PR TITLE
OCP on AWS Details: Show AWS accounts, services, and regions

### DIFF
--- a/src/pages/ocpOnAwsDetails/detailsTableItem.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsTableItem.tsx
@@ -16,7 +16,6 @@ import { ocpOnAwsDetailsSelectors } from 'store/ocpOnAwsDetails';
 import { getTestProps, testIds } from 'testIds';
 import { ComputedOcpOnAwsReportItem } from 'utils/getComputedOcpOnAwsReportItems';
 import { DetailsChart } from './detailsChart';
-import { DetailsSummary } from './detailsSummary';
 import { styles } from './detailsTableItem.styles';
 import { DetailsTag } from './detailsTag';
 import { DetailsWidget } from './detailsWidget';
@@ -98,20 +97,16 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
                   </Form>
                 </div>
               )}
-              {Boolean(groupBy === 'project') ? (
-                <DetailsSummary groupBy={groupBy} item={item} />
-              ) : (
-                widgets.map(widgetId => {
-                  return (
-                    <DetailsWidget
-                      groupBy={groupBy}
-                      item={item}
-                      key={`details-widget-${widgetId}`}
-                      widgetId={widgetId}
-                    />
-                  );
-                })
-              )}
+              {widgets.map(widgetId => {
+                return (
+                  <DetailsWidget
+                    groupBy={groupBy}
+                    item={item}
+                    key={`details-widget-${widgetId}`}
+                    widgetId={widgetId}
+                  />
+                );
+              })}
             </div>
           </GridItem>
           <GridItem lg={12} xl={6}>

--- a/src/pages/ocpOnAwsDetails/detailsWidget.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsWidget.tsx
@@ -81,7 +81,8 @@ class DetailsWidgetBase extends React.Component<DetailsWidgetProps> {
   };
 
   public componentDidMount() {
-    const { availableTabs, fetchReports, id, updateTab, widgetId } = this.props;
+    const { fetchReports, id, updateTab, widgetId } = this.props;
+    const availableTabs = this.getAvailableTabs();
     if (availableTabs) {
       updateTab(id, availableTabs[0]);
     }
@@ -98,13 +99,26 @@ class DetailsWidgetBase extends React.Component<DetailsWidgetProps> {
   };
 
   private handleTabClick = (event, tabIndex) => {
-    const { availableTabs, id, updateTab } = this.props;
+    const { id, updateTab } = this.props;
+    const availableTabs = this.getAvailableTabs();
     const tab = availableTabs[tabIndex];
 
     updateTab(id, tab);
     this.setState({
       activeTabKey: tabIndex,
     });
+  };
+
+  private getAvailableTabs = () => {
+    const { availableTabs, groupBy } = this.props;
+    const tabs = [];
+
+    availableTabs.forEach(tab => {
+      if (groupBy !== getIdKeyForTab(tab)) {
+        tabs.push(tab);
+      }
+    });
+    return tabs;
   };
 
   private getItems = (currentTab: string) => {
@@ -145,11 +159,12 @@ class DetailsWidgetBase extends React.Component<DetailsWidgetProps> {
   };
 
   private getTabItem = (tab: OcpOnAwsDetailsTab, reportItem) => {
-    const { availableTabs, reportType, report, topItems } = this.props;
+    const { reportType, report, topItems } = this.props;
     const { activeTabKey } = this.state;
 
-    const currentTab = getIdKeyForTab(tab);
+    const availableTabs = this.getAvailableTabs();
     const activeTab = getIdKeyForTab(availableTabs[activeTabKey]);
+    const currentTab = getIdKeyForTab(tab);
 
     if (activeTab === currentTab) {
       return (
@@ -177,7 +192,7 @@ class DetailsWidgetBase extends React.Component<DetailsWidgetProps> {
   };
 
   private getTabs = () => {
-    const { availableTabs } = this.props;
+    const availableTabs = this.getAvailableTabs();
 
     if (availableTabs) {
       return (


### PR DESCRIPTION
Per today's UI review, we want to show tabs for AWS accounts, services, and regions when each table row is expanded. Currently, we only show AWS services for 'group by' accounts.

Fixes https://github.com/project-koku/koku-ui/issues/645

<img width="1297" alt="Screen Shot 2019-03-28 at 1 43 52 PM" src="https://user-images.githubusercontent.com/17481322/55180291-a8f6cb80-515f-11e9-8170-2c2bf9878c66.png">
