### PR TITLE
Omit unnecessary tab requests

### DIFF
--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardActions.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardActions.ts
@@ -14,7 +14,9 @@ export const fetchWidgetReports = (id: number): ThunkAction => {
     const { previous, current, tabs } = selectWidgetQueries(state, id);
     dispatch(ocpOnAwsReportsActions.fetchReport(widget.reportType, current));
     dispatch(ocpOnAwsReportsActions.fetchReport(widget.reportType, previous));
-    dispatch(ocpOnAwsReportsActions.fetchReport(widget.reportType, tabs));
+    if (widget.availableTabs) {
+      dispatch(ocpOnAwsReportsActions.fetchReport(widget.reportType, tabs));
+    }
   };
 };
 

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardWidgets.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardWidgets.ts
@@ -52,7 +52,6 @@ export const cpuWidget: OcpOnAwsDashboardWidget = {
     titleKey: 'ocp_on_aws_dashboard.cpu_trend_title',
     type: ChartType.daily,
   },
-  currentTab: OcpOnAwsDashboardTab.projects,
 };
 
 export const memoryWidget: OcpOnAwsDashboardWidget = {
@@ -73,7 +72,6 @@ export const memoryWidget: OcpOnAwsDashboardWidget = {
     titleKey: 'ocp_on_aws_dashboard.memory_trend_title',
     type: ChartType.daily,
   },
-  currentTab: OcpOnAwsDashboardTab.projects,
 };
 
 export const volumeWidget: OcpOnAwsDashboardWidget = {


### PR DESCRIPTION
The OCP on AWS overview is generating requests for tabs that are not being displayed. Only the first cost card displays tabs. All other cards omit the tab for a smaller view. This means there are several requests being generated unnecessarily. This should help speed things up slightly?

Fixes https://github.com/project-koku/koku-ui/issues/735