### PR TITLE
Network & database cards to use new service filter

### DIFF
--- a/src/api/awsQuery.ts
+++ b/src/api/awsQuery.ts
@@ -4,8 +4,8 @@ export interface AwsFilters {
   account?: string | number;
   limit?: number;
   offset?: number;
-  product_family?: string;
   resolution?: 'daily' | 'monthly';
+  service?: string;
   time_scope_units?: 'month' | 'day';
   time_scope_value?: number;
 }

--- a/src/api/ocpOnAwsQuery.ts
+++ b/src/api/ocpOnAwsQuery.ts
@@ -3,9 +3,9 @@ import { parse, stringify } from 'qs';
 export interface OcpOnAwsFilters {
   limit?: number;
   offset?: number;
-  product_family?: string;
   project?: string | number;
   resolution?: 'daily' | 'monthly';
+  service?: string;
   time_scope_units?: 'month' | 'day';
   time_scope_value?: number;
 }

--- a/src/api/ocpQuery.ts
+++ b/src/api/ocpQuery.ts
@@ -3,9 +3,9 @@ import { parse, stringify } from 'qs';
 export interface OcpFilters {
   limit?: number;
   offset?: number;
-  product_family?: string;
   project?: string | number;
   resolution?: 'daily' | 'monthly';
+  service?: string;
   time_scope_units?: 'month' | 'day';
   time_scope_value?: number;
 }

--- a/src/store/awsDashboard/awsDashboardCommon.ts
+++ b/src/store/awsDashboard/awsDashboardCommon.ts
@@ -39,13 +39,13 @@ export interface AwsDashboardWidget {
   };
   filter?: {
     limit?: number;
-    product_family?: string;
+    service?: string;
   };
   isDetailsLink?: boolean;
   isHorizontal?: boolean;
   tabsFilter?: {
     limit?: number;
-    product_family?: string;
+    service?: string;
   };
   trend: {
     titleKey: string;

--- a/src/store/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/awsDashboard/awsDashboardWidgets.ts
@@ -75,10 +75,12 @@ export const databaseWidget: AwsDashboardWidget = {
     },
   },
   filter: {
-    product_family: 'Database Instance',
+    service:
+      'AmazonRDS,AmazonDynamoDB,AmazonElastiCache,AmazonNeptune,AmazonRedshift,AmazonDocumentDB',
   },
   tabsFilter: {
-    product_family: 'Database Instance',
+    service:
+      'AmazonRDS,AmazonDynamoDB,AmazonElastiCache,AmazonNeptune,AmazonRedshift,AmazonDocumentDB',
   },
   trend: {
     formatOptions: {},
@@ -107,10 +109,10 @@ export const networkWidget: AwsDashboardWidget = {
     },
   },
   filter: {
-    product_family: 'Load Balancer-Network',
+    service: 'AmazonVPC,AmazonCloudFront,AmazonRoute53,AmazonAPIGateway',
   },
   tabsFilter: {
-    product_family: 'Load Balancer-Network',
+    service: 'AmazonVPC,AmazonCloudFront,AmazonRoute53,AmazonAPIGateway',
   },
   trend: {
     formatOptions: {},

--- a/src/store/awsDetails/awsDetailsCommon.ts
+++ b/src/store/awsDetails/awsDetailsCommon.ts
@@ -40,13 +40,13 @@ export interface AwsDetailsWidget {
   };
   filter?: {
     limit?: number;
-    product_family?: string;
+    service?: string;
   };
   isDetailsLink?: boolean;
   isHorizontal?: boolean;
   tabsFilter?: {
     limit?: number;
-    product_family?: string;
+    service?: string;
   };
   trend?: {
     currentRequestLabelKey?: string;

--- a/src/store/ocpDashboard/ocpDashboardCommon.ts
+++ b/src/store/ocpDashboard/ocpDashboardCommon.ts
@@ -37,13 +37,13 @@ export interface OcpDashboardWidget {
   };
   filter?: {
     limit?: number;
-    product_family?: string;
+    service?: string;
   };
   isDetailsLink?: boolean;
   isHorizontal?: boolean;
   tabsFilter?: {
     limit?: number;
-    product_family?: string;
+    service?: string;
   };
   trend: {
     formatOptions: ValueFormatOptions;

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardCommon.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardCommon.ts
@@ -39,13 +39,13 @@ export interface OcpOnAwsDashboardWidget {
   };
   filter?: {
     limit?: number;
-    product_family?: string;
+    service?: string;
   };
   isDetailsLink?: boolean;
   isHorizontal?: boolean;
   tabsFilter?: {
     limit?: number;
-    product_family?: string;
+    service?: string;
   };
   trend: {
     formatOptions: ValueFormatOptions;

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardWidgets.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardWidgets.ts
@@ -127,7 +127,8 @@ export const databaseWidget: OcpOnAwsDashboardWidget = {
     },
   },
   filter: {
-    product_family: 'Database Instance',
+    service:
+      'AmazonRDS,AmazonDynamoDB,AmazonElastiCache,AmazonNeptune,AmazonRedshift,AmazonDocumentDB',
   },
   trend: {
     formatOptions: {},
@@ -147,7 +148,7 @@ export const networkWidget: OcpOnAwsDashboardWidget = {
     },
   },
   filter: {
-    product_family: 'Load Balancer-Network',
+    service: 'AmazonVPC,AmazonCloudFront,AmazonRoute53,AmazonAPIGateway',
   },
   trend: {
     formatOptions: {},

--- a/src/store/ocpOnAwsDetails/ocpOnAwsDetailsCommon.ts
+++ b/src/store/ocpOnAwsDetails/ocpOnAwsDetailsCommon.ts
@@ -41,13 +41,13 @@ export interface OcpOnAwsDetailsWidget {
   };
   filter?: {
     limit?: number;
-    product_family?: string;
+    service?: string;
   };
   isDetailsLink?: boolean;
   isHorizontal?: boolean;
   tabsFilter?: {
     limit?: number;
-    product_family?: string;
+    service?: string;
   };
   trend?: {
     currentRequestLabelKey?: string;


### PR DESCRIPTION
With this change, the network & database cards now use the new `service` filter instead of a `product_family`.

Fixes https://github.com/project-koku/koku-ui/issues/819

Ocp on AWS:
![Screen Shot 2019-04-29 at 3 19 43 PM](https://user-images.githubusercontent.com/17481322/56920820-3c3e5c00-6a92-11e9-816c-21611a6908a2.png)

AWS:
![Screen Shot 2019-04-29 at 3 20 36 PM](https://user-images.githubusercontent.com/17481322/56920865-5b3cee00-6a92-11e9-8bc4-089c26a9c43c.png)

