### PR TITLE
Missing table styles in production

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -106,6 +106,7 @@ module.exports = env => {
         },
         {
           test: /\.css$/i,
+          sideEffects: true,
           use: [
             isProduction ? MiniCssExtractPlugin.loader : 'style-loader',
             'css-loader',


### PR DESCRIPTION
For some reason, our webpack config is not chunking css files properly in production. This change ensures the probuction build outputs css files for missing table styles.

Fixes https://github.com/project-koku/koku-ui/issues/772