### PR TITLE
Show infrastructure cost in OpenShift cost chart

### DIFF
--- a/src/components/charts/costChart/__snapshots__/costChart.test.tsx.snap
+++ b/src/components/charts/costChart/__snapshots__/costChart.test.tsx.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`infrastructure is a daily value: current month data 1`] = `
+Array [
+  Object {
+    "key": "1-15-18",
+    "name": "1-15-18",
+    "units": "unit",
+    "x": 15,
+    "y": 0,
+  },
+  Object {
+    "key": "1-16-18",
+    "name": "1-16-18",
+    "units": "unit",
+    "x": 16,
+    "y": 0,
+  },
+]
+`;
+
+exports[`infrastructure is a running total: current month data 1`] = `
+Array [
+  Object {
+    "key": "1-15-18",
+    "name": "1-15-18",
+    "units": "unit",
+    "x": 15,
+    "y": 0,
+  },
+  Object {
+    "key": "1-16-18",
+    "name": "1-16-18",
+    "units": "unit",
+    "x": 16,
+    "y": 0,
+  },
+]
+`;
+
+exports[`reports are formatted to datums: current month data 1`] = `
+Array [
+  Object {
+    "key": "1-15-18",
+    "name": "1-15-18",
+    "units": "unit",
+    "x": 15,
+    "y": 0,
+  },
+]
+`;
+
+exports[`reports are formatted to datums: previous month data 1`] = `
+Array [
+  Object {
+    "key": "12-15-17",
+    "name": "12-15-17",
+    "units": "unit",
+    "x": 15,
+    "y": 0,
+  },
+]
+`;

--- a/src/components/charts/costChart/costChart.styles.ts
+++ b/src/components/charts/costChart/costChart.styles.ts
@@ -1,0 +1,97 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import {
+  global_disabled_color_100,
+  global_disabled_color_200,
+  global_FontFamily_sans_serif,
+  global_FontSize_md,
+  global_spacer_lg,
+} from '@patternfly/react-tokens';
+import { VictoryStyleInterface } from 'victory';
+
+export const chartStyles = {
+  currentInfrastructureData: {
+    data: {
+      fill: 'none',
+      stroke: '#88D080',
+      strokeDasharray: '3,3',
+    },
+  } as VictoryStyleInterface,
+  currentUsageData: {
+    data: {
+      fill: 'none',
+      stroke: '#A2DA9C',
+    },
+  } as VictoryStyleInterface,
+  legend: {
+    labels: {
+      fontFamily: global_FontFamily_sans_serif.value,
+      fontSize: 14,
+    },
+    minWidth: 175,
+  },
+  previousInfrastructureData: {
+    data: {
+      fill: 'none',
+      stroke: global_disabled_color_200.value,
+      strokeDasharray: '3,3',
+    },
+  } as VictoryStyleInterface,
+  previousUsageData: {
+    data: {
+      fill: 'none',
+      stroke: global_disabled_color_200.value,
+    },
+  } as VictoryStyleInterface,
+  // See: https://github.com/project-koku/koku-ui/issues/241
+  currentColorScale: ['#A2DA9C', '#88D080', '#6EC664', '#519149', '#3C6C37'],
+  // TBD: No grey scale, yet
+  previousColorScale: [
+    global_disabled_color_200.value,
+    global_disabled_color_100.value,
+  ],
+  yAxis: {
+    axisLabel: {
+      padding: 15,
+    },
+    grid: {
+      stroke: 'none',
+    },
+    ticks: {
+      stroke: 'none',
+    },
+    tickLabels: {
+      fontSize: 0,
+    },
+  } as VictoryStyleInterface,
+  xAxis: {
+    axisLabel: {
+      padding: 15,
+    },
+    grid: {
+      stroke: 'none',
+    },
+    ticks: {
+      stroke: 'none',
+    },
+  } as VictoryStyleInterface,
+};
+
+export const styles = StyleSheet.create({
+  chartContainer: {
+    ':not(foo) svg': {
+      overflow: 'visible',
+    },
+    marginTop: global_spacer_lg.value,
+  },
+  chartTitle: {
+    fontSize: global_FontSize_md.value,
+    marginTop: global_spacer_lg.value,
+  },
+  legend: {
+    display: 'inline-block',
+    fontSize: global_FontSize_md.value,
+    minHeight: '60px',
+    minWidth: '175px',
+    width: '50%',
+  },
+});

--- a/src/components/charts/costChart/costChart.test.tsx
+++ b/src/components/charts/costChart/costChart.test.tsx
@@ -1,0 +1,148 @@
+jest.mock('date-fns/format');
+
+import { Chart, ChartArea } from '@patternfly/react-charts';
+import { AwsReport, AwsReportData } from 'api/awsReports';
+import * as utils from 'components/charts/commonChart/chartUtils';
+import formatDate from 'date-fns/format';
+import { shallow } from 'enzyme';
+import React from 'react';
+import { CostChart, CostChartProps } from './costChart';
+
+const currentMonthReport: AwsReport = createReport('1-15-18');
+const previousMonthReport: AwsReport = createReport('12-15-17');
+
+const currentUsageData = utils.transformAwsReport(
+  currentMonthReport,
+  utils.ChartType.daily
+);
+const previousUsageData = utils.transformAwsReport(
+  previousMonthReport,
+  utils.ChartType.daily
+);
+
+jest.spyOn(utils, 'getTooltipLabel');
+
+const getTooltipLabel = utils.getTooltipLabel as jest.Mock;
+
+const props: CostChartProps = {
+  title: 'Infrastructure Title',
+  height: 100,
+  formatDatumValue: jest.fn(),
+  currentUsageData,
+  previousUsageData,
+  formatDatumOptions: {},
+};
+
+test('reports are formatted to datums', () => {
+  const view = shallow(<CostChart {...props} />);
+  const charts = view.find(ChartArea);
+  expect(charts.length).toBe(2);
+  expect(charts.at(0).prop('data')).toMatchSnapshot('previous month data');
+  expect(charts.at(1).prop('data')).toMatchSnapshot('current month data');
+});
+
+test('null previous and current reports are handled', () => {
+  const view = shallow(
+    <CostChart {...props} currentUsageData={null} previousUsageData={null} />
+  );
+  const charts = view.find(ChartArea);
+  expect(charts.length).toBe(0);
+});
+
+test('height from props is used', () => {
+  const view = shallow(<CostChart {...props} />);
+  expect(view.find(Chart).prop('height')).toBe(props.height);
+});
+
+test('labels formats with datum and value formatted from props', () => {
+  const tooltipFormatMock = jest.spyOn(utils, 'getTooltipContent');
+  const formatLabel = jest.fn();
+  tooltipFormatMock.mockImplementation(() => formatLabel);
+
+  const view = shallow(<CostChart {...props} />);
+  const datum: utils.ChartDatum = {
+    x: 1,
+    y: 1,
+    key: '1-1-1',
+    units: 'units',
+  };
+  const group = view.find(Chart);
+  group.props().containerComponent.props.labels(datum);
+  expect(getTooltipLabel).toBeCalledWith(
+    datum,
+    formatLabel,
+    props.formatDatumOptions,
+    'date'
+  );
+  expect(formatLabel).toBeCalledWith(
+    datum.y,
+    datum.units,
+    props.formatDatumOptions
+  );
+  expect(formatDate).toBeCalledWith(datum.key, expect.any(String));
+  expect(view.find(Chart).prop('height')).toBe(props.height);
+});
+
+test('labels ignores datums without a date', () => {
+  const view = shallow(<CostChart {...props} />);
+  const datum: utils.ChartDatum = {
+    x: 1,
+    y: 1,
+    key: '',
+    units: 'units',
+  };
+  const group = view.find(Chart);
+  const value = group.props().containerComponent.props.labels(datum);
+  expect(value).toBe('');
+  expect(props.formatDatumValue).not.toBeCalled();
+});
+
+test('infrastructure is a running total', () => {
+  const multiDayReport: AwsReport = {
+    data: [
+      createReportDataPoint('1-15-18', 1),
+      createReportDataPoint('1-16-18', 2),
+    ],
+  };
+  const multiDaytData = utils.transformAwsReport(
+    multiDayReport,
+    utils.ChartType.daily
+  );
+  const view = shallow(
+    <CostChart {...props} currentUsageData={multiDaytData} />
+  );
+  const charts = view.find(ChartArea);
+  expect(charts.at(1).prop('data')).toMatchSnapshot('current month data');
+});
+
+test('infrastructure is a daily value', () => {
+  const multiDayReport: AwsReport = {
+    data: [
+      createReportDataPoint('1-15-18', 1),
+      createReportDataPoint('1-16-18', 2),
+    ],
+  };
+  const multiDaytData = utils.transformAwsReport(
+    multiDayReport,
+    utils.ChartType.daily
+  );
+  const view = shallow(
+    <CostChart {...props} currentUsageData={multiDaytData} />
+  );
+  const charts = view.find(ChartArea);
+  expect(charts.at(1).prop('data')).toMatchSnapshot('current month data');
+});
+
+function createReport(date: string): AwsReport {
+  return {
+    data: [createReportDataPoint(date)],
+  };
+}
+
+function createReportDataPoint(date: string, cost = 1): AwsReportData {
+  const item = { value: cost, units: 'unit' };
+  return {
+    date,
+    values: [{ date, cost: item }],
+  };
+}

--- a/src/components/charts/costChart/index.ts
+++ b/src/components/charts/costChart/index.ts
@@ -1,0 +1,1 @@
+export { CostChart, CostChartProps } from './costChart';

--- a/src/components/reports/ocpReportSummary/ocpReportSummaryTrend.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummaryTrend.tsx
@@ -1,11 +1,11 @@
 import { css } from '@patternfly/react-styles';
-import { TrendChart, TrendChartProps } from 'components/charts/trendChart';
+import { CostChart, CostChartProps } from 'components/charts/costChart';
 import React from 'react';
 import { styles } from './ocpReportSummaryTrend.styles';
 
-const OcpReportSummaryTrend: React.SFC<TrendChartProps> = props => (
+const OcpReportSummaryTrend: React.SFC<CostChartProps> = props => (
   <div className={css(styles.chart)}>
-    <TrendChart {...props} />
+    <CostChart {...props} />
   </div>
 );
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -88,8 +88,10 @@
   },
   "chart": {
     "capacity": "Capacity",
+    "cost": "Cost, $t(months.{{month}})",
     "date_range": "{{startDate}} $t(months_abbr.{{month}}) {{year}}",
     "date_range_plural": "{{startDate}}-{{endDate}} $t(months_abbr.{{month}}) {{year}}",
+    "infrastructure_cost": "Infrastructure cost, $t(months.{{month}})",
     "limit": "Limit",
     "month": "$t(months.{{month}})",
     "requests": "Requests, $t(months.{{month}})",

--- a/src/pages/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/pages/ocpDashboard/ocpDashboardWidget.tsx
@@ -124,16 +124,36 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
       reportType !== OcpReportType.cost
         ? transformOcpReport(previousReport, trend.type, 'date', 'request')
         : undefined;
+    const currentInfrastructureData =
+      reportType === OcpReportType.cost
+        ? transformOcpReport(
+            currentReport,
+            trend.type,
+            'date',
+            'infrastructureCost'
+          )
+        : undefined;
+    const previousInfrastructureData =
+      reportType === OcpReportType.cost
+        ? transformOcpReport(
+            previousReport,
+            trend.type,
+            'date',
+            'infrastructureCost'
+          )
+        : undefined;
 
     return (
       <>
         {Boolean(reportType === OcpReportType.cost) ? (
           <OcpReportSummaryTrend
-            currentData={currentUsageData}
+            currentUsageData={currentUsageData}
+            currentInfrastructureData={currentInfrastructureData}
             formatDatumValue={formatValue}
             formatDatumOptions={trend.formatOptions}
             height={height}
-            previousData={previousUsageData}
+            previousUsageData={previousUsageData}
+            previousInfrastructureData={previousInfrastructureData}
             title={t(trend.titleKey)}
           />
         ) : (

--- a/yarn.lock
+++ b/yarn.lock
@@ -7293,6 +7293,10 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
 
+human-date@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/human-date/-/human-date-1.4.0.tgz#88bb62bd804d00fd12ee2f47dc3c3bbb1e55f99a"
+
 husky@^0.14.3:
   version "0.14.3"
   resolved "https://registry.yarnpkg.com/husky/-/husky-0.14.3.tgz#c69ed74e2d2779769a17ba8399b54ce0b63c12c3"


### PR DESCRIPTION
This update adds a new chart to show both cost and infrastructure cost. This will be shown for the OpenShift cost card only.

Fixes https://github.com/project-koku/koku-ui/issues/662

OCP Overview:
<img width="1404" alt="Screen Shot 2019-04-04 at 11 03 49 PM" src="https://user-images.githubusercontent.com/17481322/55601405-c9f68800-572e-11e9-9411-970e76e1d228.png">