### PR TITLE
Update OCP cost card title

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -221,7 +221,7 @@
   },
   "ocp_dashboard": {
     "cost_detail_label": "Total Cost",
-    "cost_title": "OpenShift Total Cost",
+    "cost_title": "Total Cost",
     "cost_trend_title": "Month to Month Daily Cost Comparison",
     "cpu_current_title": "{{date}} - Current",
     "cpu_previous_title": "{{startDate}} - {{endDate}}",


### PR DESCRIPTION
Update OCP cost card title as "Total cost".

Fixes https://github.com/project-koku/koku-ui/issues/660

![Screen Shot 2019-04-04 at 11 35 16 AM](https://user-images.githubusercontent.com/17481322/55568513-d26aa680-56cd-11e9-8573-bbd93b5fe302.png)
