### PR TITLE
fix(costmodels): general information step fit and finish

### DIFF
--- a/src/pages/createCostModelWizard/generalInformation.tsx
+++ b/src/pages/createCostModelWizard/generalInformation.tsx
@@ -1,7 +1,11 @@
 import {
+  Form,
   FormGroup,
   FormSelect,
   FormSelectOption,
+  Stack,
+  StackItem,
+  TextArea,
   TextInput,
   Title,
 } from '@patternfly/react-core';
@@ -20,57 +24,69 @@ const GeneralInformation: React.SFC<InjectedTranslateProps> = ({ t }) => {
         onDescChange,
         onTypeChange,
       }) => (
-        <>
-          <Title size="xl">{t('cost_models_wizard.general_info.title')}</Title>
-          <FormGroup
-            label={t('cost_models_wizard.general_info.name_label')}
-            isRequired
-            fieldId="name"
-          >
-            <TextInput
-              isRequired
-              type="text"
-              id="name"
-              name="name"
-              value={name}
-              onChange={onNameChange}
-            />
-          </FormGroup>
-          <FormGroup
-            label={t('cost_models_wizard.general_info.description_label')}
-            fieldId="description"
-          >
-            <TextInput
-              type="text"
-              id="description"
-              name="description"
-              value={description}
-              onChange={onDescChange}
-            />
-          </FormGroup>
-          <FormGroup
-            label={t('cost_models_wizard.general_info.source_type_label')}
-            isRequired
-            fieldId="source-type"
-          >
-            <FormSelect id="source-type" value={type} onChange={onTypeChange}>
-              <FormSelectOption
-                value=""
-                label={t(
-                  'cost_models_wizard.general_info.source_type_empty_value_label'
-                )}
-              />
-              <FormSelectOption
-                value="AWS"
-                label={t('onboarding.type_options.aws')}
-              />
-              <FormSelectOption
-                value="OCP"
-                label={t('onboarding.type_options.ocp')}
-              />
-            </FormSelect>
-          </FormGroup>
-        </>
+        <Stack gutter="md">
+          <StackItem>
+            <Title size="xl">
+              {t('cost_models_wizard.general_info.title')}
+            </Title>
+          </StackItem>
+          <StackItem>
+            <Form style={{ width: '350px' }}>
+              <FormGroup
+                label={t('cost_models_wizard.general_info.name_label')}
+                isRequired
+                fieldId="name"
+              >
+                <TextInput
+                  isRequired
+                  type="text"
+                  id="name"
+                  name="name"
+                  value={name}
+                  onChange={onNameChange}
+                />
+              </FormGroup>
+              <FormGroup
+                label={t('cost_models_wizard.general_info.description_label')}
+                fieldId="description"
+              >
+                <TextArea
+                  type="text"
+                  id="description"
+                  name="description"
+                  value={description}
+                  onChange={onDescChange}
+                />
+              </FormGroup>
+              <FormGroup
+                label={t('cost_models_wizard.general_info.source_type_label')}
+                isRequired
+                fieldId="source-type"
+              >
+                <FormSelect
+                  id="source-type"
+                  value={type}
+                  onChange={onTypeChange}
+                >
+                  <FormSelectOption
+                    value=""
+                    label={t(
+                      'cost_models_wizard.general_info.source_type_empty_value_label'
+                    )}
+                  />
+                  <FormSelectOption
+                    value="AWS"
+                    label={t('onboarding.type_options.aws')}
+                  />
+                  <FormSelectOption
+                    value="OCP"
+                    label={t('onboarding.type_options.ocp')}
+                  />
+                </FormSelect>
+              </FormGroup>
+            </Form>
+          </StackItem>
+        </Stack>
       )}
     </CostModelContext.Consumer>
   );


### PR DESCRIPTION
closes #1037 

- [x] Description field should be a text area
- [x] Padding around fields
- [x] Length of fields shouldn't fill the space. Set them to the length of the longest value in the source type option.

![image](https://user-images.githubusercontent.com/2453279/66113113-d91e9b80-e5d4-11e9-9c95-8689aac406ab.png)
