### PR TITLE
Replace custom components with PF4 components

### DIFF
--- a/src/pages/awsDashboard/awsDashboardWidget.tsx
+++ b/src/pages/awsDashboard/awsDashboardWidget.tsx
@@ -3,7 +3,6 @@ import { css } from '@patternfly/react-styles';
 import { AwsQuery, getQuery, parseQuery } from 'api/awsQuery';
 import { AwsReport, AwsReportType } from 'api/awsReports';
 import { transformAwsReport } from 'components/charts/commonChart/chartUtils';
-import { Link } from 'components/link';
 import {
   AwsReportSummary,
   AwsReportSummaryAlt,
@@ -20,6 +19,7 @@ import startOfMonth from 'date-fns/start_of_month';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 import {
   awsDashboardActions,
   awsDashboardSelectors,

--- a/src/pages/awsDetails/detailsToolbar.tsx
+++ b/src/pages/awsDetails/detailsToolbar.tsx
@@ -1,9 +1,8 @@
-import { Button, ButtonVariant } from '@patternfly/react-core';
+import { Button, ButtonVariant, TextInput } from '@patternfly/react-core';
 import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import { AwsQuery } from 'api/awsQuery';
 import { AwsReport } from 'api/awsReports';
-import { TextInput } from 'components/textInput';
 import { Filter, Toolbar } from 'patternfly-react';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -170,7 +169,6 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         onChange={this.updateCurrentValue}
         onKeyPress={this.onValueKeyPress}
         placeholder={currentFilterType.placeholder}
-        type="text"
         value={currentValue}
       />
     );

--- a/src/pages/awsDetails/exportModal.styles.ts
+++ b/src/pages/awsDetails/exportModal.styles.ts
@@ -6,6 +6,9 @@ import {
 } from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
+  form: {
+    marginLeft: global_spacer_sm.var,
+  },
   modal: {
     h2: {
       marginBottom: global_spacer_xl.value,
@@ -16,5 +19,8 @@ export const styles = StyleSheet.create({
     ul: {
       marginLeft: global_spacer_sm.var,
     },
+  },
+  title: {
+    paddingBottom: global_spacer_xl.var,
   },
 });

--- a/src/pages/awsDetails/exportModal.tsx
+++ b/src/pages/awsDetails/exportModal.tsx
@@ -1,9 +1,16 @@
-import { Button, ButtonVariant, Modal, Radio } from '@patternfly/react-core';
+import {
+  Button,
+  ButtonVariant,
+  Form,
+  FormGroup,
+  Modal,
+  Radio,
+  Title,
+} from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { AwsQuery, getQuery } from 'api/awsQuery';
 import { AwsReportType } from 'api/awsReports';
 import { AxiosError } from 'axios';
-import { FormGroup } from 'components/formGroup';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -157,31 +164,38 @@ export class ExportModalBase extends React.Component<
           </Button>,
         ]}
       >
-        <h2>{t('export.heading', { groupBy })}</h2>
-        <FormGroup label={t('export.aggregate_type')}>
-          <React.Fragment>
-            {resolutionOptions.map((option, index) => (
-              <Radio
-                key={index}
-                id={`resolution-${index}`}
-                isValid={option.value !== undefined}
-                label={t(option.label)}
-                value={option.value}
-                checked={resolution === option.value}
-                name="resolution"
-                onChange={this.handleResolutionChange}
-                aria-label={t(option.label)}
-              />
-            ))}
-          </React.Fragment>
-        </FormGroup>
-        <FormGroup label={selectedLabel}>
-          <ul>
-            {sortedItems.map((groupItem, index) => {
-              return <li key={index}>{groupItem.label}</li>;
-            })}
-          </ul>
-        </FormGroup>
+        <Title className={css(styles.title)} size="xl">
+          {t('export.heading', { groupBy })}
+        </Title>
+        <Form className={css(styles.form)}>
+          <FormGroup
+            label={t('export.aggregate_type')}
+            fieldId="aggregate-type"
+          >
+            <React.Fragment>
+              {resolutionOptions.map((option, index) => (
+                <Radio
+                  key={index}
+                  id={`resolution-${index}`}
+                  isValid={option.value !== undefined}
+                  label={t(option.label)}
+                  value={option.value}
+                  checked={resolution === option.value}
+                  name="resolution"
+                  onChange={this.handleResolutionChange}
+                  aria-label={t(option.label)}
+                />
+              ))}
+            </React.Fragment>
+          </FormGroup>
+          <FormGroup label={selectedLabel} fieldId="selected-labels">
+            <ul>
+              {sortedItems.map((groupItem, index) => {
+                return <li key={index}>{groupItem.label}</li>;
+              })}
+            </ul>
+          </FormGroup>
+        </Form>
       </Modal>
     );
   }

--- a/src/pages/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/pages/ocpDashboard/ocpDashboardWidget.tsx
@@ -3,7 +3,6 @@ import { css } from '@patternfly/react-styles';
 import { getQuery, OcpQuery, parseQuery } from 'api/ocpQuery';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
 import { transformOcpReport } from 'components/charts/commonChart/chartUtils';
-import { Link } from 'components/link';
 import {
   OcpReportSummary,
   OcpReportSummaryAlt,
@@ -21,6 +20,7 @@ import startOfMonth from 'date-fns/start_of_month';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 import { createMapStateToProps } from 'store/common';
 import {
   ocpDashboardActions,

--- a/src/pages/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/ocpDetails/detailsToolbar.tsx
@@ -1,9 +1,8 @@
-import { Button, ButtonVariant } from '@patternfly/react-core';
+import { Button, ButtonVariant, TextInput } from '@patternfly/react-core';
 import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import { OcpQuery } from 'api/ocpQuery';
 import { OcpReport } from 'api/ocpReports';
-import { TextInput } from 'components/textInput';
 import { Filter, Toolbar } from 'patternfly-react';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -170,7 +169,6 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         onChange={this.updateCurrentValue}
         onKeyPress={this.onValueKeyPress}
         placeholder={currentFilterType.placeholder}
-        type="text"
         value={currentValue}
       />
     );

--- a/src/pages/ocpDetails/exportModal.styles.ts
+++ b/src/pages/ocpDetails/exportModal.styles.ts
@@ -6,6 +6,9 @@ import {
 } from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
+  form: {
+    marginLeft: global_spacer_sm.var,
+  },
   modal: {
     h2: {
       marginBottom: global_spacer_xl.value,
@@ -16,5 +19,8 @@ export const styles = StyleSheet.create({
     ul: {
       marginLeft: global_spacer_sm.var,
     },
+  },
+  title: {
+    paddingBottom: global_spacer_xl.var,
   },
 });

--- a/src/pages/ocpDetails/exportModal.tsx
+++ b/src/pages/ocpDetails/exportModal.tsx
@@ -1,9 +1,16 @@
-import { Button, ButtonVariant, Modal, Radio } from '@patternfly/react-core';
+import {
+  Button,
+  ButtonVariant,
+  Form,
+  FormGroup,
+  Modal,
+  Radio,
+  Title,
+} from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { getQuery, OcpQuery } from 'api/ocpQuery';
 import { OcpReportType } from 'api/ocpReports';
 import { AxiosError } from 'axios';
-import { FormGroup } from 'components/formGroup';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -157,31 +164,38 @@ export class ExportModalBase extends React.Component<
           </Button>,
         ]}
       >
-        <h2>{t('export.heading', { groupBy })}</h2>
-        <FormGroup label={t('export.aggregate_type')}>
-          <React.Fragment>
-            {resolutionOptions.map((option, index) => (
-              <Radio
-                key={index}
-                id={`resolution-${index}`}
-                isValid={option.value !== undefined}
-                label={t(option.label)}
-                value={option.value}
-                checked={resolution === option.value}
-                name="resolution"
-                onChange={this.handleResolutionChange}
-                aria-label={t(option.label)}
-              />
-            ))}
-          </React.Fragment>
-        </FormGroup>
-        <FormGroup label={selectedLabel}>
-          <ul>
-            {sortedItems.map((groupItem, index) => {
-              return <li key={index}>{groupItem.label}</li>;
-            })}
-          </ul>
-        </FormGroup>
+        <Title className={css(styles.title)} size="xl">
+          {t('export.heading', { groupBy })}
+        </Title>
+        <Form className={css(styles.form)}>
+          <FormGroup
+            label={t('export.aggregate_type')}
+            fieldId="aggregate-type"
+          >
+            <React.Fragment>
+              {resolutionOptions.map((option, index) => (
+                <Radio
+                  key={index}
+                  id={`resolution-${index}`}
+                  isValid={option.value !== undefined}
+                  label={t(option.label)}
+                  value={option.value}
+                  checked={resolution === option.value}
+                  name="resolution"
+                  onChange={this.handleResolutionChange}
+                  aria-label={t(option.label)}
+                />
+              ))}
+            </React.Fragment>
+          </FormGroup>
+          <FormGroup label={selectedLabel} fieldId="selected-labels">
+            <ul>
+              {sortedItems.map((groupItem, index) => {
+                return <li key={index}>{groupItem.label}</li>;
+              })}
+            </ul>
+          </FormGroup>
+        </Form>
       </Modal>
     );
   }

--- a/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
+++ b/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
@@ -3,7 +3,6 @@ import { css } from '@patternfly/react-styles';
 import { getQuery, OcpOnAwsQuery, parseQuery } from 'api/ocpOnAwsQuery';
 import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
 import { transformOcpOnAwsReport } from 'components/charts/commonChart/chartUtils';
-import { Link } from 'components/link';
 import {
   OcpOnAwsReportSummary,
   OcpOnAwsReportSummaryAlt,
@@ -21,6 +20,7 @@ import startOfMonth from 'date-fns/start_of_month';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 import { createMapStateToProps } from 'store/common';
 import {
   ocpOnAwsDashboardActions,

--- a/src/pages/ocpOnAwsDetails/detailsToolbar.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsToolbar.tsx
@@ -1,9 +1,8 @@
-import { Button, ButtonVariant } from '@patternfly/react-core';
+import { Button, ButtonVariant, TextInput } from '@patternfly/react-core';
 import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import { OcpOnAwsQuery } from 'api/ocpOnAwsQuery';
 import { OcpOnAwsReport } from 'api/ocpOnAwsReports';
-import { TextInput } from 'components/textInput';
 import { Filter, Toolbar } from 'patternfly-react';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -170,7 +169,6 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         onChange={this.updateCurrentValue}
         onKeyPress={this.onValueKeyPress}
         placeholder={currentFilterType.placeholder}
-        type="text"
         value={currentValue}
       />
     );

--- a/src/pages/ocpOnAwsDetails/exportModal.styles.ts
+++ b/src/pages/ocpOnAwsDetails/exportModal.styles.ts
@@ -6,6 +6,9 @@ import {
 } from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
+  form: {
+    marginLeft: global_spacer_sm.var,
+  },
   modal: {
     h2: {
       marginBottom: global_spacer_xl.value,
@@ -16,5 +19,8 @@ export const styles = StyleSheet.create({
     ul: {
       marginLeft: global_spacer_sm.var,
     },
+  },
+  title: {
+    paddingBottom: global_spacer_xl.var,
   },
 });

--- a/src/pages/ocpOnAwsDetails/exportModal.tsx
+++ b/src/pages/ocpOnAwsDetails/exportModal.tsx
@@ -1,9 +1,16 @@
-import { Button, ButtonVariant, Modal, Radio } from '@patternfly/react-core';
+import {
+  Button,
+  ButtonVariant,
+  Form,
+  FormGroup,
+  Modal,
+  Radio,
+  Title,
+} from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { getQuery, OcpOnAwsQuery } from 'api/ocpOnAwsQuery';
 import { OcpOnAwsReportType } from 'api/ocpOnAwsReports';
 import { AxiosError } from 'axios';
-import { FormGroup } from 'components/formGroup';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -160,31 +167,38 @@ export class ExportModalBase extends React.Component<
           </Button>,
         ]}
       >
-        <h2>{t('export.heading', { groupBy })}</h2>
-        <FormGroup label={t('export.aggregate_type')}>
-          <React.Fragment>
-            {resolutionOptions.map((option, index) => (
-              <Radio
-                key={index}
-                id={`resolution-${index}`}
-                isValid={option.value !== undefined}
-                label={t(option.label)}
-                value={option.value}
-                checked={resolution === option.value}
-                name="resolution"
-                onChange={this.handleResolutionChange}
-                aria-label={t(option.label)}
-              />
-            ))}
-          </React.Fragment>
-        </FormGroup>
-        <FormGroup label={selectedLabel}>
-          <ul>
-            {sortedItems.map((groupItem, index) => {
-              return <li key={index}>{groupItem.label}</li>;
-            })}
-          </ul>
-        </FormGroup>
+        <Title className={css(styles.title)} size="xl">
+          {t('export.heading', { groupBy })}
+        </Title>
+        <Form className={css(styles.form)}>
+          <FormGroup
+            label={t('export.aggregate_type')}
+            fieldId="aggregate-type"
+          >
+            <React.Fragment>
+              {resolutionOptions.map((option, index) => (
+                <Radio
+                  key={index}
+                  id={`resolution-${index}`}
+                  isValid={option.value !== undefined}
+                  label={t(option.label)}
+                  value={option.value}
+                  checked={resolution === option.value}
+                  name="resolution"
+                  onChange={this.handleResolutionChange}
+                  aria-label={t(option.label)}
+                />
+              ))}
+            </React.Fragment>
+          </FormGroup>
+          <FormGroup label={selectedLabel} fieldId="selected-labels">
+            <ul>
+              {sortedItems.map((groupItem, index) => {
+                return <li key={index}>{groupItem.label}</li>;
+              })}
+            </ul>
+          </FormGroup>
+        </Form>
       </Modal>
     );
   }


### PR DESCRIPTION
Replaced custom FormGroup, TextInput, Link, and h2 tags with PF4 components. 

Note: Did not update the login page or old providers modal since those components are no longer in use. No change to the layouts.

Fixes https://github.com/project-koku/koku-ui/issues/186

Export modal:
![Screen Shot 2019-04-23 at 2 24 24 PM](https://user-images.githubusercontent.com/17481322/56606600-92178d80-65d4-11e9-9157-87c224e5ec8f.png)

Filter text input:
![Screen Shot 2019-04-23 at 4 09 04 PM](https://user-images.githubusercontent.com/17481322/56612402-54216600-65e2-11e9-92c3-48b19b665109.png)

