### PR TITLE
Reset pagination whenever table rows change

### DIFF
--- a/src/pages/awsDetails/awsDetails.tsx
+++ b/src/pages/awsDetails/awsDetails.tsx
@@ -218,7 +218,14 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     );
   };
 
-  private getRouteForQuery(query: AwsQuery) {
+  private getRouteForQuery(query: AwsQuery, reset: boolean = false) {
+    // Reset pagination
+    if (reset) {
+      query.filter = {
+        ...query.filter,
+        offset: baseQuery.filter.offset,
+      };
+    }
     return `/aws?${getQuery(query)}`;
   }
 
@@ -291,7 +298,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     } else {
       newQuery.group_by[filterType] = [filterValue];
     }
-    const filteredQuery = this.getRouteForQuery(newQuery);
+    const filteredQuery = this.getRouteForQuery(newQuery, true);
     history.replace(filteredQuery);
   };
 
@@ -318,7 +325,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
         ];
       }
     }
-    const filteredQuery = this.getRouteForQuery(newQuery);
+    const filteredQuery = this.getRouteForQuery(newQuery, true);
     history.replace(filteredQuery);
   };
 
@@ -332,7 +339,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
       },
       order_by: { cost: 'desc' },
     };
-    history.replace(this.getRouteForQuery(newQuery));
+    history.replace(this.getRouteForQuery(newQuery, true));
     this.setState({ selectedItems: [] });
   };
 
@@ -343,7 +350,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
       ...query.filter,
       limit: perPage,
     };
-    const filteredQuery = this.getRouteForQuery(newQuery);
+    const filteredQuery = this.getRouteForQuery(newQuery, true);
     history.replace(filteredQuery);
   };
 

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -218,7 +218,14 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     );
   };
 
-  private getRouteForQuery(query: OcpQuery) {
+  private getRouteForQuery(query: OcpQuery, reset: boolean = false) {
+    // Reset pagination
+    if (reset) {
+      query.filter = {
+        ...query.filter,
+        offset: baseQuery.filter.offset,
+      };
+    }
     return `/ocp?${getQuery(query)}`;
   }
 
@@ -293,7 +300,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     } else {
       newQuery.group_by[filterType] = [filterValue];
     }
-    const filteredQuery = this.getRouteForQuery(newQuery);
+    const filteredQuery = this.getRouteForQuery(newQuery, true);
     history.replace(filteredQuery);
   };
 
@@ -320,7 +327,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
         ];
       }
     }
-    const filteredQuery = this.getRouteForQuery(newQuery);
+    const filteredQuery = this.getRouteForQuery(newQuery, true);
     history.replace(filteredQuery);
   };
 
@@ -334,7 +341,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
       },
       order_by: { cost: 'desc' },
     };
-    history.replace(this.getRouteForQuery(newQuery));
+    history.replace(this.getRouteForQuery(newQuery, true));
     this.setState({ selectedItems: [] });
   };
 
@@ -345,7 +352,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
       ...query.filter,
       limit: perPage,
     };
-    const filteredQuery = this.getRouteForQuery(newQuery);
+    const filteredQuery = this.getRouteForQuery(newQuery, true);
     history.replace(filteredQuery);
   };
 

--- a/src/pages/ocpOnAwsDetails/ocpOnAwsDetails.tsx
+++ b/src/pages/ocpOnAwsDetails/ocpOnAwsDetails.tsx
@@ -222,7 +222,14 @@ class OcpOnAwsDetails extends React.Component<OcpOnAwsDetailsProps> {
     );
   };
 
-  private getRouteForQuery(query: OcpOnAwsQuery) {
+  private getRouteForQuery(query: OcpOnAwsQuery, reset: boolean = false) {
+    // Reset pagination
+    if (reset) {
+      query.filter = {
+        ...query.filter,
+        offset: baseQuery.filter.offset,
+      };
+    }
     return `/ocp-on-aws?${getQuery(query)}`;
   }
 
@@ -297,7 +304,7 @@ class OcpOnAwsDetails extends React.Component<OcpOnAwsDetailsProps> {
     } else {
       newQuery.group_by[filterType] = [filterValue];
     }
-    const filteredQuery = this.getRouteForQuery(newQuery);
+    const filteredQuery = this.getRouteForQuery(newQuery, true);
     history.replace(filteredQuery);
   };
 
@@ -324,7 +331,7 @@ class OcpOnAwsDetails extends React.Component<OcpOnAwsDetailsProps> {
         ];
       }
     }
-    const filteredQuery = this.getRouteForQuery(newQuery);
+    const filteredQuery = this.getRouteForQuery(newQuery, true);
     history.replace(filteredQuery);
   };
 
@@ -338,7 +345,7 @@ class OcpOnAwsDetails extends React.Component<OcpOnAwsDetailsProps> {
       },
       order_by: { cost: 'desc' },
     };
-    history.replace(this.getRouteForQuery(newQuery));
+    history.replace(this.getRouteForQuery(newQuery, true));
     this.setState({ selectedItems: [] });
   };
 
@@ -349,7 +356,7 @@ class OcpOnAwsDetails extends React.Component<OcpOnAwsDetailsProps> {
       ...query.filter,
       limit: perPage,
     };
-    const filteredQuery = this.getRouteForQuery(newQuery);
+    const filteredQuery = this.getRouteForQuery(newQuery, true);
     history.replace(filteredQuery);
   };
 


### PR DESCRIPTION
Reset pagination whenever table rows change. For example, when a new group_by is selected, filters are applied, or when the number of items per page changes.

Fixes https://github.com/project-koku/koku-ui/issues/850