### PR TITLE
Update APIs for Azure overview & details pages

### DIFF
--- a/src/api/azureQuery.ts
+++ b/src/api/azureQuery.ts
@@ -1,11 +1,11 @@
 import { parse, stringify } from 'qs';
 
 export interface AzureFilters {
-  account?: string | number;
+  subscription_guid?: string | number;
   limit?: number;
   offset?: number;
   resolution?: 'daily' | 'monthly';
-  service?: string;
+  service_name?: string;
   time_scope_units?: 'month' | 'day';
   time_scope_value?: number;
 }
@@ -13,16 +13,16 @@ export interface AzureFilters {
 type AzureGroupByValue = string | string[];
 
 interface AzureGroupBys {
-  service?: AzureGroupByValue;
-  account?: AzureGroupByValue;
+  service_name?: AzureGroupByValue;
+  subscription_guid?: AzureGroupByValue;
   instance_type?: AzureGroupByValue;
-  region?: AzureGroupByValue;
+  resource_location?: AzureGroupByValue;
 }
 
 interface AzureOrderBys {
-  account?: string;
-  region?: string;
-  service?: string;
+  subscription_guid?: string;
+  resource_location?: string;
+  service_name?: string;
   cost?: string;
   usage?: string;
 }

--- a/src/api/azureReports.test.ts
+++ b/src/api/azureReports.test.ts
@@ -6,5 +6,5 @@ import { AzureReportType, runReport } from './azureReports';
 test('api run reports calls axios get', () => {
   const query = 'filter[resolution]=daily';
   runReport(AzureReportType.cost, query);
-  expect(axios.get).toBeCalledWith(`reports/aws/costs/?${query}`);
+  expect(axios.get).toBeCalledWith(`reports/azure/costs/?${query}`);
 });

--- a/src/api/azureReports.ts
+++ b/src/api/azureReports.ts
@@ -7,8 +7,7 @@ export interface AzureDatum {
 }
 
 export interface AzureReportValue {
-  account?: string;
-  account_alias?: string;
+  subscription_guid?: string;
   cost: AzureDatum;
   count?: AzureDatum;
   date: string;
@@ -17,20 +16,23 @@ export interface AzureReportValue {
   derived_cost: AzureDatum;
   infrastructure_cost: AzureDatum;
   instance_type?: string;
-  region?: string;
-  service?: string;
+  resource_location?: string;
+  service_name?: string;
   usage?: AzureDatum;
 }
 
-export interface GroupByAccountData extends Omit<AzureReportData, 'accounts'> {
+export interface GroupByAccountData
+  extends Omit<AzureReportData, 'subscription_guids'> {
   account: string;
 }
 
-export interface GroupByServiceData extends Omit<AzureReportData, 'services'> {
+export interface GroupByServiceData
+  extends Omit<AzureReportData, 'service_names'> {
   service: string;
 }
 
-export interface GroupByRegionData extends Omit<AzureReportData, 'regions'> {
+export interface GroupByRegionData
+  extends Omit<AzureReportData, 'resource_locations'> {
   region: string;
 }
 
@@ -43,9 +45,9 @@ export interface AzureReportData {
   date?: string;
   delta_percent?: number;
   delta_value?: number;
-  services?: GroupByServiceData[];
-  accounts?: GroupByAccountData[];
-  regions?: GroupByRegionData[];
+  service_names?: GroupByServiceData[];
+  subscription_guids?: GroupByAccountData[];
+  resource_locations?: GroupByRegionData[];
   instance_types?: GroupByInstanceTypeData[];
   values?: AzureReportValue[];
 }
@@ -81,7 +83,7 @@ export interface AzureReportLinks {
 }
 
 export interface AzureReport {
-  meta: AzureReportMeta;
+  meta?: AzureReportMeta;
   links: AzureReportLinks;
   data: AzureReportData[];
 }
@@ -97,12 +99,12 @@ export const enum AzureReportType {
 
 // Todo: update for Azure
 export const azureReportTypePaths: Record<AzureReportType, string> = {
-  [AzureReportType.cost]: 'reports/aws/costs/',
-  [AzureReportType.database]: 'reports/aws/costs/',
-  [AzureReportType.network]: 'reports/aws/costs/',
-  [AzureReportType.storage]: 'reports/aws/storage/',
-  [AzureReportType.instanceType]: 'reports/aws/instance-types/',
-  [AzureReportType.tag]: 'tags/aws/',
+  [AzureReportType.cost]: 'reports/azure/costs/',
+  [AzureReportType.database]: 'reports/azure/costs/',
+  [AzureReportType.network]: 'reports/azure/costs/',
+  [AzureReportType.storage]: 'reports/azure/storage/',
+  [AzureReportType.instanceType]: 'reports/azure/instance-types/',
+  [AzureReportType.tag]: 'tags/azure/',
 };
 
 export function runReport(reportType: AzureReportType, query: string) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -107,10 +107,10 @@
     "storage_trend_title": "Storage usage comparison ({{units}})",
     "storage_usage_label": "Usage",
     "tabs": {
-      "accounts": "Top accounts",
       "instance_types": "Top types",
-      "regions": "Top regions",
-      "services": "Top services"
+      "resource_locations": "Top regions",
+      "service_names": "Top services",
+      "subscription_guids": "Top accounts"
     },
     "widget_subtitle": "$t(months.{{month}}), month to date",
     "widget_subtitle_tooltip": "{{startDate}} $t(months_abbr.{{month}}) {{year}}",
@@ -118,9 +118,9 @@
   },
   "azure_details": {
     "actions": {
-      "accounts": "View all accounts",
       "export": "Export data",
       "historical_data": "View historical data",
+      "subscription_guids": "View all accounts",
       "tags": "View all tags"
     },
     "change_column_title": "Month over month change",
@@ -412,8 +412,14 @@
       "project_plural": "projects",
       "region": "region",
       "region_plural": "regions",
+      "resource_location": "region",
+      "resource_location_plural": "regions",
       "service": "service",
-      "service_plural": "services"
+      "service_name": "service",
+      "service_name_plural": "services",
+      "service_plural": "services",
+      "subscription_guid": "account",
+      "subscription_guid_plural": "accounts"
     },
     "values": {
       "account": "Account",
@@ -430,8 +436,14 @@
       "project_plural": "Projects",
       "region": "Region",
       "region_plural": "Regions",
+      "resource_location": "Region",
+      "resource_location_plural": "Regions",
       "service": "Service",
-      "service_plural": "Services"
+      "service_name": "Service",
+      "service_name_plural": "Services",
+      "service_plural": "Services",
+      "subscription_guid": "Account",
+      "subscription_guid_plural": "Accounts"
     }
   },
   "loading": "Loading",
@@ -874,8 +886,8 @@
     }
   },
   "overview": {
-    "aws": "Cloud",
-    "aws_desc": "Raw cost from cloud infrastructure.",
+    "aws": "Amazon Web Services",
+    "aws_desc": "Raw cost from Amazon Web Services infrastructure.",
     "azure": "Azure",
     "azure_desc": "Raw cost from Azure infrastructure.",
     "ocp": "OpenShift",

--- a/src/pages/awsDetails/detailsTag.tsx
+++ b/src/pages/awsDetails/detailsTag.tsx
@@ -80,7 +80,7 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
     const { isOpen, showAll } = this.state;
 
     let charCount = 0;
-    const maxChars = 50;
+    const maxChars = 75;
     const someTags = [];
     const allTags = [];
 

--- a/src/pages/azureDashboard/azureDashboardWidget.test.tsx
+++ b/src/pages/azureDashboard/azureDashboardWidget.test.tsx
@@ -49,8 +49,8 @@ const props: AzureDashboardWidgetProps = {
     formatOptions: {},
   },
   topItems: { formatOptions: {} },
-  availableTabs: [AzureDashboardTab.accounts],
-  currentTab: AzureDashboardTab.accounts,
+  availableTabs: [AzureDashboardTab.subscription_guids],
+  currentTab: AzureDashboardTab.subscription_guids,
 };
 
 const getDateMock = getDate as jest.Mock;
@@ -103,9 +103,9 @@ test('trend title is translated', () => {
 
 test('id key for dashboard tab is the tab name in singular form', () => {
   [
-    AzureDashboardTab.services,
-    AzureDashboardTab.accounts,
-    AzureDashboardTab.regions,
+    AzureDashboardTab.service_names,
+    AzureDashboardTab.subscription_guids,
+    AzureDashboardTab.resource_locations,
   ].forEach(value => {
     expect(getIdKeyForTab(value)).toEqual(value.slice(0, -1));
   });

--- a/src/pages/azureDashboard/azureDashboardWidget.tsx
+++ b/src/pages/azureDashboard/azureDashboardWidget.tsx
@@ -61,12 +61,12 @@ export const getIdKeyForTab = (
   tab: AzureDashboardTab
 ): GetComputedAzureReportItemsParams['idKey'] => {
   switch (tab) {
-    case AzureDashboardTab.services:
-      return 'service';
-    case AzureDashboardTab.accounts:
-      return 'account';
-    case AzureDashboardTab.regions:
-      return 'region';
+    case AzureDashboardTab.service_names:
+      return 'service_name';
+    case AzureDashboardTab.subscription_guids:
+      return 'subscription_guid';
+    case AzureDashboardTab.resource_locations:
+      return 'resource_location';
     case AzureDashboardTab.instanceType:
       return 'instance_type';
   }

--- a/src/pages/azureDetails/azureDetails.tsx
+++ b/src/pages/azureDetails/azureDetails.tsx
@@ -66,7 +66,7 @@ const baseQuery: AzureQuery = {
     time_scope_value: -1,
   },
   group_by: {
-    account: '*',
+    subscription_guid: '*',
   },
   order_by: {
     cost: 'desc',
@@ -136,30 +136,30 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
 
   private getFilterFields = (groupById: string): any[] => {
     const { t } = this.props;
-    if (groupById === 'account') {
+    if (groupById === 'subscription_guid') {
       return [
         {
-          id: 'account',
+          id: 'subscription_guid',
           label: t('azure_details.filter.name'),
           title: t('azure_details.filter.account_select'),
           placeholder: t('azure_details.filter.account_placeholder'),
           filterType: 'text',
         },
       ];
-    } else if (groupById === 'service') {
+    } else if (groupById === 'service_name') {
       return [
         {
-          id: 'service',
+          id: 'service_name',
           label: t('azure_details.filter.name'),
           title: t('azure_details.filter.service_select'),
           placeholder: t('azure_details.filter.service_placeholder'),
           filterType: 'text',
         },
       ];
-    } else if (groupById === 'region') {
+    } else if (groupById === 'resource_location') {
       return [
         {
-          id: 'region',
+          id: 'resource_location',
           label: t('azure_details.filter.name'),
           title: t('azure_details.filter.region_select'),
           placeholder: t('azure_details.filter.region_placeholder'),
@@ -167,7 +167,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
         },
       ];
     } else {
-      // Default for group by account tags
+      // Default for group by subscription_guid tags
       return [
         {
           id: 'tag',

--- a/src/pages/azureDetails/detailsActions.tsx
+++ b/src/pages/azureDetails/detailsActions.tsx
@@ -100,7 +100,7 @@ class DetailsActionsBase extends React.Component<DetailsActionsProps> {
 
     return (
       <DetailsWidgetModal
-        groupBy="account"
+        groupBy="subscription_guid"
         isOpen={isWidgetModalOpen}
         item={item}
         onClose={this.handleWidgetModalClose}
@@ -174,7 +174,7 @@ class DetailsActionsBase extends React.Component<DetailsActionsProps> {
             <DropdownItem
               component="button"
               key="widget-action"
-              isDisabled={groupBy === 'account'}
+              isDisabled={groupBy === 'subscription_guid'}
               onClick={this.handleWidgetModalOpen}
             >
               {t('azure_details.actions.accounts')}
@@ -182,7 +182,7 @@ class DetailsActionsBase extends React.Component<DetailsActionsProps> {
             <DropdownItem
               component="button"
               key="tag-action"
-              isDisabled={groupBy !== 'account'}
+              isDisabled={groupBy !== 'subscription_guid'}
               onClick={this.handleTagModalOpen}
             >
               {t('azure_details.actions.tags')}

--- a/src/pages/azureDetails/detailsTable.tsx
+++ b/src/pages/azureDetails/detailsTable.tsx
@@ -116,7 +116,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         ]
       : [
           {
-            orderBy: groupById === 'account' ? 'account_alias' : groupById,
+            orderBy: groupById,
             title: t('azure_details.name_column_title', { groupBy: groupById }),
             transforms: [sortable],
           },

--- a/src/pages/azureDetails/detailsTableItem.tsx
+++ b/src/pages/azureDetails/detailsTableItem.tsx
@@ -77,7 +77,7 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
           </GridItem>
           <GridItem lg={12} xl={6}>
             <div className={css(styles.rightPane)}>
-              {Boolean(groupBy === 'account') && (
+              {Boolean(groupBy === 'subscription_guid') && (
                 <div className={css(styles.tagsContainer)}>
                   <Form>
                     <FormGroup

--- a/src/pages/azureDetails/detailsTag.tsx
+++ b/src/pages/azureDetails/detailsTag.tsx
@@ -80,19 +80,27 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
     const { isOpen, showAll } = this.state;
 
     let charCount = 0;
-    const maxChars = 50;
+    const maxChars = 75;
     const someTags = [];
     const allTags = [];
 
+    const addTag = (tag, val) => {
+      const prefix = someTags.length > 0 ? ', ' : '';
+      const tagString = `${prefix}${(tag as any).key}: ${val}`;
+      charCount += tagString.length;
+      allTags.push(`${(tag as any).key}: ${val}`);
+      if (charCount <= maxChars || showAll) {
+        someTags.push(tagString);
+      }
+    };
+
     if (report) {
       for (const tag of report.data) {
-        for (const val of tag.values) {
-          const prefix = someTags.length > 0 ? ', ' : '';
-          const tagString = `${prefix}${(tag as any).key}: ${val}`;
-          charCount += tagString.length;
-          allTags.push(`${(tag as any).key}: ${val}`);
-          if (charCount <= maxChars || showAll) {
-            someTags.push(tagString);
+        if (!Array.isArray(tag.values)) {
+          addTag(tag, tag.values);
+        } else {
+          for (const val of tag.values) {
+            addTag(tag, val);
           }
         }
       }
@@ -131,7 +139,7 @@ const mapStateToProps = createMapStateToProps<
 >((state, { account }) => {
   const queryString = getQuery({
     filter: {
-      account,
+      subscription_guid: account,
       resolution: 'monthly',
       time_scope_units: 'month',
       time_scope_value: -1,
@@ -148,7 +156,7 @@ const mapStateToProps = createMapStateToProps<
     queryString
   );
   return {
-    account,
+    subscription_guid: account,
     queryString,
     report,
     reportFetchStatus,

--- a/src/pages/azureDetails/detailsTagView.tsx
+++ b/src/pages/azureDetails/detailsTagView.tsx
@@ -49,8 +49,12 @@ class DetailsTagViewBase extends React.Component<DetailsTagViewProps> {
 
     if (report) {
       for (const tag of report.data) {
-        for (const val of tag.values) {
-          tags.push(`${(tag as any).key}: ${val}`);
+        if (Array.isArray(tag.values)) {
+          for (const val of tag.values) {
+            tags.push(`${(tag as any).key}: ${val}`);
+          }
+        } else {
+          tags.push(`${(tag as any).key}: ${tag.values}`);
         }
       }
     }
@@ -70,7 +74,7 @@ const mapStateToProps = createMapStateToProps<
 >((state, { account }) => {
   const queryString = getQuery({
     filter: {
-      account,
+      subscription_guid: account,
       resolution: 'monthly',
       time_scope_units: 'month',
       time_scope_value: -1,

--- a/src/pages/azureDetails/detailsToolbar.tsx
+++ b/src/pages/azureDetails/detailsToolbar.tsx
@@ -102,11 +102,25 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   };
 
   public getFilterLabel = (field, value) => {
+    const { t } = this.props;
     let filterText = '';
     if (field.title) {
       filterText = field.title;
     } else {
-      filterText = field;
+      // Normalize account, region, and service filters
+      switch (field) {
+        case 'resource_location':
+          filterText = t('azure_details.filter.region_select');
+          break;
+        case 'subscription_guid':
+          filterText = t('azure_details.filter.account_select');
+          break;
+        case 'service_name':
+          filterText = t('azure_details.filter.service_select');
+          break;
+        default:
+          filterText = field;
+      }
     }
 
     const index = filterText.indexOf('tag:');

--- a/src/pages/azureDetails/detailsWidget.tsx
+++ b/src/pages/azureDetails/detailsWidget.tsx
@@ -25,19 +25,19 @@ export const getIdKeyForTab = (
   tab: AzureDetailsTab
 ): GetComputedAzureReportItemsParams['idKey'] => {
   switch (tab) {
-    case AzureDetailsTab.accounts:
-      return 'account';
-    case AzureDetailsTab.regions:
-      return 'region';
-    case AzureDetailsTab.services:
-      return 'service';
+    case AzureDetailsTab.subscription_guids:
+      return 'subscription_guid';
+    case AzureDetailsTab.resource_locations:
+      return 'resource_location';
+    case AzureDetailsTab.service_names:
+      return 'service_name';
   }
 };
 
 export const enum AzureDetailsTab {
-  accounts = 'accounts',
-  regions = 'regions',
-  services = 'services',
+  subscription_guids = 'subscription_guids',
+  resource_locations = 'resource_locations',
+  service_names = 'service_names',
 }
 
 class DetailsWidgetBase extends React.Component<DetailsWidgetProps> {
@@ -130,9 +130,9 @@ const mapStateToProps = createMapStateToProps<DetailsWidgetOwnProps, {}>(
   state => {
     return {
       availableTabs: [
-        AzureDetailsTab.services,
-        AzureDetailsTab.accounts,
-        AzureDetailsTab.regions,
+        AzureDetailsTab.service_names,
+        AzureDetailsTab.subscription_guids,
+        AzureDetailsTab.resource_locations,
       ],
     };
   }

--- a/src/pages/azureDetails/detailsWidgetView.tsx
+++ b/src/pages/azureDetails/detailsWidgetView.tsx
@@ -124,7 +124,9 @@ class DetailsWidgetViewBase extends React.Component<DetailsWidgetViewProps> {
             type={ButtonType.button}
             variant={ButtonVariant.link}
           >
-            {t('azure_details.view_all', { value: groupBy })}
+            {t('azure_details.view_all', {
+              value: t(`group_by.top_values.${groupBy}`),
+            })}
           </Button>
           <DetailsWidgetModal
             groupBy={groupBy}

--- a/src/pages/azureDetails/groupBy.tsx
+++ b/src/pages/azureDetails/groupBy.tsx
@@ -40,9 +40,9 @@ const groupByOptions: {
   label: string;
   value: GetComputedAzureReportItemsParams['idKey'];
 }[] = [
-  { label: 'account', value: 'account' },
-  { label: 'service', value: 'service' },
-  { label: 'region', value: 'region' },
+  { label: 'subscription_guid', value: 'subscription_guid' },
+  { label: 'service_name', value: 'service_name' },
+  { label: 'resource_location', value: 'resource_location' },
 ];
 
 const reportType = AzureReportType.tag;
@@ -134,7 +134,7 @@ class GroupByBase extends React.Component<GroupByProps> {
         break;
       }
     }
-    return groupBy !== 'date' ? groupBy : 'account';
+    return groupBy !== 'date' ? groupBy : 'subscription_guid';
   };
 
   private handleGroupBySelect = event => {

--- a/src/pages/ocpDetails/detailsTag.tsx
+++ b/src/pages/ocpDetails/detailsTag.tsx
@@ -80,7 +80,7 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
     const { isOpen, showAll } = this.state;
 
     let charCount = 0;
-    const maxChars = 50;
+    const maxChars = 75;
     const someTags = [];
     const allTags = [];
 

--- a/src/pages/ocpOnAwsDetails/detailsTag.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsTag.tsx
@@ -83,7 +83,7 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
     const { isOpen, showAll } = this.state;
 
     let charCount = 0;
-    const maxChars = 50;
+    const maxChars = 75;
     const someTags = [];
     const allTags = [];
 

--- a/src/store/azureDashboard/__snapshots__/azureDashboard.test.ts.snap
+++ b/src/store/azureDashboard/__snapshots__/azureDashboard.test.ts.snap
@@ -12,7 +12,7 @@ Array [
   ],
   Array [
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[service]=*",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[service_name]=*",
   ],
 ]
 `;

--- a/src/store/azureDashboard/azureDashboard.test.ts
+++ b/src/store/azureDashboard/azureDashboard.test.ts
@@ -55,16 +55,19 @@ test('fetch widget reports', () => {
 test('changeWidgetTab', () => {
   const store = createAzureDashboardStore();
   store.dispatch(
-    actions.changeWidgetTab(costSummaryWidget.id, AzureDashboardTab.regions)
+    actions.changeWidgetTab(
+      costSummaryWidget.id,
+      AzureDashboardTab.resource_locations
+    )
   );
   const widget = selectors.selectWidget(store.getState(), costSummaryWidget.id);
-  expect(widget.currentTab).toBe(AzureDashboardTab.regions);
+  expect(widget.currentTab).toBe(AzureDashboardTab.resource_locations);
   expect(fetchReportMock).toHaveBeenCalledTimes(3);
 });
 
 describe('getGroupByForTab', () => {
   test('services tab', () => {
-    expect(getGroupByForTab(AzureDashboardTab.services)).toMatchSnapshot();
+    expect(getGroupByForTab(AzureDashboardTab.service_names)).toMatchSnapshot();
   });
 
   test('instance types tab', () => {
@@ -72,11 +75,15 @@ describe('getGroupByForTab', () => {
   });
 
   test('accounts tab', () => {
-    expect(getGroupByForTab(AzureDashboardTab.accounts)).toMatchSnapshot();
+    expect(
+      getGroupByForTab(AzureDashboardTab.subscription_guids)
+    ).toMatchSnapshot();
   });
 
   test('regions tab', () => {
-    expect(getGroupByForTab(AzureDashboardTab.regions)).toMatchSnapshot();
+    expect(
+      getGroupByForTab(AzureDashboardTab.resource_locations)
+    ).toMatchSnapshot();
   });
 
   test('unknown tab', () => {
@@ -89,8 +96,8 @@ test('getQueryForWidget', () => {
     id: 1,
     titleKey: '',
     reportType: AzureReportType.cost,
-    availableTabs: [AzureDashboardTab.accounts],
-    currentTab: AzureDashboardTab.accounts,
+    availableTabs: [AzureDashboardTab.subscription_guids],
+    currentTab: AzureDashboardTab.subscription_guids,
     details: { labelKey: '', formatOptions: {} },
     trend: {
       titleKey: '',
@@ -105,10 +112,10 @@ test('getQueryForWidget', () => {
   [
     [
       undefined,
-      'filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&group_by[account]=*',
+      'filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&group_by[subscription_guid]=*',
     ],
-    [{}, 'group_by[account]=*'],
-    [{ limit: 3 }, 'filter[limit]=3&group_by[account]=*'],
+    [{}, 'group_by[subscription_guid]=*'],
+    [{ limit: 3 }, 'filter[limit]=3&group_by[subscription_guid]=*'],
   ].forEach(value => {
     expect(getQueryForWidgetTabs(widget, value[0])).toEqual(value[1]);
   });

--- a/src/store/azureDashboard/azureDashboardCommon.ts
+++ b/src/store/azureDashboard/azureDashboardCommon.ts
@@ -18,9 +18,9 @@ interface ValueFormatOptions {
 }
 
 export const enum AzureDashboardTab {
-  services = 'services',
-  accounts = 'accounts',
-  regions = 'regions',
+  service_names = 'service_names',
+  subscription_guids = 'subscription_guids',
+  resource_locations = 'resource_locations',
   instanceType = 'instance_type',
 }
 
@@ -39,13 +39,13 @@ export interface AzureDashboardWidget {
   };
   filter?: {
     limit?: number;
-    service?: string;
+    service_name?: string;
   };
   isDetailsLink?: boolean;
   isHorizontal?: boolean;
   tabsFilter?: {
     limit?: number;
-    service?: string;
+    service_name?: string;
   };
   trend: {
     titleKey: string;
@@ -61,18 +61,18 @@ export function getGroupByForTab(
   widget: AzureDashboardWidget
 ): AzureQuery['group_by'] {
   switch (widget.currentTab) {
-    case AzureDashboardTab.services:
+    case AzureDashboardTab.service_names:
       // Use group_by for service tab and filter for others -- https://github.com/project-koku/koku-ui/issues/846
       return {
-        service:
-          widget.tabsFilter && widget.tabsFilter.service
-            ? widget.tabsFilter.service
+        service_name:
+          widget.tabsFilter && widget.tabsFilter.service_name
+            ? widget.tabsFilter.service_name
             : '*',
       };
-    case AzureDashboardTab.accounts:
-      return { account: '*' };
-    case AzureDashboardTab.regions:
-      return { region: '*' };
+    case AzureDashboardTab.subscription_guids:
+      return { subscription_guid: '*' };
+    case AzureDashboardTab.resource_locations:
+      return { resource_location: '*' };
     case AzureDashboardTab.instanceType:
       return { instance_type: '*' };
     default:
@@ -100,9 +100,9 @@ export function getQueryForWidgetTabs(
 
   // Use group_by for service tab and filter for others -- https://github.com/project-koku/koku-ui/issues/846
   if (
-    widget.currentTab === AzureDashboardTab.services &&
+    widget.currentTab === AzureDashboardTab.service_names &&
     widget.tabsFilter &&
-    widget.tabsFilter.service
+    widget.tabsFilter.service_name
   ) {
     newFilter.service = undefined;
   }

--- a/src/store/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/azureDashboard/azureDashboardWidgets.ts
@@ -20,10 +20,10 @@ export const computeWidget: AzureDashboardWidget = {
     usageKey: 'azure_dashboard.compute_usage_label',
   },
   filter: {
-    service: 'AmazonEC2',
+    service_name: 'Virtual Machines',
   },
   tabsFilter: {
-    service: 'AmazonEC2',
+    service_name: 'Virtual Machines',
   },
   trend: {
     formatOptions: {
@@ -37,8 +37,8 @@ export const computeWidget: AzureDashboardWidget = {
   },
   availableTabs: [
     AzureDashboardTab.instanceType,
-    AzureDashboardTab.accounts,
-    AzureDashboardTab.regions,
+    AzureDashboardTab.subscription_guids,
+    AzureDashboardTab.resource_locations,
   ],
   currentTab: AzureDashboardTab.instanceType,
 };
@@ -66,11 +66,11 @@ export const costSummaryWidget: AzureDashboardWidget = {
     formatOptions: {},
   },
   availableTabs: [
-    AzureDashboardTab.services,
-    AzureDashboardTab.accounts,
-    AzureDashboardTab.regions,
+    AzureDashboardTab.service_names,
+    AzureDashboardTab.subscription_guids,
+    AzureDashboardTab.resource_locations,
   ],
-  currentTab: AzureDashboardTab.services,
+  currentTab: AzureDashboardTab.service_names,
 };
 
 export const databaseWidget: AzureDashboardWidget = {
@@ -84,12 +84,10 @@ export const databaseWidget: AzureDashboardWidget = {
     },
   },
   filter: {
-    service:
-      'AmazonRDS,AmazonDynamoDB,AmazonElastiCache,AmazonNeptune,AmazonRedshift,AmazonDocumentDB',
+    service_name: 'Database,Cosmos DB,Cache for Redis',
   },
   tabsFilter: {
-    service:
-      'AmazonRDS,AmazonDynamoDB,AmazonElastiCache,AmazonNeptune,AmazonRedshift,AmazonDocumentDB',
+    service_name: 'Database,Cosmos DB,Cache for Redis',
   },
   trend: {
     formatOptions: {},
@@ -100,11 +98,11 @@ export const databaseWidget: AzureDashboardWidget = {
     formatOptions: {},
   },
   availableTabs: [
-    AzureDashboardTab.services,
-    AzureDashboardTab.accounts,
-    AzureDashboardTab.regions,
+    AzureDashboardTab.service_names,
+    AzureDashboardTab.subscription_guids,
+    AzureDashboardTab.resource_locations,
   ],
-  currentTab: AzureDashboardTab.services,
+  currentTab: AzureDashboardTab.service_names,
 };
 
 export const networkWidget: AzureDashboardWidget = {
@@ -118,10 +116,12 @@ export const networkWidget: AzureDashboardWidget = {
     },
   },
   filter: {
-    service: 'AmazonVPC,AmazonCloudFront,AmazonRoute53,AmazonAPIGateway',
+    service_name:
+      'Virtual Network,VPN,DNS,Traffic Manager,ExpressRoute,Load Balancer,Application Gateway',
   },
   tabsFilter: {
-    service: 'AmazonVPC,AmazonCloudFront,AmazonRoute53,AmazonAPIGateway',
+    service_name:
+      'Virtual Network,VPN,DNS,Traffic Manager,ExpressRoute,Load Balancer,Application Gateway',
   },
   trend: {
     formatOptions: {},
@@ -132,11 +132,11 @@ export const networkWidget: AzureDashboardWidget = {
     formatOptions: {},
   },
   availableTabs: [
-    AzureDashboardTab.services,
-    AzureDashboardTab.accounts,
-    AzureDashboardTab.regions,
+    AzureDashboardTab.service_names,
+    AzureDashboardTab.subscription_guids,
+    AzureDashboardTab.resource_locations,
   ],
-  currentTab: AzureDashboardTab.services,
+  currentTab: AzureDashboardTab.service_names,
 };
 
 export const storageWidget: AzureDashboardWidget = {
@@ -151,6 +151,12 @@ export const storageWidget: AzureDashboardWidget = {
     showUnits: true,
     usageKey: 'azure_dashboard.storage_usage_label',
   },
+  filter: {
+    service_name: 'Storage',
+  },
+  tabsFilter: {
+    service_name: 'Storage',
+  },
   trend: {
     formatOptions: {
       fractionDigits: 2,
@@ -162,9 +168,9 @@ export const storageWidget: AzureDashboardWidget = {
     formatOptions: {},
   },
   availableTabs: [
-    AzureDashboardTab.services,
-    AzureDashboardTab.accounts,
-    AzureDashboardTab.regions,
+    AzureDashboardTab.service_names,
+    AzureDashboardTab.subscription_guids,
+    AzureDashboardTab.resource_locations,
   ],
-  currentTab: AzureDashboardTab.accounts,
+  currentTab: AzureDashboardTab.subscription_guids,
 };

--- a/src/utils/getComputedAzureReportItems.test.ts
+++ b/src/utils/getComputedAzureReportItems.test.ts
@@ -5,10 +5,10 @@ import {
 
 test('get id key for groupBy', () => {
   [
-    [{ account: 's', instance_type: 's' }, 'account'],
-    [{ instance_type: 's', region: 's' }, 'instance_type'],
-    [{ region: 's', service: 's' }, 'region'],
-    [{ service: 's' }, 'service'],
+    [{ subscription_guid: 's', instance_type: 's' }, 'subscription_guid'],
+    [{ instance_type: 's', resource_location: 's' }, 'instance_type'],
+    [{ resource_location: 's', service_name: 's' }, 'resource_location'],
+    [{ service_name: 's' }, 'service_name'],
     [{}, 'date'],
     [undefined, 'date'],
   ].forEach(value => {
@@ -113,18 +113,17 @@ describe('getComputedReportItems', () => {
     ).toEqual(expected);
   });
 
-  test('set label to alias if given when label key is account', () => {
+  test('set label to alias if given when label key is subscription_guid', () => {
     const report = {
       data: [
         {
           date: '2018-09-04',
-          accounts: [
+          subscription_guids: [
             {
-              account: '1',
+              subscription_guid: '1',
               values: [
                 {
-                  account: '1',
-                  account_alias: 'alias',
+                  subscription_guid: '1',
                   count: { value: 10, units: 'instances' },
                   date: '2018-09-04',
                   derivedCost: 0,
@@ -134,10 +133,10 @@ describe('getComputedReportItems', () => {
               ],
             },
             {
-              account: '2',
+              subscription_guid: '2',
               values: [
                 {
-                  account: '2',
+                  subscription_guid: '2',
                   count: { value: 0, units: 'instances' },
                   date: '2018-09-04',
                   derivedCost: 0,
@@ -153,6 +152,8 @@ describe('getComputedReportItems', () => {
     const expected = [
       {
         cost: 48,
+        deltaPercent: undefined,
+        deltaValue: undefined,
         derivedCost: 0,
         id: '2',
         infrastructureCost: 0,
@@ -161,15 +162,17 @@ describe('getComputedReportItems', () => {
       },
       {
         cost: 12,
+        deltaPercent: undefined,
+        deltaValue: undefined,
         derivedCost: 0,
         id: '1',
         infrastructureCost: 0,
-        label: 'alias',
+        label: '1',
         units: 'Hrs',
       },
     ];
-    expect(getComputedAzureReportItems({ report, idKey: 'account' })).toEqual(
-      expected
-    );
+    expect(
+      getComputedAzureReportItems({ report, idKey: 'subscription_guid' })
+    ).toEqual(expected);
   });
 });

--- a/src/utils/getComputedAzureReportItems.ts
+++ b/src/utils/getComputedAzureReportItems.ts
@@ -78,9 +78,6 @@ export function getUnsortedComputedAzureReportItems({
         } else {
           label = value[labelKey];
         }
-        if (labelKey === 'account' && value.account_alias) {
-          label = value.account_alias;
-        }
         if (!itemMap.get(id)) {
           itemMap.set(id, {
             cost,
@@ -118,17 +115,17 @@ export function getUnsortedComputedAzureReportItems({
 export function getIdKeyForGroupBy(
   groupBy: AzureQuery['group_by'] = {}
 ): GetComputedAzureReportItemsParams['idKey'] {
-  if (groupBy.account) {
-    return 'account';
+  if (groupBy.subscription_guid) {
+    return 'subscription_guid';
   }
   if (groupBy.instance_type) {
     return 'instance_type';
   }
-  if (groupBy.region) {
-    return 'region';
+  if (groupBy.resource_location) {
+    return 'resource_location';
   }
-  if (groupBy.service) {
-    return 'service';
+  if (groupBy.service_name) {
+    return 'service_name';
   }
   return 'date';
 }


### PR DESCRIPTION
The current Azure overview and details pages are a copy of AWS. Now that the Azure APIs are available, we need to update those pages to use those APIs instead.

Fixes https://github.com/project-koku/koku-ui/issues/966

Overview
![Screen Shot 2019-09-19 at 4 12 33 PM](https://user-images.githubusercontent.com/17481322/65278101-5fc57a00-daf9-11e9-90f4-31fa06298f77.png)

Azure details
![Screen Shot 2019-09-19 at 4 12 46 PM](https://user-images.githubusercontent.com/17481322/65278119-694ee200-daf9-11e9-8115-8cb71d3489f8.png)
