### PR TITLE
fix(config): set the right routes to local koku from production

### DIFF
--- a/config/spandx.config.local.js
+++ b/config/spandx.config.local.js
@@ -4,7 +4,19 @@ const localhost =
 const localKoku = 'http://' + localhost + ':8000';
 
 exports.routes = {
-  '/r/insights/platform/cost-management/': {
+  '/api/cost-management/': {
     host: localKoku,
+  },
+  '/apps/cost-management': {
+    host: `http://${localhost}:8002`,
+  },
+  '/beta/apps/cost-management': {
+    host: `http://${localhost}:8002`,
+  },
+  '/hybrid/cost-management': {
+    host: `http://${localhost}:8002`,
+  },
+  '/beta/hybrid/cost-management': {
+    host: `http://${localhost}:8002`,
   },
 };


### PR DESCRIPTION
In order to run the local koku UI and local koku backend with the insights platform you need to set the route `api/cost-management` to the local koku backend and route `{/beta}*/{hybrid/api}/cost-management` to the insight proxy.

This PR updates `config/spandx.config.local.js` with those settings.