### PR TITLE
Ensure unsupported units don't break translations

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -608,7 +608,7 @@
   },
   "percent": "{{value}}%",
   "percent_of_cost": "{{value}} % of cost",
-  "percent_of_total": "{{value}} {{units}} ({{percent}})%",
+  "percent_of_total": "{{value}} {{units}} ({{percent}}%)",
   "providers": {
     "add_source": "Add sources",
     "bucket_error": "Bucket name cannot contain spaces, special chars and be more than 255 characters",
@@ -692,6 +692,7 @@
     "gb-mo": "GB-month",
     "hours": "hours",
     "hrs": "hours",
+    "tag-mo": "Tag-month",
     "usd": "$USD"
   }
 }

--- a/src/utils/formatValue.ts
+++ b/src/utils/formatValue.ts
@@ -10,7 +10,18 @@ export type ValueFormatter = (
 
 export const unitLookupKey = unit => {
   const lookup = unit ? unit.toLowerCase() : '';
-  return lookup;
+  switch (lookup) {
+    case 'usd':
+    case 'gb':
+    case 'gb-hours':
+    case 'gb-mo':
+    case 'core-hours':
+    case 'hrs':
+    case 'tag-mo':
+      return lookup;
+    default:
+      return '';
+  }
 };
 
 export const formatValue: ValueFormatter = (
@@ -27,6 +38,7 @@ export const formatValue: ValueFormatter = (
     case 'gb':
     case 'gb-hours':
     case 'gb-mo':
+    case 'tag-mo':
       return formatUsageGb(fValue, lookup, options);
     case 'core-hours':
     case 'hrs':


### PR DESCRIPTION
This ensures unsupported units don't break translations. If the given units are not known, we'll just omit it instead of showing something like `units.tag-mo`.

This also places the `%` character inside the parenthesis above the progress bar.

fixes https://github.com/project-koku/koku-ui/issues/909

<img width="345" alt="Screen Shot 2019-06-27 at 11 44 00 AM" src="https://user-images.githubusercontent.com/17481322/60280444-f1459700-98d0-11e9-8afb-9b79cf31ddc5.png">
