### PR TITLE
Info icons should be the same size

### DIFF
--- a/src/pages/ocpDetails/detailsHeader.styles.ts
+++ b/src/pages/ocpDetails/detailsHeader.styles.ts
@@ -3,6 +3,7 @@ import {
   global_BackgroundColor_100,
   global_Color_100,
   global_Color_200,
+  global_FontSize_md,
   global_FontSize_sm,
   global_spacer_md,
   global_spacer_sm,
@@ -37,6 +38,9 @@ export const styles = StyleSheet.create({
   info: {
     marginLeft: global_spacer_sm.value,
     verticalAlign: 'middle',
+  },
+  infoIcon: {
+    fontSize: global_FontSize_md.value,
   },
   infrastructureCost: {
     marginTop: global_spacer_xl.value,

--- a/src/pages/ocpDetails/detailsHeader.tsx
+++ b/src/pages/ocpDetails/detailsHeader.tsx
@@ -150,25 +150,27 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             <div className={css(styles.costLabel)}>
               <div className={css(styles.costLabelUnit)}>
                 {t('ocp_details.total_cost')}
-                <Popover
-                  aria-label="t('ocp_details.derived_aria_label')"
-                  enableFlip
-                  bodyContent={
-                    <>
-                      <div>{t('ocp_details.derived_cost_title')}</div>
-                      <div>{t('ocp_details.derived_cost_desc')}</div>
-                      <div className={css(styles.infrastructureCost)}>
-                        {t('ocp_details.infrastructure_cost_title')}
-                      </div>
-                      <div>{t('ocp_details.infrastructure_cost_desc')}</div>
-                    </>
-                  }
-                >
-                  <InfoCircleIcon
-                    className={css(styles.info)}
-                    onClick={this.handlePopoverClick}
-                  />
-                </Popover>
+                <span className={css(styles.infoIcon)}>
+                  <Popover
+                    aria-label="t('ocp_details.derived_aria_label')"
+                    enableFlip
+                    bodyContent={
+                      <>
+                        <div>{t('ocp_details.derived_cost_title')}</div>
+                        <div>{t('ocp_details.derived_cost_desc')}</div>
+                        <div className={css(styles.infrastructureCost)}>
+                          {t('ocp_details.infrastructure_cost_title')}
+                        </div>
+                        <div>{t('ocp_details.infrastructure_cost_desc')}</div>
+                      </>
+                    }
+                  >
+                    <InfoCircleIcon
+                      className={css(styles.info)}
+                      onClick={this.handlePopoverClick}
+                    />
+                  </Popover>
+                </span>
               </div>
               <div className={css(styles.costLabelDate)}>
                 {t('since_date', { month: today.getMonth(), date: 1 })}


### PR DESCRIPTION
The info icon shown in the Ocp details title is currently smaller than others. For example, there is an info icon in the Insights header (same page) and Overview page header.

Fixes https://github.com/project-koku/koku-ui/issues/804

Ocp details:
<img width="366" alt="Screen Shot 2019-04-26 at 11 31 46 AM" src="https://user-images.githubusercontent.com/17481322/56819768-6dabf300-6818-11e9-8fb6-3fc9313879af.png">
