### PR TITLE
fix(costmodel): setting price list is optional in creation wizard

### DIFF
--- a/src/pages/createCostModelWizard/index.tsx
+++ b/src/pages/createCostModelWizard/index.tsx
@@ -225,7 +225,7 @@ class CostModelWizardBase extends React.Component<Props, State> {
               priceListCurrent: {
                 metric: '',
                 measurement: '',
-                rate: '',
+                rate: '0',
                 justSaved: true,
               },
               tiers: [

--- a/src/pages/createCostModelWizard/steps.tsx
+++ b/src/pages/createCostModelWizard/steps.tsx
@@ -77,7 +77,7 @@ export const validatorsHash = {
     ctx =>
       ctx.priceListCurrent.metric === '' &&
       ctx.priceListCurrent.measurement === '' &&
-      ctx.priceListCurrent.rate === '',
+      ctx.priceListCurrent.rate === '0',
     ctx => ctx.markup !== '' && !isNaN(Number(ctx.markup)),
     ctx => true,
     ctx => true,


### PR DESCRIPTION
the boolean expression to enable the next button was incorrect because
the default rate is 0.  in addition, when adding a new rate the values
that were set are reset but the rate value isn't reset to 0.

this commit changes that and thus fixing the bug.

closes #985 