### PR TITLE
fix(costmodels): show available sources in the source step

### DIFF
--- a/src/pages/createCostModelWizard/api.ts
+++ b/src/pages/createCostModelWizard/api.ts
@@ -21,8 +21,8 @@ export const fetchSources = ({ type, page, perPage, query }) => {
     })
     .then(({ costmodels, sources }) => {
       const cmsHash = costmodels.reduce((acc, curr) => {
-        curr.provider_uuids.forEach(provider_uuid => {
-          acc[provider_uuid] = curr.name;
+        curr.providers.forEach(provider => {
+          acc[provider.uuid] = curr.name;
         });
         return acc;
       }, {});


### PR DESCRIPTION
this fixes the issue where no sources are displayed even though
they exist in the source step.

the issue was due to a change in the API of cost models:
the table was relaying on "provider_uuids" that was replaced
by "providers" and because of that the source list passed to
the table was empty.

closes #978 

related to #970 

//cc @chargio 