### PR TITLE
Providers modal loads overview page

### DIFF
--- a/src/pages/onboardingModal/awsConfigure/form.tsx
+++ b/src/pages/onboardingModal/awsConfigure/form.tsx
@@ -11,7 +11,12 @@ interface Props extends InjectedTranslateProps {
 
 const S3BucketForm: React.SFC<Props> = ({ t, isValid, value, onChange }) => {
   return (
-    <Form>
+    <Form
+      onSubmit={e => {
+        e.preventDefault();
+        return false;
+      }}
+    >
       <FormGroup
         isValid={isValid}
         fieldId="s3_bucket_name"

--- a/src/pages/onboardingModal/enableAccountAccess/form.tsx
+++ b/src/pages/onboardingModal/enableAccountAccess/form.tsx
@@ -11,7 +11,12 @@ interface Props extends InjectedTranslateProps {
 
 const ArnForm: React.SFC<Props> = ({ t, isValid, value, onChange }) => {
   return (
-    <Form>
+    <Form
+      onSubmit={e => {
+        e.preventDefault();
+        return false;
+      }}
+    >
       <FormGroup
         isValid={isValid}
         fieldId="arn"

--- a/src/pages/onboardingModal/sourceKind/form.tsx
+++ b/src/pages/onboardingModal/sourceKind/form.tsx
@@ -28,7 +28,12 @@ const SourceKindForm: React.SFC<Props> = ({
   typeValid,
 }) => {
   return (
-    <Form>
+    <Form
+      onSubmit={e => {
+        e.preventDefault();
+        return false;
+      }}
+    >
       <FormGroup
         isValid={nameValid}
         helperTextInvalid={t('onboarding.name_helper_invalid_text')}

--- a/src/pages/onboardingModal/usageCollector/form.tsx
+++ b/src/pages/onboardingModal/usageCollector/form.tsx
@@ -11,7 +11,12 @@ interface Props extends InjectedTranslateProps {
 
 const ClusterForm: React.SFC<Props> = ({ t, isValid, value, onChange }) => {
   return (
-    <Form>
+    <Form
+      onSubmit={e => {
+        e.preventDefault();
+        return false;
+      }}
+    >
       <FormGroup
         isValid={isValid}
         fieldId="cluster_id"


### PR DESCRIPTION
This fixes an issue with the providers modal, where pressing the 'enter' key in text inputs, loads the overview page.

Fixes https://github.com/project-koku/koku-ui/issues/813