### PR TITLE
Add filter to the tabs of the "AWS compute (EC2) instances" card

### DIFF
--- a/src/store/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/awsDashboard/awsDashboardWidgets.ts
@@ -19,6 +19,9 @@ export const computeWidget: AwsDashboardWidget = {
   filter: {
     service: 'AmazonEC2',
   },
+  tabsFilter: {
+    service: 'AmazonEC2',
+  },
   trend: {
     formatOptions: {
       fractionDigits: 2,


### PR DESCRIPTION
Need to also add a filter to the tabs of the "AWS compute (EC2) instances" card.