### PR TITLE
fix(PriceList): update price list API and display

### DIFF
--- a/src/api/rates.ts
+++ b/src/api/rates.ts
@@ -15,7 +15,8 @@ export interface TieredRate {
 
 export type Rates = PagedResponse<Rate>;
 
-export function fetchRate() {
+export function fetchRate(uuid = null) {
+  const query = uuid ? `?provider_uuid=${uuid}` : '';
   const insights = (window as any).insights;
   if (
     insights &&
@@ -24,9 +25,9 @@ export function fetchRate() {
     insights.chrome.auth.getUser
   ) {
     return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Rates>('rates/');
+      return axios.get<Rates>(`rates/${query}`);
     });
   } else {
-    return axios.get<Rates>('rates/');
+    return axios.get<Rates>(`rates/${query}`);
   }
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -313,16 +313,21 @@
     "no_change_since_date": "No change since $t(months.{{month}}) {{date}}",
     "price_list": {
       "modal": {
-        "cpu_core_request_per_hour": "CPU request per hour (core)",
-        "cpu_core_usage_per_hour": "CPU usage per hour (core)",
-        "memory_gb_request_per_hour": "Memory request per hour (GB)",
-        "memory_gb_usage_per_hour": "Memory usage per hour (GB)",
+        "Compute request rate": "Compute request rate tier {{ index }} ({{ unit }})",
+        "Compute usage rate": "Compute usage rate tier {{ index }} ({{ unit }})",
+        "Memory request rate": "Memory request rate tier {{ index }} ({{ unit }})",
+        "Memory usage rate": "Memory usage rate tier {{ index }} ({{ unit }})",
+        "Volume request rate": "Volume request rate tier {{ index }} ({{ unit }})",
+        "Volume usage rate": "Volume usage rate tier {{ index }} ({{ unit }})",
+        "applied_usage_date_range": "Applied usage date range",
+        "applied_usage_range": "Applied usage range",
+        "hours": "hourly",
         "metric": "Metric",
+        "months": "monthly",
         "no_match": "No rates were found",
+        "no_range_set": "No range set",
         "not_available": "N/A",
         "title": "{{name}} cluster price list",
-        "usage_end": "Usage end",
-        "usage_start": "Usage start",
         "value": "Value"
       }
     },

--- a/src/pages/ocpDetails/priceListModal.tsx
+++ b/src/pages/ocpDetails/priceListModal.tsx
@@ -30,9 +30,10 @@ interface Props extends InjectedTranslateProps {
 
 class PriceListModalBase extends React.Component<Props> {
   public componentDidUpdate() {
-    const { fetch, isOpen, priceListStatus: status } = this.props;
+    const { fetch, isOpen, providers, priceListStatus: status } = this.props;
     if (isOpen && status === FetchStatus.none) {
-      fetch();
+      const priceListProvider = providers.data.find(p => p.name === name);
+      fetch(priceListProvider ? priceListProvider.uuid : null);
     }
   }
 
@@ -61,7 +62,6 @@ class PriceListModalBase extends React.Component<Props> {
     const priceListProvider = providers.data.find(p => p.name === name);
     const priceListRates =
       priceListProvider && priceList[priceListProvider.uuid];
-
     return priceListRates ? (
       <PriceListTable t={t} rates={priceListRates} />
     ) : (

--- a/src/pages/ocpDetails/priceListTable.tsx
+++ b/src/pages/ocpDetails/priceListTable.tsx
@@ -2,6 +2,14 @@ import { Table, TableBody, TableHeader } from '@patternfly/react-table';
 import React from 'react';
 import { formatCurrency } from 'utils/formatValue';
 
+function getUsageRangeText(metric, t) {
+  return metric.range_value[0] === null && metric.range_value[1] === null
+    ? t('ocp_details.price_list.modal.no_range_set')
+    : `${metric.range_value[0] || ' '} - ${metric.range_value[2] || ' '} ${
+        metric.range_unit
+      }`;
+}
+
 const PriceListTable = ({ rates, t }) => {
   const notAvailableText = t('ocp_details.price_list.modal.not_available');
   return (
@@ -10,16 +18,19 @@ const PriceListTable = ({ rates, t }) => {
       cells={[
         t('ocp_details.price_list.modal.metric'),
         t('ocp_details.price_list.modal.value'),
-        t('ocp_details.price_list.modal.usage_start'),
-        t('ocp_details.price_list.modal.usage_end'),
+        t('ocp_details.price_list.modal.applied_usage_range'),
+        t('ocp_details.price_list.modal.applied_usage_date_range'),
       ]}
-      rows={Object.keys(rates).map(metric => [
-        t(`ocp_details.price_list.modal.${metric}`),
-        rates[metric].value
-          ? formatCurrency(rates[metric].value, rates[metric].unit)
+      rows={rates.map(metric => [
+        t(`ocp_details.price_list.modal.${metric.display}`, {
+          index: metric.index + 1,
+          unit: metric.range_unit,
+        }),
+        metric.value
+          ? formatCurrency(metric.value, metric.value_unit)
           : notAvailableText,
-        rates[metric].usage_start || notAvailableText,
-        rates[metric].usage_end || notAvailableText,
+        getUsageRangeText(metric, t),
+        t(`ocp_details.price_list.modal.${metric.period}`),
       ])}
     >
       <TableHeader />

--- a/src/store/priceList/__snapshots__/store.test.ts.snap
+++ b/src/store/priceList/__snapshots__/store.test.ts.snap
@@ -3,10 +3,6 @@
 exports[`default state 1`] = `
 Object {
   "error": null,
-  "modal": Object {
-    "isOpen": false,
-    "name": null,
-  },
   "rates": null,
   "status": 0,
 }
@@ -15,10 +11,6 @@ Object {
 exports[`from fetch error to fetch request 1`] = `
 Object {
   "error": [Error: Opps!],
-  "modal": Object {
-    "isOpen": false,
-    "name": null,
-  },
   "rates": null,
   "status": 2,
 }
@@ -27,10 +19,6 @@ Object {
 exports[`from fetch error to fetch request 2`] = `
 Object {
   "error": [Error: Opps!],
-  "modal": Object {
-    "isOpen": false,
-    "name": null,
-  },
   "rates": null,
   "status": 1,
 }
@@ -39,10 +27,6 @@ Object {
 exports[`from fetch request to fetch error 1`] = `
 Object {
   "error": null,
-  "modal": Object {
-    "isOpen": false,
-    "name": null,
-  },
   "rates": null,
   "status": 1,
 }
@@ -51,10 +35,6 @@ Object {
 exports[`from fetch request to fetch error 2`] = `
 Object {
   "error": [Error: Opps!],
-  "modal": Object {
-    "isOpen": false,
-    "name": null,
-  },
   "rates": null,
   "status": 2,
 }
@@ -63,10 +43,6 @@ Object {
 exports[`from fetch request to fetch success 1`] = `
 Object {
   "error": null,
-  "modal": Object {
-    "isOpen": false,
-    "name": null,
-  },
   "rates": null,
   "status": 1,
 }
@@ -75,21 +51,69 @@ Object {
 exports[`from fetch request to fetch success 2`] = `
 Object {
   "error": null,
-  "modal": Object {
-    "isOpen": false,
-    "name": null,
-  },
   "rates": Object {
-    "count": 1,
+    "count": 2,
     "data": Array [
       Object {
-        "metric": "cpu_usage_per_hour",
-        "provider_uuid": "p1",
-        "tiered": Object {
-          "unit": "usd",
-          "value": 2.03,
+        "metric": Object {
+          "display_name": "Volume request rate",
+          "name": "storage_gb_request_per_month",
+          "unit": "GB-months",
         },
-        "uuid": "a1",
+        "provider_uuids": Array [
+          "92e9b353-100e-4e38-91bd-e0143f766130",
+          "7fb3bbfb-79d2-4bf7-bd80-ec2bd665887d",
+        ],
+        "tiered_rate": Array [
+          Object {
+            "unit": "USD",
+            "usage": Object {
+              "unit": "GB-months",
+              "usage_end": null,
+              "usage_start": null,
+            },
+            "value": 0.25,
+          },
+          Object {
+            "unit": "USD",
+            "usage": Object {
+              "unit": "GB-months",
+              "usage_end": 1120,
+              "usage_start": 500,
+            },
+            "value": 0.25,
+          },
+        ],
+      },
+      Object {
+        "metric": Object {
+          "display_name": "Compute request rate",
+          "name": "cpu_core_request_per_hour",
+          "unit": "core-hours",
+        },
+        "provider_uuids": Array [
+          "92e9b353-100e-4e38-91bd-e0143f766130",
+        ],
+        "tiered_rate": Array [
+          Object {
+            "unit": "USD",
+            "usage": Object {
+              "unit": "core-hours",
+              "usage_end": 5,
+              "usage_start": null,
+            },
+            "value": 0.2,
+          },
+          Object {
+            "unit": "USD",
+            "usage": Object {
+              "unit": "GB-months",
+              "usage_end": null,
+              "usage_start": 3,
+            },
+            "value": 0.25,
+          },
+        ],
       },
     ],
     "first": "link1",
@@ -104,21 +128,69 @@ Object {
 exports[`from fetch success to fetch request 1`] = `
 Object {
   "error": null,
-  "modal": Object {
-    "isOpen": false,
-    "name": null,
-  },
   "rates": Object {
-    "count": 1,
+    "count": 2,
     "data": Array [
       Object {
-        "metric": "cpu_usage_per_hour",
-        "provider_uuid": "p1",
-        "tiered": Object {
-          "unit": "usd",
-          "value": 2.03,
+        "metric": Object {
+          "display_name": "Volume request rate",
+          "name": "storage_gb_request_per_month",
+          "unit": "GB-months",
         },
-        "uuid": "a1",
+        "provider_uuids": Array [
+          "92e9b353-100e-4e38-91bd-e0143f766130",
+          "7fb3bbfb-79d2-4bf7-bd80-ec2bd665887d",
+        ],
+        "tiered_rate": Array [
+          Object {
+            "unit": "USD",
+            "usage": Object {
+              "unit": "GB-months",
+              "usage_end": null,
+              "usage_start": null,
+            },
+            "value": 0.25,
+          },
+          Object {
+            "unit": "USD",
+            "usage": Object {
+              "unit": "GB-months",
+              "usage_end": 1120,
+              "usage_start": 500,
+            },
+            "value": 0.25,
+          },
+        ],
+      },
+      Object {
+        "metric": Object {
+          "display_name": "Compute request rate",
+          "name": "cpu_core_request_per_hour",
+          "unit": "core-hours",
+        },
+        "provider_uuids": Array [
+          "92e9b353-100e-4e38-91bd-e0143f766130",
+        ],
+        "tiered_rate": Array [
+          Object {
+            "unit": "USD",
+            "usage": Object {
+              "unit": "core-hours",
+              "usage_end": 5,
+              "usage_start": null,
+            },
+            "value": 0.2,
+          },
+          Object {
+            "unit": "USD",
+            "usage": Object {
+              "unit": "GB-months",
+              "usage_end": null,
+              "usage_start": 3,
+            },
+            "value": 0.25,
+          },
+        ],
       },
     ],
     "first": "link1",
@@ -133,21 +205,69 @@ Object {
 exports[`from fetch success to fetch request 2`] = `
 Object {
   "error": null,
-  "modal": Object {
-    "isOpen": false,
-    "name": null,
-  },
   "rates": Object {
-    "count": 1,
+    "count": 2,
     "data": Array [
       Object {
-        "metric": "cpu_usage_per_hour",
-        "provider_uuid": "p1",
-        "tiered": Object {
-          "unit": "usd",
-          "value": 2.03,
+        "metric": Object {
+          "display_name": "Volume request rate",
+          "name": "storage_gb_request_per_month",
+          "unit": "GB-months",
         },
-        "uuid": "a1",
+        "provider_uuids": Array [
+          "92e9b353-100e-4e38-91bd-e0143f766130",
+          "7fb3bbfb-79d2-4bf7-bd80-ec2bd665887d",
+        ],
+        "tiered_rate": Array [
+          Object {
+            "unit": "USD",
+            "usage": Object {
+              "unit": "GB-months",
+              "usage_end": null,
+              "usage_start": null,
+            },
+            "value": 0.25,
+          },
+          Object {
+            "unit": "USD",
+            "usage": Object {
+              "unit": "GB-months",
+              "usage_end": 1120,
+              "usage_start": 500,
+            },
+            "value": 0.25,
+          },
+        ],
+      },
+      Object {
+        "metric": Object {
+          "display_name": "Compute request rate",
+          "name": "cpu_core_request_per_hour",
+          "unit": "core-hours",
+        },
+        "provider_uuids": Array [
+          "92e9b353-100e-4e38-91bd-e0143f766130",
+        ],
+        "tiered_rate": Array [
+          Object {
+            "unit": "USD",
+            "usage": Object {
+              "unit": "core-hours",
+              "usage_end": 5,
+              "usage_start": null,
+            },
+            "value": 0.2,
+          },
+          Object {
+            "unit": "USD",
+            "usage": Object {
+              "unit": "GB-months",
+              "usage_end": null,
+              "usage_start": 3,
+            },
+            "value": 0.25,
+          },
+        ],
       },
     ],
     "first": "link1",
@@ -162,10 +282,6 @@ Object {
 exports[`from init to fetch request 1`] = `
 Object {
   "error": null,
-  "modal": Object {
-    "isOpen": false,
-    "name": null,
-  },
   "rates": null,
   "status": 0,
 }
@@ -174,11 +290,192 @@ Object {
 exports[`from init to fetch request 2`] = `
 Object {
   "error": null,
-  "modal": Object {
-    "isOpen": false,
-    "name": null,
-  },
   "rates": null,
   "status": 1,
+}
+`;
+
+exports[`rateFlatter flats tiers into array 1`] = `
+Array [
+  Object {
+    "display": "Volume request rate",
+    "index": 0,
+    "metric_type": "storage_gb_request_per_month",
+    "period": "months",
+    "provider_uuids": Array [
+      "92e9b353-100e-4e38-91bd-e0143f766130",
+      "7fb3bbfb-79d2-4bf7-bd80-ec2bd665887d",
+    ],
+    "range_unit": "GB",
+    "range_value": Array [
+      null,
+      null,
+    ],
+    "value": 0.25,
+    "value_unit": "USD",
+  },
+  Object {
+    "display": "Volume request rate",
+    "index": 1,
+    "metric_type": "storage_gb_request_per_month",
+    "period": "months",
+    "provider_uuids": Array [
+      "92e9b353-100e-4e38-91bd-e0143f766130",
+      "7fb3bbfb-79d2-4bf7-bd80-ec2bd665887d",
+    ],
+    "range_unit": "GB",
+    "range_value": Array [
+      500,
+      1120,
+    ],
+    "value": 0.25,
+    "value_unit": "USD",
+  },
+]
+`;
+
+exports[`rateFlatter flats tiers into array 2`] = `
+Array [
+  Object {
+    "display": "Compute request rate",
+    "index": 0,
+    "metric_type": "cpu_core_request_per_hour",
+    "period": "hours",
+    "provider_uuids": Array [
+      "92e9b353-100e-4e38-91bd-e0143f766130",
+    ],
+    "range_unit": "core",
+    "range_value": Array [
+      null,
+      5,
+    ],
+    "value": 0.2,
+    "value_unit": "USD",
+  },
+  Object {
+    "display": "Compute request rate",
+    "index": 1,
+    "metric_type": "cpu_core_request_per_hour",
+    "period": "months",
+    "provider_uuids": Array [
+      "92e9b353-100e-4e38-91bd-e0143f766130",
+    ],
+    "range_unit": "GB",
+    "range_value": Array [
+      3,
+      null,
+    ],
+    "value": 0.25,
+    "value_unit": "USD",
+  },
+]
+`;
+
+exports[`ratesPerProvider selector returns rates array by provider_uuid 1`] = `
+Object {
+  "7fb3bbfb-79d2-4bf7-bd80-ec2bd665887d": Array [
+    Object {
+      "display": "Volume request rate",
+      "index": 0,
+      "metric_type": "storage_gb_request_per_month",
+      "period": "months",
+      "provider_uuids": Array [
+        "92e9b353-100e-4e38-91bd-e0143f766130",
+        "7fb3bbfb-79d2-4bf7-bd80-ec2bd665887d",
+      ],
+      "range_unit": "GB",
+      "range_value": Array [
+        null,
+        null,
+      ],
+      "value": 0.25,
+      "value_unit": "USD",
+    },
+    Object {
+      "display": "Volume request rate",
+      "index": 1,
+      "metric_type": "storage_gb_request_per_month",
+      "period": "months",
+      "provider_uuids": Array [
+        "92e9b353-100e-4e38-91bd-e0143f766130",
+        "7fb3bbfb-79d2-4bf7-bd80-ec2bd665887d",
+      ],
+      "range_unit": "GB",
+      "range_value": Array [
+        500,
+        1120,
+      ],
+      "value": 0.25,
+      "value_unit": "USD",
+    },
+  ],
+  "92e9b353-100e-4e38-91bd-e0143f766130": Array [
+    Object {
+      "display": "Volume request rate",
+      "index": 0,
+      "metric_type": "storage_gb_request_per_month",
+      "period": "months",
+      "provider_uuids": Array [
+        "92e9b353-100e-4e38-91bd-e0143f766130",
+        "7fb3bbfb-79d2-4bf7-bd80-ec2bd665887d",
+      ],
+      "range_unit": "GB",
+      "range_value": Array [
+        null,
+        null,
+      ],
+      "value": 0.25,
+      "value_unit": "USD",
+    },
+    Object {
+      "display": "Volume request rate",
+      "index": 1,
+      "metric_type": "storage_gb_request_per_month",
+      "period": "months",
+      "provider_uuids": Array [
+        "92e9b353-100e-4e38-91bd-e0143f766130",
+        "7fb3bbfb-79d2-4bf7-bd80-ec2bd665887d",
+      ],
+      "range_unit": "GB",
+      "range_value": Array [
+        500,
+        1120,
+      ],
+      "value": 0.25,
+      "value_unit": "USD",
+    },
+    Object {
+      "display": "Compute request rate",
+      "index": 0,
+      "metric_type": "cpu_core_request_per_hour",
+      "period": "hours",
+      "provider_uuids": Array [
+        "92e9b353-100e-4e38-91bd-e0143f766130",
+      ],
+      "range_unit": "core",
+      "range_value": Array [
+        null,
+        5,
+      ],
+      "value": 0.2,
+      "value_unit": "USD",
+    },
+    Object {
+      "display": "Compute request rate",
+      "index": 1,
+      "metric_type": "cpu_core_request_per_hour",
+      "period": "months",
+      "provider_uuids": Array [
+        "92e9b353-100e-4e38-91bd-e0143f766130",
+      ],
+      "range_unit": "GB",
+      "range_value": Array [
+        3,
+        null,
+      ],
+      "value": 0.25,
+      "value_unit": "USD",
+    },
+  ],
 }
 `;

--- a/src/store/priceList/actions.ts
+++ b/src/store/priceList/actions.ts
@@ -2,17 +2,7 @@ import { fetchRate } from 'api/rates';
 import { Rates } from 'api/rates';
 import { AxiosError } from 'axios';
 import { Dispatch } from 'react-redux';
-import {
-  createAction,
-  createAsyncAction,
-  createStandardAction,
-} from 'typesafe-actions';
-
-export const openModal = createStandardAction('dialog/price_list/open')<
-  string
->();
-
-export const closeModal = createAction('dialog/price_list/close');
+import { createAsyncAction } from 'typesafe-actions';
 
 export const {
   request: fetchPriceListRequest,
@@ -24,10 +14,10 @@ export const {
   'priceList/fetch/failure'
 )<void, Rates, AxiosError>();
 
-export function fetchPriceList() {
+export function fetchPriceList(providerUuid) {
   return (dispatch: Dispatch, getState) => {
     dispatch(fetchPriceListRequest());
-    return fetchRate()
+    return fetchRate(providerUuid)
       .then(res => {
         dispatch(fetchPriceListSuccess(res.data));
       })

--- a/src/store/priceList/reducer.ts
+++ b/src/store/priceList/reducer.ts
@@ -3,11 +3,9 @@ import { AxiosError } from 'axios';
 import { FetchStatus } from 'store/common';
 import { ActionType, getType } from 'typesafe-actions';
 import {
-  closeModal,
   fetchPriceListFailure,
   fetchPriceListRequest,
   fetchPriceListSuccess,
-  openModal,
 } from './actions';
 
 export const stateKey = 'priceList';
@@ -16,28 +14,18 @@ export type State = Readonly<{
   rates: Rates;
   error: AxiosError;
   status: FetchStatus;
-  modal: {
-    isOpen: boolean;
-    name: string;
-  };
 }>;
 
 export const defaultState: State = {
   rates: null,
   error: null,
   status: FetchStatus.none,
-  modal: {
-    isOpen: false,
-    name: null,
-  },
 };
 
 export type Action = ActionType<
   | typeof fetchPriceListRequest
   | typeof fetchPriceListSuccess
   | typeof fetchPriceListFailure
-  | typeof closeModal
-  | typeof openModal
 >;
 
 export function reducer(state = defaultState, action: Action): State {
@@ -59,22 +47,6 @@ export function reducer(state = defaultState, action: Action): State {
         ...state,
         error: action.payload,
         status: FetchStatus.complete,
-      };
-    case getType(closeModal):
-      return {
-        ...state,
-        modal: {
-          isOpen: false,
-          name: null,
-        },
-      };
-    case getType(openModal):
-      return {
-        ...state,
-        modal: {
-          isOpen: true,
-          name: action.payload,
-        },
       };
     default:
       return state;

--- a/src/store/priceList/selectors.ts
+++ b/src/store/priceList/selectors.ts
@@ -1,6 +1,31 @@
 import { RootState } from 'store/rootReducer';
 import { stateKey } from './reducer';
 
+export const getRateTierTimeRange = (unit: string) => {
+  const sep = unit.split('-');
+  if (sep.length === 2) {
+    return { unit: sep[0], range: sep[1] };
+  }
+  return { unit: null, period: null };
+};
+
+export const rateFlatter = rate => {
+  return rate.tiered_rate.map((tier, ix) => {
+    const time_range = getRateTierTimeRange(tier.usage.unit);
+    return {
+      provider_uuids: rate.provider_uuids,
+      display: rate.metric.display_name,
+      metric_type: rate.metric.name,
+      index: ix,
+      value: tier.value,
+      value_unit: tier.unit,
+      range_value: [tier.usage.usage_start, tier.usage.usage_end],
+      range_unit: time_range.unit,
+      period: time_range.range,
+    };
+  });
+};
+
 export const priceList = (state: RootState) => state[stateKey];
 
 export const rates = (state: RootState) =>
@@ -8,21 +33,23 @@ export const rates = (state: RootState) =>
 
 export const ratesPerProvider = (state: RootState) =>
   rates(state) &&
-  rates(state).reduce(
-    (acc, rate) => ({
-      ...acc,
-      [rate.provider_uuid]: {
-        ...acc[rate.provider_uuid],
-        [rate.metric]: rate.tiered_rate[0],
-      },
-    }),
-    {}
-  );
+  rates(state)
+    .map(rateFlatter)
+    .reduce((acc, rateArray) => {
+      return [...acc, ...rateArray];
+    }, [])
+    .reduce((acc, rate) => {
+      let next = { ...acc };
+      rate.provider_uuids.forEach(uuid => {
+        const prev = acc[uuid] || [];
+        next = {
+          ...next,
+          [uuid]: [...prev, rate],
+        };
+      });
+      return next;
+    }, {});
 
 export const status = (state: RootState) => priceList(state).status;
 
 export const error = (state: RootState) => priceList(state).error;
-
-export const isModalOpen = (state: RootState) => priceList(state).modal.isOpen;
-
-export const modalName = (state: RootState) => priceList(state).modal.name;


### PR DESCRIPTION
closes #765 

Update the Price List selectors to the new API.

- [x] ~~Fetch price list for only one cluster (optional)~~ - opened a follow up issue #780 
- [x] Show friendly name
- [x] Show tier number
- [x] Show applied usage range
- [x] Show applied usage range date

Questions:
- What should I do if both `usage start` and `usage end` are null or one of them? @nlcwong 

Screenshot

![Screenshot_2019-04-19 Red Hat Cloud Software Services Cost Management](https://user-images.githubusercontent.com/2453279/56418129-bacf1880-629e-11e9-9fc6-369aa8614431.png)
