### PR TITLE
Add all AWS cards to OpenShift on AWS

### DIFF
--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboard.test.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboard.test.ts
@@ -17,7 +17,9 @@ import {
   computeWidget,
   costSummaryWidget,
   cpuWidget,
+  databaseWidget,
   memoryWidget,
+  networkWidget,
   storageWidget,
 } from './ocpOnAwsDashboardWidgets';
 
@@ -38,6 +40,8 @@ test('default state', () => {
     costSummaryWidget.id,
     computeWidget.id,
     storageWidget.id,
+    networkWidget.id,
+    databaseWidget.id,
     cpuWidget.id,
     memoryWidget.id,
   ]);

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardReducer.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardReducer.ts
@@ -5,7 +5,9 @@ import {
   computeWidget,
   costSummaryWidget,
   cpuWidget,
+  databaseWidget,
   memoryWidget,
+  networkWidget,
   storageWidget,
 } from './ocpOnAwsDashboardWidgets';
 
@@ -21,12 +23,16 @@ export const defaultState: OcpOnAwsDashboardState = {
     costSummaryWidget.id,
     computeWidget.id,
     storageWidget.id,
+    networkWidget.id,
+    databaseWidget.id,
     cpuWidget.id,
     memoryWidget.id,
   ],
   widgets: {
     [costSummaryWidget.id]: costSummaryWidget,
     [computeWidget.id]: computeWidget,
+    [databaseWidget.id]: databaseWidget,
+    [networkWidget.id]: networkWidget,
     [storageWidget.id]: storageWidget,
     [cpuWidget.id]: cpuWidget,
     [memoryWidget.id]: memoryWidget,

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardWidgets.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardWidgets.ts
@@ -110,6 +110,52 @@ export const computeWidget: OcpOnAwsDashboardWidget = {
   },
 };
 
+export const databaseWidget: OcpOnAwsDashboardWidget = {
+  id: getId(),
+  titleKey: 'ocp_on_aws_dashboard.database_title',
+  reportType: OcpOnAwsReportType.database,
+  details: {
+    costKey: 'ocp_on_aws_dashboard.database_cost_label',
+    formatOptions: {
+      fractionDigits: 2,
+    },
+  },
+  filter: {
+    product_family: 'Database Instance',
+  },
+  tabsFilter: {
+    product_family: 'Database Instance',
+  },
+  trend: {
+    formatOptions: {},
+    titleKey: 'ocp_on_aws_dashboard.database_trend_title',
+    type: ChartType.rolling,
+  },
+};
+
+export const networkWidget: OcpOnAwsDashboardWidget = {
+  id: getId(),
+  titleKey: 'ocp_on_aws_dashboard.network_title',
+  reportType: OcpOnAwsReportType.network,
+  details: {
+    costKey: 'ocp_on_aws_dashboard.database_cost_label',
+    formatOptions: {
+      fractionDigits: 2,
+    },
+  },
+  filter: {
+    product_family: 'Load Balancer-Network',
+  },
+  tabsFilter: {
+    product_family: 'Load Balancer-Network',
+  },
+  trend: {
+    formatOptions: {},
+    titleKey: 'ocp_on_aws_dashboard.network_trend_title',
+    type: ChartType.rolling,
+  },
+};
+
 export const storageWidget: OcpOnAwsDashboardWidget = {
   id: getId(),
   titleKey: 'ocp_on_aws_dashboard.storage_title',


### PR DESCRIPTION
Adds database and network AWS cards to the OpenShift on AWS overview page.

Note there is an issue with the `/reports/openshift/infrastructures/aws/cost` API returning the same cost, regardless of the product family. See https://github.com/project-koku/koku/issues/789

Fixes https://github.com/project-koku/koku-ui/issues/667

OpenShift on AWS:
![Screen Shot 2019-04-04 at 2 05 59 PM](https://user-images.githubusercontent.com/17481322/55578005-e7056980-56e2-11e9-946c-e05a38c052d9.png)
