### PR TITLE
Cost models fix typos and update wording - fit & finish

### DIFF
--- a/src/components/filter/filterComposition.tsx
+++ b/src/components/filter/filterComposition.tsx
@@ -98,7 +98,7 @@ const FilterCompositionBase: React.SFC<Props> = ({
       <TextInput
         value={value}
         placeholder={t('source_details.filter.placeholder', {
-          value: name,
+          value: name.toLowerCase(),
         })}
         id={id}
         onChange={newValue => {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -208,6 +208,7 @@
       "cost_models": "Cost models",
       "source_type": "Source type"
     },
+    "description_markup": "Percentage to add to or subtract from the base cost of the source(s)",
     "edit_cost_model": "Edit {{ cost_model }} cost model",
     "edit_markup": "Edit {{cost_model}} markup",
     "edit_markup_action": "Edit markup",
@@ -222,12 +223,12 @@
       "title": "No rates are set"
     },
     "empty_state_source": {
-      "description": "Assign a source, like an Amazon Web Services account, to apply this cost model.",
+      "description": "Select the source(s) you want to apply this cost model to.",
       "title": "No sources are assigned"
     },
     "filter": {
       "create_button": "Create cost model",
-      "placeholder": "Filter by cost model {{value}}",
+      "placeholder": "Filter by {{value}}",
       "type_options_aria_label": "select cost model type",
       "type_options_label": "Choose source type"
     },
@@ -273,7 +274,7 @@
       "invalid_markup_text": "Markup should be a positive or negative number",
       "markup_error": "Markup rate should be a number",
       "markup_label": "Markup rate",
-      "sub_title": "Enter a positive or negative percentage to add or subtract to the base cost of the sources",
+      "sub_title": "Enter a positive or negative percentage to add to or subtract from the base cost of the sources.",
       "title": "Set a markup (or discount)"
     },
     "price_list": {
@@ -303,7 +304,7 @@
       "save_rate": "Save rate",
       "storage_metric": "Storage",
       "storage_units": "GB-month",
-      "sub_title_add": "To create a price list, select a metric and fill in the values. You can set one or more rates in a price list.",
+      "sub_title_add": "Select the metric you want to assign a price to, and specify a measurement unit and rate. You can set one rate per metric in a price list.",
       "sub_title_table": "The following is a list of rates you have set so far for this price list. To continue adding rates to this price list, click \"Add another rate\". If you are finished setting this price list, click \"Next\".",
       "tier": "tier",
       "title": "Set a price list (optional)",
@@ -317,19 +318,19 @@
       "close_button": "Close",
       "create_button": "Create",
       "sub_title_details": "Review and confirm your cost model configuration. Click {{create}} to create the cost model, or {{back}} to revise.",
-      "sub_title_success": "You have successfully created",
+      "sub_title_success": "You have successfully created your cost model.",
       "title_details": "Review",
       "title_success": "Creation successful"
     },
     "source": {
-      "caption": "Select from the following sources that are of type {{ type }}",
-      "sub_title": "Select one or more source(s) for this cost model. If the source already has a cost model assigned to it, this selection will override that assignment.",
+      "caption": "Select from the following {{ type }} sources:",
+      "sub_title": "Select one or more source(s) to assign to this cost model. If the source already has a cost model assigned to it, this selection will override that assignment. You can also assign sources to your cost model at a later time.",
       "title_AWS": "Assign Amazon Web Service source(s) (optional)",
       "title_OCP": "Assign Red Hat OpenShift source(s) (optional)"
     },
     "source_table": {
       "active_filters": "Active filters:",
-      "clear_all_filters": "Clear all filter",
+      "clear_all_filters": "Clear all filters",
       "column_cost_model": "Cost model assigned",
       "column_name": "Name",
       "default_cost_model": "Default cost model",
@@ -477,7 +478,7 @@
   },
   "loading": "Loading",
   "loading_state": {
-    "sources_desc": "We are looking for your sources. Do not refresh the browser",
+    "sources_desc": "Searching for your sources. Do not refresh the browser",
     "sources_title": "Looking for sources..."
   },
   "login": {

--- a/src/pages/costModelsDetails/components/markup.tsx
+++ b/src/pages/costModelsDetails/components/markup.tsx
@@ -56,10 +56,7 @@ const MarkupCardBase: React.SFC<Props> = ({
               ]}
             />
           </CardActions>
-          <CardHeader>
-            precentage value to add or substract to the base cost of the
-            source(s)
-          </CardHeader>
+          <CardHeader>{t('cost_models_details.description_markup')}</CardHeader>
         </CardHead>
         <CardBody isFilled />
         <CardBody className={css(styles.cardBody)}>{markupValue}%</CardBody>


### PR DESCRIPTION
closes #1193 
closes #1077

- [x] In the filter box, the grey text doesn't fit (Filter by cost model name"). Shorten to "Filter by name"
![image](https://user-images.githubusercontent.com/2453279/71554897-0a6d0300-2a2e-11ea-85c7-9553ba9f18fe.png)

- [x] Change  "Enter a positive or negative percentage to add or subtract to the base cost of the sources" to "Enter a positive or negative percentage to add to or subtract **from** the base cost of the sources."
![image](https://user-images.githubusercontent.com/2453279/71554953-3c7e6500-2a2e-11ea-808e-61c463672315.png)

- [x] The message needs a period (.) at the end of it and I suggest editing out "we" since we don't use this voice elsewhere in the app.
Current text: "We are looking for your sources. Do not refresh the browser"
Revision: "Searching for your sources; do not refresh your browser."  (Searching or Looking is fine I think)
![img1](https://user-images.githubusercontent.com/2453279/71554990-ce866d80-2a2e-11ea-8632-94014d5df79f.png)

- [x] Change Assign source(s) description from "Select one or more source to this cost model. If the source already has a cost model assigned to it, this selection will override that assignment." to "Select one or more source to assign to this cost model. If the source already has a cost model assigned to it, this selection will override that assignment. You can also assign sources to your cost model at a later time."

- [x] Change from "Select from the following sources that are of type AWS" to "Select from the following AWS sources:" or "Select an AWS source:" or "Select a source from the list:"
Same for OCP.
![image](https://user-images.githubusercontent.com/2453279/71555000-13120900-2a2f-11ea-8917-d1cde9f80dd4.png)

- [x] Typo when filtering: "Clear all filter" needs to be plural: "Clear all filters"
![image](https://user-images.githubusercontent.com/2453279/71555074-34272980-2a30-11ea-9d87-5040e38171d0.png)

- [x] Current text: "To create a price list, select a metric and fill in the values. You can set one or more rates in a price list."
Revision suggestion: "Select the metric you want to assign a price to, and specify a measurement unit and rate. You can set one rate per metric in a price list."
![image](https://user-images.githubusercontent.com/2453279/71555332-b402c300-2a33-11ea-9aa4-97ebeeee0f62.png)

- [x] Message is incomplete. Edit "You have successfully created" to "You have successfully created your cost model."
![image](https://user-images.githubusercontent.com/2453279/71555341-d4cb1880-2a33-11ea-99a7-7098ec494117.png)

- [x] Change in Markup tab to "Percentage to add to or subtract **from** the base cost of the source(s)"
![image](https://user-images.githubusercontent.com/2453279/71555419-c29daa00-2a34-11ea-9d3b-51afc3065502.png)

- [x] Change "Filter by source Name" to "Filter by source **name**"
![image](https://user-images.githubusercontent.com/2453279/71555440-f678cf80-2a34-11ea-8f80-9a2a04f672d3.png)

- [x] Change "Assign a source, like an Amazon Web Services account, to apply this cost model." to  "Select the source(s) you want to apply this cost model to."
![image](https://user-images.githubusercontent.com/2453279/71555474-6b4c0980-2a35-11ea-8455-523407fef8db.png)
