### PR TITLE
fix(navigation): use history push only for user actions

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -79,9 +79,11 @@ export class App extends React.Component<AppProps, AppState> {
       insights.chrome.navigation(buildNavigation());
     }
 
-    this.appNav = insights.chrome.on('APP_NAVIGATION', event =>
-      history.push(`/${event.navId}`)
-    );
+    this.appNav = insights.chrome.on('APP_NAVIGATION', event => {
+      if (event.domEvent) {
+        history.push(`/${event.navId}`);
+      }
+    });
     this.buildNav = history.listen(() =>
       insights.chrome.navigation(buildNavigation())
     );


### PR DESCRIPTION
This will enable custom app navigation trough `insights.chrome.appNavClick({id: 'cost-management-sources', secondaryNav: true})` and not triggering redirect.