### PR TITLE
Incorrect navigation for "All projects" link

### DIFF
--- a/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
+++ b/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
@@ -89,7 +89,7 @@ class OcpOnAwsDashboardWidgetBase extends React.Component<
   private buildDetailsLink = () => {
     const { currentQuery } = this.props;
     const groupBy = parseQuery<OcpOnAwsQuery>(currentQuery).group_by;
-    return `/ocp?${getQuery({
+    return `/ocp-on-aws?${getQuery({
       group_by: groupBy,
       order_by: { cost: 'desc' },
     })}`;


### PR DESCRIPTION
This ensures the "All projects" link ,for the Ocp on Aws overview, navigates to the Ocp on AWS details page.

Fixes https://github.com/project-koku/koku-ui/issues/782