### PR TITLE
Wrap historical chart legends

### DIFF
--- a/src/components/charts/historicalCostChart/historicalCostChart.styles.ts
+++ b/src/components/charts/historicalCostChart/historicalCostChart.styles.ts
@@ -37,6 +37,7 @@ export const chartStyles = {
       fontSize: 12,
     },
   },
+  itemsPerRow: 0,
   previousCapacityData: {
     data: {
       fill: 'none',
@@ -111,6 +112,11 @@ export const styles = StyleSheet.create({
   legend: {
     paddingTop: global_spacer_2xl.value,
     marginLeft: '-100px',
+  },
+  legendWrap: {
+    paddingTop: global_spacer_2xl.value,
+    marginLeft: '100px;',
+    height: '100px;',
   },
   title: {
     marginLeft: '-' + global_spacer_lg.value,

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -30,6 +30,7 @@ interface HistoricalCostChartProps {
   formatDatumValue?: ValueFormatter;
   formatDatumOptions?: FormatOptions;
   height: number;
+  legendItemsPerRow?: number;
   previousCostData?: any;
   previousInfrastructureCostData?: any;
   title?: string;
@@ -301,7 +302,15 @@ class HistoricalCostChart extends React.Component<
       : 31;
   }
 
-  private getLegend = (datum: HistoricalLegendDatum) => {
+  private getLegend = (datum: HistoricalLegendDatum, width: number) => {
+    const { legendItemsPerRow } = this.props;
+
+    const itemsPerRow = legendItemsPerRow
+      ? legendItemsPerRow
+      : width > 700
+      ? chartStyles.itemsPerRow
+      : 2;
+
     if (datum && datum.data && datum.data.length) {
       return (
         <ChartLegend
@@ -327,6 +336,7 @@ class HistoricalCostChart extends React.Component<
           ]}
           gutter={0}
           height={25}
+          itemsPerRow={itemsPerRow}
           labelComponent={<ChartLabelTooltip content={this.getLegendTooltip} />}
           style={chartStyles.legend}
         />
@@ -415,8 +425,10 @@ class HistoricalCostChart extends React.Component<
           datum && datum.legend && datum.legend.data && datum.legend.data.length
         ) && (
           <div className={css(styles.legendContainer)}>
-            <div className={css(styles.legend)}>
-              {this.getLegend(datum.legend)}
+            <div
+              className={css(width > 700 ? styles.legend : styles.legendWrap)}
+            >
+              {this.getLegend(datum.legend, width)}
             </div>
           </div>
         )}

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.styles.ts
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.styles.ts
@@ -32,6 +32,7 @@ export const chartStyles = {
       fontSize: 12,
     },
   },
+  itemsPerRow: 0,
   previousMonth: {
     data: {
       fill: 'none',
@@ -84,9 +85,13 @@ export const styles = StyleSheet.create({
       overflow: 'visible',
     },
   },
+  legendContainer: {
+    display: 'flex',
+    justifyContent: 'center',
+  },
   legend: {
     paddingTop: global_spacer_2xl.value,
-    marginLeft: '450px;',
+    marginLeft: '300px;',
   },
   title: {
     marginLeft: '-' + global_spacer_lg.value,

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -29,6 +29,7 @@ interface HistoricalTrendChartProps {
   previousData?: any;
   formatDatumValue: ValueFormatter;
   formatDatumOptions?: FormatOptions;
+  legendItemsPerRow?: number;
   title?: string;
   xAxisLabel?: string;
   yAxisLabel?: string;
@@ -213,7 +214,9 @@ class HistoricalTrendChart extends React.Component<
       : 31;
   }
 
-  private getLegend = (datum: HistoricalLegendDatum) => {
+  private getLegend = (datum: HistoricalLegendDatum, width: number) => {
+    const { legendItemsPerRow } = this.props;
+
     if (datum && datum.data && datum.data.length) {
       return (
         <ChartLegend
@@ -239,6 +242,7 @@ class HistoricalTrendChart extends React.Component<
           ]}
           gutter={20}
           height={25}
+          itemsPerRow={legendItemsPerRow}
           labelComponent={<ChartLabelTooltip content={this.getLegendTooltip} />}
           style={chartStyles.legend}
         />
@@ -312,8 +316,10 @@ class HistoricalTrendChart extends React.Component<
         {Boolean(
           datum && datum.legend && datum.legend.data && datum.legend.data.length
         ) && (
-          <div className={css(styles.legend)}>
-            {this.getLegend(datum.legend)}
+          <div className={css(styles.legendContainer)}>
+            <div className={css(styles.legend)}>
+              {this.getLegend(datum.legend, width)}
+            </div>
           </div>
         )}
       </div>

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.styles.ts
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.styles.ts
@@ -37,6 +37,7 @@ export const chartStyles = {
       stroke: '#A2DA9C',
     },
   } as VictoryStyleInterface,
+  itemsPerRow: 0,
   legend: {
     labels: {
       fontFamily: global_FontFamily_sans_serif.value,
@@ -123,6 +124,11 @@ export const styles = StyleSheet.create({
   legend: {
     paddingTop: global_spacer_2xl.value,
     marginLeft: '-175px;',
+  },
+  legendWrap: {
+    paddingTop: global_spacer_2xl.value,
+    marginLeft: '225px;',
+    height: '125px',
   },
   title: {
     marginLeft: '-' + global_spacer_lg.value,

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -31,6 +31,7 @@ interface HistoricalUsageChartProps {
   formatDatumValue?: ValueFormatter;
   formatDatumOptions?: FormatOptions;
   height: number;
+  legendItemsPerRow?: number;
   previousLimitData?: any;
   previousRequestData?: any;
   previousUsageData?: any;
@@ -374,7 +375,15 @@ class HistoricalUsageChart extends React.Component<
       : 31;
   }
 
-  private getLegend = (datum: HistoricalLegendDatum) => {
+  private getLegend = (datum: HistoricalLegendDatum, width: number) => {
+    const { legendItemsPerRow } = this.props;
+
+    const itemsPerRow = legendItemsPerRow
+      ? legendItemsPerRow
+      : width > 800
+      ? chartStyles.itemsPerRow
+      : 2;
+
     if (datum && datum.data && datum.data.length) {
       return (
         <ChartLegend
@@ -400,6 +409,7 @@ class HistoricalUsageChart extends React.Component<
           ]}
           gutter={0}
           height={25}
+          itemsPerRow={itemsPerRow}
           labelComponent={<ChartLabelTooltip content={this.getLegendTooltip} />}
           style={chartStyles.legend}
         />
@@ -493,8 +503,10 @@ class HistoricalUsageChart extends React.Component<
           datum && datum.legend && datum.legend.data && datum.legend.data.length
         ) && (
           <div className={css(styles.legendContainer)}>
-            <div className={css(styles.legend)}>
-              {this.getLegend(datum.legend)}
+            <div
+              className={css(width > 800 ? styles.legend : styles.legendWrap)}
+            >
+              {this.getLegend(datum.legend, width)}
             </div>
           </div>
         )}


### PR DESCRIPTION
Now that the historical modal resizes horizontally, the legends should adjust as well. This ensures the legend labels are not truncated even when the modal is at it's smallest size possible. 

Note that users can scroll vertically when the height of the modal is resized smaller in height.

Fixes https://github.com/project-koku/koku-ui/issues/774

Ocp:
![ocp](https://user-images.githubusercontent.com/17481322/56388577-5015d280-61f5-11e9-9381-0e1c183eaade.png)

Ocp on AWS:
![ocp on aws](https://user-images.githubusercontent.com/17481322/56388587-5906a400-61f5-11e9-8605-5bfcd117d00c.png)

AWS:
![aws](https://user-images.githubusercontent.com/17481322/56388593-5dcb5800-61f5-11e9-8f99-fb3ddda5cc44.png)
