### PR TITLE
fix(costmodels): fit and finish to markup step in create cost model wizard

### DIFF
--- a/src/pages/createCostModelWizard/index.tsx
+++ b/src/pages/createCostModelWizard/index.tsx
@@ -81,7 +81,7 @@ const defaultState = {
   type: '',
   name: '',
   description: '',
-  markup: '0',
+  markup: '',
   filterName: '',
   sources: [],
   error: null,

--- a/src/pages/createCostModelWizard/markup.tsx
+++ b/src/pages/createCostModelWizard/markup.tsx
@@ -1,4 +1,16 @@
-import { FormGroup, TextInput, Title } from '@patternfly/react-core';
+import {
+  Form,
+  FormGroup,
+  InputGroup,
+  InputGroupText,
+  Stack,
+  StackItem,
+  Text,
+  TextContent,
+  TextInput,
+  TextVariants,
+  Title,
+} from '@patternfly/react-core';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { CostModelContext } from './context';
@@ -8,29 +20,43 @@ const Markup: React.SFC<InjectedTranslateProps> = ({ t }) => (
     {({ onMarkupChange, markup }) => {
       const isValidMarkup = !isNaN(Number(markup));
       return (
-        <>
-          <Title size="xl">{t('cost_models_wizard.markup.title')}</Title>
-          <Title size="md">{t('cost_models_wizard.markup.sub_title')}</Title>
-          <FormGroup
-            label={t('cost_models_wizard.markup.markup_label')}
-            isRequired
-            fieldId="markup"
-            helperTextInvalid={t(
-              'cost_models_wizard.markup.invalid_markup_text'
-            )}
-            isValid={isValidMarkup}
-          >
-            <TextInput
-              isRequired
-              type="text"
-              id="markup"
-              name="markup"
-              value={markup}
-              onChange={onMarkupChange}
-              isValid={isValidMarkup}
-            />
-          </FormGroup>
-        </>
+        <Stack gutter="md">
+          <StackItem>
+            <Title size="xl">{t('cost_models_wizard.markup.title')}</Title>
+          </StackItem>
+          <StackItem>
+            <TextContent>
+              <Text component={TextVariants.h6}>
+                {t('cost_models_wizard.markup.sub_title')}
+              </Text>
+            </TextContent>
+          </StackItem>
+          <StackItem>
+            <Form>
+              <FormGroup
+                label={t('cost_models_wizard.markup.markup_label')}
+                fieldId="markup"
+                helperTextInvalid={t(
+                  'cost_models_wizard.markup.invalid_markup_text'
+                )}
+                isValid={isValidMarkup}
+              >
+                <InputGroup style={{ width: '150px' }}>
+                  <TextInput
+                    type="text"
+                    id="markup"
+                    name="markup"
+                    value={markup}
+                    onChange={onMarkupChange}
+                    isValid={isValidMarkup}
+                    placeholder={'0'}
+                  />
+                  <InputGroupText style={{ borderLeft: '0' }}>%</InputGroupText>
+                </InputGroup>
+              </FormGroup>
+            </Form>
+          </StackItem>
+        </Stack>
       );
     }}
   </CostModelContext.Consumer>


### PR DESCRIPTION
closes #1042 

- [x] Percent icon next to the input
- [x] Length of the input field should be at least 340px
- [x] Placeholder should be set
- [x] Remove the asterisk 

![image](https://user-images.githubusercontent.com/2453279/66318905-ddc0b800-e924-11e9-9ecb-cebb5001e1bc.png)
