### PR TITLE
Chart tooltip styling to mimic PF4

### DIFF
--- a/src/components/charts/historicalTrendChart/historicalTrendChart.styles.ts
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.styles.ts
@@ -1,5 +1,7 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
+  c_background_image_BackgroundColor,
+  global_Color_light_200,
   global_disabled_color_200,
   global_FontFamily_sans_serif,
   global_FontSize_md,
@@ -39,6 +41,16 @@ export const chartStyles = {
       stroke: global_disabled_color_200.value,
     },
   } as VictoryStyleInterface,
+  tooltip: {
+    flyoutStyle: {
+      fill: c_background_image_BackgroundColor.value,
+      strokeWidth: 0,
+    },
+    style: {
+      fill: global_Color_light_200.value,
+      padding: 18,
+    },
+  },
   yAxis: {
     axisLabel: {
       padding: 15,

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -4,6 +4,7 @@ import {
   ChartAxis,
   ChartLegend,
   ChartTheme,
+  ChartTooltip,
   ChartVoronoiContainer,
 } from '@patternfly/react-charts';
 import { css } from '@patternfly/react-styles';
@@ -269,6 +270,13 @@ class HistoricalTrendChart extends React.Component<
 
     const container = (
       <ChartVoronoiContainer
+        labelComponent={
+          <ChartTooltip
+            flyoutStyle={chartStyles.tooltip.flyoutStyle}
+            pointerWidth={20}
+            style={chartStyles.tooltip.style}
+          />
+        }
         labels={this.getTooltipLabel}
         voronoiDimension="x"
       />

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.styles.ts
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.styles.ts
@@ -1,5 +1,7 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
+  c_background_image_BackgroundColor,
+  global_Color_light_200,
   global_FontFamily_sans_serif,
   global_FontSize_md,
   global_spacer_lg,
@@ -72,6 +74,16 @@ export const chartStyles = {
       stroke: '#7DC3E8',
     },
   } as VictoryStyleInterface,
+  tooltip: {
+    flyoutStyle: {
+      fill: c_background_image_BackgroundColor.value,
+      strokeWidth: 0,
+    },
+    style: {
+      fill: global_Color_light_200.value,
+      padding: 18,
+    },
+  },
   yAxis: {
     axisLabel: {
       padding: 15,

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -1,10 +1,10 @@
-// @ts-ignore
 import {
   Chart,
   ChartArea,
   ChartAxis,
   ChartLegend,
   ChartTheme,
+  ChartTooltip,
   ChartVoronoiContainer,
 } from '@patternfly/react-charts';
 import { css } from '@patternfly/react-styles';
@@ -472,6 +472,13 @@ class HistoricalUsageChart extends React.Component<
 
     const container = (
       <ChartVoronoiContainer
+        labelComponent={
+          <ChartTooltip
+            flyoutStyle={chartStyles.tooltip.flyoutStyle}
+            pointerWidth={20}
+            style={chartStyles.tooltip.style}
+          />
+        }
         labels={this.getTooltipLabel}
         voronoiDimension="x"
       />

--- a/src/components/charts/trendChart/trendChart.styles.ts
+++ b/src/components/charts/trendChart/trendChart.styles.ts
@@ -1,5 +1,7 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
+  c_background_image_BackgroundColor,
+  global_Color_light_200,
   global_disabled_color_200,
   global_FontFamily_sans_serif,
   global_FontSize_md,
@@ -36,6 +38,16 @@ export const chartStyles = {
       stroke: '#A2DA9C',
     },
   } as VictoryStyleInterface,
+  tooltip: {
+    flyoutStyle: {
+      fill: c_background_image_BackgroundColor.value,
+      strokeWidth: 0,
+    },
+    style: {
+      fill: global_Color_light_200.value,
+      padding: 18,
+    },
+  },
   yAxis: {
     axisLabel: {
       padding: 15,

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -5,6 +5,7 @@ import {
   ChartContainer,
   ChartLegend,
   ChartTheme,
+  ChartTooltip,
   ChartVoronoiContainer,
 } from '@patternfly/react-charts';
 import { css } from '@patternfly/react-styles';
@@ -279,6 +280,13 @@ class TrendChart extends React.Component<TrendChartProps, State> {
 
     const container = (
       <ChartVoronoiContainer
+        labelComponent={
+          <ChartTooltip
+            flyoutStyle={chartStyles.tooltip.flyoutStyle}
+            pointerWidth={20}
+            style={chartStyles.tooltip.style}
+          />
+        }
         labels={this.getTooltipLabel}
         voronoiDimension="x"
       />

--- a/src/components/charts/usageChart/usageChart.styles.ts
+++ b/src/components/charts/usageChart/usageChart.styles.ts
@@ -1,5 +1,7 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
+  c_background_image_BackgroundColor,
+  global_Color_light_200,
   global_disabled_color_100,
   global_disabled_color_200,
   global_FontFamily_sans_serif,
@@ -49,6 +51,16 @@ export const chartStyles = {
     global_disabled_color_200.value,
     global_disabled_color_100.value,
   ],
+  tooltip: {
+    flyoutStyle: {
+      fill: c_background_image_BackgroundColor.value,
+      strokeWidth: 0,
+    },
+    style: {
+      fill: global_Color_light_200.value,
+      padding: 18,
+    },
+  },
   yAxis: {
     axisLabel: {
       padding: 15,

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -5,6 +5,7 @@ import {
   ChartContainer,
   ChartLegend,
   ChartTheme,
+  ChartTooltip,
   ChartVoronoiContainer,
 } from '@patternfly/react-charts';
 import { css } from '@patternfly/react-styles';
@@ -404,6 +405,13 @@ class UsageChart extends React.Component<UsageChartProps, State> {
 
     const container = (
       <ChartVoronoiContainer
+        labelComponent={
+          <ChartTooltip
+            flyoutStyle={chartStyles.tooltip.flyoutStyle}
+            pointerWidth={20}
+            style={chartStyles.tooltip.style}
+          />
+        }
         labels={this.getTooltipLabel}
         voronoiDimension="x"
       />


### PR DESCRIPTION
Updates the chart tooltip styling to mimic PF4 tooltips. For example, the white text, black background, padding, and pointer size.

Fixes https://github.com/project-koku/koku-ui/issues/703

Single line:
<img width="500" alt="Screen Shot 2019-04-04 at 9 23 15 PM" src="https://user-images.githubusercontent.com/17481322/55598278-eb9c4300-571f-11e9-9c93-b6ca861d53ac.png">

Multi-line:
<img width="504" alt="Screen Shot 2019-04-04 at 9 23 24 PM" src="https://user-images.githubusercontent.com/17481322/55598279-ee973380-571f-11e9-8836-dc91b0129408.png">
