### PR TITLE
Fix filter by tag 400 error

### DIFF
--- a/src/pages/awsDetails/awsDetails.tsx
+++ b/src/pages/awsDetails/awsDetails.tsx
@@ -290,7 +290,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 
     const groupByTagKey = this.getGroupByTagKey();
     const newFilterType =
-      filterType === 'tag' ? `${filterType}:${groupByTagKey}` : filterType;
+      filterType === 'tag' ? `${tagKey}${groupByTagKey}` : filterType;
 
     if (newQuery.group_by[newFilterType]) {
       if (newQuery.group_by[newFilterType] === '*') {
@@ -314,7 +314,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 
     const groupByTagKey = this.getGroupByTagKey();
     const newFilterType =
-      filterType === 'tag' ? `${filterType}:${groupByTagKey}` : filterType;
+      filterType === 'tag' ? `${tagKey}${groupByTagKey}` : filterType;
 
     if (filterValue === '') {
       newQuery.group_by = {

--- a/src/pages/azureDetails/azureDetails.tsx
+++ b/src/pages/azureDetails/azureDetails.tsx
@@ -290,7 +290,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
 
     const groupByTagKey = this.getGroupByTagKey();
     const newFilterType =
-      filterType === 'tag' ? `${filterType}:${groupByTagKey}` : filterType;
+      filterType === 'tag' ? `${tagKey}${groupByTagKey}` : filterType;
 
     if (newQuery.group_by[newFilterType]) {
       if (newQuery.group_by[newFilterType] === '*') {
@@ -314,7 +314,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
 
     const groupByTagKey = this.getGroupByTagKey();
     const newFilterType =
-      filterType === 'tag' ? `${filterType}:${groupByTagKey}` : filterType;
+      filterType === 'tag' ? `${tagKey}${groupByTagKey}` : filterType;
 
     if (filterValue === '') {
       newQuery.group_by = {

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -292,7 +292,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
     const groupByTagKey = this.getGroupByTagKey();
     const newFilterType =
-      filterType === 'tag' ? `${filterType}:${groupByTagKey}` : filterType;
+      filterType === 'tag' ? `${tagKey}${groupByTagKey}` : filterType;
 
     if (newQuery.group_by[newFilterType]) {
       if (newQuery.group_by[newFilterType] === '*') {
@@ -316,7 +316,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
     const groupByTagKey = this.getGroupByTagKey();
     const newFilterType =
-      filterType === 'tag' ? `${filterType}:${groupByTagKey}` : filterType;
+      filterType === 'tag' ? `${tagKey}${groupByTagKey}` : filterType;
 
     if (filterValue === '') {
       newQuery.group_by = {

--- a/src/pages/ocpOnAwsDetails/ocpOnAwsDetails.tsx
+++ b/src/pages/ocpOnAwsDetails/ocpOnAwsDetails.tsx
@@ -296,7 +296,7 @@ class OcpOnAwsDetails extends React.Component<OcpOnAwsDetailsProps> {
 
     const groupByTagKey = this.getGroupByTagKey();
     const newFilterType =
-      filterType === 'tag' ? `${filterType}:${groupByTagKey}` : filterType;
+      filterType === 'tag' ? `${tagKey}${groupByTagKey}` : filterType;
 
     if (newQuery.group_by[newFilterType]) {
       if (newQuery.group_by[newFilterType] === '*') {
@@ -320,7 +320,7 @@ class OcpOnAwsDetails extends React.Component<OcpOnAwsDetailsProps> {
 
     const groupByTagKey = this.getGroupByTagKey();
     const newFilterType =
-      filterType === 'tag' ? `${filterType}:${groupByTagKey}` : filterType;
+      filterType === 'tag' ? `${tagKey}${groupByTagKey}` : filterType;
 
     if (filterValue === '') {
       newQuery.group_by = {


### PR DESCRIPTION
Fix filter by tag feature, which currently generates a 400 error. This problem was introduced when adding the "or:" prefix to each tag key.

Fixes https://github.com/project-koku/koku-ui/issues/1131

![chrome-capture](https://user-images.githubusercontent.com/17481322/70592969-6e2bab00-1ba9-11ea-8572-d719be466d77.gif)

