### PR TITLE
Change delta to show previous cost

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -682,8 +682,6 @@
     "cluster_label": "Cluster:",
     "cost_column_title": "Cost",
     "cost_value": "Cost: {{value}}",
-    "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
-    "decrease_since_last_month": "{{value}} decrease since last month",
     "derived_aria_label": "A description of infrastructure and derived cost",
     "derived_cost_column_title": "Derived cost",
     "derived_cost_desc": "The cost based on the user’s defined price list. Calculated as infrastructure_cost + markup, or on a premises without infrastructure, calculated as CPU usage * rate.",
@@ -712,14 +710,11 @@
       "modal_title": "{{name}} daily usage comparison",
       "view_data": "View Historical Data"
     },
-    "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
-    "increase_since_last_month": "{{value}} increase since last month",
     "infrastructure_cost_column_title": "Infrastructure cost",
     "infrastructure_cost_desc": "The cost based on raw usage data from the underlying infrastructure.",
     "infrastructure_cost_title": "Infrastructure cost",
     "more_tags": ", {{value}} more...",
     "name_column_title": "$t(group_by.values.{{groupBy}}) names",
-    "no_change_since_date": "No change since $t(months.{{month}}) {{date}}",
     "price_list": {
       "modal": {
         "applied_usage_date_range": "Applied usage date range",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -36,8 +36,6 @@
     "cost_column_subtitle": " (Total {{total}})",
     "cost_column_title": "Cost",
     "cost_value": "Cost: {{value}}",
-    "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
-    "decrease_since_last_month": "{{value}} decrease since last month",
     "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "export_link": "Export",
     "filter": {
@@ -62,11 +60,8 @@
       "storage_title": "Storage usage comparison",
       "view_data": "View historical data"
     },
-    "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
-    "increase_since_last_month": "{{value}} increase since last month",
     "more_tags": ", {{value}} more...",
     "name_column_title": "$t(group_by.values.{{groupBy}}) names",
-    "no_change_since_date": "No change since $t(months.{{month}}) {{date}}",
     "show_more": "Show more",
     "tag_column_title": "Tag names",
     "tags_label": "Related tags:",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -117,8 +117,6 @@
     "cost_column_subtitle": " (Total {{total}})",
     "cost_column_title": "Cost",
     "cost_value": "Cost: {{value}}",
-    "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
-    "decrease_since_last_month": "{{value}} decrease since last month",
     "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "export_link": "Export",
     "filter": {
@@ -143,11 +141,8 @@
       "storage_title": "Storage usage comparison",
       "view_data": "View historical data"
     },
-    "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
-    "increase_since_last_month": "{{value}} increase since last month",
     "more_tags": ", {{value}} more...",
     "name_column_title": "$t(group_by.values.{{groupBy}}) names",
-    "no_change_since_date": "No change since $t(months.{{month}}) {{date}}",
     "show_more": "Show more",
     "tag_column_title": "Tag names",
     "tags_label": "Related tags:",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -416,6 +416,8 @@
     "type_empty": "Choose source type",
     "type_ocp": "Red HatOpenShift"
   },
+  "for_date": "{{value}} for {{startDate}} $t(months_abbr.{{month}})",
+  "for_date_plural": "{{value}} for {{startDate}}-{{endDate}} $t(months_abbr.{{month}})",
   "group_by": {
     "all": "All $t(group_by.values.{{groupBy}}, { 'count': 5 })",
     "cost": "Group cost by",
@@ -584,8 +586,6 @@
     "cluster_label": "Cluster:",
     "cost_column_title": "Cost",
     "cost_value": "Cost: {{value}}",
-    "decrease_since_date": "{{value}} decrease since $t(months.{{month}}) {{date}}",
-    "decrease_since_last_month": "{{value}} decrease since last month",
     "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "export_link": "Export",
     "filter": {
@@ -618,11 +618,8 @@
       "modal_title": "{{name}} daily usage comparison",
       "view_data": "View Historical Data"
     },
-    "increase_since_date": "{{value}} increase since $t(months.{{month}}) {{date}}",
-    "increase_since_last_month": "{{value}} increase since last month",
     "more_tags": ", {{value}} more...",
     "name_column_title": "$t(group_by.values.{{groupBy}}) names",
-    "no_change_since_date": "No change since $t(months.{{month}}) {{date}}",
     "tag_column_title": "Tag names",
     "tags_label": "Related tags:",
     "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}} related tags",
@@ -952,6 +949,7 @@
   "percent": "{{value}}%",
   "percent_of_cost": "{{value}} % of cost",
   "percent_of_total": "{{value}} {{units}} ({{percent}}%)",
+  "percent_zero": "--",
   "providers": {
     "add_source": "Add sources",
     "bucket_error": "Bucket name cannot contain spaces, special chars and be more than 255 characters",

--- a/src/pages/awsDetails/detailsTable.tsx
+++ b/src/pages/awsDetails/detailsTable.tsx
@@ -18,6 +18,7 @@ import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterS
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
+import { getForDateRangeString } from 'utils/dateRange';
 import { formatCurrency } from 'utils/formatValue';
 import {
   getIdKeyForGroupBy,
@@ -223,11 +224,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     index: number
   ) => {
     const { t } = this.props;
-
-    const today = new Date();
-    const date = today.getDate();
-    const month = (((today.getMonth() - 1) % 12) + 12) % 12;
-    const value = formatCurrency(Math.abs(item.deltaValue));
+    const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
 
@@ -242,7 +239,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <div className={monthOverMonthOverride}>
         <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-          {t('percent', { value: percentage })}
+          {Boolean(percentage > 0)
+            ? t('percent', { value: percentage })
+            : t('percent_zero')}
           {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
             <span
               className={css('fa fa-sort-up', styles.infoArrow)}
@@ -264,23 +263,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           className={css(styles.infoDescription)}
           key={`month-over-month-info-${index}`}
         >
-          {Boolean(item.deltaPercent !== null && item.deltaValue > 0)
-            ? Boolean(date < 31)
-              ? t('aws_details.increase_since_date', { date, month, value })
-              : t('aws_details.increase_since_last_month', {
-                  date,
-                  month,
-                  value,
-                })
-            : Boolean(item.deltaPercent !== null && item.deltaValue < 0)
-            ? Boolean(date < 31)
-              ? t('aws_details.decrease_since_date', { date, month, value })
-              : t('aws_details.decrease_since_last_month', {
-                  date,
-                  month,
-                  value,
-                })
-            : t('aws_details.no_change_since_date', { date, month })}
+          {getForDateRangeString(value)}
         </div>
       </div>
     );

--- a/src/pages/azureDetails/detailsTable.tsx
+++ b/src/pages/azureDetails/detailsTable.tsx
@@ -18,6 +18,7 @@ import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterS
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
+import { getForDateRangeString } from 'utils/dateRange';
 import { formatCurrency } from 'utils/formatValue';
 import {
   getIdKeyForGroupBy,
@@ -223,11 +224,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     index: number
   ) => {
     const { t } = this.props;
-
-    const today = new Date();
-    const date = today.getDate();
-    const month = (((today.getMonth() - 1) % 12) + 12) % 12;
-    const value = formatCurrency(Math.abs(item.deltaValue));
+    const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
 
@@ -242,7 +239,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <div className={monthOverMonthOverride}>
         <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-          {t('percent', { value: percentage })}
+          {Boolean(percentage > 0)
+            ? t('percent', { value: percentage })
+            : t('percent_zero')}
           {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
             <span
               className={css('fa fa-sort-up', styles.infoArrow)}
@@ -264,23 +263,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           className={css(styles.infoDescription)}
           key={`month-over-month-info-${index}`}
         >
-          {Boolean(item.deltaPercent !== null && item.deltaValue > 0)
-            ? Boolean(date < 31)
-              ? t('azure_details.increase_since_date', { date, month, value })
-              : t('azure_details.increase_since_last_month', {
-                  date,
-                  month,
-                  value,
-                })
-            : Boolean(item.deltaPercent !== null && item.deltaValue < 0)
-            ? Boolean(date < 31)
-              ? t('azure_details.decrease_since_date', { date, month, value })
-              : t('azure_details.decrease_since_last_month', {
-                  date,
-                  month,
-                  value,
-                })
-            : t('azure_details.no_change_since_date', { date, month })}
+          {getForDateRangeString(value)}
         </div>
       </div>
     );

--- a/src/pages/ocpCloudDetails/detailsTable.tsx
+++ b/src/pages/ocpCloudDetails/detailsTable.tsx
@@ -18,6 +18,7 @@ import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterS
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
+import { getForDateRangeString } from 'utils/dateRange';
 import { formatCurrency } from 'utils/formatValue';
 import {
   getIdKeyForGroupBy,
@@ -225,11 +226,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     index: number
   ) => {
     const { t } = this.props;
-
-    const today = new Date();
-    const date = today.getDate();
-    const month = (((today.getMonth() - 1) % 12) + 12) % 12;
-    const value = formatCurrency(Math.abs(item.deltaValue));
+    const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
 
@@ -244,7 +241,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <div className={monthOverMonthOverride}>
         <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-          {t('percent', { value: percentage })}
+          {Boolean(percentage > 0)
+            ? t('percent', { value: percentage })
+            : t('percent_zero')}
           {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
             <span
               className={css('fa fa-sort-up', styles.infoArrow)}
@@ -266,31 +265,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           className={css(styles.infoDescription)}
           key={`month-over-month-info-${index}`}
         >
-          {Boolean(item.deltaPercent !== null && item.deltaValue > 0)
-            ? Boolean(date < 31)
-              ? t('ocp_cloud_details.increase_since_date', {
-                  date,
-                  month,
-                  value,
-                })
-              : t('ocp_cloud_details.increase_since_last_month', {
-                  date,
-                  month,
-                  value,
-                })
-            : Boolean(item.deltaPercent !== null && item.deltaValue < 0)
-            ? Boolean(date < 31)
-              ? t('ocp_cloud_details.decrease_since_date', {
-                  date,
-                  month,
-                  value,
-                })
-              : t('ocp_cloud_details.decrease_since_last_month', {
-                  date,
-                  month,
-                  value,
-                })
-            : t('ocp_cloud_details.no_change_since_date', { date, month })}
+          {getForDateRangeString(value)}
         </div>
       </div>
     );

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -18,6 +18,7 @@ import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterS
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
+import { getForDateRangeString } from 'utils/dateRange';
 import { formatCurrency } from 'utils/formatValue';
 import {
   getIdKeyForGroupBy,
@@ -300,11 +301,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     index: number
   ) => {
     const { t } = this.props;
-
-    const today = new Date();
-    const date = today.getDate();
-    const month = (((today.getMonth() - 1) % 12) + 12) % 12;
-    const value = formatCurrency(Math.abs(item.deltaValue));
+    const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
 
@@ -319,7 +316,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <div className={monthOverMonthOverride}>
         <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-          {t('percent', { value: percentage })}
+          {Boolean(percentage > 0)
+            ? t('percent', { value: percentage })
+            : t('percent_zero')}
           {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
             <span
               className={css('fa fa-sort-up', styles.infoArrow)}
@@ -341,23 +340,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           className={css(styles.infoDescription)}
           key={`month-over-month-info-${index}`}
         >
-          {Boolean(item.deltaPercent !== null && item.deltaValue > 0)
-            ? Boolean(date < 31)
-              ? t('ocp_details.increase_since_date', { date, month, value })
-              : t('ocp_details.increase_since_last_month', {
-                  date,
-                  month,
-                  value,
-                })
-            : Boolean(item.deltaPercent !== null && item.deltaValue < 0)
-            ? Boolean(date < 31)
-              ? t('ocp_details.decrease_since_date', { date, month, value })
-              : t('ocp_details.decrease_since_last_month', {
-                  date,
-                  month,
-                  value,
-                })
-            : t('ocp_details.no_change_since_date', { date, month })}
+          {getForDateRangeString(value)}
         </div>
       </div>
     );

--- a/src/utils/dateRange.ts
+++ b/src/utils/dateRange.ts
@@ -4,6 +4,29 @@ import getMonth from 'date-fns/get_month';
 import startOfMonth from 'date-fns/start_of_month';
 import i18next from 'i18next';
 
+export function getForDateRangeString(
+  value: string | number,
+  key: string = 'for_date',
+  offset: number = 1
+) {
+  const today = new Date();
+  if (offset) {
+    today.setMonth(today.getMonth() - offset);
+  }
+
+  const month = getMonth(today);
+  const endDate = formatDate(today, 'D');
+  const startDate = formatDate(startOfMonth(today), 'D');
+
+  return i18next.t(key, {
+    count: getDate(today),
+    endDate,
+    month,
+    startDate,
+    value,
+  });
+}
+
 export function getSinceDateRangeString(key: string = 'since_date') {
   const today = new Date();
   const month = getMonth(today);


### PR DESCRIPTION
This change shows the previous cost instead of a delta (i.e., the change since date).

Mock: https://marvelapp.com/1jj511j6/screen/64401384

Fixes https://github.com/project-koku/koku-ui/issues/1093

Note: did not implement the following. That depends on project-koku/koku#1395

- If the previous month was null, then we would not show it at all and just show the previous month’s amount — API change needed!

Aws details:
<img width="1230" alt="Screen Shot 2020-01-02 at 9 45 48 PM" src="https://user-images.githubusercontent.com/17481322/71704944-0aad2b80-2dab-11ea-9f90-09a0bf03012a.png">

Azure details:
<img width="1232" alt="Screen Shot 2020-01-02 at 9 45 35 PM" src="https://user-images.githubusercontent.com/17481322/71704956-18fb4780-2dab-11ea-8760-ba9badba6e4d.png">

Ocp details (no change):
<img width="1233" alt="Screen Shot 2020-01-02 at 9 39 46 PM" src="https://user-images.githubusercontent.com/17481322/71704972-244e7300-2dab-11ea-8918-cfd91e3b44f5.png">

