### PR TITLE
fix(costmodels): price list tab fit and finish

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -300,7 +300,7 @@
       "title": "Set a price list (optional)",
       "toolbar_top_aria_label": "Price list top toolbar - rates",
       "toolbar_top_results_aria_label": "results section",
-      "update_button": "Edit",
+      "update_button": "Edit rate",
       "usage": "Usage ({{units}})"
     },
     "review": {

--- a/src/pages/costModelsDetails/components/addRateModel.tsx
+++ b/src/pages/costModelsDetails/components/addRateModel.tsx
@@ -1,18 +1,29 @@
 import {
   Alert,
   Button,
+  Form,
   FormGroup,
   FormSelect,
   FormSelectOption,
+  InputGroup,
+  InputGroupText,
   Modal,
+  Stack,
+  StackItem,
+  Text,
+  TextContent,
   TextInput,
+  TextVariants,
   Title,
   TitleSize,
 } from '@patternfly/react-core';
+import { DollarSignIcon } from '@patternfly/react-icons';
+import { css } from '@patternfly/react-styles';
 import { CostModel } from 'api/costModels';
 import { Rate } from 'api/rates';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
+import { styles } from '../../createCostModelWizard/wizard.styles';
 import { units } from './priceListTier';
 
 interface RateOption {
@@ -50,9 +61,15 @@ interface State {
   rate: string;
   metric: string;
   measurement: string;
+  dirtyRate: boolean;
 }
 
-const defaultState: State = { metric: '', measurement: '', rate: '1.0' };
+const defaultState: State = {
+  metric: '',
+  measurement: '',
+  rate: '',
+  dirtyRate: false,
+};
 
 class AddRateModelBase extends React.Component<Props, State> {
   public state = defaultState;
@@ -75,8 +92,8 @@ class AddRateModelBase extends React.Component<Props, State> {
         title={t('cost_models_details.add_rate_modal.title', {
           name: current.name,
         })}
+        isSmall
         isOpen
-        isLarge
         onClose={onClose}
         actions={[
           <Button
@@ -112,95 +129,123 @@ class AddRateModelBase extends React.Component<Props, State> {
       >
         <>
           {updateError && <Alert variant="danger" title={`${updateError}`} />}
-          <Title size={TitleSize.lg}>
-            {t('cost_models_details.cost_model.source_type')}
-          </Title>
-          <div>{current.source_type}</div>
-          <br />
-          <FormGroup
-            label={t('cost_models_wizard.price_list.metric_label')}
-            fieldId="metric-selector"
-          >
-            <FormSelect
-              value={this.state.metric}
-              onChange={(metric: string) => this.setState({ metric })}
-              aria-label={t(
-                'cost_models_wizard.price_list.metric_selector_aria_label'
-              )}
-              id="metric-selector"
-            >
-              <FormSelectOption
-                isDisabled
-                value=""
-                label={t(
-                  'cost_models_wizard.price_list.default_selector_label'
-                )}
-              />
-              {Object.keys(opts).map(mtc => (
-                <FormSelectOption
-                  key={mtc}
-                  value={mtc}
-                  label={t(`cost_models_wizard.price_list.${mtc}_metric`)}
-                />
-              ))}
-            </FormSelect>
-          </FormGroup>
-          {this.state.metric !== '' && (
-            <FormGroup
-              label={t('cost_models_wizard.price_list.measurement_label')}
-              fieldId="measurement-selector"
-            >
-              <FormSelect
-                value={this.state.measurement}
-                onChange={(measurement: string) =>
-                  this.setState({ measurement })
-                }
-                aria-label={t(
-                  'cost_models_wizard.price_list.measurement_selector_aria_label'
-                )}
-                id="measurement-selector"
-              >
-                <FormSelectOption
-                  isDisabled
-                  value=""
-                  label={t(
-                    'cost_models_wizard.price_list.default_selector_label'
-                  )}
-                />
-                {opts[this.state.metric] &&
-                  opts[this.state.metric].map(msr => (
+          <Stack gutter="md">
+            <StackItem>
+              <Title size={TitleSize.lg}>
+                {t('cost_models_details.cost_model.source_type')}
+              </Title>
+            </StackItem>
+            <StackItem>
+              <TextContent>
+                <Text component={TextVariants.h6}>{current.source_type}</Text>
+              </TextContent>
+            </StackItem>
+            <StackItem>
+              <Form className={css(styles.form)}>
+                <FormGroup
+                  label={t('cost_models_wizard.price_list.metric_label')}
+                  fieldId="metric-selector"
+                >
+                  <FormSelect
+                    value={this.state.metric}
+                    onChange={(metric: string) => this.setState({ metric })}
+                    aria-label={t(
+                      'cost_models_wizard.price_list.metric_selector_aria_label'
+                    )}
+                    id="metric-selector"
+                  >
                     <FormSelectOption
-                      key={msr}
-                      value={msr}
-                      label={t(`cost_models_wizard.price_list.${msr}`, {
-                        units: units(this.state.metric),
-                      })}
+                      isDisabled
+                      value=""
+                      label={t(
+                        'cost_models_wizard.price_list.default_selector_label'
+                      )}
                     />
-                  ))}
-              </FormSelect>
-            </FormGroup>
-          )}
-          {this.state.measurement !== '' && (
-            <FormGroup
-              label={t('cost_models_wizard.price_list.rate_label')}
-              fieldId="rate-input-box"
-              helperTextInvalid={t('cost_models_wizard.price_list.rate_error')}
-              isValid={
-                !isNaN(Number(this.state.rate)) && Number(this.state.rate) > 0
-              }
-            >
-              <TextInput
-                type="text"
-                aria-label={t('cost_models_wizard.price_list.rate_aria_label')}
-                id="rate-input-box"
-                value={this.state.rate}
-                onChange={(rate: string) => this.setState({ rate })}
-                isValid={
-                  !isNaN(Number(this.state.rate)) && Number(this.state.rate) > 0
-                }
-              />
-            </FormGroup>
-          )}
+                    {Object.keys(opts).map(mtc => (
+                      <FormSelectOption
+                        key={mtc}
+                        value={mtc}
+                        label={t(`cost_models_wizard.price_list.${mtc}_metric`)}
+                      />
+                    ))}
+                  </FormSelect>
+                </FormGroup>
+                {this.state.metric !== '' && (
+                  <FormGroup
+                    label={t('cost_models_wizard.price_list.measurement_label')}
+                    fieldId="measurement-selector"
+                  >
+                    <FormSelect
+                      value={this.state.measurement}
+                      onChange={(measurement: string) =>
+                        this.setState({ measurement })
+                      }
+                      aria-label={t(
+                        'cost_models_wizard.price_list.measurement_selector_aria_label'
+                      )}
+                      id="measurement-selector"
+                    >
+                      <FormSelectOption
+                        isDisabled
+                        value=""
+                        label={t(
+                          'cost_models_wizard.price_list.default_selector_label'
+                        )}
+                      />
+                      {opts[this.state.metric] &&
+                        opts[this.state.metric].map(msr => (
+                          <FormSelectOption
+                            key={msr}
+                            value={msr}
+                            label={t(`cost_models_wizard.price_list.${msr}`, {
+                              units: units(this.state.metric),
+                            })}
+                          />
+                        ))}
+                    </FormSelect>
+                  </FormGroup>
+                )}
+                {this.state.measurement !== '' && (
+                  <FormGroup
+                    label={t('cost_models_wizard.price_list.rate_label')}
+                    fieldId="rate-input-box"
+                    helperTextInvalid={t(
+                      'cost_models_wizard.price_list.rate_error'
+                    )}
+                    isValid={
+                      (!isNaN(Number(this.state.rate)) &&
+                        Number(this.state.rate) > 0) ||
+                      !this.state.dirtyRate
+                    }
+                  >
+                    <InputGroup style={{ width: '150px' }}>
+                      <InputGroupText style={{ borderRight: '0' }}>
+                        <DollarSignIcon />
+                      </InputGroupText>
+                      <TextInput
+                        style={{ borderLeft: '0' }}
+                        type="text"
+                        aria-label={t(
+                          'cost_models_wizard.price_list.rate_aria_label'
+                        )}
+                        id="rate-input-box"
+                        placeholder="0.00"
+                        value={this.state.rate}
+                        onChange={(rate: string) =>
+                          this.setState({ rate, dirtyRate: true })
+                        }
+                        isValid={
+                          (!isNaN(Number(this.state.rate)) &&
+                            Number(this.state.rate) > 0) ||
+                          !this.state.dirtyRate
+                        }
+                      />
+                    </InputGroup>
+                  </FormGroup>
+                )}
+              </Form>
+            </StackItem>
+          </Stack>
         </>
       </Modal>
     );

--- a/src/pages/costModelsDetails/components/priceListTable.tsx
+++ b/src/pages/costModelsDetails/components/priceListTable.tsx
@@ -158,6 +158,7 @@ class PriceListTable extends React.Component<Props, State> {
           />
         )}
         <Dialog
+          isSmall
           isOpen={isDialogOpen.deleteRate}
           title={t('dialog.title', { rate: this.state.deleteRate })}
           onClose={() => {

--- a/src/pages/costModelsDetails/components/priceListTier.tsx
+++ b/src/pages/costModelsDetails/components/priceListTier.tsx
@@ -119,13 +119,6 @@ const PriceListTierDataItemBase: React.SFC<DataListItemProps> = ({
           <Dropdown
             isPlain
             dropdownItems={[
-              <DropdownItem
-                key="delete"
-                onClick={removeRate}
-                component="button"
-              >
-                {t('cost_models_wizard.price_list.delete_button')}
-              </DropdownItem>,
               updateRate && (
                 <DropdownItem
                   key="edit"
@@ -135,6 +128,14 @@ const PriceListTierDataItemBase: React.SFC<DataListItemProps> = ({
                   {t('cost_models_wizard.price_list.update_button')}
                 </DropdownItem>
               ),
+              <DropdownItem
+                key="delete"
+                onClick={removeRate}
+                component="button"
+                style={{ color: 'red' }}
+              >
+                {t('cost_models_wizard.price_list.delete_button')}
+              </DropdownItem>,
             ]}
           />
         </DataListAction>

--- a/src/pages/costModelsDetails/components/updateRateModel.tsx
+++ b/src/pages/costModelsDetails/components/updateRateModel.tsx
@@ -1,12 +1,21 @@
 import {
   Alert,
   Button,
+  Form,
   FormGroup,
+  InputGroup,
+  InputGroupText,
   Modal,
+  Stack,
+  StackItem,
+  Text,
+  TextContent,
   TextInput,
+  TextVariants,
   Title,
   TitleSize,
 } from '@patternfly/react-core';
+import { DollarSignIcon } from '@patternfly/react-icons';
 import { CostModel } from 'api/costModels';
 import React from 'react';
 import { InjectedTranslateProps } from 'react-i18next';
@@ -53,7 +62,7 @@ class UpdateRateModelBase extends React.Component<Props, State> {
       <Modal
         title={t('cost_models_details.edit_rate')}
         isOpen
-        isLarge
+        isSmall
         onClose={onClose}
         actions={[
           <Button
@@ -80,39 +89,79 @@ class UpdateRateModelBase extends React.Component<Props, State> {
       >
         <>
           {updateError && <Alert variant="danger" title={`${updateError}`} />}
-          <Title size={TitleSize.lg}>
-            {t('cost_models_details.cost_model.source_type')}
-          </Title>
-          <div>{current.source_type}</div>
-          <Title size={TitleSize.lg}>
-            {t('cost_models_wizard.price_list.metric_label')}
-          </Title>
-          <div>{t(`cost_models_wizard.price_list.${metric}_metric`)}</div>
+          <Stack gutter="md">
+            <StackItem>
+              <Title size={TitleSize.lg}>
+                {t('cost_models_details.cost_model.source_type')}
+              </Title>
+            </StackItem>
+            <StackItem>
+              <TextContent>
+                <Text component={TextVariants.h6}>{current.source_type}</Text>
+              </TextContent>
+            </StackItem>
 
-          <Title size={TitleSize.lg}>
-            {t('cost_models_wizard.price_list.measurement_label')}
-          </Title>
-          <div>
-            {t(`cost_models_wizard.price_list.${measurement}`, {
-              units: units(metric),
-            })}
-          </div>
-          <br />
-          <FormGroup
-            label={t('cost_models_wizard.price_list.rate_label')}
-            fieldId="rate-input-box"
-            helperTextInvalid={t('cost_models_wizard.price_list.rate_error')}
-            isValid={Number(this.state.rate) && Number(this.state.rate) > 0}
-          >
-            <TextInput
-              type="text"
-              aria-label={t('cost_models_wizard.price_list.rate_aria_label')}
-              id="rate-input-box"
-              value={this.state.rate}
-              onChange={(rate: string) => this.setState({ rate })}
-              isValid={Number(this.state.rate) && Number(this.state.rate) > 0}
-            />
-          </FormGroup>
+            <StackItem>
+              <Title size={TitleSize.lg}>
+                {t('cost_models_wizard.price_list.metric_label')}
+              </Title>
+            </StackItem>
+            <StackItem>
+              <TextContent>
+                <Text component={TextVariants.h6}>
+                  {t(`cost_models_wizard.price_list.${metric}_metric`)}
+                </Text>
+              </TextContent>
+            </StackItem>
+
+            <StackItem>
+              <Title size={TitleSize.lg}>
+                {t('cost_models_wizard.price_list.measurement_label')}
+              </Title>
+            </StackItem>
+            <StackItem>
+              <TextContent>
+                <Text component={TextVariants.h6}>
+                  {t(`cost_models_wizard.price_list.${measurement}`, {
+                    units: units(metric),
+                  })}
+                </Text>
+              </TextContent>
+            </StackItem>
+            <StackItem>
+              <Form>
+                <FormGroup
+                  label={t('cost_models_wizard.price_list.rate_label')}
+                  fieldId="rate-input-box"
+                  helperTextInvalid={t(
+                    'cost_models_wizard.price_list.rate_error'
+                  )}
+                  isValid={
+                    Number(this.state.rate) && Number(this.state.rate) > 0
+                  }
+                >
+                  <InputGroup style={{ width: '150px' }}>
+                    <InputGroupText style={{ borderRight: '0' }}>
+                      <DollarSignIcon />
+                    </InputGroupText>
+                    <TextInput
+                      style={{ borderLeft: '0' }}
+                      type="text"
+                      aria-label={t(
+                        'cost_models_wizard.price_list.rate_aria_label'
+                      )}
+                      id="rate-input-box"
+                      value={this.state.rate}
+                      onChange={(rate: string) => this.setState({ rate })}
+                      isValid={
+                        Number(this.state.rate) && Number(this.state.rate) > 0
+                      }
+                    />
+                  </InputGroup>
+                </FormGroup>
+              </Form>
+            </StackItem>
+          </Stack>
         </>
       </Modal>
     );


### PR DESCRIPTION
closes #1056 

- [x] show currency in the rate field at the edit rate modal
![image](https://user-images.githubusercontent.com/2453279/66874088-d9467000-efb2-11e9-8ff1-dcffc83d849a.png)

- [x] show currency + fix space between fields in the add rate modal
![image](https://user-images.githubusercontent.com/2453279/66874119-ed8a6d00-efb2-11e9-8d0a-213412447276.png)

- [x] fix the kebab options - delete in the bottom colored red
![image](https://user-images.githubusercontent.com/2453279/66874133-f9762f00-efb2-11e9-954b-17d47d3532fa.png)

- [x] make the delete rate dialog smaller
![image](https://user-images.githubusercontent.com/2453279/66874172-14e13a00-efb3-11e9-8983-933f71ae02eb.png)

