### PR TITLE
Show skeletons only when fetch status is in progress

### DIFF
--- a/src/components/reports/awsReportSummary/awsReportSummaryItems.test.tsx
+++ b/src/components/reports/awsReportSummary/awsReportSummaryItems.test.tsx
@@ -26,12 +26,6 @@ test('computes report items', () => {
   expect(props.children).toBeCalledWith({ items: [] });
 });
 
-test('returns null if a report is not present', () => {
-  shallow(<AwsReportSummaryItems {...props} report={null} />);
-  expect(utils.getComputedAwsReportItems).not.toBeCalled();
-  expect(props.children).not.toBeCalled();
-});
-
 test('does not update if the report is unchanged', () => {
   const view = shallow(<AwsReportSummaryItems {...props} />);
   view.setProps(props as any);

--- a/src/components/reports/awsReportSummary/awsReportSummaryItems.tsx
+++ b/src/components/reports/awsReportSummary/awsReportSummaryItems.tsx
@@ -5,6 +5,7 @@ import {
 } from '@red-hat-insights/insights-frontend-components/components/Skeleton';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
+import { FetchStatus } from 'store/common';
 import {
   ComputedAwsReportItem,
   getComputedAwsReportItems,
@@ -19,6 +20,7 @@ interface AwsReportSummaryItemsRenderProps {
 interface AwsReportSummaryItemsOwnProps
   extends GetComputedAwsReportItemsParams {
   children?(props: AwsReportSummaryItemsRenderProps): React.ReactNode;
+  status: number;
 }
 
 type AwsReportSummaryItemsProps = AwsReportSummaryItemsOwnProps &
@@ -59,9 +61,9 @@ class AwsReportSummaryItemsBase extends React.Component<
   }
 
   public render() {
-    const { report, children } = this.props;
+    const { children, status } = this.props;
 
-    if (!report) {
+    if (status === FetchStatus.inProgress) {
       return (
         <>
           <Skeleton size={SkeletonSize.md} />

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItems.test.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItems.test.tsx
@@ -26,12 +26,6 @@ test('computes report items', () => {
   expect(props.children).toBeCalledWith({ items: [] });
 });
 
-test('returns null if a report is not present', () => {
-  shallow(<OcpOnAwsReportSummaryItems {...props} report={null} />);
-  expect(utils.getComputedOcpOnAwsReportItems).not.toBeCalled();
-  expect(props.children).not.toBeCalled();
-});
-
 test('does not update if the report is unchanged', () => {
   const view = shallow(<OcpOnAwsReportSummaryItems {...props} />);
   view.setProps(props as any);

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItems.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryItems.tsx
@@ -5,6 +5,7 @@ import {
 } from '@red-hat-insights/insights-frontend-components/components/Skeleton';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
+import { FetchStatus } from 'store/common';
 import {
   ComputedOcpOnAwsReportItem,
   getComputedOcpOnAwsReportItems,
@@ -19,6 +20,7 @@ interface OcpOnAwsReportSummaryItemsRenderProps {
 interface OcpOnAwsReportSummaryItemsOwnProps
   extends GetComputedOcpOnAwsReportItemsParams {
   children?(props: OcpOnAwsReportSummaryItemsRenderProps): React.ReactNode;
+  status: number;
 }
 
 type OcpOnAwsReportSummaryItemsProps = OcpOnAwsReportSummaryItemsOwnProps &
@@ -59,9 +61,9 @@ class OcpOnAwsReportSummaryItemsBase extends React.Component<
   }
 
   public render() {
-    const { report, children } = this.props;
+    const { children, status } = this.props;
 
-    if (!report) {
+    if (status === FetchStatus.inProgress) {
       return (
         <>
           <Skeleton size={SkeletonSize.md} />

--- a/src/components/reports/ocpReportSummary/ocpReportSummaryItems.test.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummaryItems.test.tsx
@@ -26,12 +26,6 @@ test('computes report items', () => {
   expect(props.children).toBeCalledWith({ items: [] });
 });
 
-test('returns null if a report is not present', () => {
-  shallow(<OcpReportSummaryItems {...props} report={null} />);
-  expect(utils.getComputedOcpReportItems).not.toBeCalled();
-  expect(props.children).not.toBeCalled();
-});
-
 test('does not update if the report is unchanged', () => {
   const view = shallow(<OcpReportSummaryItems {...props} />);
   view.setProps(props as any);

--- a/src/components/reports/ocpReportSummary/ocpReportSummaryItems.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummaryItems.tsx
@@ -5,6 +5,7 @@ import {
 } from '@red-hat-insights/insights-frontend-components/components/Skeleton';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
+import { FetchStatus } from 'store/common';
 import {
   ComputedOcpReportItem,
   getComputedOcpReportItems,
@@ -19,6 +20,7 @@ interface OcpReportSummaryItemsRenderProps {
 interface OcpReportSummaryItemsOwnProps
   extends GetComputedOcpReportItemsParams {
   children?(props: OcpReportSummaryItemsRenderProps): React.ReactNode;
+  status: number;
 }
 
 type OcpReportSummaryItemsProps = OcpReportSummaryItemsOwnProps &
@@ -59,9 +61,9 @@ class OcpReportSummaryItemsBase extends React.Component<
   }
 
   public render() {
-    const { report, children } = this.props;
+    const { children, status } = this.props;
 
-    if (!report) {
+    if (status === FetchStatus.inProgress) {
       return (
         <>
           <Skeleton size={SkeletonSize.md} />

--- a/src/pages/awsDashboard/awsDashboardWidget.tsx
+++ b/src/pages/awsDashboard/awsDashboardWidget.tsx
@@ -44,6 +44,7 @@ interface AwsDashboardWidgetStateProps extends AwsDashboardWidgetStatic {
   previousReport: AwsReport;
   tabsQuery: string;
   tabsReport: AwsReport;
+  tabsReportFetchStatus: number;
 }
 
 interface AwsDashboardWidgetDispatchProps {
@@ -199,7 +200,7 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
   };
 
   private getTab = (tab: AwsDashboardTab, index: number) => {
-    const { tabsReport } = this.props;
+    const { tabsReport, tabsReportFetchStatus } = this.props;
     const currentTab = getIdKeyForTab(tab);
 
     return (
@@ -213,6 +214,7 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
             idKey={currentTab}
             key={`${currentTab}-items`}
             report={tabsReport}
+            status={tabsReportFetchStatus}
           >
             {({ items }) =>
               items.map(reportItem => this.getTabItem(tab, reportItem))
@@ -375,6 +377,11 @@ const mapStateToProps = createMapStateToProps<
       queries.previous
     ),
     tabsReport: awsReportsSelectors.selectReport(
+      state,
+      widget.reportType,
+      queries.tabs
+    ),
+    tabsReportFetchStatus: awsReportsSelectors.selectReportFetchStatus(
       state,
       widget.reportType,
       queries.tabs

--- a/src/pages/awsDetails/detailsWidgetModalView.tsx
+++ b/src/pages/awsDetails/detailsWidgetModalView.tsx
@@ -58,7 +58,7 @@ class DetailsWidgetModalViewBase extends React.Component<
   }
 
   public render() {
-    const { groupBy, report, t } = this.props;
+    const { groupBy, report, reportFetchStatus, t } = this.props;
 
     const cost = formatCurrency(
       report && report.meta && report.meta.total
@@ -74,7 +74,11 @@ class DetailsWidgetModalViewBase extends React.Component<
           </Title>
         </div>
         <div className={styles.mainContent}>
-          <AwsReportSummaryItems idKey={groupBy as any} report={report}>
+          <AwsReportSummaryItems
+            idKey={groupBy as any}
+            report={report}
+            status={reportFetchStatus}
+          >
             {({ items }) =>
               items.map(_item => (
                 <AwsReportSummaryItem

--- a/src/pages/awsDetails/detailsWidgetView.tsx
+++ b/src/pages/awsDetails/detailsWidgetView.tsx
@@ -166,6 +166,7 @@ class DetailsWidgetViewBase extends React.Component<DetailsWidgetViewProps> {
                 idKey={groupBy as any}
                 key={`${groupBy}-items`}
                 report={report}
+                status={reportFetchStatus}
               >
                 {({ items }) =>
                   items.map(reportItem => this.getTabItem(reportItem))

--- a/src/pages/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/pages/ocpDashboard/ocpDashboardWidget.tsx
@@ -45,6 +45,7 @@ interface OcpDashboardWidgetStateProps extends OcpDashboardWidgetStatic {
   previousReport: OcpReport;
   tabsQuery: string;
   tabsReport: OcpReport;
+  tabsReportFetchStatus: number;
 }
 
 interface OcpDashboardWidgetDispatchProps {
@@ -251,7 +252,7 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
   };
 
   private getTab = (tab: OcpDashboardTab, index: number) => {
-    const { tabsReport } = this.props;
+    const { tabsReport, tabsReportFetchStatus } = this.props;
     const currentTab = getIdKeyForTab(tab);
 
     return (
@@ -265,6 +266,7 @@ class OcpDashboardWidgetBase extends React.Component<OcpDashboardWidgetProps> {
             idKey={currentTab}
             key={`${currentTab}-items`}
             report={tabsReport}
+            status={tabsReportFetchStatus}
           >
             {({ items }) =>
               items.map(reportItem => this.getTabItem(tab, reportItem))
@@ -422,6 +424,11 @@ const mapStateToProps = createMapStateToProps<
       queries.previous
     ),
     tabsReport: ocpReportsSelectors.selectReport(
+      state,
+      widget.reportType,
+      queries.tabs
+    ),
+    tabsReportFetchStatus: ocpReportsSelectors.selectReportFetchStatus(
       state,
       widget.reportType,
       queries.tabs

--- a/src/pages/ocpDetails/detailsWidget.tsx
+++ b/src/pages/ocpDetails/detailsWidget.tsx
@@ -76,12 +76,16 @@ class DetailsWidgetBase extends React.Component<DetailsWidgetProps> {
   };
 
   private getSummary = () => {
-    const { report, t } = this.props;
+    const { report, reportFetchStatus, t } = this.props;
     return (
       <>
         {t('group_by.details', { groupBy: 'project' })}
         <div className={css(styles.summary)}>
-          <OcpReportSummaryItems idKey="project" report={report}>
+          <OcpReportSummaryItems
+            idKey="project"
+            report={report}
+            status={reportFetchStatus}
+          >
             {({ items }) =>
               items.map(reportItem => (
                 <OcpReportSummaryItem

--- a/src/pages/ocpDetails/detailsWidgetView.tsx
+++ b/src/pages/ocpDetails/detailsWidgetView.tsx
@@ -55,7 +55,7 @@ class DetailsWidgetViewBase extends React.Component<DetailsWidgetViewProps> {
   }
 
   public render() {
-    const { report, t } = this.props;
+    const { report, reportFetchStatus, t } = this.props;
 
     const cost = formatCurrency(
       report && report.meta && report.meta.total
@@ -71,7 +71,11 @@ class DetailsWidgetViewBase extends React.Component<DetailsWidgetViewProps> {
           </Title>
         </div>
         <div className={styles.mainContent}>
-          <OcpReportSummaryItems idKey="project" report={report}>
+          <OcpReportSummaryItems
+            idKey="project"
+            report={report}
+            status={reportFetchStatus}
+          >
             {({ items }) =>
               items.map(_item => (
                 <OcpReportSummaryItem

--- a/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
+++ b/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
@@ -46,6 +46,7 @@ interface OcpOnAwsDashboardWidgetStateProps
   previousReport: OcpOnAwsReport;
   tabsQuery: string;
   tabsReport: OcpOnAwsReport;
+  tabsReportFetchStatus: number;
 }
 
 interface OcpOnAwsDashboardWidgetDispatchProps {
@@ -251,7 +252,7 @@ class OcpOnAwsDashboardWidgetBase extends React.Component<
   };
 
   private getTab = (tab: OcpOnAwsDashboardTab, index: number) => {
-    const { tabsReport } = this.props;
+    const { tabsReport, tabsReportFetchStatus } = this.props;
     const currentTab = getIdKeyForTab(tab);
 
     return (
@@ -265,6 +266,7 @@ class OcpOnAwsDashboardWidgetBase extends React.Component<
             idKey={currentTab}
             key={`${currentTab}-items`}
             report={tabsReport}
+            status={tabsReportFetchStatus}
           >
             {({ items }) =>
               items.map(reportItem => this.getTabItem(tab, reportItem))
@@ -437,6 +439,11 @@ const mapStateToProps = createMapStateToProps<
       queries.previous
     ),
     tabsReport: ocpOnAwsReportsSelectors.selectReport(
+      state,
+      widget.reportType,
+      queries.tabs
+    ),
+    tabsReportFetchStatus: ocpOnAwsReportsSelectors.selectReportFetchStatus(
       state,
       widget.reportType,
       queries.tabs

--- a/src/pages/ocpOnAwsDetails/detailsWidgetModalView.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsWidgetModalView.tsx
@@ -61,7 +61,7 @@ class DetailsWidgetModalViewBase extends React.Component<
   }
 
   public render() {
-    const { groupBy, report, t } = this.props;
+    const { groupBy, report, reportFetchStatus, t } = this.props;
 
     const cost = formatCurrency(
       report &&
@@ -80,7 +80,11 @@ class DetailsWidgetModalViewBase extends React.Component<
           </Title>
         </div>
         <div className={styles.mainContent}>
-          <OcpOnAwsReportSummaryItems idKey={groupBy as any} report={report}>
+          <OcpOnAwsReportSummaryItems
+            idKey={groupBy as any}
+            report={report}
+            status={reportFetchStatus}
+          >
             {({ items }) =>
               items.map(_item => (
                 <OcpOnAwsReportSummaryItem

--- a/src/pages/ocpOnAwsDetails/detailsWidgetView.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsWidgetView.tsx
@@ -163,6 +163,7 @@ class DetailsWidgetViewBase extends React.Component<DetailsWidgetViewProps> {
                 idKey={groupBy as any}
                 key={`${groupBy}-items`}
                 report={report}
+                status={reportFetchStatus}
               >
                 {({ items }) =>
                   items.map(reportItem => this.getTabItem(reportItem))


### PR DESCRIPTION
This change ensures skeletons are only shown while the fetch status is in progress. If there is an request error (e.g., a 403), the skeletons will no longer be shown.

Fixes https://github.com/project-koku/koku-ui/issues/854