### PR TITLE
Broken PF tables

### DIFF
--- a/src/pages/awsDetails/detailsTable.tsx
+++ b/src/pages/awsDetails/detailsTable.tsx
@@ -163,7 +163,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         },
         {
           parent: index * 2,
-          cells: [<div key={`${index * 2}-child`}>{t('loading')}</div>],
+          cells: [
+            {
+              title: <div key={`${index * 2}-child`}>{t('loading')}</div>,
+            },
+          ],
         }
       );
     });

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -188,7 +188,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         },
         {
           parent: index * 2,
-          cells: [<div key={`${index * 2}-child`}>{t('loading')}</div>],
+          cells: [
+            {
+              title: <div key={`${index * 2}-child`}>{t('loading')}</div>,
+            },
+          ],
         }
       );
     });

--- a/src/pages/ocpOnAwsDetails/detailsTable.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsTable.tsx
@@ -168,7 +168,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         },
         {
           parent: index * 2,
-          cells: [<div key={`${index * 2}-child`}>{t('loading')}</div>],
+          cells: [
+            {
+              title: <div key={`${index * 2}-child`}>{t('loading')}</div>,
+            },
+          ],
         }
       );
     });

--- a/src/pages/sourceSettings/rowCell.tsx
+++ b/src/pages/sourceSettings/rowCell.tsx
@@ -59,11 +59,15 @@ const RowCell = (t, src: Provider, deleteAction) => {
     />
   );
   return [
-    <>{nameCol}</>,
-    <div key={`${prefix}-type`}>{t(`source_details.type.${src.type}`)}</div>,
-    <div key={`${prefix}-added-by`}>{src.created_by.username}</div>,
-    <>{dateCol}</>,
-    <>{actionCol}</>,
+    { title: nameCol },
+    {
+      title: (
+        <div key={`${prefix}-type`}>{t(`source_details.type.${src.type}`)}</div>
+      ),
+    },
+    { title: <div key={`${prefix}-added-by`}>{src.created_by.username}</div> },
+    { title: dateCol },
+    { title: actionCol },
   ];
 };
 


### PR DESCRIPTION
In our tables, we must use the title property for each PatternFly table cell. For example:

```
cells: [
  { title: <div>...</div> },
],
```

This was a breaking change with PatternFly 4 beta, but didn't show up in our build until the latest packages were installed.

Fixes https://github.com/project-koku/koku-ui/issues/835