### PR TITLE
Add missing units

### DIFF
--- a/src/components/reports/awsReportSummary/__snapshots__/awsReportSummaryItem.test.tsx.snap
+++ b/src/components/reports/awsReportSummary/__snapshots__/awsReportSummaryItem.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`gets percentage from value and total value: Rendered Label 1`] = `
   <Progress
     className=""
     id=""
-    label="formatted 100 (10%)"
+    label="percent_of_total"
     max={100}
     measureLocation="top"
     min={0}
@@ -31,7 +31,7 @@ exports[`sets percent to 0 if totalValue is 0: Rendered label 1`] = `
   <Progress
     className=""
     id=""
-    label="formatted 100 (0%)"
+    label="percent_of_total"
     max={100}
     measureLocation="top"
     min={0}

--- a/src/components/reports/awsReportSummary/awsReportSummaryDetails.test.tsx
+++ b/src/components/reports/awsReportSummary/awsReportSummaryDetails.test.tsx
@@ -6,9 +6,9 @@ import {
 } from './awsReportSummaryDetails';
 
 const props: AwsReportSummaryDetailsProps = {
-  report: { data: [], meta: { total: { cost: { value: 100, units: 'USD' } } } },
-  label: 'label',
   formatValue: jest.fn(() => 'formatedValue'),
+  report: { data: [], meta: { total: { cost: { value: 100, units: 'USD' } } } },
+  t: jest.fn(v => v),
 };
 
 test('report total is formated', () => {

--- a/src/components/reports/awsReportSummary/awsReportSummaryDetails.tsx
+++ b/src/components/reports/awsReportSummary/awsReportSummaryDetails.tsx
@@ -1,48 +1,56 @@
 import { css } from '@patternfly/react-styles';
 import { AwsReport, AwsReportType } from 'api/awsReports';
 import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
+import { unitLookupKey } from 'utils/formatValue';
 import { styles } from './awsReportSummaryDetails.styles';
 
-interface AwsReportSummaryDetailsProps {
+interface AwsReportSummaryDetailsProps extends InjectedTranslateProps {
   costLabel?: string;
   report: AwsReport;
   reportType: AwsReportType;
   formatValue?: ValueFormatter;
   formatOptions?: FormatOptions;
+  showUnits?: boolean;
   unitsLabel?: string;
   usageLabel?: string;
 }
 
-const AwsReportSummaryDetails: React.SFC<AwsReportSummaryDetailsProps> = ({
+const AwsReportSummaryDetailsBase: React.SFC<AwsReportSummaryDetailsProps> = ({
   costLabel,
   formatValue,
   formatOptions,
   report,
   reportType = AwsReportType.cost,
-  unitsLabel,
+  showUnits = false,
   usageLabel,
+  t,
 }) => {
   let cost: string | number = '----';
   let usage: string | number = '----';
-  if (report && report.meta && report.meta.total) {
-    const costUnits: string = report.meta.total.cost
-      ? report.meta.total.cost.units
-      : 'USD';
+
+  const hasTotal = report && report.meta && report.meta.total;
+  const costUnits: string =
+    hasTotal && report.meta.total.cost ? report.meta.total.cost.units : 'USD';
+  const usageUnits: string =
+    hasTotal && report.meta.total.usage ? report.meta.total.usage.units : 'USD';
+
+  if (hasTotal) {
     cost = formatValue(
       report.meta.total.cost ? report.meta.total.cost.value : 0,
       costUnits,
       formatOptions
     );
-    const usageUnits: string = report.meta.total.usage
-      ? report.meta.total.usage.units
-      : 'USD';
     usage = formatValue(
       report.meta.total.usage ? report.meta.total.usage.value : 0,
       usageUnits,
       formatOptions
     );
   }
+
+  const units = unitLookupKey(usageUnits);
+  const unitsLabel = t(`units.${units}`);
 
   if (reportType === AwsReportType.cost) {
     return (
@@ -62,7 +70,10 @@ const AwsReportSummaryDetails: React.SFC<AwsReportSummaryDetailsProps> = ({
         {Boolean(usageLabel) && (
           <div className={css(styles.valueContainer)}>
             <div className={css(styles.value)}>
-              {usage} <span className={css(styles.text)}>{unitsLabel}</span>
+              {usage}
+              {Boolean(showUnits) && (
+                <span className={css(styles.text)}>{unitsLabel}</span>
+              )}
             </div>
             <div className={css(styles.text)}>
               <div>{usageLabel}</div>
@@ -73,5 +84,7 @@ const AwsReportSummaryDetails: React.SFC<AwsReportSummaryDetailsProps> = ({
     );
   }
 };
+
+const AwsReportSummaryDetails = translate()(AwsReportSummaryDetailsBase);
 
 export { AwsReportSummaryDetails, AwsReportSummaryDetailsProps };

--- a/src/components/reports/awsReportSummary/awsReportSummaryDetails.tsx
+++ b/src/components/reports/awsReportSummary/awsReportSummaryDetails.tsx
@@ -13,7 +13,6 @@ interface AwsReportSummaryDetailsProps extends InjectedTranslateProps {
   formatValue?: ValueFormatter;
   formatOptions?: FormatOptions;
   showUnits?: boolean;
-  unitsLabel?: string;
   usageLabel?: string;
 }
 

--- a/src/components/reports/awsReportSummary/awsReportSummaryItem.test.tsx
+++ b/src/components/reports/awsReportSummary/awsReportSummaryItem.test.tsx
@@ -9,12 +9,13 @@ import {
 import { styles } from './awsReportSummaryItem.styles';
 
 const props: AwsReportSummaryItemProps = {
-  label: 'Label',
-  totalValue: 1000,
-  value: 100,
-  units: 'units',
-  formatValue: jest.fn(v => `formatted ${v}`),
   formatOptions: {},
+  formatValue: jest.fn(v => `formatted ${v}`),
+  label: 'Label',
+  t: jest.fn(v => v),
+  totalValue: 1000,
+  units: 'units',
+  value: 100,
 };
 
 // Temporarily disabled formatValue test until PF4 progress bar supports custom labels

--- a/src/components/reports/awsReportSummary/awsReportSummaryItem.tsx
+++ b/src/components/reports/awsReportSummary/awsReportSummaryItem.tsx
@@ -1,33 +1,39 @@
 import { Progress, ProgressSize } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
+import { unitLookupKey } from 'utils/formatValue';
 import { styles } from './awsReportSummaryItem.styles';
 
-interface AwsReportSummaryItemProps {
+interface AwsReportSummaryItemProps extends InjectedTranslateProps {
+  formatOptions?: FormatOptions;
+  formatValue: ValueFormatter;
   label: string;
+  totalValue: number;
   units: string;
   value: number;
-  totalValue: number;
-  formatValue: ValueFormatter;
-  formatOptions?: FormatOptions;
 }
 
-const AwsReportSummaryItem: React.SFC<AwsReportSummaryItemProps> = ({
+const AwsReportSummaryItemBase: React.SFC<AwsReportSummaryItemProps> = ({
   label,
-  value,
-  totalValue,
-  formatValue,
-  units,
   formatOptions,
+  formatValue,
+  t,
+  totalValue,
+  units,
+  value,
 }) => {
+  const lookup = unitLookupKey(units);
+  const unitsLabel = lookup !== 'usd' ? t(`units.${lookup}`) : undefined;
+
   const percent = !totalValue ? 0 : (value / totalValue) * 100;
   const percentVal = Number(percent.toFixed(2));
-  const percentLabel = `${formatValue(
-    value,
-    units,
-    formatOptions
-  )} (${percentVal}%)`;
+  const percentLabel = t('percent_of_total', {
+    percent: percentVal,
+    units: unitsLabel,
+    value: formatValue(value, units, formatOptions),
+  });
 
   return (
     <li className={css(styles.reportSummaryItem)}>
@@ -41,8 +47,10 @@ const AwsReportSummaryItem: React.SFC<AwsReportSummaryItemProps> = ({
   );
 };
 
-AwsReportSummaryItem.defaultProps = {
+AwsReportSummaryItemBase.defaultProps = {
   formatValue: v => v,
 };
+
+const AwsReportSummaryItem = translate()(AwsReportSummaryItemBase);
 
 export { AwsReportSummaryItem, AwsReportSummaryItemProps };

--- a/src/components/reports/ocpOnAwsReportSummary/__snapshots__/ocpOnAwsReportSummaryItem.test.tsx.snap
+++ b/src/components/reports/ocpOnAwsReportSummary/__snapshots__/ocpOnAwsReportSummaryItem.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`gets percentage from value and total value: Rendered Label 1`] = `
   <Progress
     className=""
     id=""
-    label="formatted 100 (10%)"
+    label="percent_of_total"
     max={100}
     measureLocation="top"
     min={0}
@@ -31,7 +31,7 @@ exports[`sets percent to 0 if totalValue is 0: Rendered label 1`] = `
   <Progress
     className=""
     id=""
-    label="formatted 100 (0%)"
+    label="percent_of_total"
     max={100}
     measureLocation="top"
     min={0}

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryDetails.test.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryDetails.test.tsx
@@ -6,9 +6,9 @@ import {
 } from './ocpOnAwsReportSummaryDetails';
 
 const props: OcpOnAwsReportSummaryDetailsProps = {
-  report: { data: [], meta: { total: { cost: { value: 100, units: 'USD' } } } },
-  label: 'label',
   formatValue: jest.fn(() => 'formatedValue'),
+  report: { data: [], meta: { total: { cost: { value: 100, units: 'USD' } } } },
+  t: jest.fn(v => v),
 };
 
 test('report total is formated', () => {

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryDetails.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryDetails.tsx
@@ -14,7 +14,6 @@ interface OcpOnAwsReportSummaryDetailsProps extends InjectedTranslateProps {
   reportType?: OcpOnAwsReportType;
   requestLabel?: string;
   showUnits?: boolean;
-  unitsLabel?: string;
   usageLabel?: string;
 }
 

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItem.test.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItem.test.tsx
@@ -9,12 +9,13 @@ import {
 import { styles } from './ocpOnAwsReportSummaryItem.styles';
 
 const props: OcpOnAwsReportSummaryItemProps = {
-  label: 'Label',
-  totalValue: 1000,
-  value: 100,
-  units: 'units',
-  formatValue: jest.fn(v => `formatted ${v}`),
   formatOptions: {},
+  formatValue: jest.fn(v => `formatted ${v}`),
+  label: 'Label',
+  t: jest.fn(v => v),
+  totalValue: 1000,
+  units: 'units',
+  value: 100,
 };
 
 // Temporarily disabled formatValue test until PF4 progress bar supports custom labels

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItem.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItem.tsx
@@ -1,33 +1,33 @@
 import { Progress, ProgressSize } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
+import { unitLookupKey } from 'utils/formatValue';
 import { styles } from './ocpOnAwsReportSummaryItem.styles';
 
-interface OcpOnAwsReportSummaryItemProps {
-  label: string;
-  units: string;
-  value: number;
-  totalValue: number;
+interface OcpOnAwsReportSummaryItemProps extends InjectedTranslateProps {
   formatValue: ValueFormatter;
   formatOptions?: FormatOptions;
+  label: string;
+  totalValue: number;
+  units: string;
+  value: number;
 }
 
-const OcpOnAwsReportSummaryItem: React.SFC<OcpOnAwsReportSummaryItemProps> = ({
-  label,
-  value,
-  totalValue,
-  formatValue,
-  units,
-  formatOptions,
-}) => {
+const OcpOnAwsReportSummaryItemBase: React.SFC<
+  OcpOnAwsReportSummaryItemProps
+> = ({ label, formatOptions, formatValue, t, totalValue, units, value }) => {
+  const lookup = unitLookupKey(units);
+  const unitsLabel = lookup !== 'usd' ? t(`units.${lookup}`) : undefined;
+
   const percent = !totalValue ? 0 : (value / totalValue) * 100;
   const percentVal = Number(percent.toFixed(2));
-  const percentLabel = `${formatValue(
-    value,
-    units,
-    formatOptions
-  )} (${percentVal}%)`;
+  const percentLabel = t('percent_of_total', {
+    percent: percentVal,
+    units: unitsLabel,
+    value: formatValue(value, units, formatOptions),
+  });
 
   return (
     <li className={css(styles.reportSummaryItem)}>
@@ -41,8 +41,10 @@ const OcpOnAwsReportSummaryItem: React.SFC<OcpOnAwsReportSummaryItemProps> = ({
   );
 };
 
-OcpOnAwsReportSummaryItem.defaultProps = {
+OcpOnAwsReportSummaryItemBase.defaultProps = {
   formatValue: v => v,
 };
+
+const OcpOnAwsReportSummaryItem = translate()(OcpOnAwsReportSummaryItemBase);
 
 export { OcpOnAwsReportSummaryItem, OcpOnAwsReportSummaryItemProps };

--- a/src/components/reports/ocpReportSummary/__snapshots__/ocpReportSummaryItem.test.tsx.snap
+++ b/src/components/reports/ocpReportSummary/__snapshots__/ocpReportSummaryItem.test.tsx.snap
@@ -9,7 +9,7 @@ exports[`gets percentage from value and total value: Rendered Label 1`] = `
   <Progress
     className=""
     id=""
-    label="formatted 100 (10%)"
+    label="percent_of_total"
     max={100}
     measureLocation="top"
     min={0}
@@ -31,7 +31,7 @@ exports[`sets percent to 0 if totalValue is 0: Rendered label 1`] = `
   <Progress
     className=""
     id=""
-    label="formatted 100 (0%)"
+    label="percent_of_total"
     max={100}
     measureLocation="top"
     min={0}

--- a/src/components/reports/ocpReportSummary/ocpReportSummaryDetails.test.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummaryDetails.test.tsx
@@ -6,9 +6,9 @@ import {
 } from './ocpReportSummaryDetails';
 
 const props: OcpReportSummaryDetailsProps = {
-  report: { data: [], meta: { total: { cost: { value: 100, units: 'USD' } } } },
-  label: 'label',
   formatValue: jest.fn(() => 'formatedValue'),
+  report: { data: [], meta: { total: { cost: { value: 100, units: 'USD' } } } },
+  t: jest.fn(v => v),
 };
 
 test('report total is formated', () => {

--- a/src/components/reports/ocpReportSummary/ocpReportSummaryDetails.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummaryDetails.tsx
@@ -1,50 +1,47 @@
 import { css } from '@patternfly/react-styles';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
 import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
 import { styles } from './ocpReportSummaryDetails.styles';
 
-interface OcpReportSummaryDetailsProps {
+interface OcpReportSummaryDetailsProps extends InjectedTranslateProps {
   formatValue?: ValueFormatter;
   formatOptions?: FormatOptions;
   report: OcpReport;
   reportType?: OcpReportType;
   requestLabel?: string;
-  unitsLabel?: string;
+  usageLabel?: string;
 }
 
-const OcpReportSummaryDetails: React.SFC<OcpReportSummaryDetailsProps> = ({
+const OcpReportSummaryDetailsBase: React.SFC<OcpReportSummaryDetailsProps> = ({
   formatValue,
   formatOptions,
   report,
   reportType = OcpReportType.cost,
   requestLabel,
-  unitsLabel,
+  usageLabel,
 }) => {
   let value: string | number = '----';
   let requestValue: string | number = '----';
 
-  if (report && report.meta && report.meta.total) {
-    if (reportType === OcpReportType.cost) {
-      const units: string = report.meta.total.cost.units
-        ? report.meta.total.cost.units
-        : 'USD';
-      value = formatValue(
-        report.meta.total.cost.value ? report.meta.total.cost.value : 0,
-        units,
-        formatOptions
-      );
-    } else {
-      const units: string = report.meta.total.usage.units
-        ? report.meta.total.usage.units
-        : 'GB';
-      value = formatValue(
-        report.meta.total.usage.value ? report.meta.total.usage.value : 0,
-        units,
-        formatOptions
-      );
+  const hasTotal = report && report.meta && report.meta.total;
+  const units: string =
+    hasTotal && report.meta.total.cost
+      ? report.meta.total.cost.units
+      : reportType === OcpReportType.cost
+      ? 'USD'
+      : 'GB';
+
+  if (hasTotal) {
+    value = formatValue(
+      report.meta.total.cost ? report.meta.total.cost.value : 0,
+      units,
+      formatOptions
+    );
+    if (reportType !== OcpReportType.cost) {
       requestValue = formatValue(
-        report.meta.total.request.value ? report.meta.total.request.value : 0,
+        report.meta.total.request ? report.meta.total.request.value : 0,
         units,
         formatOptions
       );
@@ -56,7 +53,7 @@ const OcpReportSummaryDetails: React.SFC<OcpReportSummaryDetailsProps> = ({
         <div className={css(styles.value, styles.usageValue)}>
           {value}
           <div className={css(styles.text)}>
-            <div>{unitsLabel}</div>
+            <div>{usageLabel}</div>
           </div>
         </div>
       </div>
@@ -71,5 +68,7 @@ const OcpReportSummaryDetails: React.SFC<OcpReportSummaryDetailsProps> = ({
     </>
   );
 };
+
+const OcpReportSummaryDetails = translate()(OcpReportSummaryDetailsBase);
 
 export { OcpReportSummaryDetails, OcpReportSummaryDetailsProps };

--- a/src/components/reports/ocpReportSummary/ocpReportSummaryItem.test.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummaryItem.test.tsx
@@ -10,11 +10,12 @@ import { styles } from './ocpReportSummaryItem.styles';
 
 const props: OcpReportSummaryItemProps = {
   label: 'Label',
-  totalValue: 1000,
-  value: 100,
-  units: 'units',
-  formatValue: jest.fn(v => `formatted ${v}`),
   formatOptions: {},
+  formatValue: jest.fn(v => `formatted ${v}`),
+  t: jest.fn(v => v),
+  totalValue: 1000,
+  units: 'units',
+  value: 100,
 };
 
 // Temporarily disabled formatValue test until PF4 progress bar supports custom labels

--- a/src/components/reports/ocpReportSummary/ocpReportSummaryItem.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummaryItem.tsx
@@ -1,33 +1,39 @@
 import { Progress, ProgressSize } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
+import { unitLookupKey } from 'utils/formatValue';
 import { styles } from './ocpReportSummaryItem.styles';
 
-interface OcpReportSummaryItemProps {
+interface OcpReportSummaryItemProps extends InjectedTranslateProps {
+  formatOptions?: FormatOptions;
+  formatValue: ValueFormatter;
   label: string;
+  totalValue: number;
   units: string;
   value: number;
-  totalValue: number;
-  formatValue: ValueFormatter;
-  formatOptions?: FormatOptions;
 }
 
-const OcpReportSummaryItem: React.SFC<OcpReportSummaryItemProps> = ({
-  label,
-  value,
-  totalValue,
-  formatValue,
-  units,
+const OcpReportSummaryItemBase: React.SFC<OcpReportSummaryItemProps> = ({
   formatOptions,
+  formatValue,
+  label,
+  t,
+  totalValue,
+  units,
+  value,
 }) => {
+  const lookup = unitLookupKey(units);
+  const unitsLabel = lookup !== 'usd' ? t(`units.${lookup}`) : undefined;
+
   const percent = !totalValue ? 0 : (value / totalValue) * 100;
   const percentVal = Number(percent.toFixed(2));
-  const percentLabel = `${formatValue(
-    value,
-    units,
-    formatOptions
-  )} (${percentVal}%)`;
+  const percentLabel = t('percent_of_total', {
+    percent: percentVal,
+    units: unitsLabel,
+    value: formatValue(value, units, formatOptions),
+  });
 
   return (
     <li className={css(styles.reportSummaryItem)}>
@@ -41,8 +47,10 @@ const OcpReportSummaryItem: React.SFC<OcpReportSummaryItemProps> = ({
   );
 };
 
-OcpReportSummaryItem.defaultProps = {
+OcpReportSummaryItemBase.defaultProps = {
   formatValue: v => v,
 };
+
+const OcpReportSummaryItem = translate()(OcpReportSummaryItemBase);
 
 export { OcpReportSummaryItem, OcpReportSummaryItemProps };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -91,8 +91,10 @@
     "date_range_plural": "{{startDate}}-{{endDate}} $t(months_abbr.{{month}}) {{year}}",
     "limit": "Limit",
     "month": "$t(months.{{month}})",
+    "requested": "Requested",
     "requests": "Requests, $t(months.{{month}})",
-    "usage": "Usage, $t(months.{{month}})"
+    "usage": "Usage, $t(months.{{month}})",
+    "used": "Used"
   },
   "cost_management": "Cost management",
   "error_state": {
@@ -538,6 +540,7 @@
   },
   "percent": "{{value}}%",
   "percent_of_cost": "{{value}} % of Cost",
+  "percent_of_total": "{{value}} {{units}} ({{percent}})%",
   "providers": {
     "add_source": "Add Sources",
     "bucket_error": "Bucket name cannot contain spaces, special chars and be more than 255 characters",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -17,7 +17,6 @@
     "storage_cost_label": "Cost",
     "storage_title": "Storage services",
     "storage_trend_title": "Storage usage comparison",
-    "storage_units_label": "GB",
     "storage_usage_label": "Usage",
     "tabs": {
       "accounts": "Top Accounts",
@@ -356,7 +355,6 @@
     "storage_cost_label": "Cost",
     "storage_title": "AWS storage services",
     "storage_trend_title": "Storage usage comparison",
-    "storage_units_label": "GB",
     "storage_usage_label": "Usage",
     "widget_subtitle": "$t(months.{{month}}), month to date",
     "widget_subtitle_tooltip": "{{startDate}} $t(months_abbr.{{month}}) {{year}}",

--- a/src/pages/awsDashboard/awsDashboardWidget.tsx
+++ b/src/pages/awsDashboard/awsDashboardWidget.tsx
@@ -127,7 +127,7 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
         formatValue={formatValue}
         report={currentReport}
         reportType={reportType}
-        unitsLabel={this.getDetailsLabel(details.unitsKey)}
+        showUnits={details.showUnits}
         usageLabel={this.getDetailsLabel(details.usageKey)}
       />
     );

--- a/src/pages/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/pages/ocpDashboard/ocpDashboardWidget.tsx
@@ -161,7 +161,7 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
         report={currentReport}
         reportType={reportType}
         requestLabel={this.getDetailsLabel(details.requestKey)}
-        unitsLabel={this.getDetailsLabel(details.unitsKey)}
+        usageLabel={this.getDetailsLabel(details.usageKey)}
       />
     );
   };

--- a/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
+++ b/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
@@ -172,7 +172,7 @@ class OcpOnAwsDashboardWidgetBase extends React.Component<
         report={currentReport}
         reportType={reportType}
         requestLabel={this.getDetailsLabel(details.requestKey)}
-        unitsLabel={this.getDetailsLabel(details.unitsKey)}
+        showUnits={details.showUnits}
         usageLabel={this.getDetailsLabel(details.usageKey)}
       />
     );

--- a/src/store/awsDashboard/awsDashboardCommon.ts
+++ b/src/store/awsDashboard/awsDashboardCommon.ts
@@ -34,7 +34,7 @@ export interface AwsDashboardWidget {
   details: {
     costKey?: string /** i18n label key */;
     formatOptions: ValueFormatOptions;
-    unitsKey?: string /** i18n label key */;
+    showUnits?: boolean;
     usageKey?: string /** i18n label key */;
   };
   filter?: {

--- a/src/store/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/awsDashboard/awsDashboardWidgets.ts
@@ -137,7 +137,7 @@ export const storageWidget: AwsDashboardWidget = {
     formatOptions: {
       fractionDigits: 0,
     },
-    unitsKey: 'aws_dashboard.storage_units_label',
+    showUnits: true,
     usageKey: 'aws_dashboard.storage_usage_label',
   },
   trend: {

--- a/src/store/ocpDashboard/ocpDashboardCommon.ts
+++ b/src/store/ocpDashboard/ocpDashboardCommon.ts
@@ -33,7 +33,7 @@ export interface OcpDashboardWidget {
   details: {
     formatOptions: ValueFormatOptions;
     requestKey?: string /** i18n label key */;
-    unitsKey?: string /** i18n label key */;
+    usageKey?: string /** i18n label key */;
   };
   filter?: {
     limit?: number;

--- a/src/store/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/ocpDashboard/ocpDashboardWidgets.ts
@@ -40,7 +40,7 @@ export const cpuWidget: OcpDashboardWidget = {
       fractionDigits: 0,
     },
     requestKey: 'ocp_dashboard.cpu_request_label',
-    unitsKey: 'ocp_dashboard.cpu_usage_label',
+    usageKey: 'ocp_dashboard.cpu_usage_label',
   },
   trend: {
     currentRequestLabelKey: 'ocp_dashboard.cpu_requested_label',
@@ -71,7 +71,7 @@ export const memoryWidget: OcpDashboardWidget = {
       fractionDigits: 0,
     },
     requestKey: 'ocp_dashboard.memory_request_label',
-    unitsKey: 'ocp_dashboard.memory_usage_label',
+    usageKey: 'ocp_dashboard.memory_usage_label',
   },
   trend: {
     currentRequestLabelKey: 'ocp_dashboard.memory_requested_label',

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardCommon.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardCommon.ts
@@ -34,7 +34,7 @@ export interface OcpOnAwsDashboardWidget {
     costKey?: string /** i18n label key */;
     formatOptions: ValueFormatOptions;
     requestKey?: string /** i18n label key */;
-    unitsKey?: string /** i18n label key */;
+    showUnits?: boolean;
     usageKey?: string /** i18n label key */;
   };
   filter?: {

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardWidgets.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardWidgets.ts
@@ -119,7 +119,7 @@ export const storageWidget: OcpOnAwsDashboardWidget = {
     formatOptions: {
       fractionDigits: 0,
     },
-    unitsKey: 'ocp_on_aws_dashboard.storage_units_label',
+    showUnits: true,
     usageKey: 'ocp_on_aws_dashboard.storage_usage_label',
   },
   trend: {

--- a/src/utils/formatValue.test.ts
+++ b/src/utils/formatValue.test.ts
@@ -1,7 +1,7 @@
 import * as format from './formatValue';
 
 jest.spyOn(format, 'formatCurrency');
-jest.spyOn(format, 'formatStorage');
+jest.spyOn(format, 'formatUsageGb');
 
 describe('formatValue', () => {
   const formatOptions: format.FormatOptions = {};
@@ -24,7 +24,7 @@ describe('formatValue', () => {
   test('gb unit calls format storage', () => {
     const unit = 'gb-mo';
     format.formatValue(value, unit, formatOptions);
-    expect(format.formatStorage).toBeCalledWith(value, 'gb', formatOptions);
+    expect(format.formatUsageGb).toBeCalledWith(value, 'gb', formatOptions);
   });
 
   test('null unit returns value fixed to fractionDigits', () => {

--- a/src/utils/formatValue.ts
+++ b/src/utils/formatValue.ts
@@ -8,8 +8,14 @@ export type ValueFormatter = (
   options?: FormatOptions
 ) => string | number;
 
-export const unitLookupKey = unit =>
-  unit ? unit.split('-')[0].toLowerCase() : '';
+export const unitLookupKey = unit => {
+  const lookup = unit ? unit.toLowerCase() : '';
+
+  if (lookup.includes('core-hours')) {
+    return 'hrs';
+  }
+  return lookup.split('-')[0];
+};
 
 export const formatValue: ValueFormatter = (
   value: number,
@@ -23,7 +29,9 @@ export const formatValue: ValueFormatter = (
     case 'usd':
       return formatCurrency(fValue, lookup, options);
     case 'gb':
-      return formatStorage(fValue, lookup, options);
+      return formatUsageGb(fValue, lookup, options);
+    case 'hrs':
+      return formatUsageHrs(fValue, lookup, options);
     default:
       return unknownTypeFormatter(fValue, lookup, options);
   }
@@ -54,10 +62,18 @@ export const formatCurrency: ValueFormatter = (
   });
 };
 
-export const formatStorage: ValueFormatter = (
+export const formatUsageGb: ValueFormatter = (
   value,
   _unit,
   { fractionDigits = 2 } = {}
+) => {
+  return value.toFixed(fractionDigits);
+};
+
+export const formatUsageHrs: ValueFormatter = (
+  value,
+  _unit,
+  { fractionDigits } = {}
 ) => {
   return value.toFixed(fractionDigits);
 };


### PR DESCRIPTION
Add missing units to progress bars shown on the AWS and OCP overview pages.

Fixes https://github.com/project-koku/koku-ui/issues/687

AWS:
<img width="1622" alt="Screen Shot 2019-04-03 at 11 11 05 PM" src="https://user-images.githubusercontent.com/17481322/55527292-67d25000-5666-11e9-8c95-a726aac5ea2a.png">

OpenShift:
<img width="1623" alt="ocp" src="https://user-images.githubusercontent.com/17481322/55527298-702a8b00-5666-11e9-8503-e2734b53a363.png">
