### PR TITLE
Rename "OpenShift on cloud" as "OpenShift Cloud Infrastructure"

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -175,7 +175,7 @@ function buildNavigation() {
       id: 'ocp',
     },
     {
-      title: 'OpenShift on cloud details',
+      title: 'OpenShift cloud infrastructure details',
       id: 'ocp-on-aws',
     },
     {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -516,7 +516,7 @@
     "aws_details": "Cloud details",
     "azure_details": "Azure details",
     "ocp_details": "OpenShift details",
-    "ocp_on_aws_details": "OpenShift on cloud details",
+    "ocp_on_aws_details": "OpenShift cloud infrastructure details",
     "overview": "Overview",
     "source_settings": "Cost management sources"
   },
@@ -754,7 +754,7 @@
     "tag_column_title": "Tag names",
     "tags_label": "Related tags:",
     "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}}'s related tags",
-    "title": "OpenShift on cloud details",
+    "title": "OpenShift cloud infrastructure details",
     "toolbar": {
       "active_filters": "Active filters",
       "clear_filters": "Clear all filters",
@@ -947,7 +947,7 @@
     "azure_desc": "Raw cost from Azure infrastructure.",
     "ocp": "OpenShift",
     "ocp_desc": "Total cost for OpenShift Container Platform, comprising the infrastructure cost and cost calculated from metrics.",
-    "ocp_on_aws": "OpenShift on cloud",
+    "ocp_on_aws": "OpenShift cloud infrastructure",
     "ocp_on_aws_desc": "Infrastructure cost attributed to OpenShift Container Platform, based on a subset of cloud cost data.",
     "title": "Cost Management Overview",
     "title_aria_label": "A description of OpenShift on AWS, OpenShift, AWS, and Azure"


### PR DESCRIPTION
Simply renames "OpenShift on Cloud" as "OpenShift Cloud Infrastructure"

Fixes https://github.com/project-koku/koku-ui/issues/1085

Overview
![Screen Shot 2019-11-12 at 5 40 32 PM](https://user-images.githubusercontent.com/17481322/68717123-e59ef800-0573-11ea-9595-a4ab1926e7a7.png)

Details
![Screen Shot 2019-11-12 at 5 40 46 PM](https://user-images.githubusercontent.com/17481322/68717129-e9cb1580-0573-11ea-8436-96e1a8c8a3b2.png)
