### PR TITLE
fix(costmodels): add scoped patternfly packages to the vendors bundle

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -152,7 +152,7 @@ module.exports = env => {
       splitChunks: {
         cacheGroups: {
           commons: {
-            test: /[\\/]node_modules[\\/](react|react-dom|redux)[\\/]/,
+            test: /[\\/]node_modules[\\/](react|react-dom|redux|@patternfly*)[\\/]/,
             name: 'vendor',
             chunks: 'all',
           },
@@ -177,7 +177,7 @@ module.exports = env => {
       historyApiFallback: {
         index: `${publicPath}/index.html`,
       },
-      hot: true,
+      hot: !isProduction,
       port: 8002,
       disableHostCheck: true,
       headers: {


### PR DESCRIPTION
closes #957 

**Note**:
To verify this PR fixes the problem run `yarn start --env production` and go to /beta/hybrid/cost-management.

The `--env production` will create a minified version that is similar to what is used in the QA/CI environment (paas.psi.redhat.com).
I also set `hot: !isProduction` because in production the hot-module-reload is not used and can make the bundle not to be served.

//cc @dchorvat1 
//ping @karelhala can you review this too?