### PR TITLE
VictoryStyleInterface breakage

### DIFF
--- a/src/components/charts/commonChart/chart.styles.ts
+++ b/src/components/charts/commonChart/chart.styles.ts
@@ -7,13 +7,12 @@ import {
   global_success_color_100,
   global_success_color_200,
 } from '@patternfly/react-tokens';
-import { VictoryStyleInterface } from 'victory';
 
 export const chartStyles = {
   padding: 8,
   group: {
     data: { strokeWidth: 2, fillOpacity: 0.4 },
-  } as VictoryStyleInterface,
+  },
   tooltipText: {
     fontSize: '14px',
     fill: global_Color_light_100.value,
@@ -24,13 +23,13 @@ export const chartStyles = {
       fill: global_success_color_200.value,
       stroke: global_success_color_100.value,
     },
-  } as VictoryStyleInterface,
+  },
   currentMonth: {
     data: {
       fill: global_primary_color_100.value,
       stroke: global_primary_color_200.value,
     },
-  } as VictoryStyleInterface,
+  },
 };
 
 export const styles = StyleSheet.create({

--- a/src/components/charts/costChart/costChart.styles.ts
+++ b/src/components/charts/costChart/costChart.styles.ts
@@ -9,7 +9,6 @@ import {
   global_spacer_lg,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
-import { VictoryStyleInterface } from 'victory';
 
 export const chartStyles = {
   currentCostData: {
@@ -17,14 +16,14 @@ export const chartStyles = {
       fill: 'none',
       stroke: '#A2DA9C',
     },
-  } as VictoryStyleInterface,
+  },
   currentInfrastructureCostData: {
     data: {
       fill: 'none',
       stroke: '#88D080',
       strokeDasharray: '3,3',
     },
-  } as VictoryStyleInterface,
+  },
   legend: {
     labels: {
       fontFamily: global_FontFamily_sans_serif.value,
@@ -37,14 +36,14 @@ export const chartStyles = {
       fill: 'none',
       stroke: global_disabled_color_200.value,
     },
-  } as VictoryStyleInterface,
+  },
   previousInfrastructureCostData: {
     data: {
       fill: 'none',
       stroke: global_disabled_color_200.value,
       strokeDasharray: '3,3',
     },
-  } as VictoryStyleInterface,
+  },
   // See: https://github.com/project-koku/koku-ui/issues/241
   currentColorScale: ['#A2DA9C', '#88D080', '#6EC664', '#519149', '#3C6C37'],
   // TBD: No grey scale, yet
@@ -75,7 +74,7 @@ export const chartStyles = {
     tickLabels: {
       fontSize: 0,
     },
-  } as VictoryStyleInterface,
+  },
   xAxis: {
     axisLabel: {
       padding: 15,
@@ -86,7 +85,7 @@ export const chartStyles = {
     ticks: {
       stroke: 'none',
     },
-  } as VictoryStyleInterface,
+  },
 };
 
 export const styles = StyleSheet.create({

--- a/src/components/charts/historicalCostChart/historicalCostChart.styles.ts
+++ b/src/components/charts/historicalCostChart/historicalCostChart.styles.ts
@@ -7,7 +7,6 @@ import {
   global_spacer_lg,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
-import { VictoryStyleInterface } from 'victory';
 
 export const chartStyles = {
   currentCapacityData: {
@@ -15,7 +14,7 @@ export const chartStyles = {
       fill: 'none',
       stroke: '#519149',
     },
-  } as VictoryStyleInterface,
+  },
   // See: https://github.com/project-koku/koku-ui/issues/241
   currentColorScale: ['#A2DA9C', '#88D080', '#6EC664', '#519149', '#3C6C37'],
   currentInfrastructureCostData: {
@@ -24,13 +23,13 @@ export const chartStyles = {
       stroke: '#88D080',
       strokeDasharray: '3,3',
     },
-  } as VictoryStyleInterface,
+  },
   currentCostData: {
     data: {
       fill: 'none',
       stroke: '#A2DA9C',
     },
-  } as VictoryStyleInterface,
+  },
   legend: {
     labels: {
       fontFamily: global_FontFamily_sans_serif.value,
@@ -43,7 +42,7 @@ export const chartStyles = {
       fill: 'none',
       stroke: '#00659C',
     },
-  } as VictoryStyleInterface,
+  },
   // See: https://github.com/project-koku/koku-ui/issues/241
   previousColorScale: ['#7DC3E8', '#39A5DC', '#007BBA', '#00659C', '#004D76'],
   previousInfrastructureCostData: {
@@ -52,13 +51,13 @@ export const chartStyles = {
       stroke: '#39A5DC',
       strokeDasharray: '3,3',
     },
-  } as VictoryStyleInterface,
+  },
   previousCostData: {
     data: {
       fill: 'none',
       stroke: '#7DC3E8',
     },
-  } as VictoryStyleInterface,
+  },
   tooltip: {
     flyoutStyle: {
       fill: c_background_image_BackgroundColor.value,
@@ -82,7 +81,7 @@ export const chartStyles = {
     tickLabels: {
       fontSize: 0,
     },
-  } as VictoryStyleInterface,
+  },
   xAxis: {
     axisLabel: {
       padding: 40,
@@ -93,7 +92,7 @@ export const chartStyles = {
     ticks: {
       stroke: 'none',
     },
-  } as VictoryStyleInterface,
+  },
 };
 
 export const styles = StyleSheet.create({

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.styles.ts
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.styles.ts
@@ -8,7 +8,6 @@ import {
   global_spacer_lg,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
-import { VictoryStyleInterface } from 'victory';
 
 export const chartStyles = {
   // See: https://github.com/project-koku/koku-ui/issues/241
@@ -25,7 +24,7 @@ export const chartStyles = {
       fill: 'none',
       stroke: '#A2DA9C',
     },
-  } as VictoryStyleInterface,
+  },
   legend: {
     labels: {
       fontFamily: global_FontFamily_sans_serif.value,
@@ -38,7 +37,7 @@ export const chartStyles = {
       fill: 'none',
       stroke: global_disabled_color_200.value,
     },
-  } as VictoryStyleInterface,
+  },
   tooltip: {
     flyoutStyle: {
       fill: c_background_image_BackgroundColor.value,
@@ -62,7 +61,7 @@ export const chartStyles = {
     tickLabels: {
       fontSize: 0,
     },
-  } as VictoryStyleInterface,
+  },
   xAxis: {
     axisLabel: {
       padding: 40,
@@ -73,7 +72,7 @@ export const chartStyles = {
     ticks: {
       stroke: 'none',
     },
-  } as VictoryStyleInterface,
+  },
 };
 
 export const styles = StyleSheet.create({

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.styles.ts
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.styles.ts
@@ -7,7 +7,6 @@ import {
   global_spacer_lg,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
-import { VictoryStyleInterface } from 'victory';
 
 export const chartStyles = {
   currentCapacityData: {
@@ -15,7 +14,7 @@ export const chartStyles = {
       fill: 'none',
       stroke: '#519149',
     },
-  } as VictoryStyleInterface,
+  },
   // See: https://github.com/project-koku/koku-ui/issues/241
   currentColorScale: ['#A2DA9C', '#88D080', '#6EC664', '#519149', '#3C6C37'],
   currentLimitData: {
@@ -23,20 +22,20 @@ export const chartStyles = {
       fill: 'none',
       stroke: '#6EC664',
     },
-  } as VictoryStyleInterface,
+  },
   currentRequestData: {
     data: {
       fill: 'none',
       stroke: '#88D080',
       strokeDasharray: '3,3',
     },
-  } as VictoryStyleInterface,
+  },
   currentUsageData: {
     data: {
       fill: 'none',
       stroke: '#A2DA9C',
     },
-  } as VictoryStyleInterface,
+  },
   itemsPerRow: 0,
   legend: {
     labels: {
@@ -49,7 +48,7 @@ export const chartStyles = {
       fill: 'none',
       stroke: '#00659C',
     },
-  } as VictoryStyleInterface,
+  },
   // See: https://github.com/project-koku/koku-ui/issues/241
   previousColorScale: ['#7DC3E8', '#39A5DC', '#007BBA', '#00659C', '#004D76'],
   previousLimitData: {
@@ -57,20 +56,20 @@ export const chartStyles = {
       fill: 'none',
       stroke: '#007BBA',
     },
-  } as VictoryStyleInterface,
+  },
   previousRequestData: {
     data: {
       fill: 'none',
       stroke: '#39A5DC',
       strokeDasharray: '3,3',
     },
-  } as VictoryStyleInterface,
+  },
   previousUsageData: {
     data: {
       fill: 'none',
       stroke: '#7DC3E8',
     },
-  } as VictoryStyleInterface,
+  },
   tooltip: {
     flyoutStyle: {
       fill: c_background_image_BackgroundColor.value,
@@ -94,7 +93,7 @@ export const chartStyles = {
     tickLabels: {
       fontSize: 0,
     },
-  } as VictoryStyleInterface,
+  },
   xAxis: {
     axisLabel: {
       padding: 40,
@@ -105,7 +104,7 @@ export const chartStyles = {
     ticks: {
       stroke: 'none',
     },
-  } as VictoryStyleInterface,
+  },
 };
 
 export const styles = StyleSheet.create({

--- a/src/components/charts/trendChart/trendChart.styles.ts
+++ b/src/components/charts/trendChart/trendChart.styles.ts
@@ -8,7 +8,6 @@ import {
   global_spacer_lg,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
-import { VictoryStyleInterface } from 'victory';
 
 export const chartStyles = {
   // See: https://github.com/project-koku/koku-ui/issues/241
@@ -32,13 +31,13 @@ export const chartStyles = {
       fill: 'none',
       stroke: global_disabled_color_200.value,
     },
-  } as VictoryStyleInterface,
+  },
   currentMonth: {
     data: {
       fill: 'none',
       stroke: '#A2DA9C',
     },
-  } as VictoryStyleInterface,
+  },
   tooltip: {
     flyoutStyle: {
       fill: c_background_image_BackgroundColor.value,
@@ -62,7 +61,7 @@ export const chartStyles = {
     tickLabels: {
       fontSize: 0,
     },
-  } as VictoryStyleInterface,
+  },
   xAxis: {
     axisLabel: {
       padding: 15,
@@ -73,7 +72,7 @@ export const chartStyles = {
     ticks: {
       stroke: 'none',
     },
-  } as VictoryStyleInterface,
+  },
 };
 
 export const styles = StyleSheet.create({

--- a/src/components/charts/usageChart/usageChart.styles.ts
+++ b/src/components/charts/usageChart/usageChart.styles.ts
@@ -9,7 +9,6 @@ import {
   global_spacer_lg,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
-import { VictoryStyleInterface } from 'victory';
 
 export const chartStyles = {
   currentRequestData: {
@@ -18,13 +17,13 @@ export const chartStyles = {
       stroke: '#88D080',
       strokeDasharray: '3,3',
     },
-  } as VictoryStyleInterface,
+  },
   currentUsageData: {
     data: {
       fill: 'none',
       stroke: '#A2DA9C',
     },
-  } as VictoryStyleInterface,
+  },
   legend: {
     labels: {
       fontFamily: global_FontFamily_sans_serif.value,
@@ -38,13 +37,13 @@ export const chartStyles = {
       stroke: global_disabled_color_200.value,
       strokeDasharray: '3,3',
     },
-  } as VictoryStyleInterface,
+  },
   previousUsageData: {
     data: {
       fill: 'none',
       stroke: global_disabled_color_200.value,
     },
-  } as VictoryStyleInterface,
+  },
   // See: https://github.com/project-koku/koku-ui/issues/241
   currentColorScale: ['#A2DA9C', '#88D080', '#6EC664', '#519149', '#3C6C37'],
   // TBD: No grey scale, yet
@@ -75,7 +74,7 @@ export const chartStyles = {
     tickLabels: {
       fontSize: 0,
     },
-  } as VictoryStyleInterface,
+  },
   xAxis: {
     axisLabel: {
       padding: 15,
@@ -86,7 +85,7 @@ export const chartStyles = {
     ticks: {
       stroke: 'none',
     },
-  } as VictoryStyleInterface,
+  },
 };
 
 export const styles = StyleSheet.create({


### PR DESCRIPTION
When the PatternFly charts are built with the latest Victory chart packages, the koku-ui build breaks with due to our use of VictoryStyleInterface. Apparently, Victory changed the properties and objects associated with this interface, so our current usage is no longer valid.

Fixes https://github.com/project-koku/koku-ui/issues/838