### PR TITLE
Apply logical AND to toolbar filters

### DIFF
--- a/src/api/awsQuery.ts
+++ b/src/api/awsQuery.ts
@@ -35,10 +35,51 @@ export interface AwsQuery {
   key_only?: boolean;
 }
 
+const groupByAnd = 'and:';
+
+// Adds logical AND to group_by -- https://github.com/project-koku/koku-ui/issues/704
+export function getGroupByAnd(query: AwsQuery) {
+  if (!(query && query.group_by)) {
+    return query;
+  }
+  const newQuery = {
+    ...JSON.parse(JSON.stringify(query)),
+    group_by: {},
+  };
+  for (const key of Object.keys(query.group_by)) {
+    if (query.group_by[key] === '*') {
+      newQuery.group_by[key] = query.group_by[key];
+    } else {
+      newQuery.group_by[`${groupByAnd}${key}`] = query.group_by[key];
+    }
+  }
+  return newQuery;
+}
+
 export function getQuery(query: AwsQuery) {
-  return stringify(query, { encode: false, indices: false });
+  const newQuery = getGroupByAnd(query);
+  return stringify(newQuery, { encode: false, indices: false });
+}
+
+// Removes logical AND from group_by -- https://github.com/project-koku/koku-ui/issues/704
+export function parseGroupByAnd(query: AwsQuery) {
+  if (!(query && query.group_by)) {
+    return query;
+  }
+  const newQuery = {
+    ...JSON.parse(JSON.stringify(query)),
+    group_by: {},
+  };
+  for (const key of Object.keys(query.group_by)) {
+    const index = key.indexOf(groupByAnd);
+    const groupByKey =
+      index !== -1 ? key.substring(index + groupByAnd.length) : key;
+    newQuery.group_by[groupByKey] = query.group_by[key];
+  }
+  return newQuery;
 }
 
 export function parseQuery<T = any>(query: string): T {
-  return parse(query, { ignoreQueryPrefix: true });
+  const newQuery = parse(query, { ignoreQueryPrefix: true });
+  return parseGroupByAnd(newQuery);
 }

--- a/src/api/ocpOnAwsQuery.ts
+++ b/src/api/ocpOnAwsQuery.ts
@@ -36,10 +36,51 @@ export interface OcpOnAwsQuery {
   key_only?: boolean;
 }
 
+const groupByAnd = 'and:';
+
+// Adds logical AND to group_by -- https://github.com/project-koku/koku-ui/issues/704
+export function getGroupByAnd(query: OcpOnAwsQuery) {
+  if (!(query && query.group_by)) {
+    return query;
+  }
+  const newQuery = {
+    ...JSON.parse(JSON.stringify(query)),
+    group_by: {},
+  };
+  for (const key of Object.keys(query.group_by)) {
+    if (query.group_by[key] === '*') {
+      newQuery.group_by[key] = query.group_by[key];
+    } else {
+      newQuery.group_by[`${groupByAnd}${key}`] = query.group_by[key];
+    }
+  }
+  return newQuery;
+}
+
 export function getQuery(query: OcpOnAwsQuery) {
-  return stringify(query, { encode: false, indices: false });
+  const newQuery = getGroupByAnd(query);
+  return stringify(newQuery, { encode: false, indices: false });
+}
+
+// Removes logical AND from group_by -- https://github.com/project-koku/koku-ui/issues/704
+export function parseGroupByAnd(query: OcpOnAwsQuery) {
+  if (!(query && query.group_by)) {
+    return query;
+  }
+  const newQuery = {
+    ...JSON.parse(JSON.stringify(query)),
+    group_by: {},
+  };
+  for (const key of Object.keys(query.group_by)) {
+    const index = key.indexOf(groupByAnd);
+    const groupByKey =
+      index !== -1 ? key.substring(index + groupByAnd.length) : key;
+    newQuery.group_by[groupByKey] = query.group_by[key];
+  }
+  return newQuery;
 }
 
 export function parseQuery<T = any>(query: string): T {
-  return parse(query, { ignoreQueryPrefix: true });
+  const newQuery = parse(query, { ignoreQueryPrefix: true });
+  return parseGroupByAnd(newQuery);
 }

--- a/src/api/ocpQuery.ts
+++ b/src/api/ocpQuery.ts
@@ -33,10 +33,51 @@ export interface OcpQuery {
   key_only?: boolean;
 }
 
+const groupByAnd = 'and:';
+
+// Adds logical AND to group_by -- https://github.com/project-koku/koku-ui/issues/704
+export function getGroupByAnd(query: OcpQuery) {
+  if (!(query && query.group_by)) {
+    return query;
+  }
+  const newQuery = {
+    ...JSON.parse(JSON.stringify(query)),
+    group_by: {},
+  };
+  for (const key of Object.keys(query.group_by)) {
+    if (query.group_by[key] === '*') {
+      newQuery.group_by[key] = query.group_by[key];
+    } else {
+      newQuery.group_by[`${groupByAnd}${key}`] = query.group_by[key];
+    }
+  }
+  return newQuery;
+}
+
 export function getQuery(query: OcpQuery) {
-  return stringify(query, { encode: false, indices: false });
+  const newQuery = getGroupByAnd(query);
+  return stringify(newQuery, { encode: false, indices: false });
+}
+
+// Removes logical AND from group_by -- https://github.com/project-koku/koku-ui/issues/704
+export function parseGroupByAnd(query: OcpQuery) {
+  if (!(query && query.group_by)) {
+    return query;
+  }
+  const newQuery = {
+    ...JSON.parse(JSON.stringify(query)),
+    group_by: {},
+  };
+  for (const key of Object.keys(query.group_by)) {
+    const index = key.indexOf(groupByAnd);
+    const groupByKey =
+      index !== -1 ? key.substring(index + groupByAnd.length) : key;
+    newQuery.group_by[groupByKey] = query.group_by[key];
+  }
+  return newQuery;
 }
 
 export function parseQuery<T = any>(query: string): T {
-  return parse(query, { ignoreQueryPrefix: true });
+  const newQuery = parse(query, { ignoreQueryPrefix: true });
+  return parseGroupByAnd(newQuery);
 }

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -97,11 +97,18 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
     const columns = groupByTagKey
       ? [
+          // Sorting with tag keys is not supported
           {
             title: t('ocp_details.tag_column_title'),
           },
           {
             title: t('ocp_details.change_column_title'),
+          },
+          {
+            title: t('ocp_details.infrastructure_cost_column_title'),
+          },
+          {
+            title: t('ocp_details.derived_cost_column_title'),
           },
           {
             orderBy: 'cost',
@@ -122,14 +129,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             orderBy: 'infrastructure_cost',
             title: t('ocp_details.infrastructure_cost_column_title'),
 
-            // Sort disabled for now -- https://github.com/project-koku/koku/issues/796
+            // Sort by infrastructure_cost is not supported -- https://github.com/project-koku/koku/issues/796
             // transforms: [sortable],
           },
           {
             orderBy: 'derived_cost',
             title: t('ocp_details.derived_cost_column_title'),
 
-            // Sort disabled for now -- https://github.com/project-koku/koku/issues/796
+            // Sort by derived_cost is not supported -- https://github.com/project-koku/koku/issues/796
             // transforms: [sortable],
           },
           {
@@ -196,7 +203,13 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
   private getDerivedCost = (item: ComputedOcpReportItem, index: number) => {
     const { report, t } = this.props;
-    const total = report.meta.total.derived_cost.value;
+    const total =
+      report &&
+      report.meta &&
+      report.meta.total &&
+      report.meta.total.derived_cost
+        ? report.meta.total.derived_cost.value
+        : 0;
 
     return (
       <>
@@ -232,7 +245,13 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     index: number
   ) => {
     const { report, t } = this.props;
-    const total = report.meta.total.infrastructure_cost.value;
+    const total =
+      report &&
+      report.meta &&
+      report.meta.total &&
+      report.meta.total.infrastructure_cost
+        ? report.meta.total.infrastructure_cost.value
+        : 0;
 
     return (
       <>


### PR DESCRIPTION
This change applies logical AND to the toolbar filters found in the details pages.

Fixes https://github.com/project-koku/koku-ui/issues/704

OCP, group by tag:
![Screen Shot 2019-04-10 at 1 21 32 PM](https://user-images.githubusercontent.com/17481322/55899834-c8e0b300-5b93-11e9-9a36-5837dc73368a.png)

OCP on AWS, group by project:
![Screen Shot 2019-04-10 at 1 22 19 PM](https://user-images.githubusercontent.com/17481322/55899863-d7c76580-5b93-11e9-9574-30ea602818f0.png)

AWS, group by account:
![Screen Shot 2019-04-10 at 1 22 02 PM](https://user-images.githubusercontent.com/17481322/55899893-e31a9100-5b93-11e9-8a77-06c951f473a1.png)

