### PR TITLE
Apply logical AND for multiple group_by query params

### DIFF
--- a/src/api/awsQuery.ts
+++ b/src/api/awsQuery.ts
@@ -39,7 +39,7 @@ const groupByAnd = 'and:';
 
 // Adds logical AND to group_by -- https://github.com/project-koku/koku-ui/issues/704
 export function getGroupByAnd(query: AwsQuery) {
-  if (!(query && query.group_by && Object.keys(query.group_by).length > 1)) {
+  if (!(query && query.group_by) || skipGroupByAnd(query)) {
     return query;
   }
   const newQuery = {
@@ -63,7 +63,7 @@ export function getQuery(query: AwsQuery) {
 
 // Removes logical AND from group_by -- https://github.com/project-koku/koku-ui/issues/704
 export function parseGroupByAnd(query: AwsQuery) {
-  if (!(query && query.group_by && Object.keys(query.group_by).length > 1)) {
+  if (!(query && query.group_by) || skipGroupByAnd(query)) {
     return query;
   }
   const newQuery = {
@@ -82,4 +82,19 @@ export function parseGroupByAnd(query: AwsQuery) {
 export function parseQuery<T = any>(query: string): T {
   const newQuery = parse(query, { ignoreQueryPrefix: true });
   return parseGroupByAnd(newQuery);
+}
+
+export function skipGroupByAnd(query: AwsQuery) {
+  let result = true;
+
+  if (query && query.group_by) {
+    for (const key of Object.keys(query.group_by)) {
+      const groupBy = query.group_by[key];
+      if (groupBy instanceof Array && groupBy.length > 1) {
+        result = false;
+        break;
+      }
+    }
+  }
+  return result;
 }

--- a/src/api/ocpOnAwsQuery.ts
+++ b/src/api/ocpOnAwsQuery.ts
@@ -40,7 +40,7 @@ const groupByAnd = 'and:';
 
 // Adds logical AND to group_by -- https://github.com/project-koku/koku-ui/issues/704
 export function getGroupByAnd(query: OcpOnAwsQuery) {
-  if (!(query && query.group_by && Object.keys(query.group_by).length > 1)) {
+  if (!(query && query.group_by) || skipGroupByAnd(query)) {
     return query;
   }
   const newQuery = {
@@ -64,7 +64,7 @@ export function getQuery(query: OcpOnAwsQuery) {
 
 // Removes logical AND from group_by -- https://github.com/project-koku/koku-ui/issues/704
 export function parseGroupByAnd(query: OcpOnAwsQuery) {
-  if (!(query && query.group_by && Object.keys(query.group_by).length > 1)) {
+  if (!(query && query.group_by) || skipGroupByAnd(query)) {
     return query;
   }
   const newQuery = {
@@ -83,4 +83,19 @@ export function parseGroupByAnd(query: OcpOnAwsQuery) {
 export function parseQuery<T = any>(query: string): T {
   const newQuery = parse(query, { ignoreQueryPrefix: true });
   return parseGroupByAnd(newQuery);
+}
+
+export function skipGroupByAnd(query: OcpOnAwsQuery) {
+  let result = true;
+
+  if (query && query.group_by) {
+    for (const key of Object.keys(query.group_by)) {
+      const groupBy = query.group_by[key];
+      if (groupBy instanceof Array && groupBy.length > 1) {
+        result = false;
+        break;
+      }
+    }
+  }
+  return result;
 }

--- a/src/api/ocpQuery.ts
+++ b/src/api/ocpQuery.ts
@@ -37,7 +37,7 @@ const groupByAnd = 'and:';
 
 // Adds logical AND to group_by -- https://github.com/project-koku/koku-ui/issues/704
 export function getGroupByAnd(query: OcpQuery) {
-  if (!(query && query.group_by && Object.keys(query.group_by).length > 1)) {
+  if (!(query && query.group_by) || skipGroupByAnd(query)) {
     return query;
   }
   const newQuery = {
@@ -61,7 +61,7 @@ export function getQuery(query: OcpQuery) {
 
 // Removes logical AND from group_by -- https://github.com/project-koku/koku-ui/issues/704
 export function parseGroupByAnd(query: OcpQuery) {
-  if (!(query && query.group_by && Object.keys(query.group_by).length > 1)) {
+  if (!(query && query.group_by) || skipGroupByAnd(query)) {
     return query;
   }
   const newQuery = {
@@ -80,4 +80,19 @@ export function parseGroupByAnd(query: OcpQuery) {
 export function parseQuery<T = any>(query: string): T {
   const newQuery = parse(query, { ignoreQueryPrefix: true });
   return parseGroupByAnd(newQuery);
+}
+
+export function skipGroupByAnd(query: OcpQuery) {
+  let result = true;
+
+  if (query && query.group_by) {
+    for (const key of Object.keys(query.group_by)) {
+      const groupBy = query.group_by[key];
+      if (groupBy instanceof Array && groupBy.length > 1) {
+        result = false;
+        break;
+      }
+    }
+  }
+  return result;
 }


### PR DESCRIPTION
Logical AND does not get applied to the filter results in details pages.

We don't want logical AND applied to the AWS overview network card, but expect to see the `and:` prefix when multiple group_by params are applied in the details pages. For example:

`group_by[and:project]=open&group_by[and:project]=sdn&order_by[cost]=desc`

Fixes https://github.com/project-koku/koku-ui/issues/856

![Screen Shot 2019-05-06 at 4 50 39 PM](https://user-images.githubusercontent.com/17481322/57254373-192a2400-701f-11e9-9f31-eb0c43cd26de.png)
