### PR TITLE
fix(priceList): add empty state when there are no rates

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -225,6 +225,10 @@
     "desc": "Sorry, no source with the given filter was found.",
     "title": "No match found"
   },
+  "no_rates_state": {
+    "desc": "Sorry, no rates related to cluster {{cluster}} were set.",
+    "title": "No rates found"
+  },
   "ocp_dashboard": {
     "cost_title": "Cost",
     "cost_trend_title": "Cost comparison ({{units}})",

--- a/src/pages/ocpDetails/noRatesState.styles.ts
+++ b/src/pages/ocpDetails/noRatesState.styles.ts
@@ -1,0 +1,11 @@
+import { StyleSheet } from '@patternfly/react-styles';
+import { global_spacer_xl } from '@patternfly/react-tokens';
+
+export const styles = StyleSheet.create({
+  container: {
+    display: 'flex',
+    justifyContent: 'center',
+    height: '50vh',
+    marginTop: global_spacer_xl.value,
+  },
+});

--- a/src/pages/ocpDetails/noRatesState.tsx
+++ b/src/pages/ocpDetails/noRatesState.tsx
@@ -1,0 +1,30 @@
+import {
+  EmptyState as PfEmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  Title,
+  TitleSize,
+} from '@patternfly/react-core';
+import { MoneyCheckAltIcon } from '@patternfly/react-icons';
+import { css } from '@patternfly/react-styles';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { styles } from './noRatesState.styles';
+
+interface Props extends InjectedTranslateProps {
+  cluster: string;
+}
+
+const NoRatesStateBase: React.SFC<Props> = ({ t, cluster }) => {
+  return (
+    <div className={css(styles.container)}>
+      <PfEmptyState>
+        <EmptyStateIcon icon={MoneyCheckAltIcon} />
+        <Title size={TitleSize.lg}>{t('no_rates_state.title')}</Title>
+        <EmptyStateBody>{t('no_rates_state.desc', { cluster })}</EmptyStateBody>
+      </PfEmptyState>
+    </div>
+  );
+};
+
+export const NoRatesState = translate()(NoRatesStateBase);

--- a/src/pages/ocpDetails/priceListModal.tsx
+++ b/src/pages/ocpDetails/priceListModal.tsx
@@ -15,6 +15,7 @@ import { priceListActions, priceListSelectors } from 'store/priceList';
 import { providersSelectors } from 'store/providers';
 import { styles as chartStyles } from './historicalChart.styles';
 import { modalOverride, styles } from './historicalModal.styles';
+import { NoRatesState } from './noRatesState';
 import PriceListTable from './priceListTable';
 
 interface Props extends InjectedTranslateProps {
@@ -65,7 +66,7 @@ class PriceListModalBase extends React.Component<Props> {
     return priceListRates ? (
       <PriceListTable t={t} rates={priceListRates} />
     ) : (
-      <div>{t('ocp_details.price_list.modal.no_match')}</div>
+      <NoRatesState cluster={name.toString()} />
     );
   }
 


### PR DESCRIPTION
closes #797 

//cc @dayleparker

![Screenshot_2019-04-30 Red Hat Cloud Software Services Cost Management](https://user-images.githubusercontent.com/2453279/56950112-5f721580-6b3d-11e9-90fa-202f540601cf.png)
