### PR TITLE
Show cost instead of infrastructure_cost, which omits markup cost

### DIFF
--- a/src/pages/ocpCloudDashboard/ocpCloudDashboardWidget.tsx
+++ b/src/pages/ocpCloudDashboard/ocpCloudDashboardWidget.tsx
@@ -111,7 +111,7 @@ class OcpCloudDashboardWidgetBase extends React.Component<
       reportType === OcpCloudReportType.cost ||
       reportType === OcpCloudReportType.database ||
       reportType === OcpCloudReportType.network;
-    const reportItem = costReportType ? 'infrastructureCost' : 'usage';
+    const reportItem = costReportType ? 'cost' : 'usage';
     const currentUsageData = transformOcpCloudReport(
       currentReport,
       trend.type,
@@ -302,13 +302,11 @@ class OcpCloudDashboardWidgetBase extends React.Component<
           label={reportItem.label ? reportItem.label.toString() : ''}
           totalValue={
             isCostReport
-              ? tabsReport.meta.total.infrastructure_cost.value
+              ? tabsReport.meta.total.cost.value
               : tabsReport.meta.total.usage.value
           }
           units={reportItem.units}
-          value={
-            isCostReport ? reportItem.infrastructureCost : reportItem.usage
-          }
+          value={isCostReport ? reportItem.cost : reportItem.usage}
         />
       );
     } else {
@@ -362,8 +360,8 @@ class OcpCloudDashboardWidgetBase extends React.Component<
         reportType === OcpCloudReportType.database ||
         reportType === OcpCloudReportType.network
       ) {
-        units = currentReport.meta.total.infrastructure_cost
-          ? unitLookupKey(currentReport.meta.total.infrastructure_cost.units)
+        units = currentReport.meta.total.cost
+          ? unitLookupKey(currentReport.meta.total.cost.units)
           : '';
       } else {
         units = currentReport.meta.total.usage

--- a/src/pages/ocpCloudDetails/detailsHeader.tsx
+++ b/src/pages/ocpCloudDetails/detailsHeader.tsx
@@ -94,7 +94,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
         {Boolean(showContent) && (
           <div className={css(styles.cost)}>
             <Title className={css(styles.costValue)} size="4xl">
-              {formatCurrency(report.meta.total.infrastructure_cost.value)}
+              {formatCurrency(report.meta.total.cost.value)}
             </Title>
             <div className={css(styles.costLabel)}>
               <div className={css(styles.costLabelUnit)}>

--- a/src/pages/ocpCloudDetails/detailsTable.tsx
+++ b/src/pages/ocpCloudDetails/detailsTable.tsx
@@ -94,11 +94,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const groupByTagKey = this.getGroupByTagKey();
 
     const total = formatCurrency(
-      report &&
-        report.meta &&
-        report.meta.total &&
-        report.meta.total.infrastructure_cost
-        ? report.meta.total.infrastructure_cost.value
+      report && report.meta && report.meta.total && report.meta.total.cost
+        ? report.meta.total.cost.value
         : 0
     );
 
@@ -341,17 +338,17 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
   private getTotalCost = (item: ComputedOcpCloudReportItem, index: number) => {
     const { report, t } = this.props;
-    const total = report.meta.total.infrastructure_cost.value;
+    const total = report.meta.total.cost.value;
 
     return (
       <>
-        {formatCurrency(item.infrastructureCost)}
+        {formatCurrency(item.cost)}
         <div
           className={css(styles.infoDescription)}
           key={`total-cost-${index}`}
         >
           {t('percent_of_cost', {
-            value: ((item.infrastructureCost / total) * 100).toFixed(2),
+            value: ((item.cost / total) * 100).toFixed(2),
           })}
         </div>
       </>

--- a/src/pages/ocpCloudDetails/detailsWidgetModalView.tsx
+++ b/src/pages/ocpCloudDetails/detailsWidgetModalView.tsx
@@ -64,11 +64,8 @@ class DetailsWidgetModalViewBase extends React.Component<
     const { groupBy, report, reportFetchStatus, t } = this.props;
 
     const cost = formatCurrency(
-      report &&
-        report.meta &&
-        report.meta.total &&
-        report.meta.total.infrastructure_cost
-        ? report.meta.total.infrastructure_cost.value
+      report && report.meta && report.meta.total && report.meta.total.cost
+        ? report.meta.total.cost.value
         : 0
     );
 
@@ -92,9 +89,9 @@ class DetailsWidgetModalViewBase extends React.Component<
                   formatOptions={{}}
                   formatValue={formatValue}
                   label={_item.label ? _item.label.toString() : ''}
-                  totalValue={report.meta.total.infrastructure_cost.value}
+                  totalValue={report.meta.total.cost.value}
                   units={_item.units}
-                  value={_item.infrastructureCost}
+                  value={_item.cost}
                 />
               ))
             }

--- a/src/pages/ocpCloudDetails/detailsWidgetView.tsx
+++ b/src/pages/ocpCloudDetails/detailsWidgetView.tsx
@@ -91,9 +91,9 @@ class DetailsWidgetViewBase extends React.Component<DetailsWidgetViewProps> {
         formatOptions={{}}
         formatValue={formatValue}
         label={reportItem.label ? reportItem.label.toString() : ''}
-        totalValue={report.meta.total.infrastructure_cost.value}
+        totalValue={report.meta.total.cost.value}
         units={reportItem.units}
-        value={reportItem.infrastructureCost}
+        value={reportItem.cost}
       />
     );
   };

--- a/src/pages/ocpCloudDetails/historicalChart.tsx
+++ b/src/pages/ocpCloudDetails/historicalChart.tsx
@@ -120,13 +120,13 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
       currentCostReport,
       ChartType.rolling,
       'date',
-      'infrastructureCost'
+      'cost'
     );
     const previousCostData = transformOcpCloudReport(
       previousCostReport,
       ChartType.rolling,
       'date',
-      'infrastructureCost'
+      'cost'
     );
 
     // Cpu data
@@ -209,8 +209,8 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
       currentCostReport &&
       currentCostReport.meta &&
       currentCostReport.meta.total &&
-      currentCostReport.meta.total.infrastructure_cost
-        ? currentCostReport.meta.total.infrastructure_cost.units
+      currentCostReport.meta.total.cost
+        ? currentCostReport.meta.total.cost.units
         : 'USD';
     const cpuUnits =
       currentCpuReport &&


### PR DESCRIPTION
For Ocp cloud infrastructure, we should display cost instead of infrastructure_cost, which omits markup cost.

Fixes https://github.com/project-koku/koku-ui/issues/1206