### PR TITLE
Show infrastructure cost with OpenShift card

### DIFF
--- a/src/components/reports/ocpReportSummary/__snapshots__/ocpReportSummaryDetails.test.tsx.snap
+++ b/src/components/reports/ocpReportSummary/__snapshots__/ocpReportSummaryDetails.test.tsx.snap
@@ -8,7 +8,21 @@ exports[`defaults value if report is not present 1`] = `
     <div
       className="css-1a0izfs"
     >
-      ----
+      <Tooltip
+        appendTo={[Function]}
+        className={null}
+        content="ocp_dashboard.total_cost_tooltip"
+        enableFlip={true}
+        entryDelay={500}
+        exitDelay={500}
+        maxWidth="18.75rem"
+        position="top"
+        zIndex={9999}
+      >
+        <div>
+          ----
+        </div>
+      </Tooltip>
       <div
         className="css-5bzg50"
       >
@@ -30,7 +44,21 @@ exports[`defaults value if report.meta is not present 1`] = `
     <div
       className="css-1a0izfs"
     >
-      ----
+      <Tooltip
+        appendTo={[Function]}
+        className={null}
+        content="ocp_dashboard.total_cost_tooltip"
+        enableFlip={true}
+        entryDelay={500}
+        exitDelay={500}
+        maxWidth="18.75rem"
+        position="top"
+        zIndex={9999}
+      >
+        <div>
+          ----
+        </div>
+      </Tooltip>
       <div
         className="css-5bzg50"
       >
@@ -52,7 +80,21 @@ exports[`report total is formated 1`] = `
     <div
       className="css-1a0izfs"
     >
-      formatedValue
+      <Tooltip
+        appendTo={[Function]}
+        className={null}
+        content="ocp_dashboard.total_cost_tooltip"
+        enableFlip={true}
+        entryDelay={500}
+        exitDelay={500}
+        maxWidth="18.75rem"
+        position="top"
+        zIndex={9999}
+      >
+        <div>
+          formatedValue
+        </div>
+      </Tooltip>
       <div
         className="css-5bzg50"
       >

--- a/src/components/reports/ocpReportSummary/ocpReportSummaryDetails.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummaryDetails.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
 import React from 'react';
@@ -21,14 +22,33 @@ const OcpReportSummaryDetailsBase: React.SFC<OcpReportSummaryDetailsProps> = ({
   reportType = OcpReportType.cost,
   requestLabel,
   usageLabel,
+  t,
 }) => {
   let cost: string | number = '----';
+  let derivedCost: string | number = '----';
+  let infrastructureCost: string | number = '----';
   let requestValue: string | number = '----';
 
   if (report && report.meta && report.meta.total) {
     cost = formatValue(
       report.meta.total.cost ? report.meta.total.cost.value : 0,
       report.meta.total.cost ? report.meta.total.cost.units : 'USD',
+      formatOptions
+    );
+    derivedCost = formatValue(
+      report.meta.total.derived_cost ? report.meta.total.derived_cost.value : 0,
+      report.meta.total.derived_cost
+        ? report.meta.total.derived_cost.units
+        : 'USD',
+      formatOptions
+    );
+    infrastructureCost = formatValue(
+      report.meta.total.infrastructure_cost
+        ? report.meta.total.infrastructure_cost.value
+        : 0,
+      report.meta.total.infrastructure_cost
+        ? report.meta.total.infrastructure_cost.units
+        : 'USD',
       formatOptions
     );
     if (reportType !== OcpReportType.cost) {
@@ -39,11 +59,20 @@ const OcpReportSummaryDetailsBase: React.SFC<OcpReportSummaryDetailsProps> = ({
       );
     }
   }
+
   return (
     <>
       <div className={css(styles.titleContainer)}>
         <div className={css(styles.value, styles.usageValue)}>
-          {cost}
+          <Tooltip
+            content={t('ocp_dashboard.total_cost_tooltip', {
+              derivedCost,
+              infrastructureCost,
+            })}
+            enableFlip
+          >
+            <div>{cost}</div>
+          </Tooltip>
           <div className={css(styles.text)}>
             <div>{usageLabel}</div>
           </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -248,6 +248,7 @@
       "projects": "Top projects"
     },
     "title": "OpenShift",
+    "total_cost_tooltip": "This total cost is the sum of the infrastructure cost {{infrastructureCost}} and derived cost {{derivedCost}}",
     "trend_group_legend": "$t(months.{{month}}) {{startDate}} - {{endDate}}",
     "volume_requested_label": "GB-hours requested",
     "volume_title": "OpenShift volume usage & request",


### PR DESCRIPTION
This change shows a tooltip when hovering over the total cost. This explains how the total cost is comprised of derived and infrastructure costs.

Fixes https://github.com/project-koku/koku-ui/issues/661

Mock: https://redhat.invisionapp.com/share/TYRFMZ1C8H7#/screens

OCP overview:
![Screen Shot 2019-04-09 at 3 23 05 PM](https://user-images.githubusercontent.com/17481322/55828884-66c47700-5adb-11e9-8012-a77777bdab40.png)

