### PR TITLE
Azure usage values

### DIFF
--- a/src/api/azureReports.ts
+++ b/src/api/azureReports.ts
@@ -67,6 +67,7 @@ export interface AzureReportMeta {
     [filter: string]: any;
   };
   total?: {
+    count?: AzureDatum;
     cost: AzureDatum;
     derived_cost: AzureDatum;
     infrastructure_cost: AzureDatum;

--- a/src/components/reports/azureReportSummary/azureReportSummaryDetails.tsx
+++ b/src/components/reports/azureReportSummary/azureReportSummaryDetails.tsx
@@ -38,11 +38,20 @@ const AzureReportSummaryDetailsBase: React.SFC<
       report.meta.total.cost ? report.meta.total.cost.units : 'USD',
       formatOptions
     );
-    usage = formatValue(
-      report.meta.total.usage ? report.meta.total.usage.value : 0,
-      report.meta.total.usage ? report.meta.total.usage.units : '',
-      formatOptions
-    );
+    if (report.meta.total.usage && report.meta.total.usage.value) {
+      usage = formatValue(
+        report.meta.total.usage ? report.meta.total.usage.value : 0,
+        report.meta.total.usage ? report.meta.total.usage.units : '',
+        formatOptions
+      );
+    } else {
+      // Work around for https://github.com/project-koku/koku-ui/issues/1058
+      usage = formatValue(
+        report.meta.total.usage ? (report.meta.total.usage as any) : 0,
+        report.meta.total.count ? report.meta.total.count.units : '',
+        formatOptions
+      );
+    }
   }
 
   if (reportType === AzureReportType.cost) {


### PR DESCRIPTION
This adds a temporary workaround to show usage values.

Fixes https://github.com/project-koku/koku-ui/issues/1080

Currently, the Azure instance-types API returns a single property for meta total usage, where we typically expect value and units. See https://github.com/project-koku/koku/issues/1387

Example
![Screen Shot 2019-11-11 at 1 50 26 PM](https://user-images.githubusercontent.com/17481322/68612568-cf693d00-048a-11ea-9106-d270c4df4851.png)