### PR TITLE
fixed issue #928 pf4 chart colors

### DIFF
--- a/src/components/charts/bulletChart/bulletChart.styles.ts
+++ b/src/components/charts/bulletChart/bulletChart.styles.ts
@@ -1,8 +1,5 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
-  global_danger_color_100,
-  global_spacer_md,
-  global_spacer_sm,
   chart_color_black_100,
   chart_color_black_200,
   chart_color_black_300,
@@ -12,7 +9,10 @@ import {
   chart_color_blue_200,
   chart_color_blue_300,
   chart_color_blue_400,
-  chart_color_blue_500
+  chart_color_blue_500,
+  global_danger_color_100,
+  global_spacer_md,
+  global_spacer_sm,
 } from '@patternfly/react-tokens';
 
 export const chartStyles = {
@@ -21,34 +21,22 @@ export const chartStyles = {
   legendHeight: 30,
   // See: https://github.com/project-koku/koku-ui/issues/241
   rangeColorScale: [
-    // '#ededed',
-    // '#d1d1d1',
-    // '#bbb',
-    // '#72767b',
-    // '#72767b',
-    // '#282d33',
     chart_color_black_100.value,
     chart_color_black_200.value,
     chart_color_black_300.value,
     chart_color_black_400.value,
-    chart_color_black_500.value
+    chart_color_black_500.value,
   ],
   rangeWidth: 40,
   thresholdErrorColor: global_danger_color_100.value,
   thresholdErrorWidth: 2,
   // See: https://github.com/project-koku/koku-ui/issues/241
   valueColorScale: [
-    // '#007BBA',
-    // '#bee1f4',
-    // '#7DC3E8',
-    // '#39A5DC',
-    // '#00659C',
-    // '#004D76',
     chart_color_blue_100.value,
     chart_color_blue_200.value,
     chart_color_blue_300.value,
     chart_color_blue_400.value,
-    chart_color_blue_500.value
+    chart_color_blue_500.value,
   ],
   valueWidth: 9,
 };

--- a/src/components/charts/bulletChart/bulletChart.styles.ts
+++ b/src/components/charts/bulletChart/bulletChart.styles.ts
@@ -3,6 +3,16 @@ import {
   global_danger_color_100,
   global_spacer_md,
   global_spacer_sm,
+  chart_color_black_100,
+  chart_color_black_200,
+  chart_color_black_300,
+  chart_color_black_400,
+  chart_color_black_500,
+  chart_color_blue_100,
+  chart_color_blue_200,
+  chart_color_blue_300,
+  chart_color_blue_400,
+  chart_color_blue_500
 } from '@patternfly/react-tokens';
 
 export const chartStyles = {
@@ -11,24 +21,34 @@ export const chartStyles = {
   legendHeight: 30,
   // See: https://github.com/project-koku/koku-ui/issues/241
   rangeColorScale: [
-    '#ededed',
-    '#d1d1d1',
-    '#bbb',
-    '#72767b',
-    '#72767b',
-    '#282d33',
+    // '#ededed',
+    // '#d1d1d1',
+    // '#bbb',
+    // '#72767b',
+    // '#72767b',
+    // '#282d33',
+    chart_color_black_100.value,
+    chart_color_black_200.value,
+    chart_color_black_300.value,
+    chart_color_black_400.value,
+    chart_color_black_500.value
   ],
   rangeWidth: 40,
   thresholdErrorColor: global_danger_color_100.value,
   thresholdErrorWidth: 2,
   // See: https://github.com/project-koku/koku-ui/issues/241
   valueColorScale: [
-    '#007BBA',
-    '#bee1f4',
-    '#7DC3E8',
-    '#39A5DC',
-    '#00659C',
-    '#004D76',
+    // '#007BBA',
+    // '#bee1f4',
+    // '#7DC3E8',
+    // '#39A5DC',
+    // '#00659C',
+    // '#004D76',
+    chart_color_blue_100.value,
+    chart_color_blue_200.value,
+    chart_color_blue_300.value,
+    chart_color_blue_400.value,
+    chart_color_blue_500.value
   ],
   valueWidth: 9,
 };

--- a/src/components/charts/costChart/costChart.styles.ts
+++ b/src/components/charts/costChart/costChart.styles.ts
@@ -1,16 +1,16 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
+  chart_color_green_100,
+  chart_color_green_200,
+  chart_color_green_300,
+  chart_color_green_400,
+  chart_color_green_500,
   global_disabled_color_100,
   global_disabled_color_200,
   global_FontFamily_sans_serif,
   global_FontSize_md,
   global_spacer_lg,
   global_spacer_sm,
-  chart_color_green_100,
-  chart_color_green_200,
-  chart_color_green_300,
-  chart_color_green_400,
-  chart_color_green_500
 } from '@patternfly/react-tokens';
 
 export const chartStyles = {
@@ -49,16 +49,11 @@ export const chartStyles = {
   },
   // See: https://github.com/project-koku/koku-ui/issues/241
   currentColorScale: [
-    // '#A2DA9C',
-    // '#88D080',
-    // '#6EC664',
-    // '#519149',
-    // '#3C6C37'
     chart_color_green_100.value,
     chart_color_green_200.value,
     chart_color_green_300.value,
     chart_color_green_400.value,
-    chart_color_green_500.value
+    chart_color_green_500.value,
   ],
   // TBD: No grey scale, yet
   previousColorScale: [

--- a/src/components/charts/costChart/costChart.styles.ts
+++ b/src/components/charts/costChart/costChart.styles.ts
@@ -6,6 +6,11 @@ import {
   global_FontSize_md,
   global_spacer_lg,
   global_spacer_sm,
+  chart_color_green_100,
+  chart_color_green_200,
+  chart_color_green_300,
+  chart_color_green_400,
+  chart_color_green_500
 } from '@patternfly/react-tokens';
 
 export const chartStyles = {
@@ -43,7 +48,18 @@ export const chartStyles = {
     },
   },
   // See: https://github.com/project-koku/koku-ui/issues/241
-  currentColorScale: ['#A2DA9C', '#88D080', '#6EC664', '#519149', '#3C6C37'],
+  currentColorScale: [
+    // '#A2DA9C',
+    // '#88D080',
+    // '#6EC664',
+    // '#519149',
+    // '#3C6C37'
+    chart_color_green_100.value,
+    chart_color_green_200.value,
+    chart_color_green_300.value,
+    chart_color_green_400.value,
+    chart_color_green_500.value
+  ],
   // TBD: No grey scale, yet
   previousColorScale: [
     global_disabled_color_200.value,

--- a/src/components/charts/historicalCostChart/historicalCostChart.styles.ts
+++ b/src/components/charts/historicalCostChart/historicalCostChart.styles.ts
@@ -4,6 +4,16 @@ import {
   global_spacer_2xl,
   global_spacer_lg,
   global_spacer_sm,
+  chart_color_green_100,
+  chart_color_green_200,
+  chart_color_green_300,
+  chart_color_green_400,
+  chart_color_green_500,
+  chart_color_blue_100,
+  chart_color_blue_200,
+  chart_color_blue_300,
+  chart_color_blue_400,
+  chart_color_blue_500
 } from '@patternfly/react-tokens';
 
 export const chartStyles = {
@@ -14,7 +24,18 @@ export const chartStyles = {
     },
   },
   // See: https://github.com/project-koku/koku-ui/issues/241
-  currentColorScale: ['#A2DA9C', '#88D080', '#6EC664', '#519149', '#3C6C37'],
+  currentColorScale: [
+    // '#A2DA9C',
+    // '#88D080',
+    // '#6EC664',
+    // '#519149',
+    // '#3C6C37'
+    chart_color_green_100.value,
+    chart_color_green_200.value,
+    chart_color_green_300.value,
+    chart_color_green_400.value,
+    chart_color_green_500.value
+  ],
   currentInfrastructureCostData: {
     data: {
       fill: 'none',
@@ -42,7 +63,18 @@ export const chartStyles = {
     },
   },
   // See: https://github.com/project-koku/koku-ui/issues/241
-  previousColorScale: ['#7DC3E8', '#39A5DC', '#007BBA', '#00659C', '#004D76'],
+  previousColorScale: [
+    // '#7DC3E8',
+    // '#39A5DC',
+    // '#007BBA',
+    // '#00659C',
+    // '#004D76'
+    chart_color_blue_100.value,
+    chart_color_blue_200.value,
+    chart_color_blue_300.value,
+    chart_color_blue_400.value,
+    chart_color_blue_500.value
+  ],
   previousInfrastructureCostData: {
     data: {
       fill: 'none',

--- a/src/components/charts/historicalCostChart/historicalCostChart.styles.ts
+++ b/src/components/charts/historicalCostChart/historicalCostChart.styles.ts
@@ -1,19 +1,19 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
-  global_FontFamily_sans_serif,
-  global_spacer_2xl,
-  global_spacer_lg,
-  global_spacer_sm,
+  chart_color_blue_100,
+  chart_color_blue_200,
+  chart_color_blue_300,
+  chart_color_blue_400,
+  chart_color_blue_500,
   chart_color_green_100,
   chart_color_green_200,
   chart_color_green_300,
   chart_color_green_400,
   chart_color_green_500,
-  chart_color_blue_100,
-  chart_color_blue_200,
-  chart_color_blue_300,
-  chart_color_blue_400,
-  chart_color_blue_500
+  global_FontFamily_sans_serif,
+  global_spacer_2xl,
+  global_spacer_lg,
+  global_spacer_sm,
 } from '@patternfly/react-tokens';
 
 export const chartStyles = {
@@ -25,16 +25,11 @@ export const chartStyles = {
   },
   // See: https://github.com/project-koku/koku-ui/issues/241
   currentColorScale: [
-    // '#A2DA9C',
-    // '#88D080',
-    // '#6EC664',
-    // '#519149',
-    // '#3C6C37'
     chart_color_green_100.value,
     chart_color_green_200.value,
     chart_color_green_300.value,
     chart_color_green_400.value,
-    chart_color_green_500.value
+    chart_color_green_500.value,
   ],
   currentInfrastructureCostData: {
     data: {
@@ -64,16 +59,11 @@ export const chartStyles = {
   },
   // See: https://github.com/project-koku/koku-ui/issues/241
   previousColorScale: [
-    // '#7DC3E8',
-    // '#39A5DC',
-    // '#007BBA',
-    // '#00659C',
-    // '#004D76'
     chart_color_blue_100.value,
     chart_color_blue_200.value,
     chart_color_blue_300.value,
     chart_color_blue_400.value,
-    chart_color_blue_500.value
+    chart_color_blue_500.value,
   ],
   previousInfrastructureCostData: {
     data: {

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.styles.ts
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.styles.ts
@@ -1,30 +1,25 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
+  chart_color_green_100,
+  chart_color_green_200,
+  chart_color_green_300,
+  chart_color_green_400,
+  chart_color_green_500,
   global_disabled_color_200,
   global_FontFamily_sans_serif,
   global_spacer_2xl,
   global_spacer_lg,
   global_spacer_sm,
-  chart_color_green_100,
-  chart_color_green_200,
-  chart_color_green_300,
-  chart_color_green_400,
-  chart_color_green_500
 } from '@patternfly/react-tokens';
 
 export const chartStyles = {
   // See: https://github.com/project-koku/koku-ui/issues/241
   colorScale: [
-    // '#A2DA9C',
-    // '#88D080',
-    // '#6EC664',
-    // '#519149',
-    // '#3C6C37'
     chart_color_green_100.value,
     chart_color_green_200.value,
     chart_color_green_300.value,
     chart_color_green_400.value,
-    chart_color_green_500.value
+    chart_color_green_500.value,
   ],
   currentMonth: {
     data: {

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.styles.ts
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.styles.ts
@@ -5,17 +5,26 @@ import {
   global_spacer_2xl,
   global_spacer_lg,
   global_spacer_sm,
+  chart_color_green_100,
+  chart_color_green_200,
+  chart_color_green_300,
+  chart_color_green_400,
+  chart_color_green_500
 } from '@patternfly/react-tokens';
 
 export const chartStyles = {
   // See: https://github.com/project-koku/koku-ui/issues/241
   colorScale: [
-    global_disabled_color_200.value,
-    '#A2DA9C',
-    '#88D080',
-    '#6EC664',
-    '#519149',
-    '#3C6C37',
+    // '#A2DA9C',
+    // '#88D080',
+    // '#6EC664',
+    // '#519149',
+    // '#3C6C37'
+    chart_color_green_100.value,
+    chart_color_green_200.value,
+    chart_color_green_300.value,
+    chart_color_green_400.value,
+    chart_color_green_500.value
   ],
   currentMonth: {
     data: {

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.styles.ts
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.styles.ts
@@ -1,19 +1,19 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
-  global_FontFamily_sans_serif,
-  global_spacer_2xl,
-  global_spacer_lg,
-  global_spacer_sm,
+  chart_color_blue_100,
+  chart_color_blue_200,
+  chart_color_blue_300,
+  chart_color_blue_400,
+  chart_color_blue_500,
   chart_color_green_100,
   chart_color_green_200,
   chart_color_green_300,
   chart_color_green_400,
   chart_color_green_500,
-  chart_color_blue_100,
-  chart_color_blue_200,
-  chart_color_blue_300,
-  chart_color_blue_400,
-  chart_color_blue_500
+  global_FontFamily_sans_serif,
+  global_spacer_2xl,
+  global_spacer_lg,
+  global_spacer_sm,
 } from '@patternfly/react-tokens';
 
 export const chartStyles = {
@@ -25,16 +25,11 @@ export const chartStyles = {
   },
   // See: https://github.com/project-koku/koku-ui/issues/241
   currentColorScale: [
-    // '#A2DA9C',
-    // '#88D080',
-    // '#6EC664',
-    // '#519149',
-    // '#3C6C37'
     chart_color_green_100.value,
     chart_color_green_200.value,
     chart_color_green_300.value,
     chart_color_green_400.value,
-    chart_color_green_500.value
+    chart_color_green_500.value,
   ],
   currentLimitData: {
     data: {
@@ -70,16 +65,11 @@ export const chartStyles = {
   },
   // See: https://github.com/project-koku/koku-ui/issues/241
   previousColorScale: [
-    // '#7DC3E8',
-    // '#39A5DC',
-    // '#007BBA',
-    // '#00659C',
-    // '#004D76'
     chart_color_blue_100.value,
     chart_color_blue_200.value,
     chart_color_blue_300.value,
     chart_color_blue_400.value,
-    chart_color_blue_500.value
+    chart_color_blue_500.value,
   ],
   previousLimitData: {
     data: {

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.styles.ts
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.styles.ts
@@ -4,6 +4,16 @@ import {
   global_spacer_2xl,
   global_spacer_lg,
   global_spacer_sm,
+  chart_color_green_100,
+  chart_color_green_200,
+  chart_color_green_300,
+  chart_color_green_400,
+  chart_color_green_500,
+  chart_color_blue_100,
+  chart_color_blue_200,
+  chart_color_blue_300,
+  chart_color_blue_400,
+  chart_color_blue_500
 } from '@patternfly/react-tokens';
 
 export const chartStyles = {
@@ -14,7 +24,18 @@ export const chartStyles = {
     },
   },
   // See: https://github.com/project-koku/koku-ui/issues/241
-  currentColorScale: ['#A2DA9C', '#88D080', '#6EC664', '#519149', '#3C6C37'],
+  currentColorScale: [
+    // '#A2DA9C',
+    // '#88D080',
+    // '#6EC664',
+    // '#519149',
+    // '#3C6C37'
+    chart_color_green_100.value,
+    chart_color_green_200.value,
+    chart_color_green_300.value,
+    chart_color_green_400.value,
+    chart_color_green_500.value
+  ],
   currentLimitData: {
     data: {
       fill: 'none',
@@ -48,7 +69,18 @@ export const chartStyles = {
     },
   },
   // See: https://github.com/project-koku/koku-ui/issues/241
-  previousColorScale: ['#7DC3E8', '#39A5DC', '#007BBA', '#00659C', '#004D76'],
+  previousColorScale: [
+    // '#7DC3E8',
+    // '#39A5DC',
+    // '#007BBA',
+    // '#00659C',
+    // '#004D76'
+    chart_color_blue_100.value,
+    chart_color_blue_200.value,
+    chart_color_blue_300.value,
+    chart_color_blue_400.value,
+    chart_color_blue_500.value
+  ],
   previousLimitData: {
     data: {
       fill: 'none',

--- a/src/components/charts/pieChart/pieChart.styles.ts
+++ b/src/components/charts/pieChart/pieChart.styles.ts
@@ -1,26 +1,21 @@
 import { StyleSheet } from '@patternfly/react-styles';
-import { theme } from 'styles/theme';
 import {
   chart_color_blue_100,
   chart_color_blue_200,
   chart_color_blue_300,
   chart_color_blue_400,
-  chart_color_blue_500
+  chart_color_blue_500,
 } from '@patternfly/react-tokens';
+import { theme } from 'styles/theme';
 
 export const chartStyles = {
   // See: https://github.com/project-koku/koku-ui/issues/241
   colorScale: [
-    // '#7DC3E8',
-    // '#39A5DC',
-    // '#007BBA',
-    // '#00659C',
-    // '#004D76'
     chart_color_blue_100.value,
     chart_color_blue_200.value,
     chart_color_blue_300.value,
     chart_color_blue_400.value,
-    chart_color_blue_500.value
+    chart_color_blue_500.value,
   ],
 };
 

--- a/src/components/charts/pieChart/pieChart.styles.ts
+++ b/src/components/charts/pieChart/pieChart.styles.ts
@@ -1,9 +1,27 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import { theme } from 'styles/theme';
+import {
+  chart_color_blue_100,
+  chart_color_blue_200,
+  chart_color_blue_300,
+  chart_color_blue_400,
+  chart_color_blue_500
+} from '@patternfly/react-tokens';
 
 export const chartStyles = {
   // See: https://github.com/project-koku/koku-ui/issues/241
-  colorScale: ['#7DC3E8', '#39A5DC', '#007BBA', '#00659C', '#004D76'],
+  colorScale: [
+    // '#7DC3E8',
+    // '#39A5DC',
+    // '#007BBA',
+    // '#00659C',
+    // '#004D76'
+    chart_color_blue_100.value,
+    chart_color_blue_200.value,
+    chart_color_blue_300.value,
+    chart_color_blue_400.value,
+    chart_color_blue_500.value
+  ],
 };
 
 export const styles = StyleSheet.create({

--- a/src/components/charts/trendChart/trendChart.styles.ts
+++ b/src/components/charts/trendChart/trendChart.styles.ts
@@ -1,31 +1,26 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
+  chart_color_green_100,
+  chart_color_green_200,
+  chart_color_green_300,
+  chart_color_green_400,
+  chart_color_green_500,
   global_disabled_color_200,
   global_FontFamily_sans_serif,
   global_FontSize_md,
   global_spacer_lg,
   global_spacer_sm,
-  chart_color_green_100,
-  chart_color_green_200,
-  chart_color_green_300,
-  chart_color_green_400,
-  chart_color_green_500
 } from '@patternfly/react-tokens';
 
 export const chartStyles = {
   // See: https://github.com/project-koku/koku-ui/issues/241
   colorScale: [
     global_disabled_color_200.value,
-    // '#A2DA9C',
-    // '#88D080',
-    // '#6EC664',
-    // '#519149',
-    // '#3C6C37',
     chart_color_green_100.value,
     chart_color_green_200.value,
     chart_color_green_300.value,
     chart_color_green_400.value,
-    chart_color_green_500.value
+    chart_color_green_500.value,
   ],
   legend: {
     labels: {

--- a/src/components/charts/trendChart/trendChart.styles.ts
+++ b/src/components/charts/trendChart/trendChart.styles.ts
@@ -5,17 +5,27 @@ import {
   global_FontSize_md,
   global_spacer_lg,
   global_spacer_sm,
+  chart_color_green_100,
+  chart_color_green_200,
+  chart_color_green_300,
+  chart_color_green_400,
+  chart_color_green_500
 } from '@patternfly/react-tokens';
 
 export const chartStyles = {
   // See: https://github.com/project-koku/koku-ui/issues/241
   colorScale: [
     global_disabled_color_200.value,
-    '#A2DA9C',
-    '#88D080',
-    '#6EC664',
-    '#519149',
-    '#3C6C37',
+    // '#A2DA9C',
+    // '#88D080',
+    // '#6EC664',
+    // '#519149',
+    // '#3C6C37',
+    chart_color_green_100.value,
+    chart_color_green_200.value,
+    chart_color_green_300.value,
+    chart_color_green_400.value,
+    chart_color_green_500.value
   ],
   legend: {
     labels: {

--- a/src/components/charts/usageChart/usageChart.styles.ts
+++ b/src/components/charts/usageChart/usageChart.styles.ts
@@ -6,6 +6,11 @@ import {
   global_FontSize_md,
   global_spacer_lg,
   global_spacer_sm,
+  chart_color_green_100,
+  chart_color_green_200,
+  chart_color_green_300,
+  chart_color_green_400,
+  chart_color_green_500
 } from '@patternfly/react-tokens';
 
 export const chartStyles = {
@@ -43,7 +48,18 @@ export const chartStyles = {
     },
   },
   // See: https://github.com/project-koku/koku-ui/issues/241
-  currentColorScale: ['#A2DA9C', '#88D080', '#6EC664', '#519149', '#3C6C37'],
+  currentColorScale: [
+    // '#A2DA9C',
+    // '#88D080',
+    // '#6EC664',
+    // '#519149',
+    // '#3C6C37',
+    chart_color_green_100.value,
+    chart_color_green_200.value,
+    chart_color_green_300.value,
+    chart_color_green_400.value,
+    chart_color_green_500.value
+  ],
   // TBD: No grey scale, yet
   previousColorScale: [
     global_disabled_color_200.value,

--- a/src/components/charts/usageChart/usageChart.styles.ts
+++ b/src/components/charts/usageChart/usageChart.styles.ts
@@ -1,16 +1,16 @@
 import { StyleSheet } from '@patternfly/react-styles';
 import {
+  chart_color_green_100,
+  chart_color_green_200,
+  chart_color_green_300,
+  chart_color_green_400,
+  chart_color_green_500,
   global_disabled_color_100,
   global_disabled_color_200,
   global_FontFamily_sans_serif,
   global_FontSize_md,
   global_spacer_lg,
   global_spacer_sm,
-  chart_color_green_100,
-  chart_color_green_200,
-  chart_color_green_300,
-  chart_color_green_400,
-  chart_color_green_500
 } from '@patternfly/react-tokens';
 
 export const chartStyles = {
@@ -49,16 +49,11 @@ export const chartStyles = {
   },
   // See: https://github.com/project-koku/koku-ui/issues/241
   currentColorScale: [
-    // '#A2DA9C',
-    // '#88D080',
-    // '#6EC664',
-    // '#519149',
-    // '#3C6C37',
     chart_color_green_100.value,
     chart_color_green_200.value,
     chart_color_green_300.value,
     chart_color_green_400.value,
-    chart_color_green_500.value
+    chart_color_green_500.value,
   ],
   // TBD: No grey scale, yet
   previousColorScale: [


### PR DESCRIPTION
included commented out custom colors to show change to default imported pf4 core chart colors for bullet, cost, historical cost, historical trend, historical usage, pie, trend, and usage charts