### PR TITLE
Ocp cloud infrastructure tooltips

### DIFF
--- a/src/api/ocpCloudReports.ts
+++ b/src/api/ocpCloudReports.ts
@@ -22,6 +22,7 @@ export interface OcpCloudReportValue {
   infrastructure_cost: OcpCloudDatum;
   instance_type?: string;
   limit?: OcpCloudDatum;
+  markup_cost: OcpCloudDatum;
   node?: string;
   project?: string;
   region?: string;
@@ -97,6 +98,7 @@ export interface OcpCloudReportMeta {
     derived_cost: OcpCloudDatum;
     infrastructure_cost: OcpCloudDatum;
     limit?: OcpCloudDatum;
+    markup_cost?: OcpCloudDatum;
     request?: OcpCloudDatum;
     usage?: OcpCloudDatum;
   };

--- a/src/components/reports/awsReportSummary/awsReportSummary.tsx
+++ b/src/components/reports/awsReportSummary/awsReportSummary.tsx
@@ -4,7 +4,6 @@ import {
   CardFooter,
   CardHeader,
   Title,
-  Tooltip,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import {
@@ -21,7 +20,6 @@ interface AwsReportSummaryProps extends InjectedTranslateProps {
   detailsLink?: React.ReactNode;
   status: number;
   subTitle?: string;
-  subTitleTooltip?: string;
   title: string;
 }
 
@@ -30,18 +28,13 @@ const AwsReportSummaryBase: React.SFC<AwsReportSummaryProps> = ({
   detailsLink,
   title,
   subTitle,
-  subTitleTooltip = subTitle,
   status,
   t,
 }) => (
   <Card className={css(styles.reportSummary)}>
     <CardHeader>
       <Title size="lg">{title}</Title>
-      {Boolean(subTitle) && (
-        <Tooltip content={subTitleTooltip} enableFlip>
-          <p className={css(styles.subtitle)}>{subTitle}</p>
-        </Tooltip>
-      )}
+      {Boolean(subTitle) && <p className={css(styles.subtitle)}>{subTitle}</p>}
     </CardHeader>
     <CardBody>
       {status === FetchStatus.inProgress ? (

--- a/src/components/reports/awsReportSummary/awsReportSummaryAlt.tsx
+++ b/src/components/reports/awsReportSummary/awsReportSummaryAlt.tsx
@@ -6,7 +6,6 @@ import {
   Grid,
   GridItem,
   Title,
-  Tooltip,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import {
@@ -23,7 +22,6 @@ interface AwsReportSummaryAltProps extends InjectedTranslateProps {
   detailsLink?: React.ReactNode;
   status: number;
   subTitle?: string;
-  subTitleTooltip?: string;
   tabs?: React.ReactNode;
   title: string;
 }
@@ -33,7 +31,6 @@ const AwsReportSummaryAltBase: React.SFC<AwsReportSummaryAltProps> = ({
   detailsLink,
   status,
   subTitle,
-  subTitleTooltip = subTitle,
   t,
   tabs,
   title,
@@ -45,9 +42,7 @@ const AwsReportSummaryAltBase: React.SFC<AwsReportSummaryAltProps> = ({
           <CardHeader>
             <Title size="lg">{title}</Title>
             {Boolean(subTitle) && (
-              <Tooltip content={subTitleTooltip} enableFlip>
-                <p className={css(styles.subtitle)}>{subTitle}</p>
-              </Tooltip>
+              <p className={css(styles.subtitle)}>{subTitle}</p>
             )}
           </CardHeader>
           <CardBody>

--- a/src/components/reports/azureReportSummary/azureReportSummary.tsx
+++ b/src/components/reports/azureReportSummary/azureReportSummary.tsx
@@ -4,7 +4,6 @@ import {
   CardFooter,
   CardHeader,
   Title,
-  Tooltip,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import {
@@ -21,7 +20,6 @@ interface AzureReportSummaryProps extends InjectedTranslateProps {
   detailsLink?: React.ReactNode;
   status: number;
   subTitle?: string;
-  subTitleTooltip?: string;
   title: string;
 }
 
@@ -30,18 +28,13 @@ const AzureReportSummaryBase: React.SFC<AzureReportSummaryProps> = ({
   detailsLink,
   title,
   subTitle,
-  subTitleTooltip = subTitle,
   status,
   t,
 }) => (
   <Card className={css(styles.reportSummary)}>
     <CardHeader>
       <Title size="lg">{title}</Title>
-      {Boolean(subTitle) && (
-        <Tooltip content={subTitleTooltip} enableFlip>
-          <p className={css(styles.subtitle)}>{subTitle}</p>
-        </Tooltip>
-      )}
+      {Boolean(subTitle) && <p className={css(styles.subtitle)}>{subTitle}</p>}
     </CardHeader>
     <CardBody>
       {status === FetchStatus.inProgress ? (

--- a/src/components/reports/azureReportSummary/azureReportSummaryAlt.tsx
+++ b/src/components/reports/azureReportSummary/azureReportSummaryAlt.tsx
@@ -6,7 +6,6 @@ import {
   Grid,
   GridItem,
   Title,
-  Tooltip,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import {
@@ -23,7 +22,6 @@ interface AzureReportSummaryAltProps extends InjectedTranslateProps {
   detailsLink?: React.ReactNode;
   status: number;
   subTitle?: string;
-  subTitleTooltip?: string;
   tabs?: React.ReactNode;
   title: string;
 }
@@ -33,7 +31,6 @@ const AzureReportSummaryAltBase: React.SFC<AzureReportSummaryAltProps> = ({
   detailsLink,
   status,
   subTitle,
-  subTitleTooltip = subTitle,
   t,
   tabs,
   title,
@@ -45,9 +42,7 @@ const AzureReportSummaryAltBase: React.SFC<AzureReportSummaryAltProps> = ({
           <CardHeader>
             <Title size="lg">{title}</Title>
             {Boolean(subTitle) && (
-              <Tooltip content={subTitleTooltip} enableFlip>
-                <p className={css(styles.subtitle)}>{subTitle}</p>
-              </Tooltip>
+              <p className={css(styles.subtitle)}>{subTitle}</p>
             )}
           </CardHeader>
           <CardBody>

--- a/src/components/reports/ocpCloudReportSummary/__snapshots__/ocpCloudReportSummaryDetails.test.tsx.snap
+++ b/src/components/reports/ocpCloudReportSummary/__snapshots__/ocpCloudReportSummaryDetails.test.tsx.snap
@@ -5,11 +5,43 @@ exports[`defaults value if report is not present 1`] = `
   <div
     className="css-ajqdbs"
   >
-    <div
-      className="css-1w8hocc"
+    <Tooltip
+      appendTo={[Function]}
+      aria="describedby"
+      boundary="window"
+      className=""
+      content="ocp_cloud_dashboard.total_cost_tooltip"
+      distance={15}
+      enableFlip={true}
+      entryDelay={500}
+      exitDelay={500}
+      flipBehavior={
+        Array [
+          "top",
+          "right",
+          "bottom",
+          "left",
+          "top",
+          "right",
+          "bottom",
+        ]
+      }
+      id=""
+      isAppLauncher={false}
+      isContentLeftAligned={false}
+      isVisible={false}
+      maxWidth="18.75rem"
+      position="top"
+      tippyProps={Object {}}
+      trigger="mouseenter focus"
+      zIndex={9999}
     >
-      <Component />
-    </div>
+      <div
+        className="css-1w8hocc"
+      >
+        <Component />
+      </div>
+    </Tooltip>
     <div
       className="css-1640ajm"
     >
@@ -24,11 +56,43 @@ exports[`defaults value if report.meta is not present 1`] = `
   <div
     className="css-ajqdbs"
   >
-    <div
-      className="css-1w8hocc"
+    <Tooltip
+      appendTo={[Function]}
+      aria="describedby"
+      boundary="window"
+      className=""
+      content="ocp_cloud_dashboard.total_cost_tooltip"
+      distance={15}
+      enableFlip={true}
+      entryDelay={500}
+      exitDelay={500}
+      flipBehavior={
+        Array [
+          "top",
+          "right",
+          "bottom",
+          "left",
+          "top",
+          "right",
+          "bottom",
+        ]
+      }
+      id=""
+      isAppLauncher={false}
+      isContentLeftAligned={false}
+      isVisible={false}
+      maxWidth="18.75rem"
+      position="top"
+      tippyProps={Object {}}
+      trigger="mouseenter focus"
+      zIndex={9999}
     >
-      <Component />
-    </div>
+      <div
+        className="css-1w8hocc"
+      >
+        <Component />
+      </div>
+    </Tooltip>
     <div
       className="css-1640ajm"
     >
@@ -43,11 +107,43 @@ exports[`report total is formated 1`] = `
   <div
     className="css-ajqdbs"
   >
-    <div
-      className="css-1w8hocc"
+    <Tooltip
+      appendTo={[Function]}
+      aria="describedby"
+      boundary="window"
+      className=""
+      content="ocp_cloud_dashboard.total_cost_tooltip"
+      distance={15}
+      enableFlip={true}
+      entryDelay={500}
+      exitDelay={500}
+      flipBehavior={
+        Array [
+          "top",
+          "right",
+          "bottom",
+          "left",
+          "top",
+          "right",
+          "bottom",
+        ]
+      }
+      id=""
+      isAppLauncher={false}
+      isContentLeftAligned={false}
+      isVisible={false}
+      maxWidth="18.75rem"
+      position="top"
+      tippyProps={Object {}}
+      trigger="mouseenter focus"
+      zIndex={9999}
     >
-      formatedValue
-    </div>
+      <div
+        className="css-1w8hocc"
+      >
+        formatedValue
+      </div>
+    </Tooltip>
     <div
       className="css-1640ajm"
     >

--- a/src/components/reports/ocpCloudReportSummary/ocpCloudReportSummary.tsx
+++ b/src/components/reports/ocpCloudReportSummary/ocpCloudReportSummary.tsx
@@ -4,7 +4,6 @@ import {
   CardFooter,
   CardHeader,
   Title,
-  Tooltip,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import {
@@ -21,7 +20,6 @@ interface OcpCloudReportSummaryProps extends InjectedTranslateProps {
   detailsLink?: React.ReactNode;
   status: number;
   subTitle?: string;
-  subTitleTooltip?: string;
   title: string;
 }
 
@@ -30,18 +28,13 @@ const OcpCloudReportSummaryBase: React.SFC<OcpCloudReportSummaryProps> = ({
   detailsLink,
   title,
   subTitle,
-  subTitleTooltip = subTitle,
   status,
   t,
 }) => (
   <Card className={css(styles.reportSummary)}>
     <CardHeader>
       <Title size="lg">{title}</Title>
-      {Boolean(subTitle) && (
-        <Tooltip content={subTitleTooltip} enableFlip>
-          <p className={css(styles.subtitle)}>{subTitle}</p>
-        </Tooltip>
-      )}
+      {Boolean(subTitle) && <p className={css(styles.subtitle)}>{subTitle}</p>}
     </CardHeader>
     <CardBody>
       {status === FetchStatus.inProgress ? (

--- a/src/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryAlt.tsx
+++ b/src/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryAlt.tsx
@@ -6,7 +6,6 @@ import {
   Grid,
   GridItem,
   Title,
-  Tooltip,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import {
@@ -23,23 +22,13 @@ interface OcpCloudReportSummaryAltProps extends InjectedTranslateProps {
   detailsLink?: React.ReactNode;
   status: number;
   subTitle?: string;
-  subTitleTooltip?: string;
   tabs?: React.ReactNode;
   title: string;
 }
 
 const OcpCloudReportSummaryAltBase: React.SFC<
   OcpCloudReportSummaryAltProps
-> = ({
-  children,
-  detailsLink,
-  status,
-  subTitle,
-  subTitleTooltip = subTitle,
-  t,
-  tabs,
-  title,
-}) => (
+> = ({ children, detailsLink, status, subTitle, t, tabs, title }) => (
   <Card className={css(styles.reportSummary)}>
     <Grid gutter="md">
       <GridItem lg={5} xl={6}>
@@ -47,9 +36,7 @@ const OcpCloudReportSummaryAltBase: React.SFC<
           <CardHeader>
             <Title size="lg">{title}</Title>
             {Boolean(subTitle) && (
-              <Tooltip content={subTitleTooltip} enableFlip>
-                <p className={css(styles.subtitle)}>{subTitle}</p>
-              </Tooltip>
+              <p className={css(styles.subtitle)}>{subTitle}</p>
             )}
           </CardHeader>
           <CardBody>

--- a/src/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryDetails.tsx
+++ b/src/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryDetails.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import { OcpCloudReport, OcpCloudReportType } from 'api/ocpCloudReports';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
@@ -38,6 +39,8 @@ const OcpCloudReportSummaryDetailsBase: React.SFC<
   usageLabel,
 }) => {
   let cost: string | React.ReactNode = <EmptyValueState />;
+  let infrastructureCost: string | React.ReactNode = <EmptyValueState />;
+  let markupCost: string | React.ReactNode = <EmptyValueState />;
   let request: string | React.ReactNode = <EmptyValueState />;
   let usage: string | React.ReactNode = <EmptyValueState />;
 
@@ -51,6 +54,22 @@ const OcpCloudReportSummaryDetailsBase: React.SFC<
     cost = formatValue(
       report.meta.total.cost ? report.meta.total.cost.value : 0,
       report.meta.total.cost ? report.meta.total.cost.units : 'USD',
+      formatOptions
+    );
+    infrastructureCost = formatValue(
+      report.meta.total.infrastructure_cost
+        ? report.meta.total.infrastructure_cost.value
+        : 0,
+      report.meta.total.infrastructure_cost
+        ? report.meta.total.infrastructure_cost.units
+        : 'USD',
+      formatOptions
+    );
+    markupCost = formatValue(
+      report.meta.total.markup_cost ? report.meta.total.markup_cost.value : 0,
+      report.meta.total.markup_cost
+        ? report.meta.total.markup_cost.units
+        : 'USD',
       formatOptions
     );
     if (cloudReportType) {
@@ -75,7 +94,15 @@ const OcpCloudReportSummaryDetailsBase: React.SFC<
 
   const getCostLayout = () => (
     <div className={css(styles.valueContainer)}>
-      <div className={css(styles.value)}>{cost}</div>
+      <Tooltip
+        content={t('ocp_cloud_dashboard.total_cost_tooltip', {
+          infrastructureCost,
+          markupCost,
+        })}
+        enableFlip
+      >
+        <div className={css(styles.value)}>{cost}</div>
+      </Tooltip>
       <div className={css(styles.text)}>
         <div>{costLabel}</div>
       </div>

--- a/src/components/reports/ocpReportSummary/ocpReportSummary.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummary.tsx
@@ -20,7 +20,6 @@ interface OcpReportSummaryProps extends InjectedTranslateProps {
   detailsLink?: React.ReactNode;
   status: number;
   subTitle?: string;
-  subTitleTooltip?: string;
   title: string;
 }
 

--- a/src/components/reports/ocpReportSummary/ocpReportSummary.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummary.tsx
@@ -4,7 +4,6 @@ import {
   CardFooter,
   CardHeader,
   Title,
-  Tooltip,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import {
@@ -30,18 +29,13 @@ const OcpReportSummaryBase: React.SFC<OcpReportSummaryProps> = ({
   detailsLink,
   title,
   subTitle,
-  subTitleTooltip = subTitle,
   status,
   t,
 }) => (
   <Card className={css(styles.reportSummary)}>
     <CardHeader>
       <Title size="lg">{title}</Title>
-      {Boolean(subTitle) && (
-        <Tooltip content={subTitleTooltip} enableFlip>
-          <p className={css(styles.subtitle)}>{subTitle}</p>
-        </Tooltip>
-      )}
+      {Boolean(subTitle) && <p className={css(styles.subtitle)}>{subTitle}</p>}
     </CardHeader>
     <CardBody>
       {status === FetchStatus.inProgress ? (

--- a/src/components/reports/ocpReportSummary/ocpReportSummaryAlt.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummaryAlt.tsx
@@ -6,7 +6,6 @@ import {
   Grid,
   GridItem,
   Title,
-  Tooltip,
 } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
 import {
@@ -23,7 +22,6 @@ interface OcpReportSummaryAltProps extends InjectedTranslateProps {
   detailsLink?: React.ReactNode;
   status: number;
   subTitle?: string;
-  subTitleTooltip?: string;
   tabs?: React.ReactNode;
   title: string;
 }
@@ -33,7 +31,6 @@ const OcpReportSummaryAltBase: React.SFC<OcpReportSummaryAltProps> = ({
   detailsLink,
   status,
   subTitle,
-  subTitleTooltip = subTitle,
   t,
   tabs,
   title,
@@ -45,9 +42,7 @@ const OcpReportSummaryAltBase: React.SFC<OcpReportSummaryAltProps> = ({
           <CardHeader>
             <Title size="lg">{title}</Title>
             {Boolean(subTitle) && (
-              <Tooltip content={subTitleTooltip} enableFlip>
-                <p className={css(styles.subtitle)}>{subTitle}</p>
-              </Tooltip>
+              <p className={css(styles.subtitle)}>{subTitle}</p>
             )}
           </CardHeader>
           <CardBody>

--- a/src/components/reports/ocpReportSummary/ocpReportSummaryDetails.tsx
+++ b/src/components/reports/ocpReportSummary/ocpReportSummaryDetails.tsx
@@ -41,10 +41,10 @@ const OcpReportSummaryDetailsBase: React.SFC<OcpReportSummaryDetailsProps> = ({
   usageLabel,
 }) => {
   let cost: string | React.ReactNode = <EmptyValueState />;
-  let usage: string | React.ReactNode = <EmptyValueState />;
   let derivedCost: string | React.ReactNode = <EmptyValueState />;
   let infrastructureCost: string | React.ReactNode = <EmptyValueState />;
   let request: string | React.ReactNode = <EmptyValueState />;
+  let usage: string | React.ReactNode = <EmptyValueState />;
 
   if (report && report.meta && report.meta.total) {
     cost = formatValue(

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -934,7 +934,6 @@
   "percent": "{{value}}%",
   "percent_of_cost": "{{value}} % of cost",
   "percent_of_total": "{{value}} {{units}} ({{percent}}%)",
-  "percent_zero": "--",
   "providers": {
     "add_source": "Add sources",
     "bucket_error": "Bucket name cannot contain spaces, special chars and be more than 255 characters",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -608,6 +608,11 @@
       "modal_title": "{{name}} daily usage comparison",
       "view_data": "View Historical Data"
     },
+    "infrastructure_cost_desc": "The cost based on raw usage data from the underlying infrastructure.",
+    "infrastructure_cost_title": "Infrastructure cost",
+    "markup_aria_label": "A description of infrastructure and markup cost",
+    "markup_desc": "A markup on the base cost is used to define the calculated cost of resources.",
+    "markup_title": "Markup",
     "more_tags": ", {{value}} more...",
     "name_column_title": "$t(group_by.values.{{groupBy}}) names",
     "tag_column_title": "Tag names",
@@ -624,6 +629,7 @@
       "results": "{{value}} Results"
     },
     "total_cost": "Total cost",
+    "total_cost_tooltip": "This total cost is the sum of the infrastructure cost: {{infrastructureCost}} and markup: {{markupCost}}",
     "view_all": "View all {{value}}s",
     "widget_modal_title": "{{name}} {{groupBy}}s"
   },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -549,6 +549,7 @@
     "requests_label": "Requests",
     "storage_title": "Cloud infrastructure storage services usage",
     "storage_trend_title": "Daily usage comparison ({{units}})",
+    "total_cost_tooltip": "This total cost is the sum of the infrastructure cost: {{infrastructureCost}} and markup: {{markupCost}}",
     "usage_label": "Usage",
     "volume_title": "OpenShift volume usage and requests",
     "volume_trend_title": "Daily usage and requests comparison ({{units}})",

--- a/src/pages/awsDetails/detailsTable.tsx
+++ b/src/pages/awsDetails/detailsTable.tsx
@@ -15,6 +15,7 @@ import {
 import { AwsQuery, getQuery } from 'api/awsQuery';
 import { AwsReport } from 'api/awsReports';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
+import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -228,7 +229,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
 
-    let iconOverride = 'iconOverride';
+    let iconOverride = percentage !== 0 ? 'iconOverride' : undefined;
     if (item.deltaPercent !== null && item.deltaValue < 0) {
       iconOverride += ' decrease';
     }
@@ -239,9 +240,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <div className={monthOverMonthOverride}>
         <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-          {Boolean(percentage > 0)
-            ? t('percent', { value: percentage })
-            : t('percent_zero')}
+          {Boolean(percentage > 0) ? (
+            t('percent', { value: percentage })
+          ) : (
+            <EmptyValueState />
+          )}
           {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
             <span
               className={css('fa fa-sort-up', styles.infoArrow)}

--- a/src/pages/azureDetails/detailsTable.tsx
+++ b/src/pages/azureDetails/detailsTable.tsx
@@ -15,6 +15,7 @@ import {
 import { AzureQuery, getQuery } from 'api/azureQuery';
 import { AzureReport } from 'api/azureReports';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
+import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -228,7 +229,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
 
-    let iconOverride = 'iconOverride';
+    let iconOverride = percentage !== 0 ? 'iconOverride' : undefined;
     if (item.deltaPercent !== null && item.deltaValue < 0) {
       iconOverride += ' decrease';
     }
@@ -239,9 +240,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <div className={monthOverMonthOverride}>
         <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-          {Boolean(percentage > 0)
-            ? t('percent', { value: percentage })
-            : t('percent_zero')}
+          {Boolean(percentage > 0) ? (
+            t('percent', { value: percentage })
+          ) : (
+            <EmptyValueState />
+          )}
           {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
             <span
               className={css('fa fa-sort-up', styles.infoArrow)}

--- a/src/pages/ocpCloudDetails/detailsHeader.styles.ts
+++ b/src/pages/ocpCloudDetails/detailsHeader.styles.ts
@@ -3,6 +3,7 @@ import {
   global_BackgroundColor_100,
   global_Color_100,
   global_Color_200,
+  global_FontSize_md,
   global_FontSize_sm,
   global_spacer_md,
   global_spacer_sm,
@@ -33,6 +34,16 @@ export const styles = StyleSheet.create({
     justifyContent: 'space-between',
     padding: global_spacer_xl.var,
     backgroundColor: global_BackgroundColor_100.var,
+  },
+  info: {
+    marginLeft: global_spacer_sm.value,
+    verticalAlign: 'middle',
+  },
+  infoIcon: {
+    fontSize: global_FontSize_md.value,
+  },
+  infoTitle: {
+    fontWeight: 'bold',
   },
   title: {
     paddingBottom: global_spacer_sm.var,

--- a/src/pages/ocpCloudDetails/detailsTable.tsx
+++ b/src/pages/ocpCloudDetails/detailsTable.tsx
@@ -15,6 +15,7 @@ import {
 import { getQuery, OcpCloudQuery } from 'api/ocpCloudQuery';
 import { OcpCloudReport } from 'api/ocpCloudReports';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
+import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -230,7 +231,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
 
-    let iconOverride = 'iconOverride';
+    let iconOverride = percentage !== 0 ? 'iconOverride' : undefined;
     if (item.deltaPercent !== null && item.deltaValue < 0) {
       iconOverride += ' decrease';
     }
@@ -241,9 +242,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <div className={monthOverMonthOverride}>
         <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-          {Boolean(percentage > 0)
-            ? t('percent', { value: percentage })
-            : t('percent_zero')}
+          {Boolean(percentage > 0) ? (
+            t('percent', { value: percentage })
+          ) : (
+            <EmptyValueState />
+          )}
           {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
             <span
               className={css('fa fa-sort-up', styles.infoArrow)}

--- a/src/pages/ocpDetails/detailsHeader.styles.ts
+++ b/src/pages/ocpDetails/detailsHeader.styles.ts
@@ -42,8 +42,8 @@ export const styles = StyleSheet.create({
   infoIcon: {
     fontSize: global_FontSize_md.value,
   },
-  infrastructureCost: {
-    marginTop: global_spacer_xl.value,
+  infoTitle: {
+    fontWeight: 'bold',
   },
   title: {
     paddingBottom: global_spacer_sm.var,

--- a/src/pages/ocpDetails/detailsHeader.tsx
+++ b/src/pages/ocpDetails/detailsHeader.tsx
@@ -156,12 +156,15 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
                     enableFlip
                     bodyContent={
                       <>
-                        <div>{t('ocp_details.derived_cost_title')}</div>
-                        <div>{t('ocp_details.derived_cost_desc')}</div>
-                        <div className={css(styles.infrastructureCost)}>
+                        <p className={css(styles.infoTitle)}>
+                          {t('ocp_details.derived_cost_title')}
+                        </p>
+                        <p>{t('ocp_details.derived_cost_desc')}</p>
+                        <br />
+                        <p className={css(styles.infoTitle)}>
                           {t('ocp_details.infrastructure_cost_title')}
-                        </div>
-                        <div>{t('ocp_details.infrastructure_cost_desc')}</div>
+                        </p>
+                        <p>{t('ocp_details.infrastructure_cost_desc')}</p>
                       </>
                     }
                   >

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -15,6 +15,7 @@ import {
 import { getQuery, OcpQuery } from 'api/ocpQuery';
 import { OcpReport } from 'api/ocpReports';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
+import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -305,7 +306,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
 
-    let iconOverride = 'iconOverride';
+    let iconOverride = percentage !== 0 ? 'iconOverride' : undefined;
     if (item.deltaPercent !== null && item.deltaValue < 0) {
       iconOverride += ' decrease';
     }
@@ -316,9 +317,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <div className={monthOverMonthOverride}>
         <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-          {Boolean(percentage > 0)
-            ? t('percent', { value: percentage })
-            : t('percent_zero')}
+          {Boolean(percentage > 0) ? (
+            t('percent', { value: percentage })
+          ) : (
+            <EmptyValueState />
+          )}
           {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
             <span
               className={css('fa fa-sort-up', styles.infoArrow)}

--- a/src/utils/getComputedOcpCloudReportItems.ts
+++ b/src/utils/getComputedOcpCloudReportItems.ts
@@ -20,6 +20,7 @@ export interface ComputedOcpCloudReportItem {
   infrastructureCost: number;
   label: string | number;
   limit?: number;
+  markupCost?: number;
   request?: number;
   units: string;
   usage?: number;
@@ -35,6 +36,7 @@ export interface GetComputedOcpCloudReportItemsParams {
     | 'derived_cost'
     | 'infrastructure_cost'
     | 'limit'
+    | 'markup_cost'
     | 'request'
     | 'usage'
   >;
@@ -88,6 +90,7 @@ export function getUnsortedComputedOcpCloudReportItems({
         const infrastructureCost = value.infrastructure_cost
           ? value.infrastructure_cost.value
           : 0;
+        const markupCost = value.markup_cost ? value.markup_cost.value : 0;
         // Ensure unique IDs -- https://github.com/project-koku/koku-ui/issues/706
         const idSuffix =
           idKey !== 'date' && idKey !== 'cluster' && value.cluster
@@ -125,6 +128,7 @@ export function getUnsortedComputedOcpCloudReportItems({
             infrastructureCost,
             label,
             limit,
+            markupCost,
             request,
             units,
             usage,
@@ -139,6 +143,7 @@ export function getUnsortedComputedOcpCloudReportItems({
           infrastructureCost:
             itemMap.get(id).infrastructureCost + infrastructureCost,
           limit: itemMap.get(id).limit + limit,
+          markupCost: itemMap.get(id).markupCost + markupCost,
           request: itemMap.get(id).request + request,
           usage: itemMap.get(id).usage + usage,
         });


### PR DESCRIPTION
Added "Ocp cloud infrastructure" tooltips and popover to show total cost breakdown. This appears similar to the Ocp tooltips and popover.

Fixes https://github.com/project-koku/koku-ui/issues/1207

Ocp cloud infrastructure overview:
<img width="1211" alt="Screen Shot 2020-01-02 at 11 36 21 PM" src="https://user-images.githubusercontent.com/17481322/71707635-0720a100-2db9-11ea-9c56-00c3c7334a4c.png">

Ocp cloud infrastructure details:
<img width="1212" alt="Screen Shot 2020-01-02 at 11 18 50 PM" src="https://user-images.githubusercontent.com/17481322/71707638-0c7deb80-2db9-11ea-8d83-87929f7a6c50.png">
