### PR TITLE
fix(Sources): use React.Fragment to render details table item

### DIFF
--- a/src/pages/sourceSettings/sourceSettings.tsx
+++ b/src/pages/sourceSettings/sourceSettings.tsx
@@ -124,6 +124,11 @@ class SourceSettings extends React.Component<Props, State> {
       t('source_details.column.last_contacted'),
       '',
     ];
+    const wrapper = src => (
+      <>
+        <DetailsTableItem key={`i-${src.name}-${src.type}`} source={src} />
+      </>
+    );
     const rows = sources
       .map((src, ix) => [
         {
@@ -142,9 +147,7 @@ class SourceSettings extends React.Component<Props, State> {
         },
         {
           parent: 2 * ix,
-          cells: [
-            <DetailsTableItem key={`i-${src.name}-${src.type}`} source={src} />,
-          ],
+          cells: [wrapper(src)],
           // TODO: Uncomment when bulk delete is available
           // selected: true,
         },


### PR DESCRIPTION
closes #763 

In the new PF4, components won't be rendered unless wrapped with `React.Fragment` or `<>`.