### PR TITLE
fix(costmodels): Make create and back bold text in the review step

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -313,9 +313,10 @@
       "usage": "Usage ({{units}})"
     },
     "review": {
+      "back_button": "Back",
       "close_button": "Close",
       "create_button": "Create",
-      "sub_title_details": "Review and confirm your cost model configuration. Click \"Create\" to create the cost model, or \"Back\" to revise.",
+      "sub_title_details": "Review and confirm your cost model configuration. Click {{create}} to create the cost model, or {{back}} to revise.",
       "sub_title_success": "You have successfully created",
       "title_details": "Review",
       "title_success": "Creation successful"

--- a/src/pages/createCostModelWizard/review.tsx
+++ b/src/pages/createCostModelWizard/review.tsx
@@ -19,7 +19,7 @@ import {
 } from '@patternfly/react-core';
 import { OkIcon } from '@patternfly/react-icons';
 import React from 'react';
-import { InjectedTranslateProps, translate } from 'react-i18next';
+import { InjectedTranslateProps, Interpolate, translate } from 'react-i18next';
 import { CostModelContext } from './context';
 import { getLabels, PriceListTier } from './priceListTier';
 
@@ -60,7 +60,11 @@ const ReviewDetailsBase: React.SFC<InjectedTranslateProps> = ({ t }) => (
           <StackItem>
             <TextContent>
               <Text component={TextVariants.h6}>
-                {t('cost_models_wizard.review.sub_title_details')}
+                <Interpolate
+                  i18nKey="cost_models_wizard.review.sub_title_details"
+                  create={<b>{t('cost_models_wizard.review.create_button')}</b>}
+                  back={<b>{t('cost_models_wizard.review.back_button')}</b>}
+                />
               </Text>
             </TextContent>
           </StackItem>


### PR DESCRIPTION
closes #1134 

![image](https://user-images.githubusercontent.com/2453279/70553506-e8493900-1b83-11ea-9890-0f176a79bf7c.png)
