### PR TITLE
fix(costmodels): markup tab in details page - fit and finish

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -214,6 +214,7 @@
     },
     "edit_cost_model": "Edit {{ cost_model }} cost model",
     "edit_markup": "Edit {{cost_model}} markup",
+    "edit_markup_action": "Edit markup",
     "edit_rate": "Edit rate",
     "empty_state": {
       "desc": "Create a cost model to start calculating your hybrid cloud costs using custom price lists, markups, or both. Click on the \"Create a cost model\" button below to begin the journey.",

--- a/src/pages/costModelsDetails/components/deleteMarkupDialog.tsx
+++ b/src/pages/costModelsDetails/components/deleteMarkupDialog.tsx
@@ -26,6 +26,7 @@ const DeleteMarkupDialog: React.SFC<Props> = ({
 }) => {
   return (
     <Dialog
+      isSmall
       isOpen={isOpen}
       title={t('dialog.markup.title', { cost_model: current.name })}
       onClose={() => onClose({ isOpen: false, name: 'deleteMarkup' })}

--- a/src/pages/costModelsDetails/components/markup.tsx
+++ b/src/pages/costModelsDetails/components/markup.tsx
@@ -3,6 +3,7 @@ import {
   CardActions,
   CardBody,
   CardHead,
+  CardHeader,
   DropdownItem,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
@@ -12,7 +13,6 @@ import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
-import DeleteMarkupDialog from './deleteMarkupDialog';
 import Dropdown from './dropdown';
 import { styles } from './markup.styles';
 import UpdateMarkupDialog from './updateMarkupDialog';
@@ -37,7 +37,6 @@ const MarkupCardBase: React.SFC<Props> = ({
 
   return (
     <>
-      <DeleteMarkupDialog />
       {isUpdateDialogOpen && <UpdateMarkupDialog />}
       <Card className={css(styles.card)}>
         <CardHead>
@@ -46,26 +45,21 @@ const MarkupCardBase: React.SFC<Props> = ({
               isPlain
               dropdownItems={[
                 <DropdownItem
-                  key="delete"
-                  onClick={() => {
-                    setCostModelDialog({ isOpen: true, name: 'deleteMarkup' });
-                  }}
-                  component="button"
-                >
-                  {t('cost_models_wizard.price_list.delete_button')}
-                </DropdownItem>,
-                <DropdownItem
                   key="edit"
                   onClick={() =>
                     setCostModelDialog({ isOpen: true, name: 'updateMarkup' })
                   }
                   component="button"
                 >
-                  {t('cost_models_wizard.price_list.update_button')}
+                  {t('cost_models_details.edit_markup_action')}
                 </DropdownItem>,
               ]}
             />
           </CardActions>
+          <CardHeader>
+            precentage value to add or substract to the base cost of the
+            source(s)
+          </CardHeader>
         </CardHead>
         <CardBody isFilled />
         <CardBody className={css(styles.cardBody)}>{markupValue}%</CardBody>

--- a/src/pages/costModelsDetails/components/updateMarkupDialog.tsx
+++ b/src/pages/costModelsDetails/components/updateMarkupDialog.tsx
@@ -1,7 +1,10 @@
 import {
   Alert,
   Button,
+  Form,
   FormGroup,
+  InputGroup,
+  InputGroupText,
   Modal,
   TextInput,
 } from '@patternfly/react-core';
@@ -28,7 +31,7 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
   constructor(props) {
     super(props);
     this.state = {
-      markup: String(this.props.current.markup.value),
+      markup: String(this.props.current.markup.value || 0),
     };
   }
   public render() {
@@ -46,7 +49,7 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
           cost_model: current.name,
         })}
         isOpen
-        isLarge
+        isSmall
         onClose={() => onClose({ name: 'updateMarkup', isOpen: false })}
         actions={[
           <Button
@@ -69,7 +72,11 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
               };
               updateCostModel(current.uuid, newState, 'updateMarkup');
             }}
-            isDisabled={isLoading}
+            isDisabled={
+              isNaN(Number(this.state.markup)) ||
+              Number(this.state.markup) === Number(current.markup.value || 0) ||
+              isLoading
+            }
           >
             {t('cost_models_details.add_rate_modal.save')}
           </Button>,
@@ -85,21 +92,26 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
       >
         <>
           {error && <Alert variant="danger" title={`${error}`} />}
-          <FormGroup
-            label={t('cost_models_wizard.markup.markup_label')}
-            fieldId="markup-input-box"
-            helperTextInvalid={t('cost_models_wizard.markup.markup_error')}
-            isValid={!isNaN(Number(this.state.markup))}
-          >
-            <TextInput
-              type="text"
-              aria-label={t('cost_models_wizard.markup.markup_label')}
-              id="markup-input-box"
-              value={this.state.markup}
-              onChange={(markup: string) => this.setState({ markup })}
+          <Form>
+            <FormGroup
+              label={t('cost_models_wizard.markup.markup_label')}
+              fieldId="markup-input-box"
+              helperTextInvalid={t('cost_models_wizard.markup.markup_error')}
               isValid={!isNaN(Number(this.state.markup))}
-            />
-          </FormGroup>
+            >
+              <InputGroup style={{ width: '150px' }}>
+                <TextInput
+                  type="text"
+                  aria-label={t('cost_models_wizard.markup.markup_label')}
+                  id="markup-input-box"
+                  value={this.state.markup}
+                  onChange={(markup: string) => this.setState({ markup })}
+                  isValid={!isNaN(Number(this.state.markup))}
+                />
+                <InputGroupText style={{ borderLeft: '0' }}>%</InputGroupText>
+              </InputGroup>
+            </FormGroup>
+          </Form>
         </>
       </Modal>
     );


### PR DESCRIPTION
closes #1057 

- [x] Add text to the header of the card: "precentage value to add or substract to the base cost of the source(s)."

![image](https://user-images.githubusercontent.com/2453279/66989781-b197fa80-f0cd-11e9-98b5-f8aa5b58b1e3.png)


- [x] Remove kebab toggle option and just have the action button "edit markup"

- [x] Edit dialog should be smaller

![image](https://user-images.githubusercontent.com/2453279/66990134-4ef32e80-f0ce-11e9-9c63-413ee98edb44.png)

- [x] Make markup field smaller and have the % symbol
