### PR TITLE
fix(costmodels): add price list sub-step fit and finish

### DIFF
--- a/src/pages/createCostModelWizard/addPriceList.tsx
+++ b/src/pages/createCostModelWizard/addPriceList.tsx
@@ -1,140 +1,171 @@
 import {
   Button,
+  Form,
   FormGroup,
   FormSelect,
   FormSelectOption,
+  InputGroup,
+  InputGroupText,
+  Stack,
+  StackItem,
+  Text,
+  TextContent,
   TextInput,
+  TextVariants,
   Title,
   TitleSize,
 } from '@patternfly/react-core';
+import { DollarSignIcon } from '@patternfly/react-icons';
+import { css } from '@patternfly/react-styles';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { CostModelContext } from './context';
 import { units } from './priceListTier';
+import { styles } from './wizard.styles';
 
 const AddPriceList: React.SFC<InjectedTranslateProps> = ({ t }) => {
   return (
     <CostModelContext.Consumer>
       {({ priceListCurrent, updateCurrentPL, submitCurrentPL }) => {
         return (
-          <>
-            <Title size={TitleSize.xl}>
-              {t('cost_models_wizard.price_list.title')}
-            </Title>
-            <Title size={TitleSize.md}>
-              {t('cost_models_wizard.price_list.sub_title_add')}
-            </Title>
-            <FormGroup
-              label={t('cost_models_wizard.price_list.metric_label')}
-              fieldId="metric-selector"
-            >
-              <FormSelect
-                value={priceListCurrent.metric}
-                onChange={(value: string) => updateCurrentPL('metric', value)}
-                aria-label={t(
-                  'cost_models_wizard.price_list.metric_selector_aria_label'
-                )}
-                id="metric-selector"
-              >
-                <FormSelectOption
-                  isDisabled
-                  value=""
-                  label={t(
-                    'cost_models_wizard.price_list.default_selector_label'
-                  )}
-                />
-                <FormSelectOption
-                  value="cpu"
-                  label={t('cost_models_wizard.price_list.cpu_metric')}
-                />
-                <FormSelectOption
-                  value="memory"
-                  label={t('cost_models_wizard.price_list.memory_metric')}
-                />
-                <FormSelectOption
-                  value="storage"
-                  label={t('cost_models_wizard.price_list.storage_metric')}
-                />
-              </FormSelect>
-            </FormGroup>
-            {priceListCurrent.metric !== '' && (
-              <FormGroup
-                label={t('cost_models_wizard.price_list.measurement_label')}
-                fieldId="measurement-selector"
-              >
-                <FormSelect
-                  value={priceListCurrent.measurement}
-                  onChange={(value: string) =>
-                    updateCurrentPL('measurement', value)
-                  }
-                  aria-label={t(
-                    'cost_models_wizard.price_list.measurement_selector_aria_label'
-                  )}
-                  id="measurement-selector"
+          <Stack gutter="md">
+            <StackItem>
+              <Title size={TitleSize.xl}>
+                {t('cost_models_wizard.price_list.title')}
+              </Title>
+            </StackItem>
+            <StackItem>
+              <TextContent>
+                <Text component={TextVariants.h6}>
+                  {t('cost_models_wizard.price_list.sub_title_add')}
+                </Text>
+              </TextContent>
+            </StackItem>
+            <StackItem>
+              <Form className={css(styles.form)}>
+                <FormGroup
+                  label={t('cost_models_wizard.price_list.metric_label')}
+                  fieldId="metric-selector"
                 >
-                  <FormSelectOption
-                    isDisabled
-                    value=""
-                    label={t(
-                      'cost_models_wizard.price_list.default_selector_label'
+                  <FormSelect
+                    value={priceListCurrent.metric}
+                    onChange={(value: string) =>
+                      updateCurrentPL('metric', value)
+                    }
+                    aria-label={t(
+                      'cost_models_wizard.price_list.metric_selector_aria_label'
                     )}
-                  />
-                  <FormSelectOption
-                    value="request"
-                    label={t('cost_models_wizard.price_list.request', {
-                      units: units(priceListCurrent.metric),
-                    })}
-                  />
-                  <FormSelectOption
-                    value="usage"
-                    label={t('cost_models_wizard.price_list.usage', {
-                      units: units(priceListCurrent.metric),
-                    })}
-                  />
-                </FormSelect>
-              </FormGroup>
-            )}
-            {priceListCurrent.measurement !== '' && (
-              <FormGroup
-                label={t('cost_models_wizard.price_list.rate_label')}
-                fieldId="rate-input-box"
-                helperTextInvalid={t(
-                  'cost_models_wizard.price_list.rate_error'
+                    id="metric-selector"
+                  >
+                    <FormSelectOption
+                      isDisabled
+                      value=""
+                      label={t(
+                        'cost_models_wizard.price_list.default_selector_label'
+                      )}
+                    />
+                    <FormSelectOption
+                      value="cpu"
+                      label={t('cost_models_wizard.price_list.cpu_metric')}
+                    />
+                    <FormSelectOption
+                      value="memory"
+                      label={t('cost_models_wizard.price_list.memory_metric')}
+                    />
+                    <FormSelectOption
+                      value="storage"
+                      label={t('cost_models_wizard.price_list.storage_metric')}
+                    />
+                  </FormSelect>
+                </FormGroup>
+                {priceListCurrent.metric !== '' && (
+                  <FormGroup
+                    label={t('cost_models_wizard.price_list.measurement_label')}
+                    fieldId="measurement-selector"
+                  >
+                    <FormSelect
+                      value={priceListCurrent.measurement}
+                      onChange={(value: string) =>
+                        updateCurrentPL('measurement', value)
+                      }
+                      aria-label={t(
+                        'cost_models_wizard.price_list.measurement_selector_aria_label'
+                      )}
+                      id="measurement-selector"
+                    >
+                      <FormSelectOption
+                        isDisabled
+                        value=""
+                        label={t(
+                          'cost_models_wizard.price_list.default_selector_label'
+                        )}
+                      />
+                      <FormSelectOption
+                        value="request"
+                        label={t('cost_models_wizard.price_list.request', {
+                          units: units(priceListCurrent.metric),
+                        })}
+                      />
+                      <FormSelectOption
+                        value="usage"
+                        label={t('cost_models_wizard.price_list.usage', {
+                          units: units(priceListCurrent.metric),
+                        })}
+                      />
+                    </FormSelect>
+                  </FormGroup>
                 )}
-                isValid={
-                  !isNaN(Number(priceListCurrent.rate)) &&
-                  Number(priceListCurrent.rate) >= 0
-                }
-              >
-                <TextInput
-                  type="text"
-                  aria-label={t(
-                    'cost_models_wizard.price_list.rate_aria_label'
-                  )}
-                  id="rate-input-box"
-                  value={priceListCurrent.rate}
-                  onChange={(value: string) => updateCurrentPL('rate', value)}
-                  isValid={
-                    !isNaN(Number(priceListCurrent.rate)) &&
-                    Number(priceListCurrent.rate) >= 0
-                  }
-                />
-              </FormGroup>
-            )}
-            {priceListCurrent.measurement !== '' && (
-              <div style={{ paddingTop: '20px' }}>
-                <Button
-                  onClick={submitCurrentPL}
-                  isDisabled={
-                    priceListCurrent.rate === '' ||
-                    isNaN(Number(priceListCurrent.rate))
-                  }
-                >
-                  {t('cost_models_wizard.price_list.save_rate')}
-                </Button>
-              </div>
-            )}
-          </>
+                {priceListCurrent.measurement !== '' && (
+                  <FormGroup
+                    label={t('cost_models_wizard.price_list.rate_label')}
+                    fieldId="rate-input-box"
+                    helperTextInvalid={t(
+                      'cost_models_wizard.price_list.rate_error'
+                    )}
+                    isValid={
+                      !isNaN(Number(priceListCurrent.rate)) &&
+                      Number(priceListCurrent.rate) >= 0
+                    }
+                  >
+                    <InputGroup>
+                      <InputGroupText>
+                        <DollarSignIcon />
+                      </InputGroupText>
+                      <TextInput
+                        type="text"
+                        aria-label={t(
+                          'cost_models_wizard.price_list.rate_aria_label'
+                        )}
+                        id="rate-input-box"
+                        placeholder="0.00"
+                        value={priceListCurrent.rate}
+                        onChange={(value: string) =>
+                          updateCurrentPL('rate', value)
+                        }
+                        isValid={
+                          !isNaN(Number(priceListCurrent.rate)) &&
+                          Number(priceListCurrent.rate) >= 0
+                        }
+                      />
+                    </InputGroup>
+                  </FormGroup>
+                )}
+                {priceListCurrent.measurement !== '' && (
+                  <div>
+                    <Button
+                      onClick={submitCurrentPL}
+                      isDisabled={
+                        priceListCurrent.rate === '' ||
+                        isNaN(Number(priceListCurrent.rate))
+                      }
+                    >
+                      {t('cost_models_wizard.price_list.save_rate')}
+                    </Button>
+                  </div>
+                )}
+              </Form>
+            </StackItem>
+          </Stack>
         );
       }}
     </CostModelContext.Consumer>

--- a/src/pages/createCostModelWizard/index.tsx
+++ b/src/pages/createCostModelWizard/index.tsx
@@ -96,7 +96,7 @@ const defaultState = {
   priceListCurrent: {
     metric: '',
     measurement: '',
-    rate: '0',
+    rate: '',
     justSaved: false,
   },
   createError: null,
@@ -236,7 +236,7 @@ class CostModelWizardBase extends React.Component<Props, State> {
               priceListCurrent: {
                 metric: '',
                 measurement: '',
-                rate: '0',
+                rate: '',
                 justSaved: true,
               },
               tiers: [

--- a/src/pages/createCostModelWizard/steps.tsx
+++ b/src/pages/createCostModelWizard/steps.tsx
@@ -77,7 +77,7 @@ export const validatorsHash = {
     ctx =>
       ctx.priceListCurrent.metric === '' &&
       ctx.priceListCurrent.measurement === '' &&
-      ctx.priceListCurrent.rate === '0',
+      ctx.priceListCurrent.rate === '',
     ctx => ctx.markup !== '' && !isNaN(Number(ctx.markup)),
     ctx => true,
     ctx => true,

--- a/src/pages/createCostModelWizard/wizard.styles.tsx
+++ b/src/pages/createCostModelWizard/wizard.styles.tsx
@@ -1,0 +1,7 @@
+import { StyleSheet } from '@patternfly/react-styles';
+
+export const styles = StyleSheet.create({
+  form: {
+    width: '350px',
+  },
+});


### PR DESCRIPTION
closes #1039 

- [x] Missing spaces between fields
- [x] Use place holder instead of setting a default value: `0.00`
- [x] Add a dollar sign to the rate field
- [x] Set width of fields to at least 340px

![image](https://user-images.githubusercontent.com/2453279/66118545-4fc09680-e5df-11e9-9c0f-fd923af466c9.png)
