### PR TITLE
Truncate tag names at 50 chars

### DIFF
--- a/src/pages/awsDetails/detailsTag.tsx
+++ b/src/pages/awsDetails/detailsTag.tsx
@@ -80,7 +80,7 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
     const { isOpen, showAll } = this.state;
 
     let charCount = 0;
-    const maxChars = 75;
+    const maxChars = 50;
     const someTags = [];
     const allTags = [];
 
@@ -89,11 +89,19 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
         for (const val of tag.values) {
           const prefix = someTags.length > 0 ? ', ' : '';
           const tagString = `${prefix}${(tag as any).key}: ${val}`;
+          if (showAll) {
+            someTags.push(tagString);
+          } else if (charCount <= maxChars) {
+            if (charCount + tagString.length > maxChars) {
+              someTags.push(
+                tagString.slice(0, maxChars - charCount).concat('...')
+              );
+            } else {
+              someTags.push(tagString);
+            }
+          }
           charCount += tagString.length;
           allTags.push(`${(tag as any).key}: ${val}`);
-          if (charCount <= maxChars || showAll) {
-            someTags.push(tagString);
-          }
         }
       }
     }

--- a/src/pages/azureDetails/detailsTag.tsx
+++ b/src/pages/azureDetails/detailsTag.tsx
@@ -80,18 +80,24 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
     const { isOpen, showAll } = this.state;
 
     let charCount = 0;
-    const maxChars = 75;
+    const maxChars = 50;
     const someTags = [];
     const allTags = [];
 
     const addTag = (tag, val) => {
       const prefix = someTags.length > 0 ? ', ' : '';
       const tagString = `${prefix}${(tag as any).key}: ${val}`;
+      if (showAll) {
+        someTags.push(tagString);
+      } else if (charCount <= maxChars) {
+        if (charCount + tagString.length > maxChars) {
+          someTags.push(tagString.slice(0, maxChars - charCount).concat('...'));
+        } else {
+          someTags.push(tagString);
+        }
+      }
       charCount += tagString.length;
       allTags.push(`${(tag as any).key}: ${val}`);
-      if (charCount <= maxChars || showAll) {
-        someTags.push(tagString);
-      }
     };
 
     if (report) {

--- a/src/pages/ocpDetails/detailsTag.tsx
+++ b/src/pages/ocpDetails/detailsTag.tsx
@@ -80,7 +80,7 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
     const { isOpen, showAll } = this.state;
 
     let charCount = 0;
-    const maxChars = 75;
+    const maxChars = 50;
     const someTags = [];
     const allTags = [];
 
@@ -89,11 +89,19 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
         for (const val of tag.values) {
           const prefix = someTags.length > 0 ? ', ' : '';
           const tagString = `${prefix}${(tag as any).key}: ${val}`;
+          if (showAll) {
+            someTags.push(tagString);
+          } else if (charCount <= maxChars) {
+            if (charCount + tagString.length > maxChars) {
+              someTags.push(
+                tagString.slice(0, maxChars - charCount).concat('...')
+              );
+            } else {
+              someTags.push(tagString);
+            }
+          }
           charCount += tagString.length;
           allTags.push(`${(tag as any).key}: ${val}`);
-          if (charCount <= maxChars || showAll) {
-            someTags.push(tagString);
-          }
         }
       }
     }

--- a/src/pages/ocpOnAwsDetails/detailsTag.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsTag.tsx
@@ -83,7 +83,7 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
     const { isOpen, showAll } = this.state;
 
     let charCount = 0;
-    const maxChars = 75;
+    const maxChars = 50;
     const someTags = [];
     const allTags = [];
 
@@ -92,11 +92,19 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
         for (const val of tag.values) {
           const prefix = someTags.length > 0 ? ', ' : '';
           const tagString = `${prefix}${(tag as any).key}: ${val}`;
+          if (showAll) {
+            someTags.push(tagString);
+          } else if (charCount <= maxChars) {
+            if (charCount + tagString.length > maxChars) {
+              someTags.push(
+                tagString.slice(0, maxChars - charCount).concat('...')
+              );
+            } else {
+              someTags.push(tagString);
+            }
+          }
           charCount += tagString.length;
           allTags.push(`${(tag as any).key}: ${val}`);
-          if (charCount <= maxChars || showAll) {
-            someTags.push(tagString);
-          }
         }
       }
     }


### PR DESCRIPTION
Want to truncate the "related tags" shown in the expandable area of each details table. Currently, when the number of tag characters is greater than the allowed, a tag may not be shown at all.

Fixes https://github.com/project-koku/koku-ui/issues/1018

![Screen Shot 2019-09-25 at 3 21 38 PM](https://user-images.githubusercontent.com/17481322/65633180-81b37680-dfa9-11e9-8bc1-f44021f5e9c8.png)

Hold merge until after the EMEA conference