### PR TITLE
Use infrastructure cost for OpenShift on AWS

### DIFF
--- a/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
+++ b/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
@@ -109,7 +109,7 @@ class OcpOnAwsDashboardWidgetBase extends React.Component<
     const { currentReport, previousReport, reportType, t, trend } = this.props;
 
     const reportItem =
-      reportType === OcpOnAwsReportType.cost ? 'cost' : 'usage';
+      reportType === OcpOnAwsReportType.cost ? 'infrastructure_cost' : 'usage';
     const currentUsageData = transformOcpOnAwsReport(
       currentReport,
       trend.type,

--- a/src/pages/ocpOnAwsDetails/historicalChart.tsx
+++ b/src/pages/ocpOnAwsDetails/historicalChart.tsx
@@ -97,13 +97,13 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
       currentCostReport,
       ChartType.rolling,
       'date',
-      'cost'
+      'infrastructure_cost'
     );
     const previousCostData = transformOcpOnAwsReport(
       previousCostReport,
       ChartType.rolling,
       'date',
-      'cost'
+      'infrastructure_cost'
     );
 
     // Cpu data


### PR DESCRIPTION
Using infrastructure_cost for OpenShift on AWS, instead of cost

Fixes https://github.com/project-koku/koku-ui/issues/666

OCP on cloud overview:
![Screen Shot 2019-04-04 at 11 51 21 AM](https://user-images.githubusercontent.com/17481322/55570099-bae0ed00-56d0-11e9-914d-fd51a8ef35ca.png)

OCP on cloud details:
![Screen Shot 2019-04-04 at 11 53 02 AM](https://user-images.githubusercontent.com/17481322/55570109-c0d6ce00-56d0-11e9-88af-89d08de84f1f.png)
