### PR TITLE
fix(costmodels): details page sources tab fit and finish

### DIFF
--- a/src/components/filter/filterComposition.tsx
+++ b/src/components/filter/filterComposition.tsx
@@ -17,6 +17,7 @@ interface TypeOption {
 }
 
 interface Props extends InjectedTranslateProps {
+  isSingleOption?: boolean;
   options: TypeOption[];
   id: string;
   query: Query;
@@ -70,6 +71,7 @@ const FilterCompositionBase: React.SFC<Props> = ({
   updateFilter,
   switchType,
   onSearch,
+  isSingleOption = false,
   t,
 }) => {
   const filterController =
@@ -115,14 +117,16 @@ const FilterCompositionBase: React.SFC<Props> = ({
     <>
       <ToolbarGroup>
         <ToolbarItem>
-          <SelectFilter
-            onSelect={newName => switchType({ name: newName, value: '' })}
-            selected={name}
-            options={filters.map(filter => ({
-              value: filter,
-              name: t(`filter.${filter}`),
-            }))}
-          />
+          {!isSingleOption && (
+            <SelectFilter
+              onSelect={newName => switchType({ name: newName, value: '' })}
+              selected={name}
+              options={filters.map(filter => ({
+                value: filter,
+                name: t(`filter.${filter}`),
+              }))}
+            />
+          )}
         </ToolbarItem>
         <ToolbarItem>{filterController}</ToolbarItem>
       </ToolbarGroup>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -195,6 +195,7 @@
   },
   "cost_management": "Cost management",
   "cost_models_details": {
+    "action_assign": "Assign source(s)",
     "action_delete": "Delete",
     "action_unassign": "Unassign",
     "action_view": "View details",
@@ -206,7 +207,7 @@
     },
     "add_source": "Assign source",
     "add_source_desc": "Review and confirm your changes. Click \"Finish\" to assign sources, or \"Back\" to revise.",
-    "assign_sources": "Assign sources",
+    "assign_sources": "Assign sources to {{ cost_model }} cost model",
     "cost_model": {
       "cost_models": "Cost models",
       "source_type": "Source type"
@@ -221,6 +222,10 @@
     "empty_state_rate": {
       "description": "To add rates to the price list, click on the \"Add\" rate button above.",
       "title": "No rates are set"
+    },
+    "empty_state_source": {
+      "description": "Assign a source, like an Amazon Web Services account, to apply this cost model.",
+      "title": "No sources are assigned"
     },
     "filter": {
       "create_button": "Create a cost model",
@@ -346,12 +351,12 @@
     "deleteCostModel": "Delete cost model",
     "deleteMarkup": "Delete markup rate",
     "deleteRate": "Delete rate",
-    "deleteSource": "Unassign cluster",
+    "deleteSource": "Unassign source",
     "delete_cost_model_body_green": "This action will delete {{ cost_model }} cost model from the system. This action cannot be undone.",
     "delete_cost_model_body_red": "You must unassign any sources before you can delete this cost model.",
     "delete_cost_model_body_red_costmodel_delete": "The following sources are assigned to my production cost model:",
     "delete_cost_model_title": "Delete {{ cost_model }} cost model?",
-    "delete_source_from_cost_model_body": "This will remove the assignment of {{ source }} from using the {{ cost_model }} cost model. You can then assign the cost model to a new source.",
+    "delete_source_from_cost_model_body": "This will remove the assignment of {{ source }} from the {{ cost_model }} cost model. You can then assign the cost model to a new source.",
     "delete_source_from_cost_model_title": "Unassign {{ source }} from {{ cost_model }}?",
     "markup": {
       "body": "This action will delete the markup from the {{ cost_model }} cost model. Any calculations that can be made with this markup rate will no longer be available.",

--- a/src/pages/costModelsDetails/addSourceStep.tsx
+++ b/src/pages/costModelsDetails/addSourceStep.tsx
@@ -1,4 +1,10 @@
-import { Toolbar, ToolbarSection } from '@patternfly/react-core';
+import {
+  Pagination,
+  Toolbar,
+  ToolbarGroup,
+  ToolbarItem,
+  ToolbarSection,
+} from '@patternfly/react-core';
 import { Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { CostModel } from 'api/costModels';
 import { Provider } from 'api/providers';
@@ -57,8 +63,10 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
             aria-label={this.props.t(
               'cost_models_details.sources_filter_controller'
             )}
+            style={{ justifyContent: 'space-between' }}
           >
             <FilterComposition
+              isSingleOption
               id="add_source_step_filter"
               options={[
                 { value: 'OCP', label: this.props.t('filter.type_ocp') },
@@ -82,10 +90,42 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
               }
               onSearch={n => {
                 this.props.fetch(
-                  `name=${n.Name}&limit=${n.limit}&offset=${n.offset}`
+                  `name=${n.Name}&limit=${
+                    this.props.pagination.perPage
+                  }&offset=1`
                 );
               }}
             />
+            <ToolbarGroup>
+              <ToolbarItem>
+                <Pagination
+                  itemCount={this.props.pagination.count}
+                  isDisabled={this.props.isLoadingSources}
+                  perPage={this.props.pagination.perPage}
+                  page={this.props.pagination.page}
+                  onPerPageSelect={(_evt, newPerPage) => {
+                    this.props.fetch(
+                      `limit=${newPerPage}&offset=0&${
+                        this.props.query.name
+                          ? `name=${this.props.query.name}`
+                          : ''
+                      }`
+                    );
+                  }}
+                  onSetPage={(_evt, newPage) => {
+                    this.props.fetch(
+                      `limit=${this.props.pagination.perPage}&offset=${this
+                        .props.pagination.perPage *
+                        (newPage - 1)}&${
+                        this.props.query.name
+                          ? `name=${this.props.query.name}`
+                          : ''
+                      }`
+                    );
+                  }}
+                />
+              </ToolbarItem>
+            </ToolbarGroup>
           </ToolbarSection>
           <ToolbarSection
             aria-label={this.props.t(
@@ -160,6 +200,45 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
             subTitle={this.props.t('no_match_found_state.desc')}
           />
         )}
+        <Toolbar>
+          <ToolbarSection
+            style={{ flexDirection: 'row-reverse' }}
+            aria-label={this.props.t(
+              'cost_models_details.sources_pagination_bottom'
+            )}
+          >
+            <ToolbarGroup>
+              <ToolbarItem>
+                <Pagination
+                  itemCount={this.props.pagination.count}
+                  isDisabled={this.props.isLoadingSources}
+                  perPage={this.props.pagination.perPage}
+                  page={this.props.pagination.page}
+                  onPerPageSelect={(_evt, newPerPage) => {
+                    this.props.fetch(
+                      `limit=${newPerPage}&offset=0&${
+                        this.props.query.name
+                          ? `name=${this.props.query.name}`
+                          : ''
+                      }`
+                    );
+                  }}
+                  onSetPage={(_evt, newPage) => {
+                    this.props.fetch(
+                      `limit=${this.props.pagination.perPage}&offset=${this
+                        .props.pagination.perPage *
+                        (newPage - 1)}&${
+                        this.props.query.name
+                          ? `name=${this.props.query.name}`
+                          : ''
+                      }`
+                    );
+                  }}
+                />
+              </ToolbarItem>
+            </ToolbarGroup>
+          </ToolbarSection>
+        </Toolbar>
       </>
     );
   }

--- a/src/pages/costModelsDetails/components/sourceTable.tsx
+++ b/src/pages/costModelsDetails/components/sourceTable.tsx
@@ -56,6 +56,7 @@ class SourceTableBase extends React.Component<Props, State> {
           />
         )}
         <Dialog
+          isSmall
           isOpen={isDialogOpen.deleteSource}
           title={t('dialog.delete_source_from_cost_model_title', {
             source: this.state.dialogSource,

--- a/src/pages/costModelsDetails/components/table.styles.ts
+++ b/src/pages/costModelsDetails/components/table.styles.ts
@@ -1,0 +1,9 @@
+import { StyleSheet } from '@patternfly/react-styles';
+
+export const styles = StyleSheet.create({
+  emptyState: {
+    display: 'flex',
+    flexDirection: 'row',
+    justifyContent: 'center',
+  },
+});


### PR DESCRIPTION
closes #1059 

- [x] Assign new sources should be a modal and not a wizard
![image](https://user-images.githubusercontent.com/2453279/67660274-1a516380-f967-11e9-851d-9fd9b8e547d0.png)

- [x] Delete dialog should be small dialog
![image](https://user-images.githubusercontent.com/2453279/67660357-44a32100-f967-11e9-9a67-010f15d604ed.png)
**UPDATE**
![image](https://user-images.githubusercontent.com/2453279/68222317-7c5b3a00-fff3-11e9-8b6d-6e750c599450.png)


- [x] Empty state: similar to the provider empty state (add -> assign)
![image](https://user-images.githubusercontent.com/2453279/67660316-335a1480-f967-11e9-94af-b93eddcc5ae4.png)
