### PR TITLE
Switch path from hybrid to cost-management

### DIFF
--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -10,10 +10,10 @@ module.exports = {
     '/beta/apps/cost-management': {
       host: `http://${localhost}:8002`,
     },
-    '/hybrid/cost-management': {
+    '/cost-management': {
       host: `http://${localhost}:8002`,
     },
-    '/beta/hybrid/cost-management': {
+    '/beta/cost-management': {
       host: `http://${localhost}:8002`,
     },
     // The overrides below are not necessary for typical development
@@ -22,6 +22,6 @@ module.exports = {
     // },
     // '/apps/beta/chrome': {
     //   host: 'https://ci.cloud.paas.upshift.redhat.com',
-    // },
+    // }
   },
 };

--- a/config/spandx.config.local.js
+++ b/config/spandx.config.local.js
@@ -13,10 +13,10 @@ exports.routes = {
   '/beta/apps/cost-management': {
     host: `http://${localhost}:8002`,
   },
-  '/hybrid/cost-management': {
+  '/cost-management': {
     host: `http://${localhost}:8002`,
   },
-  '/beta/hybrid/cost-management': {
+  '/beta/cost-management': {
     host: `http://${localhost}:8002`,
   },
 };

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,7 +13,8 @@ pathName.shift();
 
 let release = '/';
 if (pathName[0] === 'beta') {
-  release = `/${pathName.shift()}/`;
+  pathName.shift();
+  release = `/beta/`;
 }
 
 initApi({
@@ -30,7 +31,7 @@ const store = configureStore({
 render(
   <Provider store={store}>
     <NotificationsPortal />
-    <BrowserRouter basename={`${release}${pathName[0]}/${pathName[1]}`}>
+    <BrowserRouter basename={`${release}${pathName[0]}/${pathName[1] || ''}`}>
       <App />
     </BrowserRouter>
   </Provider>,


### PR DESCRIPTION
All references to `hybrid` should change to `cost-management`

https://github.com/project-koku/koku-ui/issues/1066

Doesn't address issues with left-side Insights nav