### PR TITLE
Legend color does not match

### DIFF
--- a/src/components/charts/costChart/costChart.styles.ts
+++ b/src/components/charts/costChart/costChart.styles.ts
@@ -5,7 +5,6 @@ import {
   chart_color_green_300,
   chart_color_green_400,
   chart_color_green_500,
-  global_disabled_color_100,
   global_disabled_color_200,
   global_FontFamily_sans_serif,
 } from '@patternfly/react-tokens';
@@ -55,7 +54,7 @@ export const chartStyles = {
   ],
   previousColorScale: [
     global_disabled_color_200.value,
-    global_disabled_color_100.value,
+    global_disabled_color_200.value,
   ],
   yAxis: {
     axisLabel: {

--- a/src/components/charts/usageChart/usageChart.styles.ts
+++ b/src/components/charts/usageChart/usageChart.styles.ts
@@ -5,7 +5,6 @@ import {
   chart_color_green_300,
   chart_color_green_400,
   chart_color_green_500,
-  global_disabled_color_100,
   global_disabled_color_200,
   global_FontFamily_sans_serif,
   global_spacer_lg,
@@ -57,7 +56,7 @@ export const chartStyles = {
   // TBD: No grey scale, yet
   previousColorScale: [
     global_disabled_color_200.value,
-    global_disabled_color_100.value,
+    global_disabled_color_200.value,
   ],
   yAxis: {
     axisLabel: {


### PR DESCRIPTION
Legend symbols for cost and Infrastructure cost should be the same previous month, grey color

Fixes https://github.com/project-koku/koku-ui/issues/1139

<img width="520" alt="Screen Shot 2019-12-10 at 10 12 03 PM" src="https://user-images.githubusercontent.com/17481322/70588365-78927880-1b9a-11ea-8fc4-c8c58b69dffd.png">
