### PR TITLE
Remove service_name from Ocp on cloud filter

### DIFF
--- a/src/api/ocpOnCloudQuery.ts
+++ b/src/api/ocpOnCloudQuery.ts
@@ -6,7 +6,6 @@ export interface OcpOnCloudFilters {
   project?: string | number;
   resolution?: 'daily' | 'monthly';
   service?: string;
-  service_name?: string;
   time_scope_units?: 'month' | 'day';
   time_scope_value?: number;
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,7 +1,7 @@
 {
   "app_title": "Koku",
   "aws_dashboard": {
-    "compute_cost_label": "Cost!!!",
+    "compute_cost_label": "Cost",
     "compute_title": "Compute (EC2) instances usage",
     "compute_trend_title": "Daily usage comparison ({{units}})",
     "compute_usage_label": "Hours",

--- a/src/store/ocpOnCloudDashboard/ocpOnCloudDashboardCommon.ts
+++ b/src/store/ocpOnCloudDashboard/ocpOnCloudDashboardCommon.ts
@@ -45,7 +45,6 @@ export interface OcpOnCloudDashboardWidget {
   filter?: {
     limit?: number;
     service?: string;
-    service_name?: string;
   };
   isDetailsLink?: boolean;
   isHorizontal?: boolean;

--- a/src/store/ocpOnCloudDashboard/ocpOnCloudDashboardWidgets.ts
+++ b/src/store/ocpOnCloudDashboard/ocpOnCloudDashboardWidgets.ts
@@ -138,8 +138,8 @@ export const databaseWidget: OcpOnCloudDashboardWidget = {
   },
   filter: {
     service:
-      'AmazonRDS,AmazonDynamoDB,AmazonElastiCache,AmazonNeptune,AmazonRedshift,AmazonDocumentDB',
-    service_name: 'Database,Cosmos DB,Cache for Redis',
+      'AmazonRDS,AmazonDynamoDB,AmazonElastiCache,AmazonNeptune,AmazonRedshift,AmazonDocumentDB,' +
+      'Database,Cosmos DB,Cache for Redis',
   },
   trend: {
     formatOptions: {},
@@ -159,8 +159,8 @@ export const networkWidget: OcpOnCloudDashboardWidget = {
     },
   },
   filter: {
-    service: 'AmazonVPC,AmazonCloudFront,AmazonRoute53,AmazonAPIGateway',
-    service_name:
+    service:
+      'AmazonVPC,AmazonCloudFront,AmazonRoute53,AmazonAPIGateway,' +
       'Virtual Network,VPN,DNS,Traffic Manager,ExpressRoute,Load Balancer,Application Gateway',
   },
   trend: {

--- a/src/store/ocpOnCloudDashboard/ocpOnCloudDashboardWidgets.ts
+++ b/src/store/ocpOnCloudDashboard/ocpOnCloudDashboardWidgets.ts
@@ -138,7 +138,7 @@ export const databaseWidget: OcpOnCloudDashboardWidget = {
   },
   filter: {
     service:
-      'AmazonRDS,AmazonDynamoDB,AmazonElastiCache,AmazonNeptune,AmazonRedshift,AmazonDocumentDB,' +
+      'AmazonRDS,AmazonDynamoDB,AmazonElastiCache,AmazonNeptune,AmazonRedshift,AmazonDocumentDB' +
       'Database,Cosmos DB,Cache for Redis',
   },
   trend: {
@@ -160,7 +160,7 @@ export const networkWidget: OcpOnCloudDashboardWidget = {
   },
   filter: {
     service:
-      'AmazonVPC,AmazonCloudFront,AmazonRoute53,AmazonAPIGateway,' +
+      'AmazonVPC,AmazonCloudFront,AmazonRoute53,AmazonAPIGateway' +
       'Virtual Network,VPN,DNS,Traffic Manager,ExpressRoute,Load Balancer,Application Gateway',
   },
   trend: {


### PR DESCRIPTION
This removes the invalid Azure service_name filter from the /all/ API used for the Ocp on cloud overview tab. We should append the following strings to the existing AWS service filter instead.

```
'Database,Cosmos DB,Cache for Redis' +
'Virtual Network,VPN,DNS,Traffic Manager,ExpressRoute,Load Balancer,Application Gateway'
```

Filters https://github.com/project-koku/koku-ui/issues/1188