### PR TITLE
Insights skeletons

### DIFF
--- a/src/components/reports/awsReportSummary/awsReportSummary.styles.ts
+++ b/src/components/reports/awsReportSummary/awsReportSummary.styles.ts
@@ -1,7 +1,19 @@
 import { StyleSheet } from '@patternfly/react-styles';
-import { global_Color_200, global_FontSize_xs } from '@patternfly/react-tokens';
+import {
+  global_Color_200,
+  global_FontSize_xs,
+  global_spacer_md,
+} from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
+  chartSkeleton: {
+    height: '125px',
+    marginBottom: global_spacer_md.value,
+    marginTop: global_spacer_md.value,
+  },
+  legendSkeleton: {
+    marginTop: global_spacer_md.value,
+  },
   reportSummary: {
     height: '100%',
   },

--- a/src/components/reports/awsReportSummary/awsReportSummary.test.tsx
+++ b/src/components/reports/awsReportSummary/awsReportSummary.test.tsx
@@ -10,13 +10,6 @@ const props: AwsReportSummaryProps = {
   t: jest.fn(v => `t(${v})`),
 };
 
-test('on fetch status in progress show loading text', () => {
-  const view = mount(
-    <AwsReportSummary {...props} status={FetchStatus.inProgress} />
-  );
-  expect(view.find(CardBody).text()).toEqual('t(loading)...');
-});
-
 test('on fetch status complete display reports', () => {
   const view = mount(
     <AwsReportSummary {...props}>hello world</AwsReportSummary>

--- a/src/components/reports/awsReportSummary/awsReportSummary.tsx
+++ b/src/components/reports/awsReportSummary/awsReportSummary.tsx
@@ -7,6 +7,10 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
+import {
+  Skeleton,
+  SkeletonSize,
+} from '@red-hat-insights/insights-frontend-components/components/Skeleton';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { FetchStatus } from 'store/common';
@@ -40,7 +44,22 @@ const AwsReportSummaryBase: React.SFC<AwsReportSummaryProps> = ({
       )}
     </CardHeader>
     <CardBody>
-      {status === FetchStatus.inProgress ? `${t('loading')}...` : children}
+      {status === FetchStatus.inProgress ? (
+        <>
+          <Skeleton size={SkeletonSize.xs} />
+          <Skeleton
+            className={css(styles.chartSkeleton)}
+            size={SkeletonSize.md}
+          />
+          <Skeleton size={SkeletonSize.sm} />
+          <Skeleton
+            className={css(styles.legendSkeleton)}
+            size={SkeletonSize.xs}
+          />
+        </>
+      ) : (
+        children
+      )}
     </CardBody>
     {Boolean(detailsLink) && <CardFooter>{detailsLink}</CardFooter>}
   </Card>

--- a/src/components/reports/awsReportSummary/awsReportSummaryAlt.styles.ts
+++ b/src/components/reports/awsReportSummary/awsReportSummaryAlt.styles.ts
@@ -3,15 +3,24 @@ import {
   global_Color_200,
   global_FontSize_xs,
   global_spacer_lg,
+  global_spacer_md,
 } from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
+  chartSkeleton: {
+    height: '175px',
+    marginBottom: global_spacer_md.value,
+    marginTop: global_spacer_md.value,
+  },
   container: {
     display: 'flex',
   },
   cost: {
     flexGrow: 1,
     minHeight: '440px',
+  },
+  legendSkeleton: {
+    marginTop: global_spacer_md.value,
   },
   reportSummary: {
     height: '100%',

--- a/src/components/reports/awsReportSummary/awsReportSummaryAlt.tsx
+++ b/src/components/reports/awsReportSummary/awsReportSummaryAlt.tsx
@@ -9,6 +9,10 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
+import {
+  Skeleton,
+  SkeletonSize,
+} from '@red-hat-insights/insights-frontend-components/components/Skeleton';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { FetchStatus } from 'store/common';
@@ -47,9 +51,22 @@ const AwsReportSummaryAltBase: React.SFC<AwsReportSummaryAltProps> = ({
             )}
           </CardHeader>
           <CardBody>
-            {status === FetchStatus.inProgress
-              ? `${t('loading')}...`
-              : children}
+            {status === FetchStatus.inProgress ? (
+              <>
+                <Skeleton size={SkeletonSize.xs} />
+                <Skeleton
+                  className={css(styles.chartSkeleton)}
+                  size={SkeletonSize.md}
+                />
+                <Skeleton size={SkeletonSize.sm} />
+                <Skeleton
+                  className={css(styles.legendSkeleton)}
+                  size={SkeletonSize.xs}
+                />
+              </>
+            ) : (
+              children
+            )}
           </CardBody>
         </div>
       </GridItem>

--- a/src/components/reports/awsReportSummary/awsReportSummaryItems.styles.ts
+++ b/src/components/reports/awsReportSummary/awsReportSummaryItems.styles.ts
@@ -1,0 +1,8 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_md } from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  skeleton: {
+    marginTop: global_spacer_md.value,
+  },
+});

--- a/src/components/reports/awsReportSummary/awsReportSummaryItems.tsx
+++ b/src/components/reports/awsReportSummary/awsReportSummaryItems.tsx
@@ -1,3 +1,8 @@
+import { css } from '@patternfly/react-styles';
+import {
+  Skeleton,
+  SkeletonSize,
+} from '@red-hat-insights/insights-frontend-components/components/Skeleton';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import {
@@ -5,6 +10,7 @@ import {
   getComputedAwsReportItems,
   GetComputedAwsReportItemsParams,
 } from 'utils/getComputedAwsReportItems';
+import { styles } from './awsReportSummaryItems.styles';
 
 interface AwsReportSummaryItemsRenderProps {
   items: ComputedAwsReportItem[];
@@ -53,10 +59,17 @@ class AwsReportSummaryItemsBase extends React.Component<
   }
 
   public render() {
-    const { report, children, t } = this.props;
+    const { report, children } = this.props;
 
     if (!report) {
-      return `${t('loading')}...`;
+      return (
+        <>
+          <Skeleton size={SkeletonSize.md} />
+          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+        </>
+      );
     } else {
       const items = this.getItems();
       return <ul>{children({ items })}</ul>;

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummary.styles.ts
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummary.styles.ts
@@ -1,7 +1,19 @@
 import { StyleSheet } from '@patternfly/react-styles';
-import { global_Color_200, global_FontSize_xs } from '@patternfly/react-tokens';
+import {
+  global_Color_200,
+  global_FontSize_xs,
+  global_spacer_md,
+} from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
+  chartSkeleton: {
+    height: '125px',
+    marginBottom: global_spacer_md.value,
+    marginTop: global_spacer_md.value,
+  },
+  legendSkeleton: {
+    marginTop: global_spacer_md.value,
+  },
   reportSummary: {
     height: '100%',
   },

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummary.test.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummary.test.tsx
@@ -13,13 +13,6 @@ const props: OcpOnAwsReportSummaryProps = {
   t: jest.fn(v => `t(${v})`),
 };
 
-test('on fetch status in progress show loading text', () => {
-  const view = mount(
-    <OcpOnAwsReportSummary {...props} status={FetchStatus.inProgress} />
-  );
-  expect(view.find(CardBody).text()).toEqual('t(loading)...');
-});
-
 test('on fetch status complete display reports', () => {
   const view = mount(
     <OcpOnAwsReportSummary {...props}>hello world</OcpOnAwsReportSummary>

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummary.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummary.tsx
@@ -7,6 +7,10 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
+import {
+  Skeleton,
+  SkeletonSize,
+} from '@red-hat-insights/insights-frontend-components/components/Skeleton';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { FetchStatus } from 'store/common';
@@ -40,7 +44,22 @@ const OcpOnAwsReportSummaryBase: React.SFC<OcpOnAwsReportSummaryProps> = ({
       )}
     </CardHeader>
     <CardBody>
-      {status === FetchStatus.inProgress ? `${t('loading')}...` : children}
+      {status === FetchStatus.inProgress ? (
+        <>
+          <Skeleton size={SkeletonSize.xs} />
+          <Skeleton
+            className={css(styles.chartSkeleton)}
+            size={SkeletonSize.md}
+          />
+          <Skeleton size={SkeletonSize.sm} />
+          <Skeleton
+            className={css(styles.legendSkeleton)}
+            size={SkeletonSize.xs}
+          />
+        </>
+      ) : (
+        children
+      )}
     </CardBody>
     {Boolean(detailsLink) && <CardFooter>{detailsLink}</CardFooter>}
   </Card>

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryAlt.styles.ts
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryAlt.styles.ts
@@ -3,15 +3,24 @@ import {
   global_Color_200,
   global_FontSize_xs,
   global_spacer_lg,
+  global_spacer_md,
 } from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
+  chartSkeleton: {
+    height: '175px',
+    marginBottom: global_spacer_md.value,
+    marginTop: global_spacer_md.value,
+  },
   container: {
     display: 'flex',
   },
   cost: {
     flexGrow: 1,
     minHeight: '440px',
+  },
+  legendSkeleton: {
+    marginTop: global_spacer_md.value,
   },
   reportSummary: {
     height: '100%',

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryAlt.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryAlt.tsx
@@ -9,6 +9,10 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
+import {
+  Skeleton,
+  SkeletonSize,
+} from '@red-hat-insights/insights-frontend-components/components/Skeleton';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { FetchStatus } from 'store/common';
@@ -49,9 +53,22 @@ const OcpOnAwsReportSummaryAltBase: React.SFC<
             )}
           </CardHeader>
           <CardBody>
-            {status === FetchStatus.inProgress
-              ? `${t('loading')}...`
-              : children}
+            {status === FetchStatus.inProgress ? (
+              <>
+                <Skeleton size={SkeletonSize.xs} />
+                <Skeleton
+                  className={css(styles.chartSkeleton)}
+                  size={SkeletonSize.md}
+                />
+                <Skeleton size={SkeletonSize.sm} />
+                <Skeleton
+                  className={css(styles.legendSkeleton)}
+                  size={SkeletonSize.xs}
+                />
+              </>
+            ) : (
+              children
+            )}
           </CardBody>
         </div>
       </GridItem>

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItems.styles.ts
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItems.styles.ts
@@ -1,0 +1,8 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_md } from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  skeleton: {
+    marginTop: global_spacer_md.value,
+  },
+});

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItems.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItems.tsx
@@ -1,3 +1,8 @@
+import { css } from '@patternfly/react-styles';
+import {
+  Skeleton,
+  SkeletonSize,
+} from '@red-hat-insights/insights-frontend-components/components/Skeleton';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import {
@@ -5,6 +10,7 @@ import {
   getComputedOcpOnAwsReportItems,
   GetComputedOcpOnAwsReportItemsParams,
 } from 'utils/getComputedOcpOnAwsReportItems';
+import { styles } from './ocpOnAwsReportSummaryItems.styles';
 
 interface OcpOnAwsReportSummaryItemsRenderProps {
   items: ComputedOcpOnAwsReportItem[];
@@ -53,10 +59,17 @@ class OcpOnAwsReportSummaryItemsBase extends React.Component<
   }
 
   public render() {
-    const { report, children, t } = this.props;
+    const { report, children } = this.props;
 
     if (!report) {
-      return `${t('loading')}...`;
+      return (
+        <>
+          <Skeleton size={SkeletonSize.md} />
+          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+        </>
+      );
     } else {
       const items = this.getItems();
       return <ul>{children({ items })}</ul>;

--- a/src/components/reports/ocpReportSummary/ocpReportSummary.styles.ts
+++ b/src/components/reports/ocpReportSummary/ocpReportSummary.styles.ts
@@ -1,7 +1,19 @@
 import { StyleSheet } from '@patternfly/react-styles';
-import { global_Color_200, global_FontSize_xs } from '@patternfly/react-tokens';
+import {
+  global_Color_200,
+  global_FontSize_xs,
+  global_spacer_md,
+} from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
+  chartSkeleton: {
+    height: '125px',
+    marginBottom: global_spacer_md.value,
+    marginTop: global_spacer_md.value,
+  },
+  legendSkeleton: {
+    marginTop: global_spacer_md.value,
+  },
   reportSummary: {
     height: '100%',
   },

--- a/src/components/reports/ocpReportSummary/ocpReportSummary.test.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummary.test.tsx
@@ -10,13 +10,6 @@ const props: OcpReportSummaryProps = {
   t: jest.fn(v => `t(${v})`),
 };
 
-test('on fetch status in progress show loading text', () => {
-  const view = mount(
-    <OcpReportSummary {...props} status={FetchStatus.inProgress} />
-  );
-  expect(view.find(CardBody).text()).toEqual('t(loading)...');
-});
-
 test('on fetch status complete display reports', () => {
   const view = mount(
     <OcpReportSummary {...props}>hello world</OcpReportSummary>

--- a/src/components/reports/ocpReportSummary/ocpReportSummary.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummary.tsx
@@ -7,6 +7,10 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
+import {
+  Skeleton,
+  SkeletonSize,
+} from '@red-hat-insights/insights-frontend-components/components/Skeleton';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { FetchStatus } from 'store/common';
@@ -40,7 +44,22 @@ const OcpReportSummaryBase: React.SFC<OcpReportSummaryProps> = ({
       )}
     </CardHeader>
     <CardBody>
-      {status === FetchStatus.inProgress ? `${t('loading')}...` : children}
+      {status === FetchStatus.inProgress ? (
+        <>
+          <Skeleton size={SkeletonSize.xs} />
+          <Skeleton
+            className={css(styles.chartSkeleton)}
+            size={SkeletonSize.md}
+          />
+          <Skeleton size={SkeletonSize.sm} />
+          <Skeleton
+            className={css(styles.legendSkeleton)}
+            size={SkeletonSize.xs}
+          />
+        </>
+      ) : (
+        children
+      )}
     </CardBody>
     {Boolean(detailsLink) && <CardFooter>{detailsLink}</CardFooter>}
   </Card>

--- a/src/components/reports/ocpReportSummary/ocpReportSummaryAlt.styles.ts
+++ b/src/components/reports/ocpReportSummary/ocpReportSummaryAlt.styles.ts
@@ -3,15 +3,24 @@ import {
   global_Color_200,
   global_FontSize_xs,
   global_spacer_lg,
+  global_spacer_md,
 } from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
+  chartSkeleton: {
+    height: '175px',
+    marginBottom: global_spacer_md.value,
+    marginTop: global_spacer_md.value,
+  },
   container: {
     display: 'flex',
   },
   cost: {
     flexGrow: 1,
     minHeight: '440px',
+  },
+  legendSkeleton: {
+    marginTop: global_spacer_md.value,
   },
   reportSummary: {
     height: '100%',

--- a/src/components/reports/ocpReportSummary/ocpReportSummaryAlt.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummaryAlt.tsx
@@ -9,6 +9,10 @@ import {
   Tooltip,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
+import {
+  Skeleton,
+  SkeletonSize,
+} from '@red-hat-insights/insights-frontend-components/components/Skeleton';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { FetchStatus } from 'store/common';
@@ -47,9 +51,22 @@ const OcpReportSummaryAltBase: React.SFC<OcpReportSummaryAltProps> = ({
             )}
           </CardHeader>
           <CardBody>
-            {status === FetchStatus.inProgress
-              ? `${t('loading')}...`
-              : children}
+            {status === FetchStatus.inProgress ? (
+              <>
+                <Skeleton size={SkeletonSize.xs} />
+                <Skeleton
+                  size={SkeletonSize.md}
+                  className={css(styles.chartSkeleton)}
+                />
+                <Skeleton size={SkeletonSize.sm} />
+                <Skeleton
+                  size={SkeletonSize.xs}
+                  className={css(styles.legendSkeleton)}
+                />
+              </>
+            ) : (
+              children
+            )}
           </CardBody>
         </div>
       </GridItem>

--- a/src/components/reports/ocpReportSummary/ocpReportSummaryItems.styles.ts
+++ b/src/components/reports/ocpReportSummary/ocpReportSummaryItems.styles.ts
@@ -1,0 +1,8 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_md } from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  skeleton: {
+    marginTop: global_spacer_md.value,
+  },
+});

--- a/src/components/reports/ocpReportSummary/ocpReportSummaryItems.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummaryItems.tsx
@@ -1,3 +1,8 @@
+import { css } from '@patternfly/react-styles';
+import {
+  Skeleton,
+  SkeletonSize,
+} from '@red-hat-insights/insights-frontend-components/components/Skeleton';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import {
@@ -5,6 +10,7 @@ import {
   getComputedOcpReportItems,
   GetComputedOcpReportItemsParams,
 } from 'utils/getComputedOcpReportItems';
+import { styles } from './ocpReportSummaryItems.styles';
 
 interface OcpReportSummaryItemsRenderProps {
   items: ComputedOcpReportItem[];
@@ -53,10 +59,17 @@ class OcpReportSummaryItemsBase extends React.Component<
   }
 
   public render() {
-    const { report, children, t } = this.props;
+    const { report, children } = this.props;
 
     if (!report) {
-      return `${t('loading')}...`;
+      return (
+        <>
+          <Skeleton size={SkeletonSize.md} />
+          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+        </>
+      );
     } else {
       const items = this.getItems();
       return <ul>{children({ items })}</ul>;

--- a/src/pages/awsDetails/detailsWidget.styles.ts
+++ b/src/pages/awsDetails/detailsWidget.styles.ts
@@ -2,6 +2,9 @@ import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md, global_spacer_xl } from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
+  skeleton: {
+    marginTop: global_spacer_md.value,
+  },
   tabs: {
     marginTop: global_spacer_xl.value,
   },

--- a/src/pages/awsDetails/detailsWidget.tsx
+++ b/src/pages/awsDetails/detailsWidget.tsx
@@ -6,6 +6,10 @@ import {
   Tabs,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
+import {
+  Skeleton,
+  SkeletonSize,
+} from '@red-hat-insights/insights-frontend-components/components/Skeleton';
 import { AwsReport, AwsReportType } from 'api/awsReports';
 import {
   AwsReportSummaryItem,
@@ -255,12 +259,19 @@ class DetailsWidgetBase extends React.Component<DetailsWidgetProps> {
   };
 
   public render() {
-    const { reportFetchStatus, t } = this.props;
+    const { reportFetchStatus } = this.props;
     return (
       <>
-        {Boolean(reportFetchStatus === FetchStatus.inProgress)
-          ? `${t('loading')}...`
-          : this.getTabs()}
+        {Boolean(reportFetchStatus === FetchStatus.inProgress) ? (
+          <>
+            <Skeleton size={SkeletonSize.md} />
+            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+          </>
+        ) : (
+          this.getTabs()
+        )}
       </>
     );
   }

--- a/src/pages/ocpOnAwsDetails/detailsWidget.styles.ts
+++ b/src/pages/ocpOnAwsDetails/detailsWidget.styles.ts
@@ -2,6 +2,9 @@ import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md, global_spacer_xl } from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
+  skeleton: {
+    marginTop: global_spacer_md.value,
+  },
   tabs: {
     marginTop: global_spacer_xl.value,
   },

--- a/src/pages/ocpOnAwsDetails/detailsWidget.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsWidget.tsx
@@ -6,6 +6,10 @@ import {
   Tabs,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
+import {
+  Skeleton,
+  SkeletonSize,
+} from '@red-hat-insights/insights-frontend-components/components/Skeleton';
 import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
 import {
   OcpOnAwsReportSummaryItem,
@@ -256,12 +260,19 @@ class DetailsWidgetBase extends React.Component<DetailsWidgetProps> {
   };
 
   public render() {
-    const { reportFetchStatus, t } = this.props;
+    const { reportFetchStatus } = this.props;
     return (
       <>
-        {Boolean(reportFetchStatus === FetchStatus.inProgress)
-          ? `${t('loading')}...`
-          : this.getTabs()}
+        {Boolean(reportFetchStatus === FetchStatus.inProgress) ? (
+          <>
+            <Skeleton size={SkeletonSize.md} />
+            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+          </>
+        ) : (
+          this.getTabs()
+        )}
       </>
     );
   }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -47,6 +47,9 @@ module.exports = env => {
     mode: isProduction ? 'production' : 'development',
     devtool: isProduction ? 'source-maps' : 'eval',
     entry: [
+      require.resolve(
+        '@red-hat-insights/insights-frontend-components/components/Skeleton.css'
+      ),
       require.resolve('patternfly/dist/css/patternfly.css'),
       require.resolve('patternfly/dist/css/patternfly-additions.css'),
       require.resolve('@patternfly/patternfly/utilities/Display/display.css'),


### PR DESCRIPTION
Replaces "Loading..." text with the Insights skeleton component.

Fixes https://github.com/project-koku/koku-ui/issues/691

Initial loading state:
<img width="1056" alt="Screen Shot 2019-04-10 at 11 12 15 PM" src="https://user-images.githubusercontent.com/17481322/55929557-3d930c00-5beb-11e9-84c6-aa6e85b0391f.png">

Cost loaded, while other cards are loading:
<img width="1054" alt="Screen Shot 2019-04-10 at 11 11 48 PM" src="https://user-images.githubusercontent.com/17481322/55929573-57345380-5beb-11e9-951a-d7ca970fb8a2.png">
