### PR TITLE
fix(onboarding): use cluster id in the contrab command

### DIFF
--- a/src/pages/onboardingModal/configure/index.ts
+++ b/src/pages/onboardingModal/configure/index.ts
@@ -1,4 +1,11 @@
 import { translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps } from 'store/common';
+import { onboardingSelectors } from 'store/onboarding';
 import ConfigureInstructions from './instructions';
 
-export default translate()(ConfigureInstructions);
+export default connect(
+  createMapStateToProps(state => ({
+    clusterId: onboardingSelectors.selectOnboardingClusterID(state),
+  }))
+)(translate()(ConfigureInstructions));

--- a/src/pages/onboardingModal/configure/instructions.tsx
+++ b/src/pages/onboardingModal/configure/instructions.tsx
@@ -10,7 +10,14 @@ import { QuestionCircleIcon } from '@patternfly/react-icons';
 import React from 'react';
 import { InjectedTranslateProps, Interpolate } from 'react-i18next';
 
-const ConfigureInstructions: React.SFC<InjectedTranslateProps> = ({ t }) => {
+interface ConfigureInstructionsProps extends InjectedTranslateProps {
+  clusterId: string;
+}
+
+const ConfigureInstructions: React.SFC<ConfigureInstructionsProps> = ({
+  t,
+  clusterId,
+}) => {
   return (
     <React.Fragment>
       <Title size="xl">{t('onboarding.configure.instructions_title')}</Title>
@@ -59,7 +66,7 @@ const ConfigureInstructions: React.SFC<InjectedTranslateProps> = ({ t }) => {
           <ClipboardCopy
             textAriaLabel={t('onboarding.configure.entry_description')}
           >
-            {`*/45 * * * * /path/to/ocp_usage.sh --collect --e OCP_CLUSTER_ID=<YOUR_OCP_IDENTIFIER>`}
+            {`*/45 * * * * /path/to/ocp_usage.sh --collect --e OCP_CLUSTER_ID="${clusterId}"`}
           </ClipboardCopy>
         </ListItem>
         <ListItem> {t('onboarding.configure.click_next')} </ListItem>


### PR DESCRIPTION
closes #1070 

![image](https://user-images.githubusercontent.com/2453279/67659527-39e78c80-f965-11e9-8a89-670da1079eb9.png)
![image](https://user-images.githubusercontent.com/2453279/67659549-48ce3f00-f965-11e9-90e8-b4ea11273e58.png)

In regard to the text copied to the clipboard, I couldn't reproduce this and I'm using Firefox. Maybe you're using a different browser?

Thanks.