### PR TITLE
'All projects' shows all cluster projects

### DIFF
--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -1,5 +1,4 @@
 import {
-  // DropdownItem,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,

--- a/src/pages/ocpDetails/detailsWidgetModal.tsx
+++ b/src/pages/ocpDetails/detailsWidgetModal.tsx
@@ -47,7 +47,7 @@ class DetailsWidgetModalBase extends React.Component<DetailsWidgetModalProps> {
           groupBy,
         })}
       >
-        <DetailsWidgetView groupBy={groupBy} />
+        <DetailsWidgetView groupBy={parentGroupBy} item={item} />
       </Modal>
     );
   }

--- a/src/pages/ocpDetails/detailsWidgetView.tsx
+++ b/src/pages/ocpDetails/detailsWidgetView.tsx
@@ -12,10 +12,12 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { ocpReportsActions, ocpReportsSelectors } from 'store/ocpReports';
 import { formatValue } from 'utils/formatValue';
 import { formatCurrency } from 'utils/formatValue';
+import { ComputedOcpReportItem } from 'utils/getComputedOcpReportItems';
 import { styles } from './detailsWidgetModal.styles';
 
 interface DetailsWidgetViewOwnProps {
   groupBy: string;
+  item: ComputedOcpReportItem;
 }
 
 interface DetailsWidgetViewStateProps {
@@ -53,7 +55,7 @@ class DetailsWidgetViewBase extends React.Component<DetailsWidgetViewProps> {
   }
 
   public render() {
-    const { groupBy, report, t } = this.props;
+    const { report, t } = this.props;
 
     const cost = formatCurrency(
       report && report.meta && report.meta.total
@@ -69,7 +71,7 @@ class DetailsWidgetViewBase extends React.Component<DetailsWidgetViewProps> {
           </Title>
         </div>
         <div className={styles.mainContent}>
-          <OcpReportSummaryItems idKey={groupBy as any} report={report}>
+          <OcpReportSummaryItems idKey="project" report={report}>
             {({ items }) =>
               items.map(_item => (
                 <OcpReportSummaryItem
@@ -93,14 +95,17 @@ class DetailsWidgetViewBase extends React.Component<DetailsWidgetViewProps> {
 const mapStateToProps = createMapStateToProps<
   DetailsWidgetViewOwnProps,
   DetailsWidgetViewStateProps
->((state, { groupBy }) => {
+>((state, { groupBy, item }) => {
   const query: OcpQuery = {
     filter: {
       time_scope_units: 'month',
       time_scope_value: -1,
       resolution: 'monthly',
     },
-    group_by: { [groupBy]: '*' },
+    group_by: {
+      project: '*',
+      [groupBy]: item.label || item.id,
+    },
   };
   const queryString = getQuery(query);
   const report = ocpReportsSelectors.selectReport(


### PR DESCRIPTION
The 'All projects' link and kebab menu open shows all cluster projects instead of the projects belonging to just that cluster.

Fixes https://github.com/project-koku/koku-ui/issues/851

![Screen Shot 2019-05-06 at 5 28 35 PM](https://user-images.githubusercontent.com/17481322/57256625-19c5b900-7025-11e9-8361-dea838eafb31.png)
