### PR TITLE
Cards: Show hero number first

### DIFF
--- a/src/components/reports/awsReportSummary/awsReportSummaryDetails.tsx
+++ b/src/components/reports/awsReportSummary/awsReportSummaryDetails.tsx
@@ -14,6 +14,7 @@ interface AwsReportSummaryDetailsProps extends InjectedTranslateProps {
   formatValue?: ValueFormatter;
   formatOptions?: FormatOptions;
   showUnits?: boolean;
+  showUsageFirst?: boolean;
   usageFormatOptions?: FormatOptions;
   usageLabel?: string;
 }
@@ -25,6 +26,7 @@ const AwsReportSummaryDetailsBase: React.SFC<AwsReportSummaryDetailsProps> = ({
   report,
   reportType = AwsReportType.cost,
   showUnits = false,
+  showUsageFirst = false,
   t,
   usageFormatOptions,
   usageLabel,
@@ -45,13 +47,19 @@ const AwsReportSummaryDetailsBase: React.SFC<AwsReportSummaryDetailsProps> = ({
     );
   }
 
-  if (reportType === AwsReportType.cost) {
-    return (
-      <div className={css(styles.reportSummaryDetails)}>
-        <div className={css(styles.value)}>{cost}</div>
+  const getCostLayout = () => (
+    <div className={css(styles.valueContainer)}>
+      <div className={css(styles.value)}>{cost}</div>
+      <div className={css(styles.text)}>
+        <div>{costLabel}</div>
       </div>
-    );
-  } else {
+    </div>
+  );
+
+  const getUsageLayout = () => {
+    if (!usageLabel) {
+      return null;
+    }
     const usageUnits: string =
       report && report.meta && report.meta.total && report.meta.total.usage
         ? report.meta.total.usage.units
@@ -60,26 +68,39 @@ const AwsReportSummaryDetailsBase: React.SFC<AwsReportSummaryDetailsProps> = ({
     const unitsLabel = t(`units.${units}`);
 
     return (
-      <>
-        <div className={css(styles.valueContainer)}>
-          <div className={css(styles.value)}>{cost}</div>
-          <div className={css(styles.text)}>
-            <div>{costLabel}</div>
-          </div>
+      <div className={css(styles.valueContainer)}>
+        <div className={css(styles.value)}>
+          {usage}
+          {Boolean(showUnits && usage >= 0) && (
+            <span className={css(styles.text)}>{unitsLabel}</span>
+          )}
         </div>
-        {Boolean(usageLabel) && (
-          <div className={css(styles.valueContainer)}>
-            <div className={css(styles.value)}>
-              {usage}
-              {Boolean(showUnits && usage >= 0) && (
-                <span className={css(styles.text)}>{unitsLabel}</span>
-              )}
-            </div>
-            <div className={css(styles.text)}>
-              <div>{usageLabel}</div>
-            </div>
-          </div>
-        )}
+        <div className={css(styles.text)}>
+          <div>{usageLabel}</div>
+        </div>
+      </div>
+    );
+  };
+
+  if (reportType === AwsReportType.cost) {
+    return (
+      <div className={css(styles.reportSummaryDetails)}>
+        <div className={css(styles.value)}>{cost}</div>
+      </div>
+    );
+  } else {
+    if (showUsageFirst) {
+      return (
+        <>
+          {getUsageLayout()}
+          {getCostLayout()}
+        </>
+      );
+    }
+    return (
+      <>
+        {getCostLayout()}
+        {getUsageLayout()}
       </>
     );
   }

--- a/src/components/reports/azureReportSummary/azureReportSummaryDetails.tsx
+++ b/src/components/reports/azureReportSummary/azureReportSummaryDetails.tsx
@@ -14,6 +14,7 @@ interface AzureReportSummaryDetailsProps extends InjectedTranslateProps {
   formatValue?: ValueFormatter;
   formatOptions?: FormatOptions;
   showUnits?: boolean;
+  showUsageFirst?: boolean;
   usageFormatOptions?: FormatOptions;
   units?: string;
   usageLabel?: string;
@@ -28,6 +29,7 @@ const AzureReportSummaryDetailsBase: React.SFC<
   report,
   reportType = AzureReportType.cost,
   showUnits = false,
+  showUsageFirst = false,
   t,
   usageFormatOptions,
   units,
@@ -58,13 +60,19 @@ const AzureReportSummaryDetailsBase: React.SFC<
     }
   }
 
-  if (reportType === AzureReportType.cost) {
-    return (
-      <div className={css(styles.reportSummaryDetails)}>
-        <div className={css(styles.value)}>{cost}</div>
+  const getCostLayout = () => (
+    <div className={css(styles.valueContainer)}>
+      <div className={css(styles.value)}>{cost}</div>
+      <div className={css(styles.text)}>
+        <div>{costLabel}</div>
       </div>
-    );
-  } else {
+    </div>
+  );
+
+  const getUsageLayout = () => {
+    if (!usageLabel) {
+      return null;
+    }
     const usageUnits: string =
       report && report.meta && report.meta.total && report.meta.total.usage
         ? report.meta.total.usage.units
@@ -74,26 +82,39 @@ const AzureReportSummaryDetailsBase: React.SFC<
     const unitsLabel = t(`units.${_units}`);
 
     return (
-      <>
-        <div className={css(styles.valueContainer)}>
-          <div className={css(styles.value)}>{cost}</div>
-          <div className={css(styles.text)}>
-            <div>{costLabel}</div>
-          </div>
+      <div className={css(styles.valueContainer)}>
+        <div className={css(styles.value)}>
+          {usage}
+          {Boolean(showUnits && usage >= 0) && (
+            <span className={css(styles.text)}>{unitsLabel}</span>
+          )}
         </div>
-        {Boolean(usageLabel) && (
-          <div className={css(styles.valueContainer)}>
-            <div className={css(styles.value)}>
-              {usage}
-              {Boolean(showUnits && usage >= 0) && (
-                <span className={css(styles.text)}>{unitsLabel}</span>
-              )}
-            </div>
-            <div className={css(styles.text)}>
-              <div>{usageLabel}</div>
-            </div>
-          </div>
-        )}
+        <div className={css(styles.text)}>
+          <div>{usageLabel}</div>
+        </div>
+      </div>
+    );
+  };
+
+  if (reportType === AzureReportType.cost) {
+    return (
+      <div className={css(styles.reportSummaryDetails)}>
+        <div className={css(styles.value)}>{cost}</div>
+      </div>
+    );
+  } else {
+    if (showUsageFirst) {
+      return (
+        <>
+          {getUsageLayout()}
+          {getCostLayout()}
+        </>
+      );
+    }
+    return (
+      <>
+        {getCostLayout()}
+        {getUsageLayout()}
       </>
     );
   }

--- a/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryDetails.tsx
+++ b/src/components/reports/ocpOnAwsReportSummary/ocpOnAwsReportSummaryDetails.tsx
@@ -15,6 +15,7 @@ interface OcpOnAwsReportSummaryDetailsProps extends InjectedTranslateProps {
   reportType?: OcpOnAwsReportType;
   requestLabel?: string;
   showUnits?: boolean;
+  showUsageFirst?: boolean;
   usageFormatOptions?: FormatOptions;
   usageLabel?: string;
 }
@@ -29,6 +30,7 @@ const OcpOnAwsReportSummaryDetailsBase: React.SFC<
   reportType = OcpOnAwsReportType.cost,
   requestLabel,
   showUnits = false,
+  showUsageFirst = false,
   t,
   usageFormatOptions,
   usageLabel,
@@ -69,6 +71,43 @@ const OcpOnAwsReportSummaryDetailsBase: React.SFC<
     }
   }
 
+  const getAwsCostLayout = () => (
+    <div className={css(styles.valueContainer)}>
+      <div className={css(styles.value)}>{cost}</div>
+      <div className={css(styles.text)}>
+        <div>{costLabel}</div>
+      </div>
+    </div>
+  );
+
+  const getAwsUsageLayout = () => {
+    if (!usageLabel) {
+      return null;
+    }
+    const usageUnits =
+      report && report.meta && report.meta.total && report.meta.total.usage
+        ? report.meta.total.usage.units
+        : '';
+    const units = unitLookupKey(usageUnits);
+    const unitsLabel = t(`units.${units}`);
+
+    return (
+      <>
+        <div className={css(styles.valueContainer)}>
+          <div className={css(styles.value)}>
+            {usage}
+            {Boolean(showUnits && usage >= 0) && (
+              <span className={css(styles.text)}>{unitsLabel}</span>
+            )}
+          </div>
+          <div className={css(styles.text)}>
+            <div>{usageLabel}</div>
+          </div>
+        </div>
+      </>
+    );
+  };
+
   if (reportType === OcpOnAwsReportType.cost) {
     return (
       <div className={css(styles.titleContainer)}>
@@ -95,34 +134,18 @@ const OcpOnAwsReportSummaryDetailsBase: React.SFC<
       </>
     );
   } else {
-    const usageUnits =
-      report && report.meta && report.meta.total && report.meta.total.usage
-        ? report.meta.total.usage.units
-        : '';
-    const units = unitLookupKey(usageUnits);
-    const unitsLabel = t(`units.${units}`);
-
+    if (showUsageFirst) {
+      return (
+        <>
+          {getAwsUsageLayout()}
+          {getAwsCostLayout()}
+        </>
+      );
+    }
     return (
       <>
-        <div className={css(styles.valueContainer)}>
-          <div className={css(styles.value)}>{cost}</div>
-          <div className={css(styles.text)}>
-            <div>{costLabel}</div>
-          </div>
-        </div>
-        {Boolean(usageLabel) && (
-          <div className={css(styles.valueContainer)}>
-            <div className={css(styles.value)}>
-              {usage}
-              {Boolean(showUnits && usage >= 0) && (
-                <span className={css(styles.text)}>{unitsLabel}</span>
-              )}
-            </div>
-            <div className={css(styles.text)}>
-              <div>{usageLabel}</div>
-            </div>
-          </div>
-        )}
+        {getAwsCostLayout()}
+        {getAwsUsageLayout()}
       </>
     );
   }

--- a/src/pages/awsDashboard/awsDashboardWidget.tsx
+++ b/src/pages/awsDashboard/awsDashboardWidget.tsx
@@ -115,7 +115,7 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
   };
 
   private getDetails = () => {
-    const { currentReport, details, reportType } = this.props;
+    const { currentReport, details, isUsageFirst, reportType } = this.props;
     const units = this.getUnits();
     return (
       <AwsReportSummaryDetails
@@ -125,6 +125,7 @@ class AwsDashboardWidgetBase extends React.Component<AwsDashboardWidgetProps> {
         report={currentReport}
         reportType={reportType}
         showUnits={details.showUnits}
+        showUsageFirst={isUsageFirst}
         usageFormatOptions={details.usageFormatOptions}
         usageLabel={this.getDetailsLabel(details.usageKey, units)}
       />

--- a/src/pages/azureDashboard/azureDashboardWidget.tsx
+++ b/src/pages/azureDashboard/azureDashboardWidget.tsx
@@ -118,7 +118,7 @@ class AzureDashboardWidgetBase extends React.Component<
   };
 
   private getDetails = () => {
-    const { currentReport, details, reportType } = this.props;
+    const { currentReport, details, isUsageFirst, reportType } = this.props;
     const units = this.getUnits();
     return (
       <AzureReportSummaryDetails
@@ -128,6 +128,7 @@ class AzureDashboardWidgetBase extends React.Component<
         report={currentReport}
         reportType={reportType}
         showUnits={details.showUnits}
+        showUsageFirst={isUsageFirst}
         usageFormatOptions={details.usageFormatOptions}
         units={units}
         usageLabel={this.getDetailsLabel(details.usageKey, units)}

--- a/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
+++ b/src/pages/ocpOnAwsDashboard/ocpOnAwsDashboardWidget.tsx
@@ -167,7 +167,7 @@ class OcpOnAwsDashboardWidgetBase extends React.Component<
   };
 
   private getDetails = () => {
-    const { currentReport, details, reportType } = this.props;
+    const { currentReport, details, isUsageFirst, reportType } = this.props;
     const units = this.getUnits();
     return (
       <OcpOnAwsReportSummaryDetails
@@ -178,6 +178,7 @@ class OcpOnAwsDashboardWidgetBase extends React.Component<
         reportType={reportType}
         requestLabel={this.getDetailsLabel(details.requestKey, units)}
         showUnits={details.showUnits}
+        showUsageFirst={isUsageFirst}
         usageFormatOptions={details.usageFormatOptions}
         usageLabel={this.getDetailsLabel(details.usageKey, units)}
       />

--- a/src/store/awsDashboard/awsDashboardCommon.ts
+++ b/src/store/awsDashboard/awsDashboardCommon.ts
@@ -44,6 +44,7 @@ export interface AwsDashboardWidget {
   };
   isDetailsLink?: boolean;
   isHorizontal?: boolean;
+  isUsageFirst?: boolean;
   tabsFilter?: {
     limit?: number;
     service?: string;

--- a/src/store/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/awsDashboard/awsDashboardWidgets.ts
@@ -22,6 +22,7 @@ export const computeWidget: AwsDashboardWidget = {
   filter: {
     service: 'AmazonEC2',
   },
+  isUsageFirst: true,
   tabsFilter: {
     service: 'AmazonEC2',
   },
@@ -154,6 +155,7 @@ export const storageWidget: AwsDashboardWidget = {
     showUnits: true,
     usageKey: 'aws_dashboard.storage_usage_label',
   },
+  isUsageFirst: true,
   trend: {
     formatOptions: {
       fractionDigits: 2,

--- a/src/store/azureDashboard/azureDashboardCommon.ts
+++ b/src/store/azureDashboard/azureDashboardCommon.ts
@@ -45,6 +45,7 @@ export interface AzureDashboardWidget {
   };
   isDetailsLink?: boolean;
   isHorizontal?: boolean;
+  isUsageFirst?: boolean;
   tabsFilter?: {
     limit?: number;
     service_name?: string;

--- a/src/store/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/azureDashboard/azureDashboardWidgets.ts
@@ -26,6 +26,7 @@ export const computeWidget: AzureDashboardWidget = {
   filter: {
     service_name: 'Virtual Machines',
   },
+  isUsageFirst: true,
   tabsFilter: {
     service_name: 'Virtual Machines',
   },
@@ -162,6 +163,7 @@ export const storageWidget: AzureDashboardWidget = {
   filter: {
     service_name: 'Storage',
   },
+  isUsageFirst: true,
   tabsFilter: {
     service_name: 'Storage',
   },

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardCommon.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardCommon.ts
@@ -44,6 +44,7 @@ export interface OcpOnAwsDashboardWidget {
   };
   isDetailsLink?: boolean;
   isHorizontal?: boolean;
+  isUsageFirst?: boolean;
   tabsFilter?: {
     limit?: number;
     service?: string;

--- a/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardWidgets.ts
+++ b/src/store/ocpOnAwsDashboard/ocpOnAwsDashboardWidgets.ts
@@ -110,6 +110,7 @@ export const computeWidget: OcpOnAwsDashboardWidget = {
     },
     usageKey: 'ocp_on_aws_dashboard.compute_usage_label',
   },
+  isUsageFirst: true,
   filter: {
     service: 'AmazonEC2',
   },
@@ -178,6 +179,7 @@ export const storageWidget: OcpOnAwsDashboardWidget = {
     showUnits: true,
     usageKey: 'ocp_on_aws_dashboard.storage_usage_label',
   },
+  isUsageFirst: true,
   trend: {
     formatOptions: {
       fractionDigits: 2,


### PR DESCRIPTION
Show usage first (i.e., the hero number) for compute and storage cards -- cost is secondary

Fixes https://github.com/project-koku/koku-ui/issues/1088

OpenShift on Aws
![Screen Shot 2019-11-12 at 6 45 03 PM](https://user-images.githubusercontent.com/17481322/68720373-fe5fdb80-057c-11ea-9da2-052784608fac.png)

Aws
![Screen Shot 2019-11-12 at 6 45 25 PM](https://user-images.githubusercontent.com/17481322/68720376-00299f00-057d-11ea-9e14-59a348bfb888.png)

Azure
![Screen Shot 2019-11-12 at 6 45 36 PM](https://user-images.githubusercontent.com/17481322/68720370-fb64eb00-057c-11ea-9774-750c2b4342e4.png)