### PR TITLE
fix(costmodels): Move header description to popover

### DIFF
--- a/src/pages/costModelsDetails/header.tsx
+++ b/src/pages/costModelsDetails/header.tsx
@@ -1,4 +1,5 @@
-import { Title } from '@patternfly/react-core';
+import { Button, ButtonVariant, Popover, Title } from '@patternfly/react-core';
+import { InfoCircleIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import React from 'react';
 import { InjectedTranslateProps } from 'react-i18next';
@@ -8,8 +9,16 @@ const Header: React.SFC<InjectedTranslateProps> = ({ t }) => (
   <header className={css(styles.header)}>
     <Title className={css(styles.title)} size="2xl">
       {t('cost_models_details.header.title')}
+      <Popover
+        aria-label={t('cost_models_details.header.sub')}
+        enableFlip
+        bodyContent={t('cost_models_details.header.sub')}
+      >
+        <Button variant={ButtonVariant.plain}>
+          <InfoCircleIcon />
+        </Button>
+      </Popover>
     </Title>
-    <Title size="md">{t('cost_models_details.header.sub')}</Title>
   </header>
 );
 


### PR DESCRIPTION
closes #1141 

![image](https://user-images.githubusercontent.com/2453279/70622764-4bd77300-1c25-11ea-8f5a-954119437bae.png)


//cc @lcouzens 