### PR TITLE
Add spinner to details loading state

### DIFF
--- a/src/components/state/loadingState/loadingState.tsx
+++ b/src/components/state/loadingState/loadingState.tsx
@@ -1,9 +1,5 @@
-import {
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateIcon,
-  Title,
-} from '@patternfly/react-core';
+import { EmptyState, EmptyStateBody, Title } from '@patternfly/react-core';
+import { Spinner } from '@patternfly/react-core/dist/esm/experimental';
 import { BinocularsIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import React from 'react';
@@ -24,7 +20,7 @@ const LoadingStateBase: React.SFC<LoadingStateProps> = ({
   return (
     <div className={css(styles.container)}>
       <EmptyState>
-        <EmptyStateIcon icon={icon} />
+        <Spinner size="lg" />
         <Title size="lg">{title}</Title>
         <EmptyStateBody>{subTitle}</EmptyStateBody>
       </EmptyState>


### PR DESCRIPTION
Added a PatternFly spinner to the details page loading state. This replaces the existing binocular icon.

Fixes https://github.com/project-koku/koku-ui/issues/1186

<img width="1101" alt="Screen Shot 2020-01-01 at 11 45 32 PM (3)" src="https://user-images.githubusercontent.com/17481322/71652101-dffe9c80-2cf0-11ea-86f7-75d3bb7c1ef6.png">