### PR TITLE
Volume card units

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -246,7 +246,7 @@
     "total_cost_tooltip": "This total cost is the sum of the infrastructure cost {{infrastructureCost}} and derived cost {{derivedCost}}",
     "volume_requested_label": "{{units}} Requested",
     "volume_title": "OpenShift volume usage & requests",
-    "volume_trend_title": "Volume usage and requests comparison ({{value}})",
+    "volume_trend_title": "Volume usage and requests comparison ({{units}})",
     "volume_usage_label": "{{units}} Used",
     "widget_subtitle": "$t(months.{{month}}), month to date",
     "widget_subtitle_tooltip": "{{startDate}} $t(months_abbr.{{month}}) {{year}}",

--- a/src/pages/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/pages/ocpDashboard/ocpDashboardWidget.tsx
@@ -134,6 +134,7 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
           )
         : undefined;
     const units = this.getUnits();
+    const title = t(trend.titleKey, { units: t(`units.${units}`) });
 
     return (
       <>
@@ -146,9 +147,7 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
             height={height}
             previousCostData={previousUsageData}
             previousInfrastructureCostData={previousInfrastructureData}
-            title={t(trend.titleKey, {
-              units: t(`units.${units}`),
-            })}
+            title={title}
           />
         ) : (
           <OcpReportSummaryUsage
@@ -159,9 +158,7 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
             height={height}
             previousRequestData={previousRequestData}
             previousUsageData={previousUsageData}
-            title={t(trend.titleKey, {
-              units: t(`units.${units}`),
-            })}
+            title={title}
           />
         )}
       </>


### PR DESCRIPTION
The legend title for the volume card doesn't display units properly. This is because the title localization doesn't use the correct parameter name.

Fixes https://github.com/project-koku/koku-ui/issues/811

![Screen Shot 2019-04-29 at 10 30 12 AM](https://user-images.githubusercontent.com/17481322/56903181-ca521c80-6a69-11e9-83bc-28105107d482.png)
