### PR TITLE
Include second pathName only for sources settings

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -31,7 +31,7 @@ const store = configureStore({
 render(
   <Provider store={store}>
     <NotificationsPortal />
-    <BrowserRouter basename={`${release}${pathName[0]}/${pathName[1] || ''}`}>
+    <BrowserRouter basename={`${release}${pathName[0]}/${pathName[1] === 'cost-management' ? pathName[1] : ''}`}>
       <App />
     </BrowserRouter>
   </Provider>,


### PR DESCRIPTION
### Fixes
If you refresh page on `/cost-management/aws` it will include `aws` as part of basename url and once user clicks on `ocp` in navigation path will be `/cost-management/aws/ocp` this is because basename calculation tries to include second part of pathName all the time. On other hand sources settings require this second part to be present.

It's a bit hacky writing consts in the path calculation, but this is quick and dirty solution, once sources will be in specific bundle (hopefully in 2 weeks) this hacky work around can be removed and basename can be only 
```JSX
<BrowserRouter basename=`${release}${pathName[0]}/` />
```