### PR TITLE
Update "no providers" empty state

### DIFF
--- a/src/components/state/noProvidersState/noProvidersState.styles.ts
+++ b/src/components/state/noProvidersState/noProvidersState.styles.ts
@@ -1,4 +1,5 @@
 import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_lg } from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
   container: {
@@ -6,5 +7,8 @@ export const styles = StyleSheet.create({
     justifyContent: 'center',
     height: '100vh',
     marginTop: '150px',
+  },
+  viewSources: {
+    marginTop: global_spacer_lg.value,
   },
 });

--- a/src/components/state/noProvidersState/noProvidersState.tsx
+++ b/src/components/state/noProvidersState/noProvidersState.tsx
@@ -1,7 +1,4 @@
 import {
-  Button,
-  ButtonType,
-  ButtonVariant,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
@@ -12,6 +9,7 @@ import { css } from '@patternfly/react-styles';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
 import { createMapStateToProps } from 'store/common';
 import { onboardingActions } from 'store/onboarding';
 import { getTestProps, testIds } from 'testIds';
@@ -27,18 +25,13 @@ type NoProvidersStateProps = NoProvidersStateOwnProps &
   NoProvidersStateDispatchProps;
 
 class NoProvidersStateBase extends React.Component<NoProvidersStateProps> {
-  private getAddSourceButton = () => {
-    const { openProvidersModal, t } = this.props;
+  private getViewSources = () => {
+    const { t } = this.props;
 
     return (
-      <Button
-        {...getTestProps(testIds.providers.add_btn)}
-        onClick={openProvidersModal}
-        type={ButtonType.submit}
-        variant={ButtonVariant.primary}
-      >
-        {t('providers.add_source')}
-      </Button>
+      <Link to="/sources" {...getTestProps(testIds.providers.view_all_link)}>
+        {t('providers.view_sources')}
+      </Link>
     );
   };
 
@@ -51,7 +44,7 @@ class NoProvidersStateBase extends React.Component<NoProvidersStateProps> {
           <EmptyStateIcon icon={DollarSignIcon} />
           <Title size="lg">{t('providers.empty_state_title')}</Title>
           <EmptyStateBody>{t('providers.empty_state_desc')}</EmptyStateBody>
-          {this.getAddSourceButton()}
+          <div className={css(styles.viewSources)}>{this.getViewSources()}</div>
         </EmptyState>
       </div>
     );

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -569,13 +569,14 @@
     "cluster_id_label": "Cluster ID",
     "confirm": "Confirm",
     "default_error": "Cannot create account",
-    "empty_state_desc": "Get started with tracking where your money is being spent by adding a source for this application. It can be found in Settings > Sources > 'Add a source' or 'Edit a source' or by clicking on the shortcut button below.",
-    "empty_state_title": "No money, no problem!",
+    "empty_state_desc": "Add a source, like an Amazon Web Services account, to see a total cost breakdown as well as usage information like instance counts and storage.",
+    "empty_state_title": "No cost data available yet",
     "name_error": "Provider name is invalid",
     "name_label": "Provider name",
     "resource_name_error": "Provider resource name must begin with \"arn:aws:\"",
     "resource_name_label": "Provider resource name",
-    "type_label": "Provider type"
+    "type_label": "Provider type",
+    "view_sources": "View all sources"
   },
   "setting": "Setting",
   "since_date": "Since $t(months.{{month}}) {{date}}",

--- a/src/testIds.ts
+++ b/src/testIds.ts
@@ -55,6 +55,7 @@ export const testIds = {
     cluster_id_input: 'provider-cluster-id-input',
     submit_btn: 'submit-btn',
     type_input: 'provider-type-input',
+    view_all_link: 'view-all-lnk',
   },
   sidebar: {
     nav: 'vertical-nav',


### PR DESCRIPTION
This updates text for "no providers" empty state. And instead of clicking "Add Sources" to launch the providers modal, the user clicks on a "View all sources", which navigates to the sources page.

Fixes https://github.com/project-koku/koku-ui/issues/801

<img width="706" alt="Screen Shot 2019-04-25 at 3 31 42 PM" src="https://user-images.githubusercontent.com/17481322/56763179-beb3dc80-676f-11e9-8c75-29362d062636.png">
