### PR TITLE
Update icon names for font awesome 5

### DIFF
--- a/src/pages/awsDetails/detailsTable.styles.ts
+++ b/src/pages/awsDetails/detailsTable.styles.ts
@@ -43,14 +43,14 @@ export const monthOverMonthOverride = css`
       &.increase {
         color: ${global_danger_color_100.value};
       }
-      .fa-sort-asc,
-      .fa-sort-desc {
+      .fa-sort-up,
+      .fa-sort-down {
         margin-left: 10px;
       }
-      .fa-sort-asc::before {
+      .fa-sort-up::before {
         color: ${global_danger_color_100.value};
       }
-      .fa-sort-desc::before {
+      .fa-sort-down::before {
         color: ${global_success_color_100.value};
       }
       span {

--- a/src/pages/awsDetails/detailsTable.tsx
+++ b/src/pages/awsDetails/detailsTable.tsx
@@ -243,14 +243,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           {t('percent', { value: percentage })}
           {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
             <span
-              className={css('fa fa-sort-asc', styles.infoArrow)}
+              className={css('fa fa-sort-up', styles.infoArrow)}
               key={`month-over-month-icon-${index}`}
             />
           )}
           {Boolean(item.deltaPercent !== null && item.deltaValue < 0) && (
             <span
               className={css(
-                'fa fa-sort-desc',
+                'fa fa-sort-down',
                 styles.infoArrow,
                 styles.infoArrowDesc
               )}

--- a/src/pages/azureDetails/detailsTable.styles.ts
+++ b/src/pages/azureDetails/detailsTable.styles.ts
@@ -43,14 +43,14 @@ export const monthOverMonthOverride = css`
       &.increase {
         color: ${global_danger_color_100.value};
       }
-      .fa-sort-asc,
-      .fa-sort-desc {
+      .fa-sort-up,
+      .fa-sort-down {
         margin-left: 10px;
       }
-      .fa-sort-asc::before {
+      .fa-sort-up::before {
         color: ${global_danger_color_100.value};
       }
-      .fa-sort-desc::before {
+      .fa-sort-down::before {
         color: ${global_success_color_100.value};
       }
       span {

--- a/src/pages/azureDetails/detailsTable.tsx
+++ b/src/pages/azureDetails/detailsTable.tsx
@@ -243,14 +243,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           {t('percent', { value: percentage })}
           {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
             <span
-              className={css('fa fa-sort-asc', styles.infoArrow)}
+              className={css('fa fa-sort-up', styles.infoArrow)}
               key={`month-over-month-icon-${index}`}
             />
           )}
           {Boolean(item.deltaPercent !== null && item.deltaValue < 0) && (
             <span
               className={css(
-                'fa fa-sort-desc',
+                'fa fa-sort-down',
                 styles.infoArrow,
                 styles.infoArrowDesc
               )}

--- a/src/pages/ocpDetails/detailsTable.styles.ts
+++ b/src/pages/ocpDetails/detailsTable.styles.ts
@@ -43,14 +43,14 @@ export const monthOverMonthOverride = css`
       &.increase {
         color: ${global_danger_color_100.value};
       }
-      .fa-sort-asc,
-      .fa-sort-desc {
+      .fa-sort-up,
+      .fa-sort-down {
         margin-left: 10px;
       }
-      .fa-sort-asc::before {
+      .fa-sort-up::before {
         color: ${global_danger_color_100.value};
       }
-      .fa-sort-desc::before {
+      .fa-sort-down::before {
         color: ${global_success_color_100.value};
       }
       span {

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -320,14 +320,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           {t('percent', { value: percentage })}
           {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
             <span
-              className={css('fa fa-sort-asc', styles.infoArrow)}
+              className={css('fa fa-sort-up', styles.infoArrow)}
               key={`month-over-month-icon-${index}`}
             />
           )}
           {Boolean(item.deltaPercent !== null && item.deltaValue < 0) && (
             <span
               className={css(
-                'fa fa-sort-desc',
+                'fa fa-sort-down',
                 styles.infoArrow,
                 styles.infoArrowDesc
               )}

--- a/src/pages/ocpOnAwsDetails/detailsTable.styles.ts
+++ b/src/pages/ocpOnAwsDetails/detailsTable.styles.ts
@@ -43,14 +43,14 @@ export const monthOverMonthOverride = css`
       &.increase {
         color: ${global_danger_color_100.value};
       }
-      .fa-sort-asc,
-      .fa-sort-desc {
+      .fa-sort-up,
+      .fa-sort-down {
         margin-left: 10px;
       }
-      .fa-sort-asc::before {
+      .fa-sort-up::before {
         color: ${global_danger_color_100.value};
       }
-      .fa-sort-desc::before {
+      .fa-sort-down::before {
         color: ${global_success_color_100.value};
       }
       span {

--- a/src/pages/ocpOnAwsDetails/detailsTable.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsTable.tsx
@@ -248,14 +248,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           {t('percent', { value: percentage })}
           {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
             <span
-              className={css('fa fa-sort-asc', styles.infoArrow)}
+              className={css('fa fa-sort-up', styles.infoArrow)}
               key={`month-over-month-icon-${index}`}
             />
           )}
           {Boolean(item.deltaPercent !== null && item.deltaValue < 0) && (
             <span
               className={css(
-                'fa fa-sort-desc',
+                'fa fa-sort-down',
                 styles.infoArrow,
                 styles.infoArrowDesc
               )}


### PR DESCRIPTION
Need to rename icons for Font Awesome 5. 

We're using `fa-sort-asc` and `fa-sort-desc`, but it's `fa-sort-up` and `fa-sort-down` in fa5 https://fontawesome.com/icons/sort-up?style=solid

Fixes https://github.com/project-koku/koku-ui/issues/1020

![Screen Shot 2019-09-25 at 4 14 40 PM](https://user-images.githubusercontent.com/17481322/65636247-f12c6480-dfaf-11e9-8b43-a85192918de4.png)

Hold merge until after the EMEA conference