### PR TITLE
feat(costmodels): get provider's cost models from /providers API

### DIFF
--- a/src/api/providers.ts
+++ b/src/api/providers.ts
@@ -31,6 +31,11 @@ export interface ProviderRequest {
   billing_source?: ProviderBillingSource;
 }
 
+export interface ProviderCostModel {
+  name: string;
+  uuid: string;
+}
+
 export interface Provider {
   uuid?: string;
   name?: string;
@@ -40,6 +45,7 @@ export interface Provider {
   customer?: ProviderCustomer;
   created_by?: ProviderCreatedBy;
   created_timestamp?: Date;
+  cost_models?: ProviderCostModel[];
 }
 
 export interface Providers {

--- a/src/pages/createCostModelWizard/api.ts
+++ b/src/pages/createCostModelWizard/api.ts
@@ -1,4 +1,3 @@
-import { fetchCostModels } from 'api/costModels';
 import { fetchProviders } from 'api/providers';
 
 export const fetchSources = ({ type, page, perPage, query }) => {
@@ -14,22 +13,10 @@ export const fetchSources = ({ type, page, perPage, query }) => {
   )
     .then(sources => sources.data.data)
     .then(sources => {
-      return fetchCostModels().then(cms => ({
-        costmodels: cms.data.data,
-        sources,
-      }));
-    })
-    .then(({ costmodels, sources }) => {
-      const cmsHash = costmodels.reduce((acc, curr) => {
-        curr.providers.forEach(provider => {
-          acc[provider.uuid] = curr.name;
-        });
-        return acc;
-      }, {});
       return sources.map(src => ({
         name: src.name,
-        costmodel: cmsHash[src.uuid],
         uuid: src.uuid,
+        costmodel: src.cost_models.map(cm => cm.name).join(','),
         selected: false,
       }));
     });


### PR DESCRIPTION
closes #1128 

Use the cost_models data from the response of providers API instead of doing N+1 calls.