### PR TITLE
Handle scenario where API returns null cost

### DIFF
--- a/src/utils/getComputedAwsReportItems.ts
+++ b/src/utils/getComputedAwsReportItems.ts
@@ -90,7 +90,11 @@ export function getUnsortedComputedAwsReportItems({
             id,
             infrastructureCost,
             label,
-            units: value.usage ? value.usage.units : value.cost.units,
+            units: value.usage
+              ? value.usage.units
+              : value.cost
+              ? value.cost.units
+              : 'USD',
           });
           return;
         }

--- a/src/utils/getComputedAzureReportItems.ts
+++ b/src/utils/getComputedAzureReportItems.ts
@@ -87,7 +87,11 @@ export function getUnsortedComputedAzureReportItems({
             id,
             infrastructureCost,
             label,
-            units: value.usage ? value.usage.units : value.cost.units,
+            units: value.usage
+              ? value.usage.units
+              : value.cost
+              ? value.cost.units
+              : 'USD',
           });
           return;
         }

--- a/src/utils/getComputedOcpOnAwsReportItems.ts
+++ b/src/utils/getComputedOcpOnAwsReportItems.ts
@@ -108,7 +108,11 @@ export function getUnsortedComputedOcpOnAwsReportItems({
         const limit = value.limit ? value.limit.value : 0;
         const request = value.request ? value.request.value : 0;
         const usage = value.usage ? value.usage.value : 0;
-        const units = value.usage ? value.usage.units : value.cost.units;
+        const units = value.usage
+          ? value.usage.units
+          : value.cost
+          ? value.cost.units
+          : 'USD';
         if (!itemMap.get(id)) {
           itemMap.set(id, {
             capacity,

--- a/src/utils/getComputedOcpReportItems.ts
+++ b/src/utils/getComputedOcpReportItems.ts
@@ -104,7 +104,11 @@ export function getUnsortedComputedOcpReportItems({
         const limit = value.limit ? value.limit.value : 0;
         const request = value.request ? value.request.value : 0;
         const usage = value.usage ? value.usage.value : 0;
-        const units = value.usage ? value.usage.units : value.cost.units;
+        const units = value.usage
+          ? value.usage.units
+          : value.cost
+          ? value.cost.units
+          : 'USD';
         if (!itemMap.get(id)) {
           itemMap.set(id, {
             capacity,


### PR DESCRIPTION
The OpenShift on AWS overview page is generating an error because the /v1/reports/openshift/infrastructures/aws/costs API is returning null for cost. This change ensures the UI handles that scenario by providing its own default units.

Fixes https://github.com/project-koku/koku-ui/issues/1011