### PR TITLE
Fixed navigation from overview to details page

### DIFF
--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,6 +1,7 @@
 declare let insights: Insights;
 
 interface Chrome {
+  appNavClick: ({ id: string, secondaryNav: boolean }) => void;
   init: () => void;
   identifyApp: (appId: string) => void;
   navigation: (navFunc: any) => void;

--- a/src/pages/awsDashboard/awsDashboardWidget.tsx
+++ b/src/pages/awsDashboard/awsDashboardWidget.tsx
@@ -1,6 +1,6 @@
 import { Tab, Tabs } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
-import { AwsQuery, getQuery, parseQuery } from 'api/awsQuery';
+import { getQuery } from 'api/awsQuery';
 import { AwsReport, AwsReportType } from 'api/awsReports';
 import { transformAwsReport } from 'components/charts/commonChart/chartUtils';
 import {
@@ -82,11 +82,12 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
     fetchReports(widgetId);
   }
 
-  private buildDetailsLink = () => {
-    const { currentQuery } = this.props;
-    const groupBy = parseQuery<AwsQuery>(currentQuery).group_by;
+  private buildDetailsLink = (tab: AwsDashboardTab) => {
+    const currentTab = getIdKeyForTab(tab);
     return `/aws?${getQuery({
-      group_by: groupBy,
+      group_by: {
+        [currentTab]: '*',
+      },
       order_by: { cost: 'desc' },
     })}`;
   };
@@ -137,7 +138,7 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
     return (
       isDetailsLink && (
         <Link
-          to={this.buildDetailsLink()}
+          to={this.buildDetailsLink(currentTab)}
           onClick={this.handleInsightsNavClick}
         >
           {this.getDetailsLinkTitle(currentTab)}
@@ -199,7 +200,7 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
 
   private getTab = (tab: AwsDashboardTab, index: number) => {
     const { tabsReport } = this.props;
-    const currentTab = getIdKeyForTab(tab as AwsDashboardTab);
+    const currentTab = getIdKeyForTab(tab);
 
     return (
       <Tab

--- a/src/pages/awsDashboard/awsDashboardWidget.tsx
+++ b/src/pages/awsDashboard/awsDashboardWidget.tsx
@@ -91,16 +91,6 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
     })}`;
   };
 
-  private handleTabClick = (event, tabIndex) => {
-    const { availableTabs, id, updateTab } = this.props;
-    const tab = availableTabs[tabIndex];
-
-    updateTab(id, tab);
-    this.setState({
-      activeTabKey: tabIndex,
-    });
-  };
-
   private getChart = (height: number) => {
     const { currentReport, previousReport, t, trend } = this.props;
     const currentData = transformAwsReport(currentReport, trend.type);
@@ -146,7 +136,10 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
     const { currentTab, isDetailsLink } = this.props;
     return (
       isDetailsLink && (
-        <Link to={this.buildDetailsLink()}>
+        <Link
+          to={this.buildDetailsLink()}
+          onClick={this.handleInsightsNavClick}
+        >
           {this.getDetailsLinkTitle(currentTab)}
         </Link>
       )
@@ -330,6 +323,20 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
         <div className={css(styles.tabs)}>{this.getTabs()}</div>
       </AwsReportSummary>
     );
+  };
+
+  private handleInsightsNavClick = () => {
+    insights.chrome.appNavClick({ id: 'aws', secondaryNav: true });
+  };
+
+  private handleTabClick = (event, tabIndex) => {
+    const { availableTabs, id, updateTab } = this.props;
+    const tab = availableTabs[tabIndex];
+
+    updateTab(id, tab);
+    this.setState({
+      activeTabKey: tabIndex,
+    });
   };
 
   public render() {

--- a/src/pages/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/pages/ocpDashboard/ocpDashboardWidget.tsx
@@ -90,16 +90,6 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
     })}`;
   };
 
-  private handleTabClick = (event, tabIndex) => {
-    const { availableTabs, id } = this.props;
-    const tab = availableTabs[tabIndex];
-
-    this.props.updateTab(id, tab);
-    this.setState({
-      activeTabKey: tabIndex,
-    });
-  };
-
   private getChart = (height: number) => {
     const { currentReport, previousReport, reportType, t, trend } = this.props;
 
@@ -201,7 +191,10 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
     const { currentTab, isDetailsLink } = this.props;
     return (
       isDetailsLink && (
-        <Link to={this.buildDetailsLink()}>
+        <Link
+          to={this.buildDetailsLink()}
+          onClick={this.handleInsightsNavClick}
+        >
           {this.getDetailsLinkTitle(currentTab)}
         </Link>
       )
@@ -380,6 +373,20 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
         <div className={css(styles.tabs)}>{this.getTabs()}</div>
       </OcpReportSummary>
     );
+  };
+
+  private handleInsightsNavClick = () => {
+    insights.chrome.appNavClick({ id: 'ocp', secondaryNav: true });
+  };
+
+  private handleTabClick = (event, tabIndex) => {
+    const { availableTabs, id } = this.props;
+    const tab = availableTabs[tabIndex];
+
+    this.props.updateTab(id, tab);
+    this.setState({
+      activeTabKey: tabIndex,
+    });
   };
 
   public render() {

--- a/src/pages/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/pages/ocpDashboard/ocpDashboardWidget.tsx
@@ -1,6 +1,6 @@
 import { Tab, Tabs } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
-import { getQuery, OcpQuery, parseQuery } from 'api/ocpQuery';
+import { getQuery } from 'api/ocpQuery';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
 import { transformOcpReport } from 'components/charts/commonChart/chartUtils';
 import {
@@ -81,11 +81,12 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
     fetchReports(widgetId);
   }
 
-  private buildDetailsLink = () => {
-    const { currentQuery } = this.props;
-    const groupBy = parseQuery<OcpQuery>(currentQuery).group_by;
+  private buildDetailsLink = (tab: OcpDashboardTab) => {
+    const currentTab = getIdKeyForTab(tab);
     return `/ocp?${getQuery({
-      group_by: groupBy,
+      group_by: {
+        [currentTab]: '*',
+      },
       order_by: { cost: 'desc' },
     })}`;
   };
@@ -192,7 +193,7 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
     return (
       isDetailsLink && (
         <Link
-          to={this.buildDetailsLink()}
+          to={this.buildDetailsLink(currentTab)}
           onClick={this.handleInsightsNavClick}
         >
           {this.getDetailsLinkTitle(currentTab)}
@@ -254,7 +255,7 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
 
   private getTab = (tab: OcpDashboardTab, index: number) => {
     const { tabsReport } = this.props;
-    const currentTab = getIdKeyForTab(tab as OcpDashboardTab);
+    const currentTab = getIdKeyForTab(tab);
 
     return (
       <Tab

--- a/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
+++ b/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
@@ -1,6 +1,6 @@
 import { Tab, Tabs } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
-import { getQuery, OcpOnAwsQuery, parseQuery } from 'api/ocpOnAwsQuery';
+import { getQuery } from 'api/ocpOnAwsQuery';
 import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
 import { transformOcpOnAwsReport } from 'components/charts/commonChart/chartUtils';
 import {
@@ -86,11 +86,12 @@ class OcpOnAwsDashboardWidgetBase extends React.Component<
     fetchReports(widgetId);
   }
 
-  private buildDetailsLink = () => {
-    const { currentQuery } = this.props;
-    const groupBy = parseQuery<OcpOnAwsQuery>(currentQuery).group_by;
+  private buildDetailsLink = (tab: OcpOnAwsDashboardTab) => {
+    const currentTab = getIdKeyForTab(tab);
     return `/ocp-on-aws?${getQuery({
-      group_by: groupBy,
+      group_by: {
+        [currentTab]: '*',
+      },
       order_by: { cost: 'desc' },
     })}`;
   };
@@ -189,7 +190,7 @@ class OcpOnAwsDashboardWidgetBase extends React.Component<
     return (
       isDetailsLink && (
         <Link
-          to={this.buildDetailsLink()}
+          to={this.buildDetailsLink(currentTab)}
           onClick={this.handleInsightsNavClick}
         >
           {this.getDetailsLinkTitle(currentTab)}
@@ -251,7 +252,7 @@ class OcpOnAwsDashboardWidgetBase extends React.Component<
 
   private getTab = (tab: OcpOnAwsDashboardTab, index: number) => {
     const { tabsReport } = this.props;
-    const currentTab = getIdKeyForTab(tab as OcpOnAwsDashboardTab);
+    const currentTab = getIdKeyForTab(tab);
 
     return (
       <Tab

--- a/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
+++ b/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
@@ -95,16 +95,6 @@ class OcpOnAwsDashboardWidgetBase extends React.Component<
     })}`;
   };
 
-  private handleTabClick = (event, tabIndex) => {
-    const { availableTabs, id, updateTab } = this.props;
-    const tab = availableTabs[tabIndex];
-
-    updateTab(id, tab);
-    this.setState({
-      activeTabKey: tabIndex,
-    });
-  };
-
   private getChart = (height: number) => {
     const { currentReport, previousReport, reportType, t, trend } = this.props;
 
@@ -198,7 +188,10 @@ class OcpOnAwsDashboardWidgetBase extends React.Component<
     const { currentTab, isDetailsLink } = this.props;
     return (
       isDetailsLink && (
-        <Link to={this.buildDetailsLink()}>
+        <Link
+          to={this.buildDetailsLink()}
+          onClick={this.handleInsightsNavClick}
+        >
           {this.getDetailsLinkTitle(currentTab)}
         </Link>
       )
@@ -389,6 +382,20 @@ class OcpOnAwsDashboardWidgetBase extends React.Component<
         {this.getTabs()}
       </OcpOnAwsReportSummary>
     );
+  };
+
+  private handleInsightsNavClick = () => {
+    insights.chrome.appNavClick({ id: 'ocp-on-aws', secondaryNav: true });
+  };
+
+  private handleTabClick = (event, tabIndex) => {
+    const { availableTabs, id, updateTab } = this.props;
+    const tab = availableTabs[tabIndex];
+
+    updateTab(id, tab);
+    this.setState({
+      activeTabKey: tabIndex,
+    });
   };
 
   public render() {


### PR DESCRIPTION
This fixes an issue where the Insights navigation links (in the left-side navigation pane) are not made active and highlighted properly. That is, when clicking on the "top" tabs links in the overview (i.e., "All clusters", "All services", etc.) and navigating to details pages.

This also ensures that when the user is navigated to the appropriate details page, the correct group_by is selected.

Fixes https://github.com/project-koku/koku-ui/issues/756
Fixes https://github.com/project-koku/koku-ui/issues/793

![chrome-capture](https://user-images.githubusercontent.com/17481322/56678150-ffd4bf80-668f-11e9-8407-5c8ce318a57f.gif)
