### PR TITLE
Add white space to overview description pop up

### DIFF
--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -268,14 +268,17 @@ class OverviewBase extends React.Component<OverviewProps> {
                           {t('overview.ocp_on_aws')}
                         </p>
                         <p>{t('overview.ocp_on_aws_desc')}</p>
+                        <br />
                         <p className={css(styles.infoTitle)}>
                           {t('overview.ocp')}
                         </p>
                         <p>{t('overview.ocp_desc')}</p>
+                        <br />
                         <p className={css(styles.infoTitle)}>
                           {t('overview.aws')}
                         </p>
                         <p>{t('overview.aws_desc')}</p>
+                        <br />
                         <p className={css(styles.infoTitle)}>
                           {t('overview.azure')}
                         </p>


### PR DESCRIPTION
Adds white spacing between sections to the overview description pop up.

Fixes https://github.com/project-koku/koku-ui/issues/1140

<img width="709" alt="Screen Shot 2019-12-10 at 9 57 17 PM" src="https://user-images.githubusercontent.com/17481322/70587647-74fdf200-1b98-11ea-91df-5f07ec1ff4fb.png">
