### PR TITLE
Add tertiary navigation for AWS and Azure details

### DIFF
--- a/src/components/details/tertiaryNav.tsx
+++ b/src/components/details/tertiaryNav.tsx
@@ -1,0 +1,109 @@
+import {
+  Nav,
+  NavItem,
+  NavList,
+  NavVariants,
+  Title,
+  TitleSize,
+} from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { RouteComponentProps } from 'react-router';
+import { withRouter } from 'react-router-dom';
+import { styles } from '../../pages/azureDetails/detailsHeader.styles';
+
+export const enum TertiaryNavItem {
+  aws = 'aws',
+  azure = 'azure',
+}
+
+export const getIdKeyForNavItem = (navItem: TertiaryNavItem) => {
+  switch (navItem) {
+    case TertiaryNavItem.aws:
+      return 'aws';
+    case TertiaryNavItem.azure:
+      return 'azure';
+  }
+};
+
+interface TertiaryNavOwnProps {
+  activeItem: TertiaryNavItem;
+}
+
+interface AvailableNavItem {
+  navItem: TertiaryNavItem;
+}
+
+type TertiaryNavProps = TertiaryNavOwnProps &
+  InjectedTranslateProps &
+  RouteComponentProps<void>;
+
+export class TertiaryNavBase extends React.Component<TertiaryNavProps> {
+  private getAvailableNavItems = () => {
+    const availableTabs = [
+      {
+        navItem: TertiaryNavItem.aws,
+      },
+      {
+        navItem: TertiaryNavItem.azure,
+      },
+    ];
+    return availableTabs;
+  };
+
+  private getNavItemTitle = (navItem: TertiaryNavItem) => {
+    const { t } = this.props;
+
+    if (navItem === TertiaryNavItem.aws) {
+      return t('aws_details.title');
+    } else if (navItem === TertiaryNavItem.azure) {
+      return t('azure_details.title');
+    }
+  };
+
+  private getNavItem = (navItem: TertiaryNavItem, index: number) => {
+    const { activeItem } = this.props;
+    const navItemKey = getIdKeyForNavItem(navItem);
+
+    return (
+      <NavItem
+        key={navItemKey}
+        itemId={navItemKey}
+        isActive={activeItem === navItem}
+      >
+        <Title className={css(styles.title)} size={TitleSize['2xl']}>
+          {this.getNavItemTitle(navItem)}
+        </Title>
+      </NavItem>
+    );
+  };
+
+  // tslint:disable-next-line:no-empty
+  public handleOnSelect = selectedItem => {
+    const { history } = this.props;
+    if (selectedItem.itemId === TertiaryNavItem.aws) {
+      history.replace('/aws');
+    } else if (selectedItem.itemId === TertiaryNavItem.azure) {
+      history.replace('/azure');
+    }
+  };
+
+  public render() {
+    const availableNavItems: AvailableNavItem[] = this.getAvailableNavItems();
+
+    return (
+      <Nav onSelect={this.handleOnSelect}>
+        <NavList variant={NavVariants.tertiary}>
+          {availableNavItems.map((val, index) =>
+            this.getNavItem(val.navItem, index)
+          )}
+        </NavList>
+      </Nav>
+    );
+  }
+}
+
+const TertiaryNav = withRouter(translate()(TertiaryNavBase));
+
+export { TertiaryNav };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -75,7 +75,7 @@
     "tag_column_title": "Tag names",
     "tags_label": "Related tags:",
     "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s related tags",
-    "title": "Cloud details",
+    "title": "Amazon Web Services",
     "toolbar": {
       "active_filters": "Active filters",
       "clear_filters": "Clear all filters",
@@ -164,7 +164,7 @@
     "tag_column_title": "Tag names",
     "tags_label": "Related tags:",
     "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s related tags",
-    "title": "Cloud details",
+    "title": "Azure",
     "toolbar": {
       "active_filters": "Active filters",
       "clear_filters": "Clear all filters",

--- a/src/pages/awsDetails/detailsHeader.styles.ts
+++ b/src/pages/awsDetails/detailsHeader.styles.ts
@@ -34,6 +34,9 @@ export const styles = StyleSheet.create({
     padding: global_spacer_xl.var,
     backgroundColor: global_BackgroundColor_100.var,
   },
+  nav: {
+    marginBottom: global_spacer_xl.var,
+  },
   title: {
     paddingBottom: global_spacer_sm.var,
   },

--- a/src/pages/awsDetails/detailsHeader.tsx
+++ b/src/pages/awsDetails/detailsHeader.tsx
@@ -1,10 +1,11 @@
-import { Title, TitleSize } from '@patternfly/react-core';
+import { Title } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { AwsQuery, getQuery } from 'api/awsQuery';
 import { AwsReport, AwsReportType } from 'api/awsReports';
 import { Providers, ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/providersQuery';
 import { AxiosError } from 'axios';
+import { TertiaryNav, TertiaryNavItem } from 'components/details/tertiaryNav';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -83,9 +84,9 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     return (
       <header className={css(styles.header)}>
         <div>
-          <Title className={css(styles.title)} size={TitleSize['2xl']}>
-            {t('aws_details.title')}
-          </Title>
+          <div className={css(styles.nav)}>
+            <TertiaryNav activeItem={TertiaryNavItem.aws} />
+          </div>
           {Boolean(showContent) && <GroupBy onItemClicked={onGroupByClicked} />}
         </div>
         {Boolean(showContent) && (

--- a/src/pages/azureDetails/detailsHeader.styles.ts
+++ b/src/pages/azureDetails/detailsHeader.styles.ts
@@ -34,6 +34,9 @@ export const styles = StyleSheet.create({
     padding: global_spacer_xl.var,
     backgroundColor: global_BackgroundColor_100.var,
   },
+  nav: {
+    marginBottom: global_spacer_xl.var,
+  },
   title: {
     paddingBottom: global_spacer_sm.var,
   },

--- a/src/pages/azureDetails/detailsHeader.tsx
+++ b/src/pages/azureDetails/detailsHeader.tsx
@@ -1,10 +1,11 @@
-import { Title, TitleSize } from '@patternfly/react-core';
+import { Title } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { AzureQuery, getQuery } from 'api/azureQuery';
 import { AzureReport, AzureReportType } from 'api/azureReports';
 import { Providers, ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/providersQuery';
 import { AxiosError } from 'axios';
+import { TertiaryNav, TertiaryNavItem } from 'components/details/tertiaryNav';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -83,9 +84,9 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     return (
       <header className={css(styles.header)}>
         <div>
-          <Title className={css(styles.title)} size={TitleSize['2xl']}>
-            {t('azure_details.title')}
-          </Title>
+          <div className={css(styles.nav)}>
+            <TertiaryNav activeItem={TertiaryNavItem.azure} />
+          </div>
           {Boolean(showContent) && <GroupBy onItemClicked={onGroupByClicked} />}
         </div>
         {Boolean(showContent) && (


### PR DESCRIPTION
Per my discussion with @nlcwong , we want to use the PF4 navigation component as 3rd level navigation to the AWS and Azure details pages.

We're also removing "details" from the page title and just using "Amazon Web Services" and "Azure".

Fixes https://github.com/project-koku/koku-ui/issues/965

![Screen Shot 2019-09-10 at 4 25 12 PM](https://user-images.githubusercontent.com/17481322/64648038-22216c80-d3e8-11e9-948e-c6b68b455216.png)
