### PR TITLE
Overview header font size

### DIFF
--- a/src/pages/awsDetails/detailsHeader.tsx
+++ b/src/pages/awsDetails/detailsHeader.tsx
@@ -1,4 +1,4 @@
-import { Title } from '@patternfly/react-core';
+import { Title, TitleSize } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { AwsQuery, getQuery } from 'api/awsQuery';
 import { AwsReport, AwsReportType } from 'api/awsReports';
@@ -83,7 +83,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     return (
       <header className={css(styles.header)}>
         <div>
-          <Title className={css(styles.title)} size="2xl">
+          <Title className={css(styles.title)} size={TitleSize['2xl']}>
             {t('aws_details.title')}
           </Title>
           {Boolean(showContent) && <GroupBy onItemClicked={onGroupByClicked} />}

--- a/src/pages/ocpDetails/detailsHeader.tsx
+++ b/src/pages/ocpDetails/detailsHeader.tsx
@@ -1,4 +1,4 @@
-import { Popover, Title, Tooltip } from '@patternfly/react-core';
+import { Popover, Title, TitleSize, Tooltip } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import { getQuery, OcpQuery } from 'api/ocpQuery';
@@ -129,7 +129,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     return (
       <header className={css(styles.header)}>
         <div>
-          <Title className={css(styles.title)} size="2xl">
+          <Title className={css(styles.title)} size={TitleSize['2xl']}>
             {t('ocp_details.title')}
           </Title>
           {Boolean(showContent) && <GroupBy onItemClicked={onGroupByClicked} />}

--- a/src/pages/ocpOnAwsDetails/detailsHeader.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsHeader.tsx
@@ -1,4 +1,4 @@
-import { Title } from '@patternfly/react-core';
+import { Title, TitleSize } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { getQuery, OcpOnAwsQuery } from 'api/ocpOnAwsQuery';
 import { OcpOnAwsReport, OcpOnAwsReportType } from 'api/ocpOnAwsReports';
@@ -86,7 +86,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     return (
       <header className={css(styles.header)}>
         <div>
-          <Title className={css(styles.title)} size="2xl">
+          <Title className={css(styles.title)} size={TitleSize['2xl']}>
             {t('ocp_on_aws_details.title')}
           </Title>
           {Boolean(showContent) && <GroupBy onItemClicked={onGroupByClicked} />}

--- a/src/pages/overview/overview.styles.ts
+++ b/src/pages/overview/overview.styles.ts
@@ -1,11 +1,18 @@
 import { StyleSheet } from '@patternfly/react-styles';
-import { global_spacer_lg, global_spacer_sm } from '@patternfly/react-tokens';
+import {
+  global_FontSize_md,
+  global_spacer_lg,
+  global_spacer_sm,
+} from '@patternfly/react-tokens';
 import { css } from 'emotion';
 
 export const styles = StyleSheet.create({
   info: {
     marginLeft: global_spacer_sm.value,
     verticalAlign: 'middle',
+  },
+  infoIcon: {
+    fontSize: global_FontSize_md.value,
   },
   infoTitle: {
     fontWeight: 'bold',

--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -248,29 +248,37 @@ class OverviewBase extends React.Component<OverviewProps> {
           }`}
         >
           <header className="pf-u-display-flex pf-u-justify-content-space-between pf-u-align-items-center">
-            <Title size={TitleSize.lg}>
+            <Title size={TitleSize['2xl']}>
               {t('overview.title')}
-              <Popover
-                aria-label="t('ocp_details.derived_aria_label')"
-                enableFlip
-                bodyContent={
-                  <>
-                    <p className={css(styles.infoTitle)}>
-                      {t('overview.ocp_on_aws')}
-                    </p>
-                    <p>{t('overview.ocp_on_aws_desc')}</p>
-                    <p className={css(styles.infoTitle)}>{t('overview.ocp')}</p>
-                    <p>{t('overview.ocp_desc')}</p>
-                    <p className={css(styles.infoTitle)}>{t('overview.aws')}</p>
-                    <p>{t('overview.aws_desc')}</p>
-                  </>
-                }
-              >
-                <InfoCircleIcon
-                  className={css(styles.info)}
-                  onClick={this.handlePopoverClick}
-                />
-              </Popover>
+              {Boolean(showTabs) && (
+                <span className={css(styles.infoIcon)}>
+                  <Popover
+                    aria-label="t('ocp_details.derived_aria_label')"
+                    enableFlip
+                    bodyContent={
+                      <>
+                        <p className={css(styles.infoTitle)}>
+                          {t('overview.ocp_on_aws')}
+                        </p>
+                        <p>{t('overview.ocp_on_aws_desc')}</p>
+                        <p className={css(styles.infoTitle)}>
+                          {t('overview.ocp')}
+                        </p>
+                        <p>{t('overview.ocp_desc')}</p>
+                        <p className={css(styles.infoTitle)}>
+                          {t('overview.aws')}
+                        </p>
+                        <p>{t('overview.aws_desc')}</p>
+                      </>
+                    }
+                  >
+                    <InfoCircleIcon
+                      className={css(styles.info)}
+                      onClick={this.handlePopoverClick}
+                    />
+                  </Popover>
+                </span>
+              )}
             </Title>
             {this.getAddSourceButton()}
           </header>


### PR DESCRIPTION
All headers should be the same font size. In addition, we should also hide the info icon for an empty state (i.e., when there are no providers).

Fixes https://github.com/project-koku/koku-ui/issues/799

Overview:
<img width="565" alt="Screen Shot 2019-04-25 at 11 26 49 AM" src="https://user-images.githubusercontent.com/17481322/56748121-44726080-674d-11e9-8579-497d0cf5874d.png">
