### PR TITLE
Update OCP on AWS card title

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -329,7 +329,7 @@
     "compute_trend_title": "Compute usage comparison",
     "compute_usage_label": "Hours",
     "cost_detail_label": "Total Cost",
-    "cost_title": "Total Cost",
+    "cost_title": "Infrastructure Cost",
     "cost_trend_title": "Cost comparison ($USD)",
     "cpu_current_title": "{{date}} - Current",
     "cpu_previous_title": "{{startDate}} - {{endDate}}",


### PR DESCRIPTION
Update OCP on AWS card title to "Infrastructure cost"

Fixes https://github.com/project-koku/koku-ui/issues/665

![Screen Shot 2019-04-04 at 11 38 21 AM](https://user-images.githubusercontent.com/17481322/55568794-5fadfb00-56ce-11e9-9b08-593a2e2cf52e.png)
