### PR TITLE
Bullet chart tooltip styling

### DIFF
--- a/src/components/charts/bulletChart/bulletChart.styles.ts
+++ b/src/components/charts/bulletChart/bulletChart.styles.ts
@@ -1,5 +1,7 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
+  c_background_image_BackgroundColor,
+  global_Color_light_200,
   global_danger_color_100,
   global_spacer_md,
   global_spacer_sm,
@@ -21,6 +23,16 @@ export const chartStyles = {
   rangeWidth: 40,
   thresholdErrorColor: global_danger_color_100.value,
   thresholdErrorWidth: 1,
+  tooltip: {
+    flyoutStyle: {
+      fill: c_background_image_BackgroundColor.value,
+      strokeWidth: 0,
+    },
+    style: {
+      fill: global_Color_light_200.value,
+      padding: 18,
+    },
+  },
   // See: https://github.com/project-koku/koku-ui/issues/241
   valueColorScale: [
     '#007BBA',

--- a/src/components/charts/bulletChart/bulletChart.tsx
+++ b/src/components/charts/bulletChart/bulletChart.tsx
@@ -99,7 +99,16 @@ class BulletChart extends React.Component<BulletChartProps, State> {
         <Chart height={chartStyles.height} width={width}>
           <ChartGroup
             horizontal
-            labelComponent={<ChartTooltip dx={-10} dy={30} orientation="top" />}
+            labelComponent={
+              <ChartTooltip
+                dx={-10}
+                dy={30}
+                flyoutStyle={chartStyles.tooltip.flyoutStyle}
+                orientation="top"
+                pointerWidth={20}
+                style={chartStyles.tooltip.style}
+              />
+            }
           >
             {Boolean(sortedRanges) &&
               sortedRanges.map((val, index) => {
@@ -141,7 +150,13 @@ class BulletChart extends React.Component<BulletChartProps, State> {
           {Boolean(thresholdError) && (
             <ChartBar
               data={[{ x: thresholdError.value, y: 2 }]}
-              labelComponent={<ChartTooltip />}
+              labelComponent={
+                <ChartTooltip
+                  flyoutStyle={chartStyles.tooltip.flyoutStyle}
+                  pointerWidth={20}
+                  style={chartStyles.tooltip.style}
+                />
+              }
               labels={[thresholdError.tooltip]}
               style={{
                 data: {


### PR DESCRIPTION
Update bullet chart tooltip styling to look more like PF4 tooltips

Fixes ttps://github.com/project-koku/koku-ui/issues/746

<img width="572" alt="Screen Shot 2019-04-11 at 11 24 33 PM" src="https://user-images.githubusercontent.com/17481322/56010872-59fa7b80-5cb3-11e9-8c6b-6821d7ca8485.png">
