### PR TITLE
Add mechanism to identify the "correct" app for the insights chrome.

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -70,8 +70,14 @@ export class App extends React.Component<AppProps, AppState> {
     } = this.props;
 
     insights.chrome.init();
-    insights.chrome.identifyApp('cost-management');
-    insights.chrome.navigation(buildNavigation());
+    const currentPath = window.location.pathname.split('/').slice(-1)[0];
+    if (currentPath === 'sources') {
+      insights.chrome.identifyApp('cost-management-sources');
+      insights.chrome.navigation(buildSourcesNavigation());
+    } else {
+      insights.chrome.identifyApp('cost-management');
+      insights.chrome.navigation(buildNavigation());
+    }
 
     this.appNav = insights.chrome.on('APP_NAVIGATION', event =>
       history.push(`/${event.navId}`)
@@ -165,6 +171,15 @@ function buildNavigation() {
       title: 'OpenShift on cloud details',
       id: 'ocp-on-aws',
     },
+  ].map(item => ({
+    ...item,
+    active: item.id === currentPath,
+  }));
+}
+
+function buildSourcesNavigation() {
+  const currentPath = window.location.pathname.split('/').slice(-1)[0];
+  return [
     {
       title: 'Cost Management Sources',
       id: 'sources',


### PR DESCRIPTION
Bug fix for the sources link.

Go from:
<img width="1025" alt="image" src="https://user-images.githubusercontent.com/29379759/56979085-ec6d9c80-6b46-11e9-9a13-c43829594146.png">

To "Cost Management Sources":
<img width="1032" alt="image" src="https://user-images.githubusercontent.com/29379759/56979160-16bf5a00-6b47-11e9-9139-f16adfe14128.png">

Only remaining but is for some reason the left-hand nav under Settings highlights "Catalog Sources"