### PR TITLE
Ensure release name is not omitted from router path

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -10,8 +10,9 @@ import { configureStore } from './store';
 const pathName = window.location.pathname.split('/');
 pathName.shift();
 
+let release = '/';
 if (pathName[0] === 'beta') {
-  pathName.shift();
+  release = `/${pathName.shift()}/`;
 }
 
 initApi({
@@ -27,7 +28,7 @@ const store = configureStore({
 
 render(
   <Provider store={store}>
-    <BrowserRouter basename={`${pathName[0]}/${pathName[1]}`}>
+    <BrowserRouter basename={`${release}${pathName[0]}/${pathName[1]}`}>
       <App />
     </BrowserRouter>
   </Provider>,


### PR DESCRIPTION
This should add the release name (e.g., /beta) into the router path.

Fixes https://github.com/project-koku/koku-ui/issues/683