### PR TITLE
Overview empty state

### DIFF
--- a/src/components/reports/awsReportSummary/__snapshots__/awsReportSummaryDetails.test.tsx.snap
+++ b/src/components/reports/awsReportSummary/__snapshots__/awsReportSummaryDetails.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`defaults value if report is not present 1`] = `
   <div
     className="css-1w8hocc"
   >
-    ----
+    <Component />
   </div>
 </div>
 `;
@@ -19,7 +19,7 @@ exports[`defaults value if report.meta is not present 1`] = `
   <div
     className="css-1w8hocc"
   >
-    ----
+    <Component />
   </div>
 </div>
 `;

--- a/src/components/reports/awsReportSummary/awsReportSummaryDetails.tsx
+++ b/src/components/reports/awsReportSummary/awsReportSummaryDetails.tsx
@@ -1,5 +1,6 @@
 import { css } from '@patternfly/react-styles';
 import { AwsReport, AwsReportType } from 'api/awsReports';
+import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
@@ -26,8 +27,8 @@ const AwsReportSummaryDetailsBase: React.SFC<AwsReportSummaryDetailsProps> = ({
   t,
   usageLabel,
 }) => {
-  let cost: string | number = '----';
-  let usage: string | number = '----';
+  let cost: string | React.ReactNode = <EmptyValueState />;
+  let usage: string | React.ReactNode = <EmptyValueState />;
 
   if (report && report.meta && report.meta.total) {
     cost = formatValue(
@@ -68,7 +69,7 @@ const AwsReportSummaryDetailsBase: React.SFC<AwsReportSummaryDetailsProps> = ({
           <div className={css(styles.valueContainer)}>
             <div className={css(styles.value)}>
               {usage}
-              {Boolean(showUnits) && (
+              {Boolean(showUnits && usage >= 0) && (
                 <span className={css(styles.text)}>{unitsLabel}</span>
               )}
             </div>

--- a/src/components/reports/ocpOnAwsReportSummary/__snapshots__/ocpOnAwsReportSummaryDetails.test.tsx.snap
+++ b/src/components/reports/ocpOnAwsReportSummary/__snapshots__/ocpOnAwsReportSummaryDetails.test.tsx.snap
@@ -7,7 +7,7 @@ exports[`defaults value if report is not present 1`] = `
   <div
     className="css-qvzirm"
   >
-    ----
+    <Component />
   </div>
 </div>
 `;
@@ -19,7 +19,7 @@ exports[`defaults value if report.meta is not present 1`] = `
   <div
     className="css-qvzirm"
   >
-    ----
+    <Component />
   </div>
 </div>
 `;

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryDetails.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryDetails.tsx
@@ -1,5 +1,6 @@
 import { css } from '@patternfly/react-styles';
 import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
+import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
@@ -30,9 +31,9 @@ const OcpOnAwsReportSummaryDetailsBase: React.SFC<
   t,
   usageLabel,
 }) => {
-  let cost: string | number = '----';
-  let request: string | number = '----';
-  let usage: string | number = '----';
+  let cost: string | React.ReactNode = <EmptyValueState />;
+  let request: string | React.ReactNode = <EmptyValueState />;
+  let usage: string | React.ReactNode = <EmptyValueState />;
 
   const awsReportType =
     reportType === OcpOnAwsReportType.database ||
@@ -111,7 +112,7 @@ const OcpOnAwsReportSummaryDetailsBase: React.SFC<
           <div className={css(styles.valueContainer)}>
             <div className={css(styles.value)}>
               {usage}
-              {Boolean(showUnits) && (
+              {Boolean(showUnits && usage >= 0) && (
                 <span className={css(styles.text)}>{unitsLabel}</span>
               )}
             </div>

--- a/src/components/reports/ocpReportSummary/__snapshots__/ocpReportSummaryDetails.test.tsx.snap
+++ b/src/components/reports/ocpReportSummary/__snapshots__/ocpReportSummaryDetails.test.tsx.snap
@@ -21,7 +21,7 @@ exports[`defaults value if report is not present 1`] = `
         zIndex={9999}
       >
         <div>
-          ----
+          <Component />
         </div>
       </Tooltip>
       <div
@@ -58,7 +58,7 @@ exports[`defaults value if report.meta is not present 1`] = `
         zIndex={9999}
       >
         <div>
-          ----
+          <Component />
         </div>
       </Tooltip>
       <div

--- a/src/components/reports/ocpReportSummary/ocpReportSummaryDetails.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummaryDetails.tsx
@@ -1,6 +1,7 @@
 import { Tooltip } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
+import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
@@ -24,11 +25,11 @@ const OcpReportSummaryDetailsBase: React.SFC<OcpReportSummaryDetailsProps> = ({
   usageLabel,
   t,
 }) => {
-  let cost: string | number = '----';
-  let usage: string | number = '----';
-  let derivedCost: string | number = '----';
-  let infrastructureCost: string | number = '----';
-  let requestValue: string | number = '----';
+  let cost: string | React.ReactNode = <EmptyValueState />;
+  let usage: string | React.ReactNode = <EmptyValueState />;
+  let derivedCost: string | React.ReactNode = <EmptyValueState />;
+  let infrastructureCost: string | React.ReactNode = <EmptyValueState />;
+  let requestValue: string | React.ReactNode = <EmptyValueState />;
 
   if (report && report.meta && report.meta.total) {
     cost = formatValue(

--- a/src/components/state/emptyValueState/emptyValueState.styles.ts
+++ b/src/components/state/emptyValueState/emptyValueState.styles.ts
@@ -1,0 +1,8 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_FontSize_sm } from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  container: {
+    fontSize: global_FontSize_sm.value,
+  },
+});

--- a/src/components/state/emptyValueState/emptyValueState.tsx
+++ b/src/components/state/emptyValueState/emptyValueState.tsx
@@ -1,0 +1,12 @@
+import { MinusIcon } from '@patternfly/react-icons';
+import { css } from '@patternfly/react-styles';
+import React from 'react';
+import { styles } from './emptyValueState.styles';
+
+export const EmptyValueState: React.SFC = () => {
+  return (
+    <span className={css(styles.container)}>
+      <MinusIcon />
+    </span>
+  );
+};

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -6,13 +6,13 @@
     "compute_trend_title": "Compute instances ({{units}})",
     "compute_usage_label": "Hours",
     "cost_title": "Total Cost",
-    "cost_trend_title": "Cost comparison (${{units}})",
+    "cost_trend_title": "Cost comparison ({{units}})",
     "database_cost_label": "Cost",
     "database_title": "Database services",
-    "database_trend_title": "Database cost comparison (${{units}})",
+    "database_trend_title": "Database cost comparison ({{units}})",
     "network_cost_label": "Cost",
     "network_title": "Network services",
-    "network_trend_title": "Network cost comparison (${{units}})",
+    "network_trend_title": "Network cost comparison ({{units}})",
     "storage_cost_label": "Cost",
     "storage_title": "Storage services",
     "storage_trend_title": "Storage usage comparison ({{units}})",
@@ -55,7 +55,7 @@
       "tag_select": "Tag"
     },
     "historical": {
-      "cost_label": "Cost ($)",
+      "cost_label": "Cost ({{units}})",
       "cost_title": "Cost comparison",
       "day_of_month_label": "Day of month",
       "instance_label": "Hours",
@@ -227,7 +227,7 @@
   },
   "ocp_dashboard": {
     "cost_title": "Cost",
-    "cost_trend_title": "Cost comparison (${{units}})",
+    "cost_trend_title": "Cost comparison ({{units}})",
     "cpu_requested_label": "{{units}} Requested",
     "cpu_title": "CPU usage & requests",
     "cpu_trend_title": "CPU usage and requests ({{units}})",
@@ -293,7 +293,7 @@
       "tag_select": "Tag"
     },
     "historical": {
-      "cost_label": "Cost (${{units}})",
+      "cost_label": "Cost ({{units}})",
       "cost_title": "Cost comparison",
       "cpu_label": "{{units}}",
       "cpu_title": "CPU usage, request, and limit comparison",
@@ -347,21 +347,21 @@
     "compute_trend_title": "Compute instances comparison ({{units}})",
     "compute_usage_label": "Hours",
     "cost_title": "Infrastructure cost",
-    "cost_trend_title": "Cost comparison (${{units}})",
+    "cost_trend_title": "Cost comparison ({{units}})",
     "cpu_requested_label": "{{units}} Requested",
     "cpu_title": "OpenShift CPU usage and requests",
     "cpu_trend_title": "CPU usage and requests comparison ({{units}})",
     "cpu_usage_label": "{{units}} Used",
     "database_cost_label": "Cost",
     "database_title": "AWS database services",
-    "database_trend_title": "Database cost comparison (${{units}})",
+    "database_trend_title": "Database cost comparison ({{units}})",
     "memory_requested_label": "{{units}} Requested",
     "memory_title": "OpenShift memory usage and requests",
     "memory_trend_title": "Memory usage and requests comparison ({{units}})",
     "memory_usage_label": "{{units}} Used",
     "network_cost_label": "Cost",
     "network_title": "AWS network services",
-    "network_trend_title": "Network cost comparison (${{units}})",
+    "network_trend_title": "Network cost comparison ({{units}})",
     "storage_cost_label": "Cost",
     "storage_title": "AWS storage services",
     "storage_trend_title": "Storage usage comparison ({{units}})",
@@ -410,7 +410,7 @@
       "tag_select": "Tag"
     },
     "historical": {
-      "cost_label": "Cost ($)",
+      "cost_label": "Cost ({{units}})",
       "cost_title": "Cost comparison",
       "cpu_capacity_label": "Capacity ({{date}})",
       "cpu_label": "core-hours",
@@ -608,12 +608,13 @@
     "usd": "{{value}}"
   },
   "units": {
+    "": "",
     "core-hours": "core-hours",
     "gb": "GB",
     "gb-hours": "GB-hours",
     "gb-mo": "GB-month",
     "hours": "hours",
     "hrs": "hours",
-    "usd": "USD"
+    "usd": "$USD"
   }
 }

--- a/src/pages/awsDetails/historicalChart.tsx
+++ b/src/pages/awsDetails/historicalChart.tsx
@@ -15,7 +15,7 @@ import { connect } from 'react-redux';
 import * as awsReportsActions from 'store/awsReports/awsReportsActions';
 import * as awsReportsSelectors from 'store/awsReports/awsReportsSelectors';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { formatValue } from 'utils/formatValue';
+import { formatValue, unitLookupKey } from 'utils/formatValue';
 import { chartStyles, styles } from './historicalChart.styles';
 
 interface HistoricalModalOwnProps {
@@ -151,6 +151,14 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
       'cost'
     );
 
+    const costUnits =
+      currentCostReport &&
+      currentCostReport.meta &&
+      currentCostReport.meta.total &&
+      currentCostReport.meta.total.cost
+        ? currentCostReport.meta.total.cost.units
+        : 'USD';
+
     return (
       <div className={css(styles.chartContainer)}>
         <div className={css(styles.costChart)}>
@@ -166,7 +174,9 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
               previousData={previousCostData}
               title={t('aws_details.historical.cost_title')}
               xAxisLabel={t('aws_details.historical.day_of_month_label')}
-              yAxisLabel={t('aws_details.historical.cost_label')}
+              yAxisLabel={t('aws_details.historical.cost_label', {
+                units: t(`units.${unitLookupKey(costUnits)}`),
+              })}
             />
           )}
         </div>

--- a/src/pages/ocpDetails/detailsHeader.tsx
+++ b/src/pages/ocpDetails/detailsHeader.tsx
@@ -6,6 +6,7 @@ import { OcpReport, OcpReportType } from 'api/ocpReports';
 import { Providers, ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/providersQuery';
 import { AxiosError } from 'axios';
+import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -96,9 +97,9 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       providers.meta &&
       providers.meta.count > 0;
 
-    let cost: string | number = '----';
-    let derivedCost: string | number = '----';
-    let infrastructureCost: string | number = '----';
+    let cost: string | React.ReactNode = <EmptyValueState />;
+    let derivedCost: string | React.ReactNode = <EmptyValueState />;
+    let infrastructureCost: string | React.ReactNode = <EmptyValueState />;
 
     if (report && report.meta && report.meta.total) {
       cost = formatValue(

--- a/src/utils/formatValue.ts
+++ b/src/utils/formatValue.ts
@@ -46,7 +46,7 @@ const unknownTypeFormatter: ValueFormatter = (
 
 export const formatCurrency: ValueFormatter = (
   value,
-  _unit,
+  unit,
   { fractionDigits = 2 } = {}
 ) => {
   let fValue = value;
@@ -55,7 +55,7 @@ export const formatCurrency: ValueFormatter = (
   }
   return fValue.toLocaleString('en', {
     style: 'currency',
-    currency: 'USD',
+    currency: unit || 'USD',
     minimumFractionDigits: fractionDigits,
     maximumFractionDigits: fractionDigits,
   });


### PR DESCRIPTION
Overview empty state when no reports are available. Replaces multiple dashes with a single PatternFly "minus" icon.

Fixes https://github.com/project-koku/koku-ui/issues/228

Overview:
<img width="1679" alt="Screen Shot 2019-04-22 at 5 35 43 PM" src="https://user-images.githubusercontent.com/17481322/56534011-d0567380-6526-11e9-976a-42879ea5b369.png">

