### PR TITLE
Move titles above charts

### DIFF
--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -309,7 +309,7 @@ class CostChart extends React.Component<CostChartProps, State> {
     if (!(chartDatum && chartDatum.data && chartDatum.data.length)) {
       return null;
     }
-    const { legendItemsPerRow, title } = this.props;
+    const { legendItemsPerRow } = this.props;
     const itemsPerRow = legendItemsPerRow
       ? legendItemsPerRow
       : width > 400
@@ -348,7 +348,6 @@ class CostChart extends React.Component<CostChartProps, State> {
         itemsPerRow={itemsPerRow}
         responsive={false}
         style={chartStyles.legend}
-        title={title}
       />
     );
   };
@@ -393,7 +392,7 @@ class CostChart extends React.Component<CostChartProps, State> {
   }
 
   public render() {
-    const { height, containerHeight = height, padding } = this.props;
+    const { height, containerHeight = height, padding, title } = this.props;
     const { chartDatum, width } = this.state;
 
     const container = (
@@ -413,6 +412,7 @@ class CostChart extends React.Component<CostChartProps, State> {
         ref={this.containerRef}
         style={{ height: width > 400 ? containerHeight : containerHeight + 75 }}
       >
+        <div>{title}</div>
         <Chart
           containerComponent={container}
           domain={domain}

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -212,7 +212,6 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     if (!(chartDatum && chartDatum.data && chartDatum.data.length)) {
       return null;
     }
-    const { title } = this.props;
     const eventHandlers = {
       onClick: () => {
         return [
@@ -246,7 +245,6 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         height={25}
         orientation={width > 150 ? 'horizontal' : 'vertical'}
         style={chartStyles.legend}
-        title={title}
       />
     );
   };
@@ -278,7 +276,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   }
 
   public render() {
-    const { height, containerHeight = height, padding } = this.props;
+    const { height, containerHeight = height, padding, title } = this.props;
     const { chartDatum, width } = this.state;
 
     const container = (
@@ -299,6 +297,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         ref={this.containerRef}
         style={{ height: containerHeight }}
       >
+        <div>{title}</div>
         <Chart
           containerComponent={container}
           domain={domain}

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -314,7 +314,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
     if (!(chartDatum && chartDatum.data && chartDatum.data.length)) {
       return null;
     }
-    const { legendItemsPerRow, title } = this.props;
+    const { legendItemsPerRow } = this.props;
     const itemsPerRow = legendItemsPerRow
       ? legendItemsPerRow
       : width > 300
@@ -353,7 +353,6 @@ class UsageChart extends React.Component<UsageChartProps, State> {
         itemsPerRow={itemsPerRow}
         responsive
         style={chartStyles.legend}
-        title={title}
       />
     );
   };
@@ -398,7 +397,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
   }
 
   public render() {
-    const { height, containerHeight = height, padding } = this.props;
+    const { height, containerHeight = height, padding, title } = this.props;
     const { chartDatum, width } = this.state;
 
     const container = (
@@ -418,6 +417,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
         ref={this.containerRef}
         style={{ height: containerHeight }}
       >
+        <div>{title}</div>
         <Chart
           containerComponent={container}
           domain={domain}


### PR DESCRIPTION
This moves chart titles, in the overview pages, from the legend to above the chart.

Mock: https://marvelapp.com/1jj511j6/screen/63870434

Fixes https://github.com/project-koku/koku-ui/issues/1198

Ocp on cloud
<img width="1126" alt="Screen Shot 2020-01-01 at 3 03 29 PM" src="https://user-images.githubusercontent.com/17481322/71645522-e9afe200-2ca7-11ea-8325-b6646423aced.png">

Ocp
<img width="565" alt="Screen Shot 2020-01-01 at 3 03 58 PM" src="https://user-images.githubusercontent.com/17481322/71645529-f7fdfe00-2ca7-11ea-8f03-ce7753df43e7.png">

Aws
<img width="1126" alt="Screen Shot 2020-01-01 at 3 04 25 PM" src="https://user-images.githubusercontent.com/17481322/71645536-06e4b080-2ca8-11ea-8635-89c67fd4326e.png">

Azure
<img width="1126" alt="Screen Shot 2020-01-01 at 3 04 56 PM" src="https://user-images.githubusercontent.com/17481322/71645548-18c65380-2ca8-11ea-89a3-2f09f9c1ce57.png">

