### PR TITLE
Ensure unique IDs while flattening report items

### DIFF
--- a/src/utils/getComputedOcpOnAwsReportItems.ts
+++ b/src/utils/getComputedOcpOnAwsReportItems.ts
@@ -88,7 +88,12 @@ export function getUnsortedComputedOcpOnAwsReportItems({
         const infrastructureCost = value.infrastructure_cost
           ? value.infrastructure_cost.value
           : 0;
-        const id = value[idKey];
+        // Ensure unique IDs -- https://github.com/project-koku/koku-ui/issues/706
+        const idSuffix =
+          idKey !== 'date' && idKey !== 'cluster' && value.cluster
+            ? `-${value.cluster}`
+            : '';
+        const id = `${value[idKey]}${idSuffix}`;
         let label;
         if (labelKey === 'cluster' && value.cluster_alias) {
           label = value.cluster_alias;

--- a/src/utils/getComputedOcpReportItems.ts
+++ b/src/utils/getComputedOcpReportItems.ts
@@ -87,7 +87,12 @@ export function getUnsortedComputedOcpReportItems({
         const infrastructureCost = value.infrastructure_cost
           ? value.infrastructure_cost.value
           : 0;
-        const id = value[idKey];
+        // Ensure unique IDs -- https://github.com/project-koku/koku-ui/issues/706
+        const idSuffix =
+          idKey !== 'date' && idKey !== 'cluster' && value.cluster
+            ? `-${value.cluster}`
+            : '';
+        const id = `${value[idKey]}${idSuffix}`;
         let label;
         if (labelKey === 'cluster' && value.cluster_alias) {
           label = value.cluster_alias;


### PR DESCRIPTION
While processing API reports, we flatten items for the detail tables and charts. Items are stored using project, cluster, node, or tag as map identifiers. As long as those values are unique, there is no issue. However, there may be projects in different clusters with the same name. In that case, IDs could override each other in our flattened list.

This change ensures we use unique IDs while flattening report items.

Fixes https://github.com/project-koku/koku-ui/issues/706