### PR TITLE
Bullet chart usage shows wrong value

### DIFF
--- a/src/pages/ocpDetails/detailsChart.tsx
+++ b/src/pages/ocpDetails/detailsChart.tsx
@@ -202,7 +202,7 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
                   cpuDatum.limit.value ? [{ name: cpuDatum.limit.legend }] : []
                 }
                 height={200}
-                labels={datum => `${datum.tooltip}`}
+                labels={({ datum }) => `${datum.tooltip}`}
                 legendPosition="bottom-left"
                 legendItemsPerRow={itemsPerRow}
                 padding={{
@@ -216,7 +216,7 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
                     ? [
                         {
                           tooltip: cpuDatum.usage[0].tooltip,
-                          y: cpuDatum.limit.value,
+                          y: cpuDatum.usage[0].value,
                         },
                       ]
                     : []
@@ -270,7 +270,7 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
                     : []
                 }
                 height={200}
-                labels={datum => `${datum.tooltip}`}
+                labels={({ datum }) => `${datum.tooltip}`}
                 legendPosition="bottom-left"
                 legendItemsPerRow={itemsPerRow}
                 padding={{

--- a/src/pages/ocpOnAwsDetails/detailsChart.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsChart.tsx
@@ -205,7 +205,7 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
                   cpuDatum.limit.value ? [{ name: cpuDatum.limit.legend }] : []
                 }
                 height={200}
-                labels={datum => `${datum.tooltip}`}
+                labels={({ datum }) => `${datum.tooltip}`}
                 legendPosition="bottom-left"
                 legendItemsPerRow={itemsPerRow}
                 padding={{
@@ -219,7 +219,7 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
                     ? [
                         {
                           tooltip: cpuDatum.usage[0].tooltip,
-                          y: cpuDatum.limit.value,
+                          y: cpuDatum.usage[0].value,
                         },
                       ]
                     : []
@@ -273,7 +273,7 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
                     : []
                 }
                 height={200}
-                labels={datum => `${datum.tooltip}`}
+                labels={({ datum }) => `${datum.tooltip}`}
                 legendPosition="bottom-left"
                 legendItemsPerRow={itemsPerRow}
                 padding={{


### PR DESCRIPTION
Fixed the bullet chart, shown in the Ocp and Ocp on AWS details pages, to show the correct value for usage. Also ensured tooltips are displayed correctly -- label syntax needed to be modified, due to the Victory charts update.

Fixes https://github.com/project-koku/koku-ui/issues/1024

Hold merge until after the EMEA conference