### PR TITLE
OpenShift details cost title

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -321,7 +321,7 @@
       "export": "Export",
       "results": "{{value}} Results"
     },
-    "total_cost": "Total Cost"
+    "total_cost": "Cost"
   },
   "ocp_on_aws_dashboard": {
     "compute_cost_label": "Cost",


### PR DESCRIPTION
Updates OpenShift details cost title from "Total Cost" to "Cost".

Fixes https://github.com/project-koku/koku-ui/issues/673

<img width="1150" alt="Screen Shot 2019-04-06 at 9 54 06 PM" src="https://user-images.githubusercontent.com/17481322/55677492-a1999580-58b6-11e9-8c9a-4ef7014afcb1.png">
