### PR TITLE
fix(onboarding): update ocp and aws providers once on source creation

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -107,16 +107,17 @@ export class App extends React.Component<AppProps, AppState> {
       onboardingStatus,
     } = this.props;
 
+    const wasOnboardingUpdated: boolean =
+      prevProps.onboardingStatus !== onboardingStatus &&
+      onboardingStatus === FetchStatus.complete;
     if (
-      (!awsProviders ||
-        (onboardingStatus === FetchStatus.complete && !onboardingErrors)) &&
+      (!awsProviders || (wasOnboardingUpdated && !onboardingErrors)) &&
       (awsProvidersFetchStatus !== FetchStatus.inProgress && !awsProvidersError)
     ) {
       this.fetchAwsProviders();
     }
     if (
-      (!ocpProviders ||
-        (onboardingStatus === FetchStatus.complete && !onboardingErrors)) &&
+      (!ocpProviders || (wasOnboardingUpdated && !onboardingErrors)) &&
       (ocpProvidersFetchStatus !== FetchStatus.inProgress && !ocpProvidersError)
     ) {
       this.fetchOcpProviders();


### PR DESCRIPTION
fixes #907 
In general, I added another check that makes sure koku-ui won't sent more than 1 request per provider type when onboarding is completed successfully. 
By using prev props I can tell if a new source was added succesfully and in that moment to send a request.