### PR TITLE
Omit capacity from bullet charts

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -255,12 +255,10 @@
   },
   "ocp_details": {
     "bullet": {
-      "cpu_capacity": "Capacity - {{value}} {{units}}",
       "cpu_label": "CPU",
       "cpu_limit": "Limit - {{value}} {{units}}",
       "cpu_requests": "Requests - {{value}} {{units}}",
       "cpu_usage": "Usage - {{value}} {{units}}",
-      "memory_capacity": "Capacity - {{value}} {{units}}",
       "memory_label": "Memory",
       "memory_limit": "Limit - {{value}} {{units}}",
       "memory_requests": "Requests - {{value}} {{units}}",
@@ -367,12 +365,10 @@
   },
   "ocp_on_aws_details": {
     "bullet": {
-      "cpu_capacity": "Capacity - {{value}} {{units}}",
       "cpu_label": "CPU",
       "cpu_limit": "Limit - {{value}} {{units}}",
       "cpu_requests": "Requests - {{value}} {{units}}",
       "cpu_usage": "Usage - {{value}} {{units}}",
-      "memory_capacity": "Capacity - {{value}} {{units}}",
       "memory_label": "Memory",
       "memory_limit": "Limit - {{value}} {{units}}",
       "memory_requests": "Requests - {{value}} {{units}}",

--- a/src/pages/ocpDetails/detailsChart.tsx
+++ b/src/pages/ocpDetails/detailsChart.tsx
@@ -13,7 +13,6 @@ import { ComputedOcpReportItem } from 'utils/getComputedOcpReportItems';
 import { styles } from './detailsChart.styles';
 
 export interface ChartDatum {
-  capacity: number;
   legend: any[];
   limit: any;
   ranges: any[];
@@ -63,17 +62,12 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
   private getChartDatum(report: OcpReport, labelKey: string): ChartDatum {
     const { t } = this.props;
     const datum: ChartDatum = {
-      capacity: 0,
       legend: [],
       limit: {},
       ranges: [],
       values: [],
     };
     if (report && report.meta && report.meta.total) {
-      datum.capacity = Math.trunc(report.meta.total.capacity.value);
-      const capacityUnits = t(
-        `units.${unitLookupKey(report.meta.total.capacity.units)}`
-      );
       const limit = Math.trunc(report.meta.total.limit.value);
       const limitUnits = t(
         `units.${unitLookupKey(report.meta.total.limit.units)}`
@@ -110,18 +104,6 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
             units: requestUnits,
           }),
           value: Math.trunc(request),
-        },
-        {
-          color: chartStyles.rangeColorScale[0], // '#ededed'
-          legend: t(`ocp_details.bullet.${labelKey}_capacity`, {
-            value: datum.capacity,
-            units: capacityUnits,
-          }),
-          tooltip: t(`ocp_details.bullet.${labelKey}_capacity`, {
-            value: datum.capacity,
-            units: capacityUnits,
-          }),
-          value: Math.trunc(datum.capacity),
         },
       ];
       datum.values = [

--- a/src/pages/ocpOnAwsDetails/detailsChart.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsChart.tsx
@@ -16,7 +16,6 @@ import { ComputedOcpOnAwsReportItem } from 'utils/getComputedOcpOnAwsReportItems
 import { styles } from './detailsChart.styles';
 
 export interface ChartDatum {
-  capacity: number;
   legend: any[];
   limit: any;
   ranges: any[];
@@ -66,17 +65,12 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
   private getChartDatum(report: OcpOnAwsReport, labelKey: string): ChartDatum {
     const { t } = this.props;
     const datum: ChartDatum = {
-      capacity: 0,
       legend: [],
       limit: {},
       ranges: [],
       values: [],
     };
     if (report && report.meta && report.meta.total) {
-      datum.capacity = Math.trunc(report.meta.total.capacity.value);
-      const capacityUnits = t(
-        `units.${unitLookupKey(report.meta.total.capacity.units)}`
-      );
       const limit = Math.trunc(report.meta.total.limit.value);
       const limitUnits = t(
         `units.${unitLookupKey(report.meta.total.limit.units)}`
@@ -113,18 +107,6 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
             units: requestUnits,
           }),
           value: Math.trunc(request),
-        },
-        {
-          color: chartStyles.rangeColorScale[0], // '#ededed'
-          legend: t(`ocp_details.bullet.${labelKey}_capacity`, {
-            value: datum.capacity,
-            units: capacityUnits,
-          }),
-          tooltip: t(`ocp_details.bullet.${labelKey}_capacity`, {
-            value: datum.capacity,
-            units: capacityUnits,
-          }),
-          value: Math.trunc(datum.capacity),
         },
       ];
       datum.values = [


### PR DESCRIPTION
This change omits the capacity from bullet charts. There's a possible the capacity could be really long and skew the charts.

Fixes: https://github.com/project-koku/koku-ui/issues/741