### PR TITLE
Skip rounding up cost for compute and storage cards

### DIFF
--- a/src/components/reports/awsReportSummary/awsReportSummaryDetails.styles.ts
+++ b/src/components/reports/awsReportSummary/awsReportSummaryDetails.styles.ts
@@ -28,5 +28,6 @@ export const styles = StyleSheet.create({
     display: 'inline-block',
     marginBottom: global_spacer_md.value,
     width: '50%',
+    wordWrap: 'break-word',
   },
 });

--- a/src/components/reports/awsReportSummary/awsReportSummaryDetails.tsx
+++ b/src/components/reports/awsReportSummary/awsReportSummaryDetails.tsx
@@ -14,6 +14,7 @@ interface AwsReportSummaryDetailsProps extends InjectedTranslateProps {
   formatValue?: ValueFormatter;
   formatOptions?: FormatOptions;
   showUnits?: boolean;
+  usageFormatOptions?: FormatOptions;
   usageLabel?: string;
 }
 
@@ -25,6 +26,7 @@ const AwsReportSummaryDetailsBase: React.SFC<AwsReportSummaryDetailsProps> = ({
   reportType = AwsReportType.cost,
   showUnits = false,
   t,
+  usageFormatOptions,
   usageLabel,
 }) => {
   let cost: string | React.ReactNode = <EmptyValueState />;
@@ -39,7 +41,7 @@ const AwsReportSummaryDetailsBase: React.SFC<AwsReportSummaryDetailsProps> = ({
     usage = formatValue(
       report.meta.total.usage ? report.meta.total.usage.value : 0,
       report.meta.total.usage ? report.meta.total.usage.units : '',
-      formatOptions
+      usageFormatOptions ? usageFormatOptions : formatOptions
     );
   }
 

--- a/src/components/reports/azureReportSummary/azureReportSummaryDetails.styles.ts
+++ b/src/components/reports/azureReportSummary/azureReportSummaryDetails.styles.ts
@@ -28,5 +28,6 @@ export const styles = StyleSheet.create({
     display: 'inline-block',
     marginBottom: global_spacer_md.value,
     width: '50%',
+    wordWrap: 'break-word',
   },
 });

--- a/src/components/reports/azureReportSummary/azureReportSummaryDetails.tsx
+++ b/src/components/reports/azureReportSummary/azureReportSummaryDetails.tsx
@@ -14,6 +14,7 @@ interface AzureReportSummaryDetailsProps extends InjectedTranslateProps {
   formatValue?: ValueFormatter;
   formatOptions?: FormatOptions;
   showUnits?: boolean;
+  usageFormatOptions?: FormatOptions;
   usageLabel?: string;
 }
 
@@ -27,6 +28,7 @@ const AzureReportSummaryDetailsBase: React.SFC<
   reportType = AzureReportType.cost,
   showUnits = false,
   t,
+  usageFormatOptions,
   usageLabel,
 }) => {
   let cost: string | React.ReactNode = <EmptyValueState />;
@@ -42,14 +44,14 @@ const AzureReportSummaryDetailsBase: React.SFC<
       usage = formatValue(
         report.meta.total.usage ? report.meta.total.usage.value : 0,
         report.meta.total.usage ? report.meta.total.usage.units : '',
-        formatOptions
+        usageFormatOptions ? usageFormatOptions : formatOptions
       );
     } else {
       // Work around for https://github.com/project-koku/koku-ui/issues/1058
       usage = formatValue(
         report.meta.total.usage ? (report.meta.total.usage as any) : 0,
         report.meta.total.count ? report.meta.total.count.units : '',
-        formatOptions
+        usageFormatOptions ? usageFormatOptions : formatOptions
       );
     }
   }

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryDetails.styles.ts
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryDetails.styles.ts
@@ -38,5 +38,6 @@ export const styles = StyleSheet.create({
     display: 'inline-block',
     marginBottom: global_spacer_md.value,
     width: '50%',
+    wordWrap: 'break-word',
   },
 });

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryDetails.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryDetails.tsx
@@ -15,6 +15,7 @@ interface OcpOnAwsReportSummaryDetailsProps extends InjectedTranslateProps {
   reportType?: OcpOnAwsReportType;
   requestLabel?: string;
   showUnits?: boolean;
+  usageFormatOptions?: FormatOptions;
   usageLabel?: string;
 }
 
@@ -29,6 +30,7 @@ const OcpOnAwsReportSummaryDetailsBase: React.SFC<
   requestLabel,
   showUnits = false,
   t,
+  usageFormatOptions,
   usageLabel,
 }) => {
   let cost: string | React.ReactNode = <EmptyValueState />;
@@ -51,13 +53,13 @@ const OcpOnAwsReportSummaryDetailsBase: React.SFC<
       usage = formatValue(
         report.meta.total.usage ? report.meta.total.usage.value : 0,
         report.meta.total.usage ? report.meta.total.usage.units : '',
-        formatOptions
+        usageFormatOptions ? usageFormatOptions : formatOptions
       );
     } else {
       usage = formatValue(
         report.meta.total.usage ? report.meta.total.usage.value : 0,
         report.meta.total.usage ? report.meta.total.usage.units : '',
-        formatOptions
+        usageFormatOptions ? usageFormatOptions : formatOptions
       );
       request = formatValue(
         report.meta.total.request ? report.meta.total.request.value : 0,

--- a/src/pages/awsDashboard/awsDashboardWidget.tsx
+++ b/src/pages/awsDashboard/awsDashboardWidget.tsx
@@ -125,6 +125,7 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
         report={currentReport}
         reportType={reportType}
         showUnits={details.showUnits}
+        usageFormatOptions={details.usageFormatOptions}
         usageLabel={this.getDetailsLabel(details.usageKey, units)}
       />
     );

--- a/src/pages/azureDashboard/azureDashboardWidget.tsx
+++ b/src/pages/azureDashboard/azureDashboardWidget.tsx
@@ -127,6 +127,7 @@ class AzureDashboardWidgetBase extends React.Component<
         report={currentReport}
         reportType={reportType}
         showUnits={details.showUnits}
+        usageFormatOptions={details.usageFormatOptions}
         usageLabel={this.getDetailsLabel(details.usageKey, units)}
       />
     );

--- a/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
+++ b/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
@@ -178,6 +178,7 @@ class OcpOnAwsDashboardWidgetBase extends React.Component<
         reportType={reportType}
         requestLabel={this.getDetailsLabel(details.requestKey, units)}
         showUnits={details.showUnits}
+        usageFormatOptions={details.usageFormatOptions}
         usageLabel={this.getDetailsLabel(details.usageKey, units)}
       />
     );

--- a/src/store/awsDashboard/awsDashboardCommon.ts
+++ b/src/store/awsDashboard/awsDashboardCommon.ts
@@ -35,6 +35,7 @@ export interface AwsDashboardWidget {
     costKey?: string /** i18n label key */;
     formatOptions: ValueFormatOptions;
     showUnits?: boolean;
+    usageFormatOptions?: ValueFormatOptions;
     usageKey?: string /** i18n label key */;
   };
   filter?: {

--- a/src/store/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/awsDashboard/awsDashboardWidgets.ts
@@ -12,6 +12,9 @@ export const computeWidget: AwsDashboardWidget = {
   details: {
     costKey: 'aws_dashboard.compute_cost_label',
     formatOptions: {
+      fractionDigits: 2,
+    },
+    usageFormatOptions: {
       fractionDigits: 0,
     },
     usageKey: 'aws_dashboard.compute_usage_label',
@@ -143,6 +146,9 @@ export const storageWidget: AwsDashboardWidget = {
   details: {
     costKey: 'aws_dashboard.storage_cost_label',
     formatOptions: {
+      fractionDigits: 2,
+    },
+    usageFormatOptions: {
       fractionDigits: 0,
     },
     showUnits: true,

--- a/src/store/azureDashboard/azureDashboardCommon.ts
+++ b/src/store/azureDashboard/azureDashboardCommon.ts
@@ -35,6 +35,7 @@ export interface AzureDashboardWidget {
     costKey?: string /** i18n label key */;
     formatOptions: ValueFormatOptions;
     showUnits?: boolean;
+    usageFormatOptions?: ValueFormatOptions;
     usageKey?: string /** i18n label key */;
   };
   filter?: {

--- a/src/store/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/azureDashboard/azureDashboardWidgets.ts
@@ -15,6 +15,9 @@ export const computeWidget: AzureDashboardWidget = {
   details: {
     costKey: 'azure_dashboard.compute_cost_label',
     formatOptions: {
+      fractionDigits: 2,
+    },
+    usageFormatOptions: {
       fractionDigits: 0,
     },
     usageKey: 'azure_dashboard.compute_usage_label',
@@ -146,9 +149,12 @@ export const storageWidget: AzureDashboardWidget = {
   details: {
     costKey: 'azure_dashboard.storage_cost_label',
     formatOptions: {
-      fractionDigits: 0,
+      fractionDigits: 2,
     },
     showUnits: true,
+    usageFormatOptions: {
+      fractionDigits: 0,
+    },
     usageKey: 'azure_dashboard.storage_usage_label',
   },
   filter: {

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardCommon.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardCommon.ts
@@ -35,6 +35,7 @@ export interface OcpOnAwsDashboardWidget {
     formatOptions: ValueFormatOptions;
     requestKey?: string /** i18n label key */;
     showUnits?: boolean;
+    usageFormatOptions?: ValueFormatOptions;
     usageKey?: string /** i18n label key */;
   };
   filter?: {

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardWidgets.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardWidgets.ts
@@ -103,6 +103,9 @@ export const computeWidget: OcpOnAwsDashboardWidget = {
   details: {
     costKey: 'ocp_on_aws_dashboard.compute_cost_label',
     formatOptions: {
+      fractionDigits: 2,
+    },
+    usageFormatOptions: {
       fractionDigits: 0,
     },
     usageKey: 'ocp_on_aws_dashboard.compute_usage_label',
@@ -167,6 +170,9 @@ export const storageWidget: OcpOnAwsDashboardWidget = {
   details: {
     costKey: 'ocp_on_aws_dashboard.storage_cost_label',
     formatOptions: {
+      fractionDigits: 2,
+    },
+    usageFormatOptions: {
       fractionDigits: 0,
     },
     showUnits: true,


### PR DESCRIPTION
Added a `usageFormatOptions` property to format cost and usage values separately. This allows the compute and storage cards to show 2 decimal places for cost, while the usage value continues to have zero decimal places.

Fixes https://github.com/project-koku/koku-ui/issues/1087

![Screen Shot 2019-11-12 at 1 12 56 PM](https://user-images.githubusercontent.com/17481322/68698142-43b8e480-054e-11ea-94be-5813bd3a6b8a.png)

