### PR TITLE
OCP details: Derived and infrastructure cost column

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -269,6 +269,7 @@
     "cost_column_title": "Cost (Total {{total}})",
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
+    "derived_cost_column_title": "Derived cost",
     "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "export_link": "Export",
     "filter": {
@@ -303,6 +304,7 @@
     },
     "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
     "increase_since_last_month": "{{value}} increase since last month",
+    "infrastructure_cost_column_title": "Infrastructure cost",
     "more_tags": ", {{value}} more...",
     "name_column_title": "$t(group_by.values.{{groupBy}}) Names",
     "no_change_since_date": "No change since $t(months.{{month}}) {{date}}",

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -119,6 +119,20 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             title: t('ocp_details.change_column_title'),
           },
           {
+            orderBy: 'infrastructure_cost',
+            title: t('ocp_details.infrastructure_cost_column_title'),
+
+            // Sort disabled for now -- https://github.com/project-koku/koku/issues/796
+            // transforms: [sortable],
+          },
+          {
+            orderBy: 'derived_cost',
+            title: t('ocp_details.derived_cost_column_title'),
+
+            // Sort disabled for now -- https://github.com/project-koku/koku/issues/796
+            // transforms: [sortable],
+          },
+          {
             orderBy: 'cost',
             title: t('ocp_details.cost_column_title', { total }),
             transforms: [sortable],
@@ -134,12 +148,16 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     computedItems.map((item, index) => {
       const label = item && item.label !== null ? item.label : '';
       const monthOverMonth = this.getMonthOverMonthCost(item, index);
+      const InfrastructureCost = this.getInfrastructureCost(item, index);
+      const derivedCost = this.getDerivedCost(item, index);
       const cost = this.getTotalCost(item, index);
       rows.push(
         {
           cells: [
             { title: <div>{label}</div> },
             { title: <div>{monthOverMonth}</div> },
+            { title: <div>{InfrastructureCost}</div> },
+            { title: <div>{derivedCost}</div> },
             { title: <div>{cost}</div> },
           ],
           isOpen: false,
@@ -176,6 +194,25 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     );
   };
 
+  private getDerivedCost = (item: ComputedOcpReportItem, index: number) => {
+    const { report, t } = this.props;
+    const total = report.meta.total.derived_cost.value;
+
+    return (
+      <>
+        {formatCurrency(item.derivedCost)}
+        <div
+          className={css(styles.infoDescription)}
+          key={`total-cost-${index}`}
+        >
+          {t('percent_of_cost', {
+            value: ((item.derivedCost / total) * 100).toFixed(2),
+          })}
+        </div>
+      </>
+    );
+  };
+
   private getGroupByTagKey = () => {
     const { query } = this.props;
     let groupByTagKey;
@@ -188,6 +225,28 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       }
     }
     return groupByTagKey;
+  };
+
+  private getInfrastructureCost = (
+    item: ComputedOcpReportItem,
+    index: number
+  ) => {
+    const { report, t } = this.props;
+    const total = report.meta.total.infrastructure_cost.value;
+
+    return (
+      <>
+        {formatCurrency(item.infrastructureCost)}
+        <div
+          className={css(styles.infoDescription)}
+          key={`total-cost-${index}`}
+        >
+          {t('percent_of_cost', {
+            value: ((item.infrastructureCost / total) * 100).toFixed(2),
+          })}
+        </div>
+      </>
+    );
   };
 
   private getMonthOverMonthCost = (


### PR DESCRIPTION
This update adds derived and infrastructure cost column to the OCP details table.

Note: Sorting by derived and infrastructure costs is not enabled, for now. See https://github.com/project-koku/koku/issues/796

Fixes https://github.com/project-koku/koku-ui/issues/669

<img width="1526" alt="Screen Shot 2019-04-07 at 11 17 36 AM" src="https://user-images.githubusercontent.com/17481322/55685687-17d5e080-5927-11e9-9e00-1f1b12d7e8a5.png">
