### PR TITLE
Ensure bullet chart renders without requests or limit

### DIFF
--- a/src/components/charts/bulletChart/bulletChart.tsx
+++ b/src/components/charts/bulletChart/bulletChart.tsx
@@ -91,7 +91,7 @@ class BulletChart extends React.Component<BulletChartProps, State> {
         ranges[i].color ? ranges[i].color : chartStyles.rangeColorScale[i]
       );
     }
-    if (thresholdError) {
+    if (thresholdError && thresholdError.legend) {
       legendData.push({ name: thresholdError.legend });
       legendColorScale.push(chartStyles.thresholdErrorColor);
     }
@@ -110,7 +110,7 @@ class BulletChart extends React.Component<BulletChartProps, State> {
     const maxValue = Math.max(
       ...sortedRanges.map(val => val.value),
       ...sortedValues.map(val => val.value),
-      thresholdError.value
+      thresholdError.value || 0
     );
 
     const container = (
@@ -132,7 +132,7 @@ class BulletChart extends React.Component<BulletChartProps, State> {
           width={width}
         >
           <ChartGroup horizontal>
-            {Boolean(sortedRanges) &&
+            {Boolean(sortedRanges && sortedRanges.length) &&
               sortedRanges.map((val, index) => {
                 return (
                   <ChartBar
@@ -150,7 +150,7 @@ class BulletChart extends React.Component<BulletChartProps, State> {
                   />
                 );
               })}
-            {Boolean(sortedValues) &&
+            {Boolean(sortedValues && sortedValues.length) &&
               sortedValues.map((val, index) => {
                 return (
                   <ChartBar
@@ -169,7 +169,7 @@ class BulletChart extends React.Component<BulletChartProps, State> {
                 );
               })}
           </ChartGroup>
-          {Boolean(thresholdError) && (
+          {Boolean(thresholdError && thresholdError.value) && (
             <ChartLine
               data={[
                 { x: 0, y: thresholdError.value },

--- a/src/pages/ocpDetails/detailsChart.tsx
+++ b/src/pages/ocpDetails/detailsChart.tsx
@@ -72,57 +72,62 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
       values: [],
     };
     if (report && report.meta && report.meta.total) {
-      const limit = Math.trunc(report.meta.total.limit.value);
-      const limitUnits = t(
-        `units.${unitLookupKey(report.meta.total.limit.units)}`
-      );
-      const request = Math.trunc(report.meta.total.request.value);
-      const requestUnits = t(
-        `units.${unitLookupKey(report.meta.total.request.units)}`
-      );
-      const usage = Math.trunc(report.meta.total.usage.value);
-      const usageUnits = t(
-        `units.${unitLookupKey(report.meta.total.usage.units)}`
-      );
-
-      datum.limit = {
-        legend: t(`ocp_details.bullet.${labelKey}_limit`, {
-          value: limit,
-          units: limitUnits,
-        }),
-        tooltip: t(`ocp_details.bullet.${labelKey}_limit`, {
-          value: limit,
-          units: limitUnits,
-        }),
-        value: Math.trunc(limit),
-      };
-      datum.ranges = [
-        {
-          color: chartStyles.valueColorScale[1], // '#bee1f4'
-          legend: t(`ocp_details.bullet.${labelKey}_requests`, {
-            value: request,
-            units: requestUnits,
+      if (report.meta.total.limit !== null) {
+        const limit = Math.trunc(report.meta.total.limit.value);
+        const limitUnits = t(
+          `units.${unitLookupKey(report.meta.total.limit.units)}`
+        );
+        datum.limit = {
+          legend: t(`ocp_details.bullet.${labelKey}_limit`, {
+            value: limit,
+            units: limitUnits,
           }),
-          tooltip: t(`ocp_details.bullet.${labelKey}_requests`, {
-            value: request,
-            units: requestUnits,
+          tooltip: t(`ocp_details.bullet.${labelKey}_limit`, {
+            value: limit,
+            units: limitUnits,
           }),
-          value: Math.trunc(request),
-        },
-      ];
-      datum.values = [
-        {
-          legend: t(`ocp_details.bullet.${labelKey}_usage`, {
-            value: usage,
-            units: usageUnits,
-          }),
-          tooltip: t(`ocp_details.bullet.${labelKey}_usage`, {
-            value: usage,
-            units: usageUnits,
-          }),
-          value: Math.trunc(usage),
-        },
-      ];
+          value: Math.trunc(limit),
+        };
+      }
+      if (report.meta.total.request !== null) {
+        const request = Math.trunc(report.meta.total.request.value);
+        const requestUnits = t(
+          `units.${unitLookupKey(report.meta.total.request.units)}`
+        );
+        datum.ranges = [
+          {
+            color: chartStyles.valueColorScale[1], // '#bee1f4'
+            legend: t(`ocp_details.bullet.${labelKey}_requests`, {
+              value: request,
+              units: requestUnits,
+            }),
+            tooltip: t(`ocp_details.bullet.${labelKey}_requests`, {
+              value: request,
+              units: requestUnits,
+            }),
+            value: Math.trunc(request),
+          },
+        ];
+      }
+      if (report.meta.total.usage !== null) {
+        const usage = Math.trunc(report.meta.total.usage.value);
+        const usageUnits = t(
+          `units.${unitLookupKey(report.meta.total.usage.units)}`
+        );
+        datum.values = [
+          {
+            legend: t(`ocp_details.bullet.${labelKey}_usage`, {
+              value: usage,
+              units: usageUnits,
+            }),
+            tooltip: t(`ocp_details.bullet.${labelKey}_usage`, {
+              value: usage,
+              units: usageUnits,
+            }),
+            value: Math.trunc(usage),
+          },
+        ];
+      }
     }
     return datum;
   }

--- a/src/pages/ocpOnAwsDetails/detailsChart.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsChart.tsx
@@ -75,57 +75,62 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
       values: [],
     };
     if (report && report.meta && report.meta.total) {
-      const limit = Math.trunc(report.meta.total.limit.value);
-      const limitUnits = t(
-        `units.${unitLookupKey(report.meta.total.limit.units)}`
-      );
-      const request = Math.trunc(report.meta.total.request.value);
-      const requestUnits = t(
-        `units.${unitLookupKey(report.meta.total.request.units)}`
-      );
-      const usage = Math.trunc(report.meta.total.usage.value);
-      const usageUnits = t(
-        `units.${unitLookupKey(report.meta.total.usage.units)}`
-      );
-
-      datum.limit = {
-        legend: t(`ocp_details.bullet.${labelKey}_limit`, {
-          value: limit,
-          units: limitUnits,
-        }),
-        tooltip: t(`ocp_details.bullet.${labelKey}_limit`, {
-          value: limit,
-          units: limitUnits,
-        }),
-        value: Math.trunc(limit),
-      };
-      datum.ranges = [
-        {
-          color: chartStyles.valueColorScale[1], // '#bee1f4'
-          legend: t(`ocp_details.bullet.${labelKey}_requests`, {
-            value: request,
-            units: requestUnits,
+      if (report.meta.total.limit !== null) {
+        const limit = Math.trunc(report.meta.total.limit.value);
+        const limitUnits = t(
+          `units.${unitLookupKey(report.meta.total.limit.units)}`
+        );
+        datum.limit = {
+          legend: t(`ocp_details.bullet.${labelKey}_limit`, {
+            value: limit,
+            units: limitUnits,
           }),
-          tooltip: t(`ocp_details.bullet.${labelKey}_requests`, {
-            value: request,
-            units: requestUnits,
+          tooltip: t(`ocp_details.bullet.${labelKey}_limit`, {
+            value: limit,
+            units: limitUnits,
           }),
-          value: Math.trunc(request),
-        },
-      ];
-      datum.values = [
-        {
-          legend: t(`ocp_details.bullet.${labelKey}_usage`, {
-            value: usage,
-            units: usageUnits,
-          }),
-          tooltip: t(`ocp_details.bullet.${labelKey}_usage`, {
-            value: usage,
-            units: usageUnits,
-          }),
-          value: Math.trunc(usage),
-        },
-      ];
+          value: Math.trunc(limit),
+        };
+      }
+      if (report.meta.total.request !== null) {
+        const request = Math.trunc(report.meta.total.request.value);
+        const requestUnits = t(
+          `units.${unitLookupKey(report.meta.total.request.units)}`
+        );
+        datum.ranges = [
+          {
+            color: chartStyles.valueColorScale[1], // '#bee1f4'
+            legend: t(`ocp_details.bullet.${labelKey}_requests`, {
+              value: request,
+              units: requestUnits,
+            }),
+            tooltip: t(`ocp_details.bullet.${labelKey}_requests`, {
+              value: request,
+              units: requestUnits,
+            }),
+            value: Math.trunc(request),
+          },
+        ];
+      }
+      if (report.meta.total.usage !== null) {
+        const usage = Math.trunc(report.meta.total.usage.value);
+        const usageUnits = t(
+          `units.${unitLookupKey(report.meta.total.usage.units)}`
+        );
+        datum.values = [
+          {
+            legend: t(`ocp_details.bullet.${labelKey}_usage`, {
+              value: usage,
+              units: usageUnits,
+            }),
+            tooltip: t(`ocp_details.bullet.${labelKey}_usage`, {
+              value: usage,
+              units: usageUnits,
+            }),
+            value: Math.trunc(usage),
+          },
+        ];
+      }
     }
     return datum;
   }


### PR DESCRIPTION
The reports/openshift/compute API currently returns null for limit and request. This is a known issue with koku (https://github.com/project-koku/koku/issues/927), but we can still ensure that the bullet chart renders without these values.

Fixes https://github.com/project-koku/koku-ui/issues/915

Without requests or limit:
<img width="964" alt="Screen Shot 2019-07-14 at 11 06 17 PM" src="https://user-images.githubusercontent.com/17481322/61194019-e179d100-a68c-11e9-99ab-a1c05c90e3e0.png">

Without limit:
<img width="1278" alt="Screen Shot 2019-07-14 at 11 06 53 PM" src="https://user-images.githubusercontent.com/17481322/61194027-f3f40a80-a68c-11e9-96ee-1ff0296076cb.png">
