### PR TITLE
OpenShift details top projects

### DIFF
--- a/src/pages/ocpDetails/detailsTableItem.tsx
+++ b/src/pages/ocpDetails/detailsTableItem.tsx
@@ -84,7 +84,7 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
                   </Form>
                 </div>
               )}
-              {Boolean(groupBy !== 'project') && (
+              {Boolean(groupBy === 'cluster') && (
                 <DetailsSummary groupBy={groupBy} item={item} />
               )}
             </div>


### PR DESCRIPTION
Removes top projects when OpenShift details is grouped by node.

Fixes https://github.com/project-koku/koku-ui/issues/672

Group by node:
<img width="1269" alt="Screen Shot 2019-04-06 at 10 08 29 PM" src="https://user-images.githubusercontent.com/17481322/55677589-be36cd00-58b8-11e9-84a9-aa02ea6cfc12.png">

Group by cluster:
<img width="1262" alt="Screen Shot 2019-04-06 at 10 08 38 PM" src="https://user-images.githubusercontent.com/17481322/55677590-c42cae00-58b8-11e9-9bd2-2faaed4ca812.png">
