### PR TITLE
Add filter for "AWS compute (EC2) instances" card

### DIFF
--- a/src/store/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/awsDashboard/awsDashboardWidgets.ts
@@ -16,6 +16,9 @@ export const computeWidget: AwsDashboardWidget = {
     },
     usageKey: 'aws_dashboard.compute_usage_label',
   },
+  filter: {
+    service: 'AmazonEC2',
+  },
   trend: {
     formatOptions: {
       fractionDigits: 2,

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardWidgets.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardWidgets.ts
@@ -107,6 +107,9 @@ export const computeWidget: OcpOnAwsDashboardWidget = {
     },
     usageKey: 'ocp_on_aws_dashboard.compute_usage_label',
   },
+  filter: {
+    service: 'AmazonEC2',
+  },
   trend: {
     formatOptions: {
       fractionDigits: 2,


### PR DESCRIPTION
We need to apply the following filter for the "AWS compute (EC2) instances" card, shown in both "Ocp on AWS" and "AWS" overview tabs.

`filter[service]=AmazonEC2`

Fixes https://github.com/project-koku/koku-ui/issues/830