### PR TITLE
Update cloud details tertiary navigation

### DIFF
--- a/src/components/details/tertiaryNav.tsx
+++ b/src/components/details/tertiaryNav.tsx
@@ -1,17 +1,8 @@
-import {
-  Nav,
-  NavItem,
-  NavList,
-  NavVariants,
-  Title,
-  TitleSize,
-} from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
+import { Nav, NavItem, NavList, NavVariants } from '@patternfly/react-core';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { RouteComponentProps } from 'react-router';
 import { withRouter } from 'react-router-dom';
-import { styles } from '../../pages/azureDetails/detailsHeader.styles';
 
 export const enum TertiaryNavItem {
   aws = 'aws',
@@ -72,9 +63,7 @@ export class TertiaryNavBase extends React.Component<TertiaryNavProps> {
         itemId={navItemKey}
         isActive={activeItem === navItem}
       >
-        <Title className={css(styles.title)} size={TitleSize['2xl']}>
-          {this.getNavItemTitle(navItem)}
-        </Title>
+        {this.getNavItemTitle(navItem)}
       </NavItem>
     );
   };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -524,8 +524,7 @@
     "Dec"
   ],
   "navigation": {
-    "aws_details": "Cloud details",
-    "azure_details": "Azure details",
+    "cloud_details": "Cloud details",
     "ocp_details": "OpenShift details",
     "ocp_on_cloud_details": "OpenShift cloud infrastructure details",
     "overview": "Overview",

--- a/src/pages/awsDetails/detailsHeader.tsx
+++ b/src/pages/awsDetails/detailsHeader.tsx
@@ -1,4 +1,4 @@
-import { Title } from '@patternfly/react-core';
+import { Title, TitleSize } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { AwsQuery, getQuery } from 'api/awsQuery';
 import { AwsReport, AwsReportType } from 'api/awsReports';
@@ -84,6 +84,9 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     return (
       <header className={css(styles.header)}>
         <div>
+          <Title className={css(styles.title)} size={TitleSize['2xl']}>
+            {t('navigation.cloud_details')}
+          </Title>
           <div className={css(styles.nav)}>
             <TertiaryNav activeItem={TertiaryNavItem.aws} />
           </div>

--- a/src/pages/azureDetails/detailsHeader.tsx
+++ b/src/pages/azureDetails/detailsHeader.tsx
@@ -1,4 +1,4 @@
-import { Title } from '@patternfly/react-core';
+import { Title, TitleSize } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { AzureQuery, getQuery } from 'api/azureQuery';
 import { AzureReport, AzureReportType } from 'api/azureReports';
@@ -84,6 +84,9 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     return (
       <header className={css(styles.header)}>
         <div>
+          <Title className={css(styles.title)} size={TitleSize['2xl']}>
+            {t('navigation.cloud_details')}
+          </Title>
           <div className={css(styles.nav)}>
             <TertiaryNav activeItem={TertiaryNavItem.azure} />
           </div>


### PR DESCRIPTION
Modified the tertiary navigation, for the "Cloud details" page, to use standard font size. (This was overridden because it replaced the page title.) Then, added "Cloud details" as a title above the tertiary nav.

Fixes https://github.com/project-koku/koku-ui/issues/1112

Before
<img width="1137" alt="Screen Shot 2020-01-01 at 3 23 59 PM" src="https://user-images.githubusercontent.com/17481322/71645878-b02da580-2cac-11ea-85b3-1aa8dcd3f8ce.png">

After
<img width="1379" alt="Screen Shot 2020-01-01 at 3 34 47 PM" src="https://user-images.githubusercontent.com/17481322/71645881-b3c12c80-2cac-11ea-801a-eed3dd14be21.png">
