### PR TITLE
Tooltips appear behind bar charts

### DIFF
--- a/src/components/reports/awsReportSummary/awsReportSummaryAlt.styles.ts
+++ b/src/components/reports/awsReportSummary/awsReportSummaryAlt.styles.ts
@@ -18,6 +18,7 @@ export const styles = StyleSheet.create({
   cost: {
     flexGrow: 1,
     minHeight: '440px',
+    marginRight: global_spacer_md.value,
   },
   legendSkeleton: {
     marginTop: global_spacer_md.value,

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryAlt.styles.ts
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryAlt.styles.ts
@@ -18,6 +18,7 @@ export const styles = StyleSheet.create({
   cost: {
     flexGrow: 1,
     minHeight: '440px',
+    marginRight: global_spacer_md.value,
   },
   legendSkeleton: {
     marginTop: global_spacer_md.value,

--- a/src/components/reports/ocpReportSummary/ocpReportSummaryAlt.styles.ts
+++ b/src/components/reports/ocpReportSummary/ocpReportSummaryAlt.styles.ts
@@ -18,6 +18,7 @@ export const styles = StyleSheet.create({
   cost: {
     flexGrow: 1,
     minHeight: '440px',
+    marginRight: global_spacer_md.value,
   },
   legendSkeleton: {
     marginTop: global_spacer_md.value,


### PR DESCRIPTION
This fixes a very minor issue where the tooltip box can appear slightly behind the overview tab's bar charts.

Fixes https://github.com/project-koku/koku-ui/issues/828

Ocp on Aws:
![Screen Shot 2019-05-01 at 6 45 13 PM](https://user-images.githubusercontent.com/17481322/57048403-ca0c7980-6c41-11e9-9541-444a3c5ac8e3.png)

AWS:
![Screen Shot 2019-05-01 at 6 45 23 PM](https://user-images.githubusercontent.com/17481322/57048406-ced12d80-6c41-11e9-99d2-182fe4977e35.png)
