### PR TITLE
Azure overview bars show zero percentages

### DIFF
--- a/src/pages/azureDashboard/azureDashboardWidget.tsx
+++ b/src/pages/azureDashboard/azureDashboardWidget.tsx
@@ -235,7 +235,13 @@ class AzureDashboardWidgetBase extends React.Component<
   };
 
   private getTabItem = (tab: AzureDashboardTab, reportItem) => {
-    const { availableTabs, reportType, tabsReport, topItems } = this.props;
+    const {
+      availableTabs,
+      details,
+      reportType,
+      tabsReport,
+      topItems,
+    } = this.props;
     const { activeTabKey } = this.state;
 
     const currentTab = getIdKeyForTab(tab);
@@ -257,8 +263,10 @@ class AzureDashboardWidgetBase extends React.Component<
             isCostReport
               ? tabsReport.meta.total.cost.value
               : tabsReport.meta.total.usage.value
+              ? tabsReport.meta.total.usage.value
+              : (tabsReport.meta.total.usage as any)
           }
-          units={reportItem.units}
+          units={details.units ? details.units : reportItem.units}
           value={reportItem.cost}
         />
       );


### PR DESCRIPTION
This change adds a workaround for an unexpected `usage` property format.

Currently, the Azure instance-types API returns a single property for meta total usage, where we typically expect value and units. See project-koku/koku#1387

Fixes https://github.com/project-koku/koku-ui/issues/1058

![Screen Shot 2019-11-12 at 6 10 00 PM](https://user-images.githubusercontent.com/17481322/68718786-42041680-0578-11ea-8fcb-03dde7f87b4f.png)
