### PR TITLE
Show 'Others' when applying group_by tag keys

### DIFF
--- a/src/pages/awsDetails/awsDetails.tsx
+++ b/src/pages/awsDetails/awsDetails.tsx
@@ -73,6 +73,8 @@ const baseQuery: AwsQuery = {
   },
 };
 
+const tagKey = 'or:tag:';
+
 class AwsDetails extends React.Component<AwsDetailsProps> {
   protected defaultState: AwsDetailsState = {
     columns: [],
@@ -125,7 +127,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     return (
       <ExportModal
         isAllItems={selectedItems.length === computedItems.length}
-        groupBy={groupByTagKey ? `tag:${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
         isOpen={isExportModalOpen}
         items={selectedItems}
         onClose={this.handleExportModalClose}
@@ -186,9 +188,9 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     let groupByTag;
 
     for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf('tag:');
+      const tagIndex = groupBy.indexOf(tagKey);
       if (tagIndex !== -1) {
-        groupByTag = groupBy.substring(tagIndex + 4) as any;
+        groupByTag = groupBy.substring(tagIndex + tagKey.length) as any;
         break;
       }
     }
@@ -241,7 +243,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 
     return (
       <DetailsTable
-        groupBy={groupByTagKey ? `tag:${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
         onSelected={this.handleSelected}
         onSort={this.handleSort}
         query={query}

--- a/src/pages/awsDetails/detailsTable.tsx
+++ b/src/pages/awsDetails/detailsTable.tsx
@@ -48,6 +48,8 @@ interface DetailsTableState {
 
 type DetailsTableProps = DetailsTableOwnProps & InjectedTranslateProps;
 
+const tagKey = 'or:tag:';
+
 class DetailsTableBase extends React.Component<DetailsTableProps> {
   public state: DetailsTableState = {
     columns: [],
@@ -156,7 +158,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           isOpen: false,
           item,
           tableItem: {
-            groupBy: groupByTagKey ? `tag:${groupByTagKey}` : groupById,
+            groupBy: groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById,
             index,
             item,
             query,
@@ -207,9 +209,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     let groupByTagKey;
 
     for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf('tag:');
+      const tagIndex = groupBy.indexOf(tagKey);
       if (tagIndex !== -1) {
-        groupByTagKey = groupBy.substring(tagIndex + 4) as any;
+        groupByTagKey = groupBy.substring(tagIndex + tagKey.length) as any;
         break;
       }
     }

--- a/src/pages/awsDetails/detailsToolbar.tsx
+++ b/src/pages/awsDetails/detailsToolbar.tsx
@@ -36,6 +36,8 @@ interface DetailsToolbarOwnProps {
 
 type DetailsToolbarProps = DetailsToolbarOwnProps & InjectedTranslateProps;
 
+const tagKey = 'or:tag:';
+
 export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   public state = {
     activeFilters: [],
@@ -95,7 +97,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     const { currentFilterType } = this.state;
     const filterLabel = this.getFilterLabel(field, value);
     return {
-      field: field.indexOf('tag:') === 0 ? field : currentFilterType.id,
+      field: field.indexOf(tagKey) === 0 ? field : currentFilterType.id,
       label: filterLabel,
       value,
     };
@@ -109,9 +111,9 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       filterText = field;
     }
 
-    const index = filterText.indexOf('tag:');
+    const index = filterText.indexOf(tagKey);
     if (index === 0) {
-      filterText = 'Tag: ' + filterText.slice(4) + ': ';
+      filterText = 'Tag: ' + filterText.slice(tagKey.length) + ': ';
     } else {
       filterText =
         filterText.charAt(0).toUpperCase() + filterText.slice(1) + ': ';

--- a/src/pages/awsDetails/exportModal.tsx
+++ b/src/pages/awsDetails/exportModal.tsx
@@ -58,6 +58,8 @@ const resolutionOptions: {
   { label: 'Monthly', value: 'monthly' },
 ];
 
+const tagKey = 'or:tag:';
+
 export class ExportModalBase extends React.Component<
   ExportModalProps,
   ExportModalState
@@ -133,7 +135,7 @@ export class ExportModalBase extends React.Component<
     }
 
     let selectedLabel = t('export.selected', { groupBy });
-    if (groupBy.indexOf('tag:') !== -1) {
+    if (groupBy.indexOf(tagKey) !== -1) {
       selectedLabel = t('export.selected_tags');
     }
 

--- a/src/pages/awsDetails/groupBy.tsx
+++ b/src/pages/awsDetails/groupBy.tsx
@@ -47,6 +47,8 @@ const groupByOptions: {
 
 const reportType = AwsReportType.tag;
 
+const tagKey = 'or:tag:';
+
 class GroupByBase extends React.Component<GroupByProps> {
   protected defaultState: GroupByState = {
     isGroupByOpen: false,
@@ -108,8 +110,8 @@ class GroupByBase extends React.Component<GroupByProps> {
       return data.map(val => (
         <DropdownItem
           component="button"
-          key={`tag:${val}`}
-          onClick={() => this.handleGroupByClick(`tag:${val}`)}
+          key={`${tagKey}${val}`}
+          onClick={() => this.handleGroupByClick(`${tagKey}${val}`)}
         >
           {t('group_by.tag', { key: val })}
         </DropdownItem>
@@ -128,7 +130,7 @@ class GroupByBase extends React.Component<GroupByProps> {
         : [];
 
     for (const key of groupByKeys) {
-      const index = key.indexOf('tag:');
+      const index = key.indexOf(tagKey);
       if (index !== -1) {
         groupBy = key;
         break;
@@ -158,10 +160,10 @@ class GroupByBase extends React.Component<GroupByProps> {
       ...this.getDropDownTags(),
     ];
 
-    const index = currentItem ? currentItem.indexOf('tag:') : -1;
+    const index = currentItem ? currentItem.indexOf(tagKey) : -1;
     const label =
       index !== -1
-        ? t('group_by.tag', { key: currentItem.slice(4) })
+        ? t('group_by.tag', { key: currentItem.slice(tagKey.length) })
         : t(`group_by.values.${currentItem}`);
 
     return (

--- a/src/pages/azureDetails/azureDetails.tsx
+++ b/src/pages/azureDetails/azureDetails.tsx
@@ -73,6 +73,8 @@ const baseQuery: AzureQuery = {
   },
 };
 
+const tagKey = 'or:tag:';
+
 class AzureDetails extends React.Component<AzureDetailsProps> {
   protected defaultState: AzureDetailsState = {
     columns: [],
@@ -125,7 +127,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     return (
       <ExportModal
         isAllItems={selectedItems.length === computedItems.length}
-        groupBy={groupByTagKey ? `tag:${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
         isOpen={isExportModalOpen}
         items={selectedItems}
         onClose={this.handleExportModalClose}
@@ -186,9 +188,9 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     let groupByTag;
 
     for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf('tag:');
+      const tagIndex = groupBy.indexOf(tagKey);
       if (tagIndex !== -1) {
-        groupByTag = groupBy.substring(tagIndex + 4) as any;
+        groupByTag = groupBy.substring(tagIndex + tagKey.length) as any;
         break;
       }
     }
@@ -241,7 +243,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
 
     return (
       <DetailsTable
-        groupBy={groupByTagKey ? `tag:${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
         onSelected={this.handleSelected}
         onSort={this.handleSort}
         query={query}

--- a/src/pages/azureDetails/detailsTable.tsx
+++ b/src/pages/azureDetails/detailsTable.tsx
@@ -48,6 +48,8 @@ interface DetailsTableState {
 
 type DetailsTableProps = DetailsTableOwnProps & InjectedTranslateProps;
 
+const tagKey = 'or:tag:';
+
 class DetailsTableBase extends React.Component<DetailsTableProps> {
   public state: DetailsTableState = {
     columns: [],
@@ -156,7 +158,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           isOpen: false,
           item,
           tableItem: {
-            groupBy: groupByTagKey ? `tag:${groupByTagKey}` : groupById,
+            groupBy: groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById,
             index,
             item,
             query,
@@ -207,9 +209,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     let groupByTagKey;
 
     for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf('tag:');
+      const tagIndex = groupBy.indexOf(tagKey);
       if (tagIndex !== -1) {
-        groupByTagKey = groupBy.substring(tagIndex + 4) as any;
+        groupByTagKey = groupBy.substring(tagIndex + tagKey.length) as any;
         break;
       }
     }

--- a/src/pages/azureDetails/detailsToolbar.tsx
+++ b/src/pages/azureDetails/detailsToolbar.tsx
@@ -36,6 +36,8 @@ interface DetailsToolbarOwnProps {
 
 type DetailsToolbarProps = DetailsToolbarOwnProps & InjectedTranslateProps;
 
+const tagKey = 'or:tag:';
+
 export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   public state = {
     activeFilters: [],
@@ -95,7 +97,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     const { currentFilterType } = this.state;
     const filterLabel = this.getFilterLabel(field, value);
     return {
-      field: field.indexOf('tag:') === 0 ? field : currentFilterType.id,
+      field: field.indexOf(tagKey) === 0 ? field : currentFilterType.id,
       label: filterLabel,
       value,
     };
@@ -123,7 +125,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       }
     }
 
-    const index = filterText.indexOf('tag:');
+    const index = filterText.indexOf(tagKey);
     if (index === 0) {
       filterText = 'Tag: ' + filterText.slice(4) + ': ';
     } else {

--- a/src/pages/azureDetails/exportModal.tsx
+++ b/src/pages/azureDetails/exportModal.tsx
@@ -58,6 +58,8 @@ const resolutionOptions: {
   { label: 'Monthly', value: 'monthly' },
 ];
 
+const tagKey = 'or:tag:';
+
 export class ExportModalBase extends React.Component<
   ExportModalProps,
   ExportModalState
@@ -133,7 +135,7 @@ export class ExportModalBase extends React.Component<
     }
 
     let selectedLabel = t('export.selected', { groupBy });
-    if (groupBy.indexOf('tag:') !== -1) {
+    if (groupBy.indexOf(tagKey) !== -1) {
       selectedLabel = t('export.selected_tags');
     }
 

--- a/src/pages/azureDetails/groupBy.tsx
+++ b/src/pages/azureDetails/groupBy.tsx
@@ -47,6 +47,8 @@ const groupByOptions: {
 
 const reportType = AzureReportType.tag;
 
+const tagKey = 'or:tag:';
+
 class GroupByBase extends React.Component<GroupByProps> {
   protected defaultState: GroupByState = {
     isGroupByOpen: false,
@@ -108,8 +110,8 @@ class GroupByBase extends React.Component<GroupByProps> {
       return data.map(val => (
         <DropdownItem
           component="button"
-          key={`tag:${val}`}
-          onClick={() => this.handleGroupByClick(`tag:${val}`)}
+          key={`${tagKey}${val}`}
+          onClick={() => this.handleGroupByClick(`${tagKey}${val}`)}
         >
           {t('group_by.tag', { key: val })}
         </DropdownItem>
@@ -128,7 +130,7 @@ class GroupByBase extends React.Component<GroupByProps> {
         : [];
 
     for (const key of groupByKeys) {
-      const index = key.indexOf('tag:');
+      const index = key.indexOf(tagKey);
       if (index !== -1) {
         groupBy = key;
         break;
@@ -158,10 +160,10 @@ class GroupByBase extends React.Component<GroupByProps> {
       ...this.getDropDownTags(),
     ];
 
-    const index = currentItem ? currentItem.indexOf('tag:') : -1;
+    const index = currentItem ? currentItem.indexOf(tagKey) : -1;
     const label =
       index !== -1
-        ? t('group_by.tag', { key: currentItem.slice(4) })
+        ? t('group_by.tag', { key: currentItem.slice(tagKey.length) })
         : t(`group_by.values.${currentItem}`);
 
     return (

--- a/src/pages/ocpDetails/detailsActions.tsx
+++ b/src/pages/ocpDetails/detailsActions.tsx
@@ -26,6 +26,8 @@ interface DetailsActionsState {
 
 type DetailsActionsProps = DetailsActionsOwnProps & InjectedTranslateProps;
 
+const tagKey = 'or:tag:';
+
 class DetailsActionsBase extends React.Component<DetailsActionsProps> {
   protected defaultState: DetailsActionsState = {
     isDropdownOpen: false,
@@ -193,7 +195,7 @@ class DetailsActionsBase extends React.Component<DetailsActionsProps> {
             <DropdownItem
               component="button"
               key="price-list-action"
-              isDisabled={groupBy.includes('tag:')}
+              isDisabled={groupBy.includes(tagKey)}
               onClick={this.handlePriceListModalOpen}
             >
               {t('ocp_details.actions.price_list')}

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -47,6 +47,8 @@ interface DetailsTableState {
 
 type DetailsTableProps = DetailsTableOwnProps & InjectedTranslateProps;
 
+const tagKey = 'or:tag:';
+
 class DetailsTableBase extends React.Component<DetailsTableProps> {
   public state: DetailsTableState = {
     columns: [],
@@ -180,7 +182,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           isOpen: false,
           item,
           tableItem: {
-            groupBy: groupByTagKey ? `tag:${groupByTagKey}` : groupById,
+            groupBy: groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById,
             index,
             item,
             query,
@@ -256,9 +258,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     let groupByTagKey;
 
     for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf('tag:');
+      const tagIndex = groupBy.indexOf(tagKey);
       if (tagIndex !== -1) {
-        groupByTagKey = groupBy.substring(tagIndex + 4) as any;
+        groupByTagKey = groupBy.substring(tagIndex + tagKey.length) as any;
         break;
       }
     }

--- a/src/pages/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/ocpDetails/detailsToolbar.tsx
@@ -36,6 +36,8 @@ interface DetailsToolbarOwnProps {
 
 type DetailsToolbarProps = DetailsToolbarOwnProps & InjectedTranslateProps;
 
+const tagKey = 'or:tag:';
+
 export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   public state = {
     activeFilters: [],
@@ -95,7 +97,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     const { currentFilterType } = this.state;
     const filterLabel = this.getFilterLabel(field, value);
     return {
-      field: field.indexOf('tag:') === 0 ? field : currentFilterType.id,
+      field: field.indexOf(tagKey) === 0 ? field : currentFilterType.id,
       label: filterLabel,
       value,
     };
@@ -109,9 +111,9 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       filterText = field;
     }
 
-    const index = filterText.indexOf('tag:');
+    const index = filterText.indexOf(tagKey);
     if (index === 0) {
-      filterText = 'Tag: ' + filterText.slice(4) + ': ';
+      filterText = 'Tag: ' + filterText.slice(tagKey.length) + ': ';
     } else {
       filterText =
         filterText.charAt(0).toUpperCase() + filterText.slice(1) + ': ';

--- a/src/pages/ocpDetails/exportModal.tsx
+++ b/src/pages/ocpDetails/exportModal.tsx
@@ -58,6 +58,8 @@ const resolutionOptions: {
   { label: 'Monthly', value: 'monthly' },
 ];
 
+const tagKey = 'or:tag:';
+
 export class ExportModalBase extends React.Component<
   ExportModalProps,
   ExportModalState
@@ -133,7 +135,7 @@ export class ExportModalBase extends React.Component<
     }
 
     let selectedLabel = t('export.selected', { groupBy });
-    if (groupBy.indexOf('tag:') !== -1) {
+    if (groupBy.indexOf(tagKey) !== -1) {
       selectedLabel = t('export.selected_tags');
     }
 

--- a/src/pages/ocpDetails/groupBy.tsx
+++ b/src/pages/ocpDetails/groupBy.tsx
@@ -47,6 +47,8 @@ const groupByOptions: {
 
 const reportType = OcpReportType.tag;
 
+const tagKey = 'or:tag:';
+
 class GroupByBase extends React.Component<GroupByProps> {
   protected defaultState: GroupByState = {
     isGroupByOpen: false,
@@ -108,8 +110,8 @@ class GroupByBase extends React.Component<GroupByProps> {
       return data.map(val => (
         <DropdownItem
           component="button"
-          key={`tag:${val}`}
-          onClick={() => this.handleGroupByClick(`tag:${val}`)}
+          key={`${tagKey}${val}`}
+          onClick={() => this.handleGroupByClick(`${tagKey}${val}`)}
         >
           {t('group_by.tag', { key: val })}
         </DropdownItem>
@@ -128,7 +130,7 @@ class GroupByBase extends React.Component<GroupByProps> {
         : [];
 
     for (const key of groupByKeys) {
-      const index = key.indexOf('tag:');
+      const index = key.indexOf(tagKey);
       if (index !== -1) {
         groupBy = key;
         break;
@@ -158,10 +160,10 @@ class GroupByBase extends React.Component<GroupByProps> {
       ...this.getDropDownTags(),
     ];
 
-    const index = currentItem ? currentItem.indexOf('tag:') : -1;
+    const index = currentItem ? currentItem.indexOf(tagKey) : -1;
     const label =
       index !== -1
-        ? t('group_by.tag', { key: currentItem.slice(4) })
+        ? t('group_by.tag', { key: currentItem.slice(tagKey.length) })
         : t(`group_by.values.${currentItem}`);
 
     return (

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -56,6 +56,8 @@ type OcpDetailsProps = OcpDetailsStateProps &
 
 const reportType = OcpReportType.cost;
 
+const tagKey = 'or:tag:';
+
 const baseQuery: OcpQuery = {
   delta: 'cost',
   filter: {
@@ -125,7 +127,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     return (
       <ExportModal
         isAllItems={selectedItems.length === computedItems.length}
-        groupBy={groupByTagKey ? `tag:${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
         isOpen={isExportModalOpen}
         items={selectedItems}
         onClose={this.handleExportModalClose}
@@ -186,9 +188,9 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     let groupByTagKey;
 
     for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf('tag:');
+      const tagIndex = groupBy.indexOf(tagKey);
       if (tagIndex !== -1) {
-        groupByTagKey = groupBy.substring(tagIndex + 4) as any;
+        groupByTagKey = groupBy.substring(tagIndex + tagKey.length) as any;
         break;
       }
     }
@@ -241,7 +243,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
     return (
       <DetailsTable
-        groupBy={groupByTagKey ? `tag:${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
         onSelected={this.handleSelected}
         onSort={this.handleSort}
         query={query}

--- a/src/pages/ocpOnAwsDetails/detailsTable.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsTable.tsx
@@ -48,6 +48,8 @@ interface DetailsTableState {
 
 type DetailsTableProps = DetailsTableOwnProps & InjectedTranslateProps;
 
+const tagKey = 'or:tag:';
+
 class DetailsTableBase extends React.Component<DetailsTableProps> {
   public state: DetailsTableState = {
     columns: [],
@@ -161,7 +163,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           isOpen: false,
           item,
           tableItem: {
-            groupBy: groupByTagKey ? `tag:${groupByTagKey}` : groupById,
+            groupBy: groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById,
             index,
             item,
             query,
@@ -212,9 +214,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     let groupByTagKey;
 
     for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf('tag:');
+      const tagIndex = groupBy.indexOf(tagKey);
       if (tagIndex !== -1) {
-        groupByTagKey = groupBy.substring(tagIndex + 4) as any;
+        groupByTagKey = groupBy.substring(tagIndex + tagKey.length) as any;
         break;
       }
     }

--- a/src/pages/ocpOnAwsDetails/detailsToolbar.tsx
+++ b/src/pages/ocpOnAwsDetails/detailsToolbar.tsx
@@ -36,6 +36,8 @@ interface DetailsToolbarOwnProps {
 
 type DetailsToolbarProps = DetailsToolbarOwnProps & InjectedTranslateProps;
 
+const tagKey = 'or:tag:';
+
 export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   public state = {
     activeFilters: [],
@@ -95,7 +97,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     const { currentFilterType } = this.state;
     const filterLabel = this.getFilterLabel(field, value);
     return {
-      field: field.indexOf('tag:') === 0 ? field : currentFilterType.id,
+      field: field.indexOf(tagKey) === 0 ? field : currentFilterType.id,
       label: filterLabel,
       value,
     };
@@ -109,9 +111,9 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       filterText = field;
     }
 
-    const index = filterText.indexOf('tag:');
+    const index = filterText.indexOf(tagKey);
     if (index === 0) {
-      filterText = 'Tag: ' + filterText.slice(4) + ': ';
+      filterText = 'Tag: ' + filterText.slice(tagKey.length) + ': ';
     } else {
       filterText =
         filterText.charAt(0).toUpperCase() + filterText.slice(1) + ': ';

--- a/src/pages/ocpOnAwsDetails/exportModal.tsx
+++ b/src/pages/ocpOnAwsDetails/exportModal.tsx
@@ -61,6 +61,8 @@ const resolutionOptions: {
   { label: 'Monthly', value: 'monthly' },
 ];
 
+const tagKey = 'or:tag:';
+
 export class ExportModalBase extends React.Component<
   ExportModalProps,
   ExportModalState
@@ -136,7 +138,7 @@ export class ExportModalBase extends React.Component<
     }
 
     let selectedLabel = t('export.selected', { groupBy });
-    if (groupBy.indexOf('tag:') !== -1) {
+    if (groupBy.indexOf(tagKey) !== -1) {
       selectedLabel = t('export.selected_tags');
     }
 

--- a/src/pages/ocpOnAwsDetails/groupBy.tsx
+++ b/src/pages/ocpOnAwsDetails/groupBy.tsx
@@ -50,6 +50,8 @@ const groupByOptions: {
 
 const reportType = OcpOnAwsReportType.tag;
 
+const tagKey = 'or:tag:';
+
 class GroupByBase extends React.Component<GroupByProps> {
   protected defaultState: GroupByState = {
     isGroupByOpen: false,
@@ -111,8 +113,8 @@ class GroupByBase extends React.Component<GroupByProps> {
       return data.map(val => (
         <DropdownItem
           component="button"
-          key={`tag:${val}`}
-          onClick={() => this.handleGroupByClick(`tag:${val}`)}
+          key={`${tagKey}${val}`}
+          onClick={() => this.handleGroupByClick(`${tagKey}${val}`)}
         >
           {t('group_by.tag', { key: val })}
         </DropdownItem>
@@ -131,7 +133,7 @@ class GroupByBase extends React.Component<GroupByProps> {
         : [];
 
     for (const key of groupByKeys) {
-      const index = key.indexOf('tag:');
+      const index = key.indexOf(tagKey);
       if (index !== -1) {
         groupBy = key;
         break;
@@ -161,10 +163,10 @@ class GroupByBase extends React.Component<GroupByProps> {
       ...this.getDropDownTags(),
     ];
 
-    const index = currentItem ? currentItem.indexOf('tag:') : -1;
+    const index = currentItem ? currentItem.indexOf(tagKey) : -1;
     const label =
       index !== -1
-        ? t('group_by.tag', { key: currentItem.slice(4) })
+        ? t('group_by.tag', { key: currentItem.slice(tagKey.length) })
         : t(`group_by.values.${currentItem}`);
 
     return (

--- a/src/pages/ocpOnAwsDetails/ocpOnAwsDetails.tsx
+++ b/src/pages/ocpOnAwsDetails/ocpOnAwsDetails.tsx
@@ -60,6 +60,8 @@ type OcpOnAwsDetailsProps = OcpOnAwsDetailsStateProps &
 
 const reportType = OcpOnAwsReportType.cost;
 
+const tagKey = 'or:tag:';
+
 const baseQuery: OcpOnAwsQuery = {
   delta: 'cost',
   filter: {
@@ -129,7 +131,7 @@ class OcpOnAwsDetails extends React.Component<OcpOnAwsDetailsProps> {
     return (
       <ExportModal
         isAllItems={selectedItems.length === computedItems.length}
-        groupBy={groupByTagKey ? `tag:${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
         isOpen={isExportModalOpen}
         items={selectedItems}
         onClose={this.handleExportModalClose}
@@ -190,9 +192,9 @@ class OcpOnAwsDetails extends React.Component<OcpOnAwsDetailsProps> {
     let groupByTagKey;
 
     for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf('tag:');
+      const tagIndex = groupBy.indexOf(tagKey);
       if (tagIndex !== -1) {
-        groupByTagKey = groupBy.substring(tagIndex + 4) as any;
+        groupByTagKey = groupBy.substring(tagIndex + tagKey.length) as any;
         break;
       }
     }
@@ -245,7 +247,7 @@ class OcpOnAwsDetails extends React.Component<OcpOnAwsDetailsProps> {
 
     return (
       <DetailsTable
-        groupBy={groupByTagKey ? `tag:${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
         onSelected={this.handleSelected}
         onSort={this.handleSort}
         query={query}


### PR DESCRIPTION
This updates the details pages to show 'Others' when applying group_by tag keys. 

Fixes https://github.com/project-koku/koku-ui/issues/1090

In the example below, selecting the 'environment' tag in the group-by dropdown results in showing 'no-environment' in the table results.

![Screen Shot 2019-11-12 at 11 01 55 AM](https://user-images.githubusercontent.com/17481322/68688500-d486c480-053c-11ea-83c1-1cf98586d6a6.png)

Note: When applying the 'environment' tag; for example, I see 'no-environment' in the results. I can reproduce this with AWS, Azure, and OpenShift on AWS; however, I do not see this behavior with OpenShift.