### PR TITLE
fix(sources): breadcrumb typo and functionality

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -616,7 +616,7 @@
     "type_label": "Provider type",
     "view_sources": "View all sources"
   },
-  "setting": "Setting",
+  "settings": "Settings",
   "since_date": "Since $t(months.{{month}}) {{date}}",
   "source_details": {
     "add_source": "Add source",

--- a/src/pages/sourceSettings/header.tsx
+++ b/src/pages/sourceSettings/header.tsx
@@ -7,10 +7,8 @@ import { styles } from './sourceSettings.styles';
 const Header: React.SFC<InjectedTranslateProps> = ({ t }) => (
   <header className={css(styles.header)}>
     <Breadcrumb className={css(styles.breadcrumb)}>
-      <BreadcrumbItem to="#">{t('setting')}</BreadcrumbItem>
-      <BreadcrumbItem to="#" isActive>
-        {t('cost_management')}
-      </BreadcrumbItem>
+      <BreadcrumbItem>{t('settings')}</BreadcrumbItem>
+      <BreadcrumbItem isActive>{t('cost_management')}</BreadcrumbItem>
     </Breadcrumb>
     <Title className={css(styles.title)} size="2xl">
       {t('source_details.title')}


### PR DESCRIPTION
closes #865 

//cc @dchorvat1 