### PR TITLE
OCP on Aws: Cannot group by tag

### DIFF
--- a/src/pages/ocpOnAwsDetails/detailsTableItem.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsTableItem.tsx
@@ -124,10 +124,10 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
                       fieldId="tags"
                     >
                       <DetailsTag
+                        account={item.label || item.id}
                         groupBy={groupBy}
                         id="tags"
                         item={item}
-                        project={item.label || item.id}
                       />
                     </FormGroup>
                   </Form>

--- a/src/pages/ocpOnAwsDetails/detailsTag.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsTag.tsx
@@ -1,24 +1,21 @@
 import { css } from '@patternfly/react-styles';
-import { getQuery } from 'api/ocpOnAwsQuery';
-import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import { getQuery } from 'api/awsQuery';
+import { AwsReport, AwsReportType } from 'api/awsReports';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
+import { awsReportsActions, awsReportsSelectors } from 'store/awsReports';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import {
-  ocpOnAwsReportsActions,
-  ocpOnAwsReportsSelectors,
-} from 'store/ocpOnAwsReports';
 import { getTestProps, testIds } from 'testIds';
 import { ComputedOcpOnAwsReportItem } from 'utils/getComputedOcpOnAwsReportItems';
 import { styles } from './detailsTag.styles';
 import { DetailsTagModal } from './detailsTagModal';
 
 interface DetailsTagOwnProps {
+  account: string | number;
   groupBy: string;
   id?: string;
   item: ComputedOcpOnAwsReportItem;
-  project: string | number;
 }
 
 interface DetailsTagState {
@@ -28,12 +25,12 @@ interface DetailsTagState {
 
 interface DetailsTagStateProps {
   queryString?: string;
-  report?: OcpOnAwsReport;
+  report?: AwsReport;
   reportFetchStatus?: FetchStatus;
 }
 
 interface DetailsTagDispatchProps {
-  fetchReport?: typeof ocpOnAwsReportsActions.fetchReport;
+  fetchReport?: typeof awsReportsActions.fetchReport;
 }
 
 type DetailsTagProps = DetailsTagOwnProps &
@@ -41,7 +38,7 @@ type DetailsTagProps = DetailsTagOwnProps &
   DetailsTagDispatchProps &
   InjectedTranslateProps;
 
-const reportType = OcpOnAwsReportType.tag;
+const reportType = AwsReportType.tag;
 
 class DetailsTagBase extends React.Component<DetailsTagProps> {
   protected defaultState: DetailsTagState = {
@@ -79,7 +76,7 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
   };
 
   public render() {
-    const { groupBy, id, item, project, report, t } = this.props;
+    const { account, groupBy, id, item, report, t } = this.props;
     const { isDetailsModalOpen, showAll } = this.state;
 
     let charCount = 0;
@@ -117,11 +114,11 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
           </a>
         )}
         <DetailsTagModal
+          account={account}
           groupBy={groupBy}
           isOpen={isDetailsModalOpen}
           item={item}
           onClose={this.handleDetailsModalClose}
-          project={project}
         />
       </div>
     );
@@ -131,27 +128,27 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
 const mapStateToProps = createMapStateToProps<
   DetailsTagOwnProps,
   DetailsTagStateProps
->((state, { project }) => {
+>((state, { account }) => {
   const queryString = getQuery({
     filter: {
-      project,
+      account,
       resolution: 'monthly',
       time_scope_units: 'month',
       time_scope_value: -1,
     },
   });
-  const report = ocpOnAwsReportsSelectors.selectReport(
+  const report = awsReportsSelectors.selectReport(
     state,
     reportType,
     queryString
   );
-  const reportFetchStatus = ocpOnAwsReportsSelectors.selectReportFetchStatus(
+  const reportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
     state,
     reportType,
     queryString
   );
   return {
-    project,
+    account,
     queryString,
     report,
     reportFetchStatus,
@@ -159,7 +156,7 @@ const mapStateToProps = createMapStateToProps<
 });
 
 const mapDispatchToProps: DetailsTagDispatchProps = {
-  fetchReport: ocpOnAwsReportsActions.fetchReport,
+  fetchReport: awsReportsActions.fetchReport,
 };
 
 const DetailsTag = translate()(

--- a/src/pages/ocpOnAwsDetails/detailsTagModal.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsTagModal.tsx
@@ -1,34 +1,31 @@
 import { Modal } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
-import { getQuery } from 'api/ocpOnAwsQuery';
-import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import { getQuery } from 'api/awsQuery';
+import { AwsReport, AwsReportType } from 'api/awsReports';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
+import { awsReportsActions, awsReportsSelectors } from 'store/awsReports';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import {
-  ocpOnAwsReportsActions,
-  ocpOnAwsReportsSelectors,
-} from 'store/ocpOnAwsReports';
 import { ComputedOcpOnAwsReportItem } from 'utils/getComputedOcpOnAwsReportItems';
 import { modalOverride, styles } from './detailsTagModal.styles';
 
 interface DetailsTagModalOwnProps {
+  account: string | number;
   groupBy: string;
   isOpen: boolean;
   item: ComputedOcpOnAwsReportItem;
   onClose(isOpen: boolean);
-  project: string | number;
 }
 
 interface DetailsTagModalStateProps {
   queryString?: string;
-  report?: OcpOnAwsReport;
+  report?: AwsReport;
   reportFetchStatus?: FetchStatus;
 }
 
 interface DetailsTagModalDispatchProps {
-  fetchReport?: typeof ocpOnAwsReportsActions.fetchReport;
+  fetchReport?: typeof awsReportsActions.fetchReport;
 }
 
 type DetailsTagModalProps = DetailsTagModalOwnProps &
@@ -36,7 +33,7 @@ type DetailsTagModalProps = DetailsTagModalOwnProps &
   DetailsTagModalDispatchProps &
   InjectedTranslateProps;
 
-const reportType = OcpOnAwsReportType.tag;
+const reportType = AwsReportType.tag;
 
 class DetailsTagModalBase extends React.Component<DetailsTagModalProps> {
   constructor(props: DetailsTagModalProps) {
@@ -100,21 +97,21 @@ class DetailsTagModalBase extends React.Component<DetailsTagModalProps> {
 const mapStateToProps = createMapStateToProps<
   DetailsTagModalOwnProps,
   DetailsTagModalStateProps
->((state, { project }) => {
+>((state, { account }) => {
   const queryString = getQuery({
     filter: {
-      project,
+      account,
       resolution: 'monthly',
       time_scope_units: 'month',
       time_scope_value: -1,
     },
   });
-  const report = ocpOnAwsReportsSelectors.selectReport(
+  const report = awsReportsSelectors.selectReport(
     state,
     reportType,
     queryString
   );
-  const reportFetchStatus = ocpOnAwsReportsSelectors.selectReportFetchStatus(
+  const reportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
     state,
     reportType,
     queryString
@@ -127,7 +124,7 @@ const mapStateToProps = createMapStateToProps<
 });
 
 const mapDispatchToProps: DetailsTagModalDispatchProps = {
-  fetchReport: ocpOnAwsReportsActions.fetchReport,
+  fetchReport: awsReportsActions.fetchReport,
 };
 
 const DetailsTagModal = translate()(

--- a/src/pages/ocpOnAwsDetails/groupBy.tsx
+++ b/src/pages/ocpOnAwsDetails/groupBy.tsx
@@ -1,16 +1,13 @@
 import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
-import { getQuery, OcpOnAwsQuery } from 'api/ocpOnAwsQuery';
-import { parseQuery } from 'api/ocpOnAwsQuery';
-import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import { AwsQuery, getQuery } from 'api/awsQuery';
+import { parseQuery } from 'api/awsQuery';
+import { AwsReport, AwsReportType } from 'api/awsReports';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
+import { awsReportsActions, awsReportsSelectors } from 'store/awsReports';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import {
-  ocpOnAwsReportsActions,
-  ocpOnAwsReportsSelectors,
-} from 'store/ocpOnAwsReports';
 import { GetComputedOcpOnAwsReportItemsParams } from 'utils/getComputedOcpOnAwsReportItems';
 import { getIdKeyForGroupBy } from 'utils/getComputedOcpOnAwsReportItems';
 import { styles } from './groupBy.styles';
@@ -21,12 +18,12 @@ interface GroupByOwnProps {
 }
 
 interface GroupByStateProps {
-  report?: OcpOnAwsReport;
+  report?: AwsReport;
   reportFetchStatus?: FetchStatus;
 }
 
 interface GroupByDispatchProps {
-  fetchReport?: typeof ocpOnAwsReportsActions.fetchReport;
+  fetchReport?: typeof awsReportsActions.fetchReport;
 }
 
 interface GroupByState {
@@ -48,7 +45,7 @@ const groupByOptions: {
   { label: 'project', value: 'project' },
 ];
 
-const reportType = OcpOnAwsReportType.tag;
+const reportType = AwsReportType.tag;
 
 class GroupByBase extends React.Component<GroupByProps> {
   protected defaultState: GroupByState = {
@@ -123,7 +120,7 @@ class GroupByBase extends React.Component<GroupByProps> {
   };
 
   private getGroupBy = () => {
-    const queryFromRoute = parseQuery<OcpOnAwsQuery>(location.search);
+    const queryFromRoute = parseQuery<AwsQuery>(location.search);
     let groupBy: string = getIdKeyForGroupBy(queryFromRoute.group_by);
     const groupByKeys =
       queryFromRoute && queryFromRoute.group_by
@@ -199,12 +196,12 @@ const mapStateToProps = createMapStateToProps<
     },
     key_only: true,
   });
-  const report = ocpOnAwsReportsSelectors.selectReport(
+  const report = awsReportsSelectors.selectReport(
     state,
     reportType,
     queryString
   );
-  const reportFetchStatus = ocpOnAwsReportsSelectors.selectReportFetchStatus(
+  const reportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
     state,
     reportType,
     queryString
@@ -217,7 +214,7 @@ const mapStateToProps = createMapStateToProps<
 });
 
 const mapDispatchToProps: GroupByDispatchProps = {
-  fetchReport: ocpOnAwsReportsActions.fetchReport,
+  fetchReport: awsReportsActions.fetchReport,
 };
 
 const GroupBy = translate()(


### PR DESCRIPTION
When attempting OCP on AWS is groupped by tag, the API returns a "400 Bad Request". The specific message is "Unsupported parameter" message. We need to call the tags API for AWS.

Fixes https://github.com/project-koku/koku-ui/issues/647