### PR TITLE
Historical modal title

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -58,7 +58,7 @@
       "day_of_month_label": "Day of Month",
       "instance_label": "Hrs",
       "instance_title": "Month over Month Total $t(group_by.values.{{groupBy}}) Instance Hours",
-      "modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Historical Data",
+      "modal_title": "{{name}} daily usage comparison",
       "storage_label": "GB",
       "storage_title": "Month over Month Total $t(group_by.values.{{groupBy}}) Storage",
       "view_data": "View Historical Data"
@@ -297,7 +297,7 @@
       "memory_requested_label": "Requested ({{date}})",
       "memory_title": "Month over Month Total $t(group_by.values.{{groupBy}}) Memory Usage, Request, Limit, and Capacity",
       "memory_usage_label": "Used ({{date}})",
-      "modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Historical Data",
+      "modal_title": "{{name}} daily usage comparison",
       "project_title": "Top Projects",
       "view_data": "View Historical Data"
     },
@@ -409,7 +409,7 @@
       "memory_requested_label": "Requested ({{date}})",
       "memory_title": "Month over Month Total $t(group_by.values.{{groupBy}}) Memory Usage, Request, Limit, and Capacity",
       "memory_usage_label": "Used ({{date}})",
-      "modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s Historical Data",
+      "modal_title": "{{name}} daily usage comparison",
       "project_title": "Top Projects",
       "view_data": "View Historical Data"
     },


### PR DESCRIPTION
The historical modal title, shown in the details pages, should read: `<project name> daily usage comparison`.

Fixes https://github.com/project-koku/koku-ui/issues/675

<img width="1142" alt="Screen Shot 2019-04-07 at 5 13 32 PM" src="https://user-images.githubusercontent.com/17481322/55689908-82ebdb00-5958-11e9-97d5-a4818d2ed64a.png">
