### PR TITLE
AWS overview network and database card values don't add up

### DIFF
--- a/src/api/awsQuery.ts
+++ b/src/api/awsQuery.ts
@@ -39,7 +39,7 @@ const groupByAnd = 'and:';
 
 // Adds logical AND to group_by -- https://github.com/project-koku/koku-ui/issues/704
 export function getGroupByAnd(query: AwsQuery) {
-  if (!(query && query.group_by)) {
+  if (!(query && query.group_by && Object.keys(query.group_by).length > 1)) {
     return query;
   }
   const newQuery = {
@@ -63,7 +63,7 @@ export function getQuery(query: AwsQuery) {
 
 // Removes logical AND from group_by -- https://github.com/project-koku/koku-ui/issues/704
 export function parseGroupByAnd(query: AwsQuery) {
-  if (!(query && query.group_by)) {
+  if (!(query && query.group_by && Object.keys(query.group_by).length > 1)) {
     return query;
   }
   const newQuery = {

--- a/src/api/ocpOnAwsQuery.ts
+++ b/src/api/ocpOnAwsQuery.ts
@@ -40,7 +40,7 @@ const groupByAnd = 'and:';
 
 // Adds logical AND to group_by -- https://github.com/project-koku/koku-ui/issues/704
 export function getGroupByAnd(query: OcpOnAwsQuery) {
-  if (!(query && query.group_by)) {
+  if (!(query && query.group_by && Object.keys(query.group_by).length > 1)) {
     return query;
   }
   const newQuery = {
@@ -64,7 +64,7 @@ export function getQuery(query: OcpOnAwsQuery) {
 
 // Removes logical AND from group_by -- https://github.com/project-koku/koku-ui/issues/704
 export function parseGroupByAnd(query: OcpOnAwsQuery) {
-  if (!(query && query.group_by)) {
+  if (!(query && query.group_by && Object.keys(query.group_by).length > 1)) {
     return query;
   }
   const newQuery = {

--- a/src/api/ocpQuery.ts
+++ b/src/api/ocpQuery.ts
@@ -37,7 +37,7 @@ const groupByAnd = 'and:';
 
 // Adds logical AND to group_by -- https://github.com/project-koku/koku-ui/issues/704
 export function getGroupByAnd(query: OcpQuery) {
-  if (!(query && query.group_by)) {
+  if (!(query && query.group_by && Object.keys(query.group_by).length > 1)) {
     return query;
   }
   const newQuery = {
@@ -61,7 +61,7 @@ export function getQuery(query: OcpQuery) {
 
 // Removes logical AND from group_by -- https://github.com/project-koku/koku-ui/issues/704
 export function parseGroupByAnd(query: OcpQuery) {
-  if (!(query && query.group_by)) {
+  if (!(query && query.group_by && Object.keys(query.group_by).length > 1)) {
     return query;
   }
   const newQuery = {

--- a/src/store/awsDashboard/__snapshots__/awsDashboard.test.ts.snap
+++ b/src/store/awsDashboard/__snapshots__/awsDashboard.test.ts.snap
@@ -17,28 +17,12 @@ Array [
 ]
 `;
 
-exports[`getGroupByForTab accounts tab 1`] = `
-Object {
-  "account": "*",
-}
-`;
+exports[`getGroupByForTab accounts tab 1`] = `Object {}`;
 
-exports[`getGroupByForTab instance types tab 1`] = `
-Object {
-  "instance_type": "*",
-}
-`;
+exports[`getGroupByForTab instance types tab 1`] = `Object {}`;
 
-exports[`getGroupByForTab regions tab 1`] = `
-Object {
-  "region": "*",
-}
-`;
+exports[`getGroupByForTab regions tab 1`] = `Object {}`;
 
-exports[`getGroupByForTab services tab 1`] = `
-Object {
-  "service": "*",
-}
-`;
+exports[`getGroupByForTab services tab 1`] = `Object {}`;
 
 exports[`getGroupByForTab unknown tab 1`] = `Object {}`;


### PR DESCRIPTION
AWS network & database card queries must use group_by instead of a filter for the service tab only.

Note that other tabs appear to still need the wild card (e.g., `group_by[accounts]=* `and `group_by[regions]=*`) along with the current filter for the costs to add up correctly.

Also need to ensure we don't apply logical AND to the group_by here.

Fixes https://github.com/project-koku/koku-ui/issues/846

Top services:
![Screen Shot 2019-05-02 at 11 31 06 AM](https://user-images.githubusercontent.com/17481322/57087344-d3dbbe80-6ccd-11e9-8640-a9ca863c5c3a.png)

Top regions:
![Screen Shot 2019-05-02 at 11 32 52 AM](https://user-images.githubusercontent.com/17481322/57087453-100f1f00-6cce-11e9-9346-d4bbb8a2120a.png)
