### PR TITLE
OCP details popover & tooltip for derived and infrastructure cost

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -276,6 +276,8 @@
     "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
     "decrease_since_last_month": "{{value}} decrease since last month",
     "derived_cost_column_title": "Derived cost",
+    "derived_cost_desc": "The cost based on the user’s defined price list. Calculated as infrastructure_cost + markup, or on a premises without infrastructure, calculated as CPU usage * rate.",
+    "derived_cost_title": "Derived cost",
     "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "export_link": "Export",
     "filter": {
@@ -311,6 +313,8 @@
     "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
     "increase_since_last_month": "{{value}} increase since last month",
     "infrastructure_cost_column_title": "Infrastructure cost",
+    "infrastructure_cost_desc": "The cost based on raw usage data from the underlying infrastructure.",
+    "infrastructure_cost_title": "Infrastructure cost",
     "more_tags": ", {{value}} more...",
     "name_column_title": "$t(group_by.values.{{groupBy}}) Names",
     "no_change_since_date": "No change since $t(months.{{month}}) {{date}}",
@@ -330,6 +334,7 @@
       "results": "{{value}} Results"
     },
     "total_cost": "Cost",
+    "total_cost_tooltip": "This total cost is the sum of the infrastructure cost: {{infrastructureCost}} and derived cost: {{derivedCost}}",
     "view_all": "View all {{value}}s"
   },
   "ocp_on_aws_dashboard": {

--- a/src/pages/ocpDetails/detailsHeader.styles.ts
+++ b/src/pages/ocpDetails/detailsHeader.styles.ts
@@ -34,6 +34,13 @@ export const styles = StyleSheet.create({
     padding: global_spacer_xl.var,
     backgroundColor: global_BackgroundColor_100.var,
   },
+  info: {
+    marginLeft: global_spacer_sm.value,
+    verticalAlign: 'middle',
+  },
+  infrastructureCost: {
+    marginTop: global_spacer_xl.value,
+  },
   title: {
     paddingBottom: global_spacer_sm.var,
   },


### PR DESCRIPTION
The popover, when clicking the info icon, describes what derived and infrastructure costs are. The tooltip shows the actual derived and infrastructure costs.

Fixes https://github.com/project-koku/koku-ui/issues/670

Cost tooltip:
![Screen Shot 2019-04-09 at 5 34 55 PM](https://user-images.githubusercontent.com/17481322/55837160-83b67580-5aee-11e9-8160-6629518d486b.png)

Info icon popover:
![Screen Shot 2019-04-09 at 5 36 13 PM](https://user-images.githubusercontent.com/17481322/55837171-95981880-5aee-11e9-85ca-9fe73f206809.png)
