### PR TITLE
fix(costmodel): if metric is no longer available don't show rate

### DIFF
--- a/src/pages/costModelsDetails/components/addRateModel.tsx
+++ b/src/pages/costModelsDetails/components/addRateModel.tsx
@@ -167,15 +167,16 @@ class AddRateModelBase extends React.Component<Props, State> {
                     'cost_models_wizard.price_list.default_selector_label'
                   )}
                 />
-                {opts[this.state.metric].map(msr => (
-                  <FormSelectOption
-                    key={msr}
-                    value={msr}
-                    label={t(`cost_models_wizard.price_list.${msr}`, {
-                      units: units(this.state.metric),
-                    })}
-                  />
-                ))}
+                {opts[this.state.metric] &&
+                  opts[this.state.metric].map(msr => (
+                    <FormSelectOption
+                      key={msr}
+                      value={msr}
+                      label={t(`cost_models_wizard.price_list.${msr}`, {
+                        units: units(this.state.metric),
+                      })}
+                    />
+                  ))}
               </FormSelect>
             </FormGroup>
           )}


### PR DESCRIPTION
closes #992 
closes #994 

make sure metric exists in the available rate options before rendering.
this fixes the problem of syncing between modal state and redux store.
