### PR TITLE
feat(costmodels): markup is optional on creating cost model

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -274,7 +274,7 @@
       "markup_error": "Markup rate should be a number",
       "markup_label": "Markup rate",
       "sub_title": "Enter a positive or negative percentage to add or subtract to the base cost of the sources",
-      "title": "Set a markup (or discount)"
+      "title": "Set a markup (or discount) (optional)"
     },
     "price_list": {
       "actions": "price list tier actions",

--- a/src/pages/createCostModelWizard/index.tsx
+++ b/src/pages/createCostModelWizard/index.tsx
@@ -82,7 +82,7 @@ const defaultState = {
   type: '',
   name: '',
   description: '',
-  markup: '',
+  markup: '0',
   filterName: '',
   sources: [],
   error: null,

--- a/src/pages/createCostModelWizard/markup.tsx
+++ b/src/pages/createCostModelWizard/markup.tsx
@@ -72,7 +72,6 @@ class Markup extends React.Component<
                           }
                         }}
                         isValid={isValid}
-                        placeholder={'0'}
                       />
                       <InputGroupText style={{ borderLeft: '0' }}>
                         %


### PR DESCRIPTION
closes #1159 

This patch sets a default value to Markup and adds "(optional)" to the title of the step.
By doing so the user is no longer forced to specify Markup unless he/she needs to.