### PR TITLE
Details page should stretch with table rows

### DIFF
--- a/src/pages/awsDetails/awsDetails.styles.ts
+++ b/src/pages/awsDetails/awsDetails.styles.ts
@@ -13,12 +13,11 @@ export const styles = StyleSheet.create({
   },
   content: {
     backgroundColor: global_BackgroundColor_300.value,
+    paddingBottom: global_spacer_xl.value,
     paddingTop: global_spacer_xl.value,
-    height: '100%',
   },
   paginationContainer: {
     backgroundColor: global_BackgroundColor_light_100.value,
-    marginBottom: global_spacer_xl.value,
     marginLeft: global_spacer_xl.value,
     marginRight: global_spacer_xl.value,
   },

--- a/src/pages/azureDetails/azureDetails.styles.ts
+++ b/src/pages/azureDetails/azureDetails.styles.ts
@@ -13,12 +13,11 @@ export const styles = StyleSheet.create({
   },
   content: {
     backgroundColor: global_BackgroundColor_300.value,
+    paddingBottom: global_spacer_xl.value,
     paddingTop: global_spacer_xl.value,
-    height: '100%',
   },
   paginationContainer: {
     backgroundColor: global_BackgroundColor_light_100.value,
-    marginBottom: global_spacer_xl.value,
     marginLeft: global_spacer_xl.value,
     marginRight: global_spacer_xl.value,
   },

--- a/src/pages/ocpDetails/ocpDetails.styles.ts
+++ b/src/pages/ocpDetails/ocpDetails.styles.ts
@@ -9,8 +9,8 @@ import {
 export const styles = StyleSheet.create({
   content: {
     backgroundColor: global_BackgroundColor_300.value,
+    paddingBottom: global_spacer_xl.value,
     paddingTop: global_spacer_xl.value,
-    height: '100%',
   },
   ocpDetails: {
     backgroundColor: global_BackgroundColor_300.value,
@@ -18,7 +18,6 @@ export const styles = StyleSheet.create({
   },
   paginationContainer: {
     backgroundColor: global_BackgroundColor_light_100.value,
-    marginBottom: global_spacer_xl.value,
     marginLeft: global_spacer_xl.value,
     marginRight: global_spacer_xl.value,
   },

--- a/src/pages/ocpOnAwsDetails/ocpOnAwsDetails.styles.ts
+++ b/src/pages/ocpOnAwsDetails/ocpOnAwsDetails.styles.ts
@@ -9,8 +9,8 @@ import {
 export const styles = StyleSheet.create({
   content: {
     backgroundColor: global_BackgroundColor_300.value,
+    paddingBottom: global_spacer_xl.value,
     paddingTop: global_spacer_xl.value,
-    height: '100%',
   },
   ocpOnAwsDetails: {
     backgroundColor: global_BackgroundColor_300.value,
@@ -18,7 +18,6 @@ export const styles = StyleSheet.create({
   },
   paginationContainer: {
     backgroundColor: global_BackgroundColor_light_100.value,
-    marginBottom: global_spacer_xl.value,
     marginLeft: global_spacer_xl.value,
     marginRight: global_spacer_xl.value,
   },


### PR DESCRIPTION
This ensures the details pages stretch properly as the number of table rows are increased. 

Note that the Cost model details page uses `height: '182vh'`, but that makes the page scroll unnecessarily.

Fixes https://github.com/project-koku/koku-ui/issues/1022

![Screen Shot 2019-09-25 at 4 59 58 PM](https://user-images.githubusercontent.com/17481322/65639352-ee347280-dfb5-11e9-9155-937e93652573.png)

Hold merge until after the EMEA conference