### PR TITLE
Replace PF3 toolbar with PF4 components

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "i18next-xhr-backend": "^1.5.1",
     "js-file-download": "^0.4.4",
     "mini-css-extract-plugin": "^0.4.5",
-    "patternfly-react": "^2.29.1",
     "qs": "^6.5.2",
     "react-bootstrap": "^0.32.4",
     "react-dom": "^16.6.3",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -47,6 +47,7 @@
     "filter": {
       "account_placeholder": "Filter by account",
       "account_select": "Account",
+      "name": "Name",
       "region_placeholder": "Filter by region",
       "region_select": "Region",
       "service_placeholder": "Filter by service",
@@ -76,9 +77,12 @@
     "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s related tags",
     "title": "Cloud details",
     "toolbar": {
-      "active_filters": "Active filters:",
+      "active_filters": "Active filters",
       "clear_filters": "Clear all filters",
       "export": "Export",
+      "filter_aria_label": "Filter section",
+      "filter_results_aria_label": "Filter results section",
+      "filter_type_aria_label": "Select filter type",
       "results": "{{value}} Results"
     },
     "total_cost": "Total cost",
@@ -402,6 +406,7 @@
     "filter": {
       "cluster_placeholder": "Filter by cluster",
       "cluster_select": "Cluster",
+      "name": "Name",
       "node_placeholder": "Filter by node",
       "node_select": "Node",
       "project_placeholder": "Filter by project",
@@ -457,9 +462,12 @@
     "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s related tags",
     "title": "OpenShift details",
     "toolbar": {
-      "active_filters": "Active filters:",
+      "active_filters": "Active filters",
       "clear_filters": "Clear all filters",
       "export": "Export",
+      "filter_aria_label": "Filter section",
+      "filter_results_aria_label": "Filter results section",
+      "filter_type_aria_label": "Select filter type",
       "results": "{{value}} Results"
     },
     "total_cost": "Cost",
@@ -528,6 +536,7 @@
     "filter": {
       "cluster_placeholder": "Filter by cluster",
       "cluster_select": "Cluster",
+      "name": "Name",
       "node_placeholder": "Filter by node",
       "node_select": "Node",
       "project_placeholder": "Filter by project",
@@ -564,9 +573,12 @@
     "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s related tags",
     "title": "OpenShift on cloud details",
     "toolbar": {
-      "active_filters": "Active filters:",
+      "active_filters": "Active filters",
       "clear_filters": "Clear all filters",
       "export": "Export",
+      "filter_aria_label": "Filter section",
+      "filter_results_aria_label": "Filter results section",
+      "filter_type_aria_label": "Select filter type",
       "results": "{{value}} Results"
     },
     "total_cost": "Total cost",

--- a/src/pages/awsDetails/awsDetails.styles.ts
+++ b/src/pages/awsDetails/awsDetails.styles.ts
@@ -2,20 +2,9 @@ import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_300,
   global_BackgroundColor_light_100,
-  global_BorderRadius_sm,
-  global_Color_100,
-  global_Color_200,
-  global_FontSize_lg,
-  global_FontSize_md,
-  global_FontSize_sm,
-  global_FontSize_xs,
-  global_FontWeight_normal,
-  global_LineHeight_md,
   global_spacer_md,
-  global_spacer_sm,
   global_spacer_xl,
 } from '@patternfly/react-tokens';
-import { css } from 'emotion';
 
 export const styles = StyleSheet.create({
   awsDetails: {
@@ -41,111 +30,4 @@ export const styles = StyleSheet.create({
     marginLeft: global_spacer_xl.value,
     marginRight: global_spacer_xl.value,
   },
-  toolbarContainer: {
-    backgroundColor: global_BackgroundColor_300.value,
-  },
 });
-
-export const toolbarOverride = css`
-  margin-left: ${global_spacer_xl.value};
-  margin-right: ${global_spacer_xl.value};
-
-  .pf-c-button {
-    border-radius: 0;
-    padding-left: 0;
-    padding-right: 0;
-    display: inline-flex;
-    align-items: center;
-  }
-
-  .fa-download {
-    color: ${global_Color_100.value};
-    margin-right: ${global_spacer_sm.value};
-    font-size: 1.125rem;
-  }
-
-  .toolbar-pf-actions {
-    display: flex;
-    padding-top: ${global_spacer_sm.value};
-    padding-bottom: ${global_spacer_sm.value};
-  }
-
-  .form-group {
-    border: none;
-  }
-
-  .btn {
-    line-height: 28px;
-  }
-
-  .btn-link {
-    color: ${global_Color_200.value};
-    margin-left: ${global_spacer_sm.value};
-  }
-
-  .btn-link .fa {
-    font-size: ${global_FontSize_lg.value};
-  }
-
-  .pf-m-plain {
-    padding: 0;
-    display: flex;
-    align-items: center;
-  }
-
-  .dropdown .btn {
-    border-radius: ${global_BorderRadius_sm.value};
-    background: transparent;
-    box-shadow: none;
-    border-color: #c7c7c7;
-    font-size: ${global_FontSize_md.value};
-    font-weight: 500;
-    padding-left: ${global_spacer_sm.value};
-    padding-right: ${global_spacer_sm.value};
-  }
-
-  input[type='text'] {
-    border-color: #c7c7c7;
-    border-radius: ${global_BorderRadius_sm.value};
-  }
-
-  /* filter results */
-
-  .toolbar-pf-results {
-    font-size: ${global_FontSize_sm.value};
-    padding: ${global_spacer_sm.value} 0;
-    line-heght: ${global_LineHeight_md.value};
-    font-weight: ${global_FontWeight_normal.value};
-
-    .col-sm-12 {
-      display: flex;
-      align-items: center;
-    }
-
-    h5 {
-      font-size: ${global_FontSize_sm.value};
-      font-weight: ${global_FontWeight_normal.value};
-      line-height: ${global_LineHeight_md.value};
-    }
-
-    .filter-pf-active-label {
-      line-height: ${global_LineHeight_md.value};
-    }
-
-    .list-inline {
-      line-height: ${global_LineHeight_md.value};
-    }
-
-    .label {
-      font-size: ${global_FontSize_xs.value};
-      border-radius: ${global_BorderRadius_sm.value};
-      display: inline-flex;
-      align-items: center;
-    }
-
-    .pf-remove-button {
-      display: inline-flex;
-      font-weight: ${global_FontWeight_normal.value};
-    }
-  }
-`;

--- a/src/pages/awsDetails/awsDetails.tsx
+++ b/src/pages/awsDetails/awsDetails.tsx
@@ -20,7 +20,7 @@ import {
   getIdKeyForGroupBy,
   getUnsortedComputedAwsReportItems,
 } from 'utils/getComputedAwsReportItems';
-import { styles, toolbarOverride } from './awsDetails.styles';
+import { styles } from './awsDetails.styles';
 import { DetailsHeader } from './detailsHeader';
 import { DetailsTable } from './detailsTable';
 import { DetailsToolbar } from './detailsToolbar';
@@ -140,6 +140,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
       return [
         {
           id: 'account',
+          label: t('aws_details.filter.name'),
           title: t('aws_details.filter.account_select'),
           placeholder: t('aws_details.filter.account_placeholder'),
           filterType: 'text',
@@ -149,6 +150,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
       return [
         {
           id: 'service',
+          label: t('aws_details.filter.name'),
           title: t('aws_details.filter.service_select'),
           placeholder: t('aws_details.filter.service_placeholder'),
           filterType: 'text',
@@ -158,6 +160,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
       return [
         {
           id: 'region',
+          label: t('aws_details.filter.name'),
           title: t('aws_details.filter.region_select'),
           placeholder: t('aws_details.filter.region_placeholder'),
           filterType: 'text',
@@ -168,6 +171,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
       return [
         {
           id: 'tag',
+          label: t('aws_details.filter.name'),
           title: t('aws_details.filter.tag_select'),
           placeholder: t('aws_details.filter.tag_placeholder'),
           filterType: 'text',
@@ -246,7 +250,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     );
   };
 
-  private getToolbar = (computedItems: ComputedAwsReportItem[]) => {
+  private getToolbar = () => {
     const { selectedItems } = this.state;
     const { query, report, t } = this.props;
 
@@ -265,7 +269,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
         pagination={this.getPagination()}
         query={query}
         report={report}
-        resultsTotal={computedItems.length}
+        resultsTotal={report ? report.meta.count : 0}
       />
     );
   };
@@ -436,12 +440,8 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
           <LoadingState />
         ) : (
           <div className={css(styles.content)}>
-            <div className={css(styles.toolbarContainer)}>
-              <div className={toolbarOverride}>
-                {this.getToolbar(computedItems)}
-                {this.getExportModal(computedItems)}
-              </div>
-            </div>
+            {this.getToolbar()}
+            {this.getExportModal(computedItems)}
             <div className={css(styles.tableContainer)}>{this.getTable()}</div>
             <div className={css(styles.paginationContainer)}>
               <div className={css(styles.pagination)}>

--- a/src/pages/awsDetails/detailsToolbar.styles.ts
+++ b/src/pages/awsDetails/detailsToolbar.styles.ts
@@ -1,6 +1,9 @@
 import { StyleSheet } from '@patternfly/react-styles';
-import { global_spacer_md } from '@patternfly/react-tokens';
-import { css } from 'emotion';
+import {
+  global_BackgroundColor_100,
+  global_spacer_md,
+  global_spacer_xl,
+} from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
   export: {
@@ -9,10 +12,13 @@ export const styles = StyleSheet.create({
   paginationContainer: {
     width: '100%',
   },
+  toolbarContainer: {
+    backgroundColor: global_BackgroundColor_100.value,
+    paddingBottom: global_spacer_md.value,
+    paddingTop: global_spacer_md.value,
+    paddingLeft: global_spacer_xl.value,
+    paddingRight: global_spacer_xl.value,
+    marginLeft: global_spacer_xl.value,
+    marginRight: global_spacer_xl.value,
+  },
 });
-
-export const btnOverride = css`
-  &.pf-c-button {
-    --pf-c-button--m-disabled--BackgroundColor: none;
-  }
-`;

--- a/src/pages/awsDetails/detailsToolbar.tsx
+++ b/src/pages/awsDetails/detailsToolbar.tsx
@@ -1,13 +1,24 @@
-import { Button, ButtonVariant, TextInput } from '@patternfly/react-core';
+import {
+  Button,
+  ButtonVariant,
+  Chip,
+  FormSelect,
+  FormSelectOption,
+  TextInput,
+  Title,
+  TitleSize,
+  Toolbar,
+  ToolbarGroup,
+  ToolbarItem,
+  ToolbarSection,
+} from '@patternfly/react-core';
 import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import { AwsQuery } from 'api/awsQuery';
 import { AwsReport } from 'api/awsReports';
-import { Filter, Toolbar } from 'patternfly-react';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { isEqual } from 'utils/equal';
-import { btnOverride } from './detailsToolbar.styles';
 import { styles } from './detailsToolbar.styles';
 
 interface DetailsToolbarOwnProps {
@@ -67,7 +78,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     this.setState({ activeFilters });
   };
 
-  public clearFilters = (event: React.FormEvent<HTMLAnchorElement>) => {
+  public clearFilters = (event: React.FormEvent<HTMLButtonElement>) => {
     const { currentFilterType } = this.state;
     this.setState({ activeFilters: [] });
     this.props.onFilterRemoved(currentFilterType.id, '');
@@ -176,74 +187,95 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   public render() {
-    const { isExportDisabled, pagination, t } = this.props;
-    const { activeFilters, currentFilterType } = this.state;
+    const { filterFields, isExportDisabled, pagination, t } = this.props;
+    const { activeFilters } = this.state;
 
     return (
-      <Toolbar>
-        <Filter>
-          <Filter.TypeSelector
-            filterTypes={this.props.filterFields}
-            currentFilterType={currentFilterType}
-            onFilterTypeSelected={this.selectFilterType}
-          />
-          {this.renderInput()}
-        </Filter>
-        <div className="form-group">
-          <Button
-            className={btnOverride}
-            isDisabled={isExportDisabled}
-            onClick={this.handleExportClicked}
-            variant={ButtonVariant.link}
+      <div className={css(styles.toolbarContainer)}>
+        <Toolbar>
+          <ToolbarSection
+            aria-label={t('ocp_details.toolbar.filter_aria_label')}
           >
-            <span className={css(styles.export)}>
-              {t('aws_details.toolbar.export')}
-            </span>
-            <ExternalLinkSquareAltIcon />
-          </Button>
-        </div>
-        {pagination && (
-          <div className={css(styles.paginationContainer)}>
-            <Toolbar.RightContent>{pagination}</Toolbar.RightContent>
-          </div>
-        )}
-        {!activeFilters ||
-          (activeFilters.length === 0 && (
-            <Toolbar.Results>
-              <h5>
-                {t('aws_details.toolbar.results', {
-                  value: this.props.resultsTotal,
-                })}
-              </h5>
-            </Toolbar.Results>
-          ))}
-        {activeFilters && activeFilters.length > 0 && (
-          <Toolbar.Results>
-            <h5>
-              {t('aws_details.toolbar.results', {
-                value: this.props.resultsTotal,
-              })}
-            </h5>
-            <Filter.ActiveLabel>
-              {t('aws_details.toolbar.active_filters')}
-            </Filter.ActiveLabel>
-            <Filter.List>
-              {activeFilters.map((item, index) => (
-                <Filter.Item
-                  key={index}
-                  onRemove={this.removeFilter}
-                  filterData={item}
+            <ToolbarGroup>
+              <ToolbarItem>
+                <FormSelect
+                  aria-label={t('ocp_details.toolbar.filter_type_aria_label')}
                 >
-                  {item.label}
-                </Filter.Item>
-              ))}
-            </Filter.List>
-            <a href="#" onClick={this.clearFilters}>
-              {t('aws_details.toolbar.clear_filters')}
-            </a>
-          </Toolbar.Results>
-        )}
-      </Toolbar>
+                  {filterFields.map(({ id, label }) => {
+                    return (
+                      <FormSelectOption
+                        key={`filter-type-${id}`}
+                        label={label}
+                        value={id}
+                      />
+                    );
+                  })}
+                </FormSelect>
+              </ToolbarItem>
+              <ToolbarItem>{this.renderInput()}</ToolbarItem>
+            </ToolbarGroup>
+            <ToolbarGroup>
+              <ToolbarItem>
+                <Button
+                  isDisabled={isExportDisabled}
+                  onClick={this.handleExportClicked}
+                  variant={ButtonVariant.link}
+                >
+                  <span className={css(styles.export)}>
+                    {t('ocp_details.toolbar.export')}
+                  </span>
+                  <ExternalLinkSquareAltIcon />
+                </Button>
+              </ToolbarItem>
+            </ToolbarGroup>
+            <ToolbarGroup style={{ marginLeft: 'auto' }}>
+              <ToolbarItem>{pagination}</ToolbarItem>
+            </ToolbarGroup>
+          </ToolbarSection>
+          <ToolbarSection
+            aria-label={t('ocp_details.toolbar.filter_results_aria_label')}
+          >
+            <ToolbarGroup>
+              <ToolbarItem>
+                <Title size={TitleSize.md} headingLevel="h5">
+                  {t('ocp_details.toolbar.results', {
+                    value: this.props.resultsTotal,
+                  })}
+                </Title>
+              </ToolbarItem>
+            </ToolbarGroup>
+            {activeFilters.length > 0 && (
+              <React.Fragment>
+                <ToolbarGroup>
+                  <ToolbarItem>
+                    {t('ocp_details.toolbar.active_filters')}
+                  </ToolbarItem>
+                </ToolbarGroup>
+                <ToolbarGroup>
+                  <ToolbarItem>
+                    {activeFilters.map((item, index) => (
+                      <Chip
+                        style={{ paddingRight: '20px' }}
+                        key={`applied-filter-${index}`}
+                        onClick={() => this.removeFilter(item)}
+                      >
+                        {item.label}
+                      </Chip>
+                    ))}
+                  </ToolbarItem>
+                </ToolbarGroup>
+                <ToolbarGroup>
+                  <ToolbarItem>
+                    <Button onClick={this.clearFilters} variant="plain">
+                      {t('ocp_details.toolbar.clear_filters')}
+                    </Button>
+                  </ToolbarItem>
+                </ToolbarGroup>
+              </React.Fragment>
+            )}
+          </ToolbarSection>
+        </Toolbar>
+      </div>
     );
   }
 }

--- a/src/pages/ocpDetails/detailsToolbar.styles.ts
+++ b/src/pages/ocpDetails/detailsToolbar.styles.ts
@@ -1,6 +1,9 @@
 import { StyleSheet } from '@patternfly/react-styles';
-import { global_spacer_md } from '@patternfly/react-tokens';
-import { css } from 'emotion';
+import {
+  global_BackgroundColor_100,
+  global_spacer_md,
+  global_spacer_xl,
+} from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
   export: {
@@ -9,10 +12,13 @@ export const styles = StyleSheet.create({
   paginationContainer: {
     width: '100%',
   },
+  toolbarContainer: {
+    backgroundColor: global_BackgroundColor_100.value,
+    paddingBottom: global_spacer_md.value,
+    paddingTop: global_spacer_md.value,
+    paddingLeft: global_spacer_xl.value,
+    paddingRight: global_spacer_xl.value,
+    marginLeft: global_spacer_xl.value,
+    marginRight: global_spacer_xl.value,
+  },
 });
-
-export const btnOverride = css`
-  &.pf-c-button {
-    --pf-c-button--m-disabled--BackgroundColor: none;
-  }
-`;

--- a/src/pages/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/ocpDetails/detailsToolbar.tsx
@@ -1,13 +1,24 @@
-import { Button, ButtonVariant, TextInput } from '@patternfly/react-core';
+import {
+  Button,
+  ButtonVariant,
+  Chip,
+  FormSelect,
+  FormSelectOption,
+  TextInput,
+  Title,
+  TitleSize,
+  Toolbar,
+  ToolbarGroup,
+  ToolbarItem,
+  ToolbarSection,
+} from '@patternfly/react-core';
 import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import { OcpQuery } from 'api/ocpQuery';
 import { OcpReport } from 'api/ocpReports';
-import { Filter, Toolbar } from 'patternfly-react';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { isEqual } from 'utils/equal';
-import { btnOverride } from './detailsToolbar.styles';
 import { styles } from './detailsToolbar.styles';
 
 interface DetailsToolbarOwnProps {
@@ -67,7 +78,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     this.setState({ activeFilters });
   };
 
-  public clearFilters = (event: React.FormEvent<HTMLAnchorElement>) => {
+  public clearFilters = (event: React.FormEvent<HTMLButtonElement>) => {
     const { currentFilterType } = this.state;
     this.setState({ activeFilters: [] });
     this.props.onFilterRemoved(currentFilterType.id, '');
@@ -176,74 +187,95 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   public render() {
-    const { isExportDisabled, pagination, t } = this.props;
-    const { activeFilters, currentFilterType } = this.state;
+    const { filterFields, isExportDisabled, pagination, t } = this.props;
+    const { activeFilters } = this.state;
 
     return (
-      <Toolbar>
-        <Filter>
-          <Filter.TypeSelector
-            filterTypes={this.props.filterFields}
-            currentFilterType={currentFilterType}
-            onFilterTypeSelected={this.selectFilterType}
-          />
-          {this.renderInput()}
-        </Filter>
-        <div className="form-group">
-          <Button
-            className={btnOverride}
-            isDisabled={isExportDisabled}
-            onClick={this.handleExportClicked}
-            variant={ButtonVariant.link}
+      <div className={css(styles.toolbarContainer)}>
+        <Toolbar>
+          <ToolbarSection
+            aria-label={t('ocp_details.toolbar.filter_aria_label')}
           >
-            <span className={css(styles.export)}>
-              {t('ocp_details.toolbar.export')}
-            </span>
-            <ExternalLinkSquareAltIcon />
-          </Button>
-        </div>
-        {pagination && (
-          <div className={css(styles.paginationContainer)}>
-            <Toolbar.RightContent>{pagination}</Toolbar.RightContent>
-          </div>
-        )}
-        {!activeFilters ||
-          (activeFilters.length === 0 && (
-            <Toolbar.Results>
-              <h5>
-                {t('ocp_details.toolbar.results', {
-                  value: this.props.resultsTotal,
-                })}
-              </h5>
-            </Toolbar.Results>
-          ))}
-        {activeFilters && activeFilters.length > 0 && (
-          <Toolbar.Results>
-            <h5>
-              {t('ocp_details.toolbar.results', {
-                value: this.props.resultsTotal,
-              })}
-            </h5>
-            <Filter.ActiveLabel>
-              {t('ocp_details.toolbar.active_filters')}
-            </Filter.ActiveLabel>
-            <Filter.List>
-              {activeFilters.map((item, index) => (
-                <Filter.Item
-                  key={index}
-                  onRemove={this.removeFilter}
-                  filterData={item}
+            <ToolbarGroup>
+              <ToolbarItem>
+                <FormSelect
+                  aria-label={t('ocp_details.toolbar.filter_type_aria_label')}
                 >
-                  {item.label}
-                </Filter.Item>
-              ))}
-            </Filter.List>
-            <a href="#" onClick={this.clearFilters}>
-              {t('ocp_details.toolbar.clear_filters')}
-            </a>
-          </Toolbar.Results>
-        )}
-      </Toolbar>
+                  {filterFields.map(({ id, label }) => {
+                    return (
+                      <FormSelectOption
+                        key={`filter-type-${id}`}
+                        label={label}
+                        value={id}
+                      />
+                    );
+                  })}
+                </FormSelect>
+              </ToolbarItem>
+              <ToolbarItem>{this.renderInput()}</ToolbarItem>
+            </ToolbarGroup>
+            <ToolbarGroup>
+              <ToolbarItem>
+                <Button
+                  isDisabled={isExportDisabled}
+                  onClick={this.handleExportClicked}
+                  variant={ButtonVariant.link}
+                >
+                  <span className={css(styles.export)}>
+                    {t('ocp_details.toolbar.export')}
+                  </span>
+                  <ExternalLinkSquareAltIcon />
+                </Button>
+              </ToolbarItem>
+            </ToolbarGroup>
+            <ToolbarGroup style={{ marginLeft: 'auto' }}>
+              <ToolbarItem>{pagination}</ToolbarItem>
+            </ToolbarGroup>
+          </ToolbarSection>
+          <ToolbarSection
+            aria-label={t('ocp_details.toolbar.filter_results_aria_label')}
+          >
+            <ToolbarGroup>
+              <ToolbarItem>
+                <Title size={TitleSize.md} headingLevel="h5">
+                  {t('ocp_details.toolbar.results', {
+                    value: this.props.resultsTotal,
+                  })}
+                </Title>
+              </ToolbarItem>
+            </ToolbarGroup>
+            {activeFilters.length > 0 && (
+              <React.Fragment>
+                <ToolbarGroup>
+                  <ToolbarItem>
+                    {t('ocp_details.toolbar.active_filters')}
+                  </ToolbarItem>
+                </ToolbarGroup>
+                <ToolbarGroup>
+                  <ToolbarItem>
+                    {activeFilters.map((item, index) => (
+                      <Chip
+                        style={{ paddingRight: '20px' }}
+                        key={`applied-filter-${index}`}
+                        onClick={() => this.removeFilter(item)}
+                      >
+                        {item.label}
+                      </Chip>
+                    ))}
+                  </ToolbarItem>
+                </ToolbarGroup>
+                <ToolbarGroup>
+                  <ToolbarItem>
+                    <Button onClick={this.clearFilters} variant="plain">
+                      {t('ocp_details.toolbar.clear_filters')}
+                    </Button>
+                  </ToolbarItem>
+                </ToolbarGroup>
+              </React.Fragment>
+            )}
+          </ToolbarSection>
+        </Toolbar>
+      </div>
     );
   }
 }

--- a/src/pages/ocpDetails/ocpDetails.styles.ts
+++ b/src/pages/ocpDetails/ocpDetails.styles.ts
@@ -2,20 +2,9 @@ import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_300,
   global_BackgroundColor_light_100,
-  global_BorderRadius_sm,
-  global_Color_100,
-  global_Color_200,
-  global_FontSize_lg,
-  global_FontSize_md,
-  global_FontSize_sm,
-  global_FontSize_xs,
-  global_FontWeight_normal,
-  global_LineHeight_md,
   global_spacer_md,
-  global_spacer_sm,
   global_spacer_xl,
 } from '@patternfly/react-tokens';
-import { css } from 'emotion';
 
 export const styles = StyleSheet.create({
   content: {
@@ -37,115 +26,8 @@ export const styles = StyleSheet.create({
     backgroundColor: global_BackgroundColor_light_100.value,
     padding: global_spacer_md.value,
   },
-  toolbarContainer: {
-    backgroundColor: global_BackgroundColor_300.value,
-  },
   tableContainer: {
     marginLeft: global_spacer_xl.value,
     marginRight: global_spacer_xl.value,
   },
 });
-
-export const toolbarOverride = css`
-  margin-left: ${global_spacer_xl.value};
-  margin-right: ${global_spacer_xl.value};
-
-  .pf-c-button {
-    border-radius: 0;
-    padding-left: 0;
-    padding-right: 0;
-    display: inline-flex;
-    align-items: center;
-  }
-
-  .fa-download {
-    color: ${global_Color_100.value};
-    margin-right: ${global_spacer_sm.value};
-    font-size: 1.125rem;
-  }
-
-  .toolbar-pf-actions {
-    display: flex;
-    padding-top: ${global_spacer_sm.value};
-    padding-bottom: ${global_spacer_sm.value};
-  }
-
-  .form-group {
-    border: none;
-  }
-
-  .btn {
-    line-height: 28px;
-  }
-
-  .btn-link {
-    color: ${global_Color_200.value};
-    margin-left: ${global_spacer_sm.value};
-  }
-
-  .btn-link .fa {
-    font-size: ${global_FontSize_lg.value};
-  }
-
-  .pf-m-plain {
-    padding: 0;
-    display: flex;
-    align-items: center;
-  }
-
-  .dropdown .btn {
-    border-radius: ${global_BorderRadius_sm.value};
-    background: transparent;
-    box-shadow: none;
-    border-color: #c7c7c7;
-    font-size: ${global_FontSize_md.value};
-    font-weight: 500;
-    padding-left: ${global_spacer_sm.value};
-    padding-right: ${global_spacer_sm.value};
-  }
-
-  input[type='text'] {
-    border-color: #c7c7c7;
-    border-radius: ${global_BorderRadius_sm.value};
-  }
-
-  /* filter results */
-
-  .toolbar-pf-results {
-    font-size: ${global_FontSize_sm.value};
-    padding: ${global_spacer_sm.value} 0;
-    line-heght: ${global_LineHeight_md.value};
-    font-weight: ${global_FontWeight_normal.value};
-
-    .col-sm-12 {
-      display: flex;
-      align-items: center;
-    }
-
-    h5 {
-      font-size: ${global_FontSize_sm.value};
-      font-weight: ${global_FontWeight_normal.value};
-      line-height: ${global_LineHeight_md.value};
-    }
-
-    .filter-pf-active-label {
-      line-height: ${global_LineHeight_md.value};
-    }
-
-    .list-inline {
-      line-height: ${global_LineHeight_md.value};
-    }
-
-    .label {
-      font-size: ${global_FontSize_xs.value};
-      border-radius: ${global_BorderRadius_sm.value};
-      display: inline-flex;
-      align-items: center;
-    }
-
-    .pf-remove-button {
-      display: inline-flex;
-      font-weight: ${global_FontWeight_normal.value};
-    }
-  }
-`;

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -24,7 +24,7 @@ import { DetailsHeader } from './detailsHeader';
 import { DetailsTable } from './detailsTable';
 import { DetailsToolbar } from './detailsToolbar';
 import { ExportModal } from './exportModal';
-import { styles, toolbarOverride } from './ocpDetails.styles';
+import { styles } from './ocpDetails.styles';
 
 interface OcpDetailsStateProps {
   providers: Providers;
@@ -140,6 +140,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
       return [
         {
           id: 'cluster',
+          label: t('ocp_details.filter.name'),
           title: t('ocp_details.filter.cluster_select'),
           placeholder: t('ocp_details.filter.cluster_placeholder'),
           filterType: 'text',
@@ -149,6 +150,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
       return [
         {
           id: 'node',
+          label: t('ocp_details.filter.name'),
           title: t('ocp_details.filter.node_select'),
           placeholder: t('ocp_details.filter.node_placeholder'),
           filterType: 'text',
@@ -158,6 +160,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
       return [
         {
           id: 'project',
+          label: t('ocp_details.filter.name'),
           title: t('ocp_details.filter.project_select'),
           placeholder: t('ocp_details.filter.project_placeholder'),
           filterType: 'text',
@@ -168,6 +171,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
       return [
         {
           id: 'tag',
+          label: t('ocp_details.filter.name'),
           title: t('ocp_details.filter.tag_select'),
           placeholder: t('ocp_details.filter.tag_placeholder'),
           filterType: 'text',
@@ -246,7 +250,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     );
   };
 
-  private getToolbar = (computedItems: ComputedOcpReportItem[]) => {
+  private getToolbar = () => {
     const { selectedItems } = this.state;
     const { query, report, t } = this.props;
 
@@ -267,7 +271,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
         pagination={this.getPagination()}
         query={query}
         report={report}
-        resultsTotal={computedItems.length}
+        resultsTotal={report ? report.meta.count : 0}
       />
     );
   };
@@ -438,12 +442,8 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
           <LoadingState />
         ) : (
           <div className={css(styles.content)}>
-            <div className={css(styles.toolbarContainer)}>
-              <div className={toolbarOverride}>
-                {this.getToolbar(computedItems)}
-                {this.getExportModal(computedItems)}
-              </div>
-            </div>
+            {this.getToolbar()}
+            {this.getExportModal(computedItems)}
             <div className={css(styles.tableContainer)}>{this.getTable()}</div>
             <div className={css(styles.paginationContainer)}>
               <div className={css(styles.pagination)}>

--- a/src/pages/ocpOnAwsDetails/detailsToolbar.styles.ts
+++ b/src/pages/ocpOnAwsDetails/detailsToolbar.styles.ts
@@ -1,6 +1,9 @@
 import { StyleSheet } from '@patternfly/react-styles';
-import { global_spacer_md } from '@patternfly/react-tokens';
-import { css } from 'emotion';
+import {
+  global_BackgroundColor_100,
+  global_spacer_md,
+  global_spacer_xl,
+} from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
   export: {
@@ -9,10 +12,13 @@ export const styles = StyleSheet.create({
   paginationContainer: {
     width: '100%',
   },
+  toolbarContainer: {
+    backgroundColor: global_BackgroundColor_100.value,
+    paddingBottom: global_spacer_md.value,
+    paddingTop: global_spacer_md.value,
+    paddingLeft: global_spacer_xl.value,
+    paddingRight: global_spacer_xl.value,
+    marginLeft: global_spacer_xl.value,
+    marginRight: global_spacer_xl.value,
+  },
 });
-
-export const btnOverride = css`
-  &.pf-c-button {
-    --pf-c-button--m-disabled--BackgroundColor: none;
-  }
-`;

--- a/src/pages/ocpOnAwsDetails/detailsToolbar.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsToolbar.tsx
@@ -1,13 +1,24 @@
-import { Button, ButtonVariant, TextInput } from '@patternfly/react-core';
+import {
+  Button,
+  ButtonVariant,
+  Chip,
+  FormSelect,
+  FormSelectOption,
+  TextInput,
+  Title,
+  TitleSize,
+  Toolbar,
+  ToolbarGroup,
+  ToolbarItem,
+  ToolbarSection,
+} from '@patternfly/react-core';
 import { ExternalLinkSquareAltIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import { OcpOnAwsQuery } from 'api/ocpOnAwsQuery';
 import { OcpOnAwsReport } from 'api/ocpOnAwsReports';
-import { Filter, Toolbar } from 'patternfly-react';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { isEqual } from 'utils/equal';
-import { btnOverride } from './detailsToolbar.styles';
 import { styles } from './detailsToolbar.styles';
 
 interface DetailsToolbarOwnProps {
@@ -67,7 +78,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     this.setState({ activeFilters });
   };
 
-  public clearFilters = (event: React.FormEvent<HTMLAnchorElement>) => {
+  public clearFilters = (event: React.FormEvent<HTMLButtonElement>) => {
     const { currentFilterType } = this.state;
     this.setState({ activeFilters: [] });
     this.props.onFilterRemoved(currentFilterType.id, '');
@@ -176,74 +187,95 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   public render() {
-    const { isExportDisabled, pagination, t } = this.props;
-    const { activeFilters, currentFilterType } = this.state;
+    const { filterFields, isExportDisabled, pagination, t } = this.props;
+    const { activeFilters } = this.state;
 
     return (
-      <Toolbar>
-        <Filter>
-          <Filter.TypeSelector
-            filterTypes={this.props.filterFields}
-            currentFilterType={currentFilterType}
-            onFilterTypeSelected={this.selectFilterType}
-          />
-          {this.renderInput()}
-        </Filter>
-        <div className="form-group">
-          <Button
-            className={btnOverride}
-            isDisabled={isExportDisabled}
-            onClick={this.handleExportClicked}
-            variant={ButtonVariant.link}
+      <div className={css(styles.toolbarContainer)}>
+        <Toolbar>
+          <ToolbarSection
+            aria-label={t('ocp_details.toolbar.filter_aria_label')}
           >
-            <span className={css(styles.export)}>
-              {t('ocp_on_aws_details.toolbar.export')}
-            </span>
-            <ExternalLinkSquareAltIcon />
-          </Button>
-        </div>
-        {pagination && (
-          <div className={css(styles.paginationContainer)}>
-            <Toolbar.RightContent>{pagination}</Toolbar.RightContent>
-          </div>
-        )}
-        {!activeFilters ||
-          (activeFilters.length === 0 && (
-            <Toolbar.Results>
-              <h5>
-                {t('ocp_on_aws_details.toolbar.results', {
-                  value: this.props.resultsTotal,
-                })}
-              </h5>
-            </Toolbar.Results>
-          ))}
-        {activeFilters && activeFilters.length > 0 && (
-          <Toolbar.Results>
-            <h5>
-              {t('ocp_on_aws_details.toolbar.results', {
-                value: this.props.resultsTotal,
-              })}
-            </h5>
-            <Filter.ActiveLabel>
-              {t('ocp_on_aws_details.toolbar.active_filters')}
-            </Filter.ActiveLabel>
-            <Filter.List>
-              {activeFilters.map((item, index) => (
-                <Filter.Item
-                  key={index}
-                  onRemove={this.removeFilter}
-                  filterData={item}
+            <ToolbarGroup>
+              <ToolbarItem>
+                <FormSelect
+                  aria-label={t('ocp_details.toolbar.filter_type_aria_label')}
                 >
-                  {item.label}
-                </Filter.Item>
-              ))}
-            </Filter.List>
-            <a href="#" onClick={this.clearFilters}>
-              {t('ocp_on_aws_details.toolbar.clear_filters')}
-            </a>
-          </Toolbar.Results>
-        )}
-      </Toolbar>
+                  {filterFields.map(({ id, label }) => {
+                    return (
+                      <FormSelectOption
+                        key={`filter-type-${id}`}
+                        label={label}
+                        value={id}
+                      />
+                    );
+                  })}
+                </FormSelect>
+              </ToolbarItem>
+              <ToolbarItem>{this.renderInput()}</ToolbarItem>
+            </ToolbarGroup>
+            <ToolbarGroup>
+              <ToolbarItem>
+                <Button
+                  isDisabled={isExportDisabled}
+                  onClick={this.handleExportClicked}
+                  variant={ButtonVariant.link}
+                >
+                  <span className={css(styles.export)}>
+                    {t('ocp_details.toolbar.export')}
+                  </span>
+                  <ExternalLinkSquareAltIcon />
+                </Button>
+              </ToolbarItem>
+            </ToolbarGroup>
+            <ToolbarGroup style={{ marginLeft: 'auto' }}>
+              <ToolbarItem>{pagination}</ToolbarItem>
+            </ToolbarGroup>
+          </ToolbarSection>
+          <ToolbarSection
+            aria-label={t('ocp_details.toolbar.filter_results_aria_label')}
+          >
+            <ToolbarGroup>
+              <ToolbarItem>
+                <Title size={TitleSize.md} headingLevel="h5">
+                  {t('ocp_details.toolbar.results', {
+                    value: this.props.resultsTotal,
+                  })}
+                </Title>
+              </ToolbarItem>
+            </ToolbarGroup>
+            {activeFilters.length > 0 && (
+              <React.Fragment>
+                <ToolbarGroup>
+                  <ToolbarItem>
+                    {t('ocp_details.toolbar.active_filters')}
+                  </ToolbarItem>
+                </ToolbarGroup>
+                <ToolbarGroup>
+                  <ToolbarItem>
+                    {activeFilters.map((item, index) => (
+                      <Chip
+                        style={{ paddingRight: '20px' }}
+                        key={`applied-filter-${index}`}
+                        onClick={() => this.removeFilter(item)}
+                      >
+                        {item.label}
+                      </Chip>
+                    ))}
+                  </ToolbarItem>
+                </ToolbarGroup>
+                <ToolbarGroup>
+                  <ToolbarItem>
+                    <Button onClick={this.clearFilters} variant="plain">
+                      {t('ocp_details.toolbar.clear_filters')}
+                    </Button>
+                  </ToolbarItem>
+                </ToolbarGroup>
+              </React.Fragment>
+            )}
+          </ToolbarSection>
+        </Toolbar>
+      </div>
     );
   }
 }

--- a/src/pages/ocpOnAwsDetails/ocpOnAwsDetails.styles.ts
+++ b/src/pages/ocpOnAwsDetails/ocpOnAwsDetails.styles.ts
@@ -2,20 +2,9 @@ import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_300,
   global_BackgroundColor_light_100,
-  global_BorderRadius_sm,
-  global_Color_100,
-  global_Color_200,
-  global_FontSize_lg,
-  global_FontSize_md,
-  global_FontSize_sm,
-  global_FontSize_xs,
-  global_FontWeight_normal,
-  global_LineHeight_md,
   global_spacer_md,
-  global_spacer_sm,
   global_spacer_xl,
 } from '@patternfly/react-tokens';
-import { css } from 'emotion';
 
 export const styles = StyleSheet.create({
   content: {
@@ -37,115 +26,8 @@ export const styles = StyleSheet.create({
     backgroundColor: global_BackgroundColor_light_100.value,
     padding: global_spacer_md.value,
   },
-  toolbarContainer: {
-    backgroundColor: global_BackgroundColor_300.value,
-  },
   tableContainer: {
     marginLeft: global_spacer_xl.value,
     marginRight: global_spacer_xl.value,
   },
 });
-
-export const toolbarOverride = css`
-  margin-left: ${global_spacer_xl.value};
-  margin-right: ${global_spacer_xl.value};
-
-  .pf-c-button {
-    border-radius: 0;
-    padding-left: 0;
-    padding-right: 0;
-    display: inline-flex;
-    align-items: center;
-  }
-
-  .fa-download {
-    color: ${global_Color_100.value};
-    margin-right: ${global_spacer_sm.value};
-    font-size: 1.125rem;
-  }
-
-  .toolbar-pf-actions {
-    display: flex;
-    padding-top: ${global_spacer_sm.value};
-    padding-bottom: ${global_spacer_sm.value};
-  }
-
-  .form-group {
-    border: none;
-  }
-
-  .btn {
-    line-height: 28px;
-  }
-
-  .btn-link {
-    color: ${global_Color_200.value};
-    margin-left: ${global_spacer_sm.value};
-  }
-
-  .btn-link .fa {
-    font-size: ${global_FontSize_lg.value};
-  }
-
-  .pf-m-plain {
-    padding: 0;
-    display: flex;
-    align-items: center;
-  }
-
-  .dropdown .btn {
-    border-radius: ${global_BorderRadius_sm.value};
-    background: transparent;
-    box-shadow: none;
-    border-color: #c7c7c7;
-    font-size: ${global_FontSize_md.value};
-    font-weight: 500;
-    padding-left: ${global_spacer_sm.value};
-    padding-right: ${global_spacer_sm.value};
-  }
-
-  input[type='text'] {
-    border-color: #c7c7c7;
-    border-radius: ${global_BorderRadius_sm.value};
-  }
-
-  /* filter results */
-
-  .toolbar-pf-results {
-    font-size: ${global_FontSize_sm.value};
-    padding: ${global_spacer_sm.value} 0;
-    line-heght: ${global_LineHeight_md.value};
-    font-weight: ${global_FontWeight_normal.value};
-
-    .col-sm-12 {
-      display: flex;
-      align-items: center;
-    }
-
-    h5 {
-      font-size: ${global_FontSize_sm.value};
-      font-weight: ${global_FontWeight_normal.value};
-      line-height: ${global_LineHeight_md.value};
-    }
-
-    .filter-pf-active-label {
-      line-height: ${global_LineHeight_md.value};
-    }
-
-    .list-inline {
-      line-height: ${global_LineHeight_md.value};
-    }
-
-    .label {
-      font-size: ${global_FontSize_xs.value};
-      border-radius: ${global_BorderRadius_sm.value};
-      display: inline-flex;
-      align-items: center;
-    }
-
-    .pf-remove-button {
-      display: inline-flex;
-      font-weight: ${global_FontWeight_normal.value};
-    }
-  }
-`;

--- a/src/pages/ocpOnAwsDetails/ocpOnAwsDetails.tsx
+++ b/src/pages/ocpOnAwsDetails/ocpOnAwsDetails.tsx
@@ -27,7 +27,7 @@ import { DetailsHeader } from './detailsHeader';
 import { DetailsTable } from './detailsTable';
 import { DetailsToolbar } from './detailsToolbar';
 import { ExportModal } from './exportModal';
-import { styles, toolbarOverride } from './ocpOnAwsDetails.styles';
+import { styles } from './ocpOnAwsDetails.styles';
 
 interface OcpOnAwsDetailsStateProps {
   providers: Providers;
@@ -144,6 +144,7 @@ class OcpOnAwsDetails extends React.Component<OcpOnAwsDetailsProps> {
       return [
         {
           id: 'cluster',
+          label: t('ocp_on_aws_details.filter.name'),
           title: t('ocp_on_aws_details.filter.cluster_select'),
           placeholder: t('ocp_on_aws_details.filter.cluster_placeholder'),
           filterType: 'text',
@@ -153,6 +154,7 @@ class OcpOnAwsDetails extends React.Component<OcpOnAwsDetailsProps> {
       return [
         {
           id: 'node',
+          label: t('ocp_on_aws_details.filter.name'),
           title: t('ocp_on_aws_details.filter.node_select'),
           placeholder: t('ocp_on_aws_details.filter.node_placeholder'),
           filterType: 'text',
@@ -162,6 +164,7 @@ class OcpOnAwsDetails extends React.Component<OcpOnAwsDetailsProps> {
       return [
         {
           id: 'project',
+          label: t('ocp_on_aws_details.filter.name'),
           title: t('ocp_on_aws_details.filter.project_select'),
           placeholder: t('ocp_on_aws_details.filter.project_placeholder'),
           filterType: 'text',
@@ -172,6 +175,7 @@ class OcpOnAwsDetails extends React.Component<OcpOnAwsDetailsProps> {
       return [
         {
           id: 'tag',
+          label: t('ocp_on_aws_details.filter.name'),
           title: t('ocp_on_aws_details.filter.tag_select'),
           placeholder: t('ocp_on_aws_details.filter.tag_placeholder'),
           filterType: 'text',
@@ -250,7 +254,7 @@ class OcpOnAwsDetails extends React.Component<OcpOnAwsDetailsProps> {
     );
   };
 
-  private getToolbar = (computedItems: ComputedOcpOnAwsReportItem[]) => {
+  private getToolbar = () => {
     const { selectedItems } = this.state;
     const { query, report, t } = this.props;
 
@@ -271,7 +275,7 @@ class OcpOnAwsDetails extends React.Component<OcpOnAwsDetailsProps> {
         pagination={this.getPagination()}
         query={query}
         report={report}
-        resultsTotal={computedItems.length}
+        resultsTotal={report ? report.meta.count : 0}
       />
     );
   };
@@ -442,12 +446,8 @@ class OcpOnAwsDetails extends React.Component<OcpOnAwsDetailsProps> {
           <LoadingState />
         ) : (
           <div className={css(styles.content)}>
-            <div className={css(styles.toolbarContainer)}>
-              <div className={toolbarOverride}>
-                {this.getToolbar(computedItems)}
-                {this.getExportModal(computedItems)}
-              </div>
-            </div>
+            {this.getToolbar()}
+            {this.getExportModal(computedItems)}
             <div className={css(styles.tableContainer)}>{this.getTable()}</div>
             <div className={css(styles.paginationContainer)}>
               <div className={css(styles.pagination)}>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -8,13 +8,6 @@ body {
   display: flex;
 }
 
-/* PF4 reset fix since PF3 is being loaded after PF4 */
-a {
-  font-weight: var(--pf-global--link--FontWeight);
-  color: var(--pf-global--link--Color);
-  text-decoration: var(--pf-global--link--TextDecoration);
-}
-
 .pf-l-grid > *,
 .pf-l-grid .pf-l-grid__item {
   min-height: 0;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -50,11 +50,7 @@ module.exports = env => {
       require.resolve(
         '@red-hat-insights/insights-frontend-components/components/Skeleton.css'
       ),
-      require.resolve('patternfly/dist/css/patternfly.css'),
-      require.resolve('patternfly/dist/css/patternfly-additions.css'),
-      require.resolve('@patternfly/patternfly/patternfly-variables.css'),
-      require.resolve('@patternfly/patternfly/utilities/Display/display.css'),
-      require.resolve('@patternfly/patternfly/utilities/Flex/flex.css'),
+      require.resolve('@patternfly/patternfly/patternfly-addons.css'),
       path.join(srcDir, './styles/global.css'),
       path.join(srcDir, 'index.tsx'),
     ],

--- a/yarn.lock
+++ b/yarn.lock
@@ -10527,31 +10527,6 @@ patternfly-bootstrap-treeview@~2.1.0:
     bootstrap "3.3.x"
     jquery ">= 2.1.x"
 
-patternfly-react@^2.29.1:
-  version "2.29.1"
-  resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.29.1.tgz#3def482e4ca48b0c0b0ccad13b32a6eb49d4e9c4"
-  dependencies:
-    bootstrap-slider-without-jquery "^10.0.0"
-    breakjs "^1.0.0"
-    classnames "^2.2.5"
-    css-element-queries "^1.0.1"
-    lodash "^4.17.11"
-    patternfly "^3.58.0"
-    react-bootstrap "^0.32.1"
-    react-bootstrap-switch "^15.5.3"
-    react-bootstrap-typeahead "^3.1.3"
-    react-c3js "^0.1.20"
-    react-click-outside "^3.0.1"
-    react-collapse "^4.0.3"
-    react-fontawesome "^1.6.1"
-    react-motion "^0.5.2"
-    reactabular-table "^8.14.0"
-    recompose "^0.26.0"
-    uuid "^3.3.2"
-  optionalDependencies:
-    sortabular "^1.5.1"
-    table-resolver "^3.2.0"
-
 patternfly-react@^2.34.3:
   version "2.35.1"
   resolved "https://registry.yarnpkg.com/patternfly-react/-/patternfly-react-2.35.1.tgz#8b7df346fda0a3f1a3d8ad553ee412c8ef5add5a"
@@ -11813,21 +11788,6 @@ react-bootstrap-switch@^15.5.3:
   version "15.5.3"
   resolved "https://registry.yarnpkg.com/react-bootstrap-switch/-/react-bootstrap-switch-15.5.3.tgz#97287791d4ec0d1892d142542e7e5248002b1251"
 
-react-bootstrap-typeahead@^3.1.3:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/react-bootstrap-typeahead/-/react-bootstrap-typeahead-3.2.1.tgz#a982d3dca65efa003abe70743402b4ffeac8540f"
-  dependencies:
-    classnames "^2.2.0"
-    escape-string-regexp "^1.0.5"
-    invariant "^2.2.1"
-    lodash "^4.17.2"
-    prop-types "^15.5.8"
-    prop-types-extra "^1.0.1"
-    react-onclickoutside "^6.1.1"
-    react-overlays "^0.8.1"
-    react-popper "^1.0.0"
-    warning "^4.0.1"
-
 react-bootstrap-typeahead@^3.4.1:
   version "3.4.1"
   resolved "https://registry.yarnpkg.com/react-bootstrap-typeahead/-/react-bootstrap-typeahead-3.4.1.tgz#484c3c1be635c49898ca8dce59a6c71f2fce5888"
@@ -12052,10 +12012,6 @@ react-motion@^0.5.2:
     performance-now "^0.2.0"
     prop-types "^15.5.8"
     raf "^3.1.0"
-
-react-onclickoutside@^6.1.1:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/react-onclickoutside/-/react-onclickoutside-6.7.1.tgz#6a5b5b8b4eae6b776259712c89c8a2b36b17be93"
 
 react-overlays@^0.8.0, react-overlays@^0.8.1:
   version "0.8.3"


### PR DESCRIPTION
This replaces the PF3 toolbar, used in the Ocp, Ocp on AWS, and AWS details pages, with PF4 components.

**This eliminates the dependency on PatternFly 3. The PF3 style sheet includes via webpack, our custom CSS overrides, and patternfly-react components have all been removed.**

Fixes https://github.com/project-koku/koku-ui/issues/208

Ocp details:
![Screen Shot 2019-08-22 at 11 47 20 AM](https://user-images.githubusercontent.com/17481322/63529444-aad87700-c4d2-11e9-8a2e-5b7a16988d7f.png)

Ocp on AWS details:
![Screen Shot 2019-08-22 at 11 48 08 AM](https://user-images.githubusercontent.com/17481322/63529495-bc218380-c4d2-11e9-8a00-923199572b3d.png)

AWS on details:
![Screen Shot 2019-08-22 at 11 32 00 AM](https://user-images.githubusercontent.com/17481322/63528667-5680c780-c4d1-11e9-926d-062637b5a335.png)