### PR TITLE
spandx not configured properly

### DIFF
--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -7,10 +7,10 @@ module.exports = {
     '/apps/cost-management': {
       host: `http://${localhost}:8002`,
     },
-    '/hcm/cost-management': {
+    '/hybrid/cost-management': {
       host: `http://${localhost}:8002`,
     },
-    '/apps/chrome': {
+    '/hybrid/chrome': {
       host: 'https://ci.cloud.paas.upshift.redhat.com',
     },
   },


### PR DESCRIPTION
The current spandx config uses /apps instead of /hybrid. This forces chrome to use the legacy navigation pane, while the unused /hcm route appears to cause the UI to hang.

Fixes https://github.com/project-koku/koku-ui/issues/712