### PR TITLE
Use compact pagination controls for details

### DIFF
--- a/src/pages/awsDetails/awsDetails.tsx
+++ b/src/pages/awsDetails/awsDetails.tsx
@@ -213,6 +213,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 
     return (
       <Pagination
+        isCompact
         itemCount={count}
         onPerPageSelect={this.handlePerPageSelect}
         onSetPage={this.handleSetPage}

--- a/src/pages/azureDetails/azureDetails.tsx
+++ b/src/pages/azureDetails/azureDetails.tsx
@@ -213,6 +213,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
 
     return (
       <Pagination
+        isCompact
         itemCount={count}
         onPerPageSelect={this.handlePerPageSelect}
         onSetPage={this.handleSetPage}

--- a/src/pages/ocpCloudDetails/ocpCloudDetails.tsx
+++ b/src/pages/ocpCloudDetails/ocpCloudDetails.tsx
@@ -176,6 +176,7 @@ class OcpCloudDetails extends React.Component<OcpCloudDetailsProps> {
 
     return (
       <Pagination
+        isCompact
         itemCount={count}
         onPerPageSelect={this.handlePerPageSelect}
         onSetPage={this.handleSetPage}

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -213,6 +213,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
     return (
       <Pagination
+        isCompact
         itemCount={count}
         onPerPageSelect={this.handlePerPageSelect}
         onSetPage={this.handleSetPage}


### PR DESCRIPTION
We should use PatternFly's compact pagination controls for each details page.

Fixes #1223

<img width="1253" alt="Screen Shot 2020-01-12 at 4 21 15 PM" src="https://user-images.githubusercontent.com/17481322/72225840-08d82a80-3558-11ea-899c-c200cdd19f9b.png">
