### PR TITLE
Ocp details: Filter by many things

### DIFF
--- a/src/api/ocpReports.ts
+++ b/src/api/ocpReports.ts
@@ -21,6 +21,7 @@ export interface OcpReportValue {
   node?: string;
   project?: string;
   request?: OcpDatum;
+  tags?: string;
   usage: OcpDatum;
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -713,12 +713,12 @@
     "export_link": "Export",
     "filter": {
       "cluster_placeholder": "Filter by cluster",
-      "cluster_select": "Cluster",
-      "name": "Name",
+      "cluster_select": "Cluster name",
       "node_placeholder": "Filter by node",
-      "node_select": "Node",
+      "node_select": "Node name",
       "project_placeholder": "Filter by project",
-      "project_select": "Project",
+      "project_select": "Project name",
+      "tag_name": "Tags",
       "tag_placeholder": "Filter by tag",
       "tag_select": "Tag"
     },

--- a/src/pages/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/ocpDetails/detailsToolbar.tsx
@@ -2,8 +2,6 @@ import {
   Button,
   ButtonVariant,
   Chip,
-  FormSelect,
-  FormSelectOption,
   TextInput,
   Title,
   TitleSize,
@@ -20,11 +18,12 @@ import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { isEqual } from 'utils/equal';
 import { styles } from './detailsToolbar.styles';
+import { FilterBy } from './filterBy';
 
 interface DetailsToolbarOwnProps {
   isExportDisabled: boolean;
-  filterFields: any[];
   exportText: string;
+  groupBy: string;
   onExportClicked();
   onFilterAdded(filterType: string, filterValue: string);
   onFilterRemoved(filterType: string, filterValue: string);
@@ -41,7 +40,7 @@ const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project
 export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   public state = {
     activeFilters: [],
-    currentFilterType: this.props.filterFields[0],
+    currentFilterType: this.props.groupBy,
     currentValue: '',
     currentViewType: 'list',
     filterCategory: undefined,
@@ -49,58 +48,57 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   };
 
   public componentDidUpdate(prevProps: DetailsToolbarProps, prevState) {
-    const { filterFields, query, report } = this.props;
+    const { groupBy, query, report } = this.props;
     if (report && !isEqual(report, prevProps.report)) {
       this.addQuery(query);
     }
-    if (!isEqual(filterFields, prevProps.filterFields)) {
+    if (groupBy !== prevProps.groupBy) {
       this.setState({
-        currentFilterType: this.props.filterFields[0],
+        currentFilterType: groupBy,
       });
     }
   }
 
   public addQuery = (query: OcpQuery) => {
     const activeFilters = [];
-    Object.keys(query.group_by).forEach(key => {
-      if (query.group_by[key] !== '*') {
-        if (Array.isArray(query.group_by[key])) {
-          query.group_by[key].forEach(value => {
-            const field = (key as any).id || key;
+    if (query.filter_by) {
+      Object.keys(query.filter_by).forEach(key => {
+        if (Array.isArray(query.filter_by[key])) {
+          query.filter_by[key].forEach(value => {
+            const field = key;
             const filter = this.getFilter(field, value);
             activeFilters.push(filter);
           });
         } else {
-          const field = (key as any).id || key;
-          const filter = this.getFilter(field, query.group_by[key]);
+          const field = key;
+          const filter = this.getFilter(field, query.filter_by[key]);
           activeFilters.push(filter);
         }
-      }
-    });
+      });
+    }
     this.setState({ activeFilters });
   };
 
   public clearFilters = (event: React.FormEvent<HTMLButtonElement>) => {
-    const { currentFilterType } = this.state;
     this.setState({ activeFilters: [] });
-    this.props.onFilterRemoved(currentFilterType.id, '');
+    this.props.onFilterRemoved(this.props.groupBy, '');
     event.preventDefault();
   };
 
   // Note: Active filters are set upon page refresh -- don't need to do that here
   public filterAdded = (field, value) => {
     const { currentFilterType } = this.state;
-    this.props.onFilterAdded(currentFilterType.id, value);
+    this.props.onFilterAdded(currentFilterType, value);
   };
 
   public getFilter = (field, value) => {
-    const { currentFilterType } = this.state;
     const filterLabel = this.getFilterLabel(field, value);
-    return {
-      field: field.indexOf(tagKey) === 0 ? field : currentFilterType.id,
+    const result = {
+      field,
       label: filterLabel,
       value,
     };
+    return result;
   };
 
   public getFilterLabel = (field, value) => {
@@ -158,7 +156,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     }
   };
 
-  public selectFilterType = filterType => {
+  public selectFilterType = (filterType: string) => {
     const { currentFilterType } = this.state;
     if (currentFilterType !== filterType) {
       this.setState({
@@ -173,23 +171,30 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   };
 
   public renderInput() {
+    const { t } = this.props;
     const { currentFilterType, currentValue } = this.state;
     if (!currentFilterType) {
       return null;
     }
+    const index = currentFilterType ? currentFilterType.indexOf(tagKey) : -1;
+    const placeholder =
+      index === 0
+        ? t('ocp_cloud_details.filter.tag_placeholder')
+        : t(`ocp_cloud_details.filter.${currentFilterType}_placeholder`);
+
     return (
       <TextInput
         id="filter"
         onChange={this.updateCurrentValue}
         onKeyPress={this.onValueKeyPress}
-        placeholder={currentFilterType.placeholder}
+        placeholder={placeholder}
         value={currentValue}
       />
     );
   }
 
   public render() {
-    const { filterFields, isExportDisabled, pagination, t } = this.props;
+    const { isExportDisabled, groupBy, pagination, t } = this.props;
     const { activeFilters } = this.state;
 
     return (
@@ -200,19 +205,10 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
           >
             <ToolbarGroup>
               <ToolbarItem>
-                <FormSelect
-                  aria-label={t('ocp_details.toolbar.filter_type_aria_label')}
-                >
-                  {filterFields.map(({ id, label }) => {
-                    return (
-                      <FormSelectOption
-                        key={`filter-type-${id}`}
-                        label={label}
-                        value={id}
-                      />
-                    );
-                  })}
-                </FormSelect>
+                <FilterBy
+                  groupBy={groupBy}
+                  onItemClicked={this.selectFilterType}
+                />
               </ToolbarItem>
               <ToolbarItem>{this.renderInput()}</ToolbarItem>
             </ToolbarGroup>

--- a/src/pages/ocpDetails/filterBy.styles.ts
+++ b/src/pages/ocpDetails/filterBy.styles.ts
@@ -1,0 +1,7 @@
+import { StyleSheet } from '@patternfly/react-styles';
+
+export const styles = StyleSheet.create({
+  filterContainer: {
+    display: 'inline-flex',
+  },
+});

--- a/src/pages/ocpDetails/filterBy.tsx
+++ b/src/pages/ocpDetails/filterBy.tsx
@@ -1,0 +1,300 @@
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import { getQuery } from 'api/ocpQuery';
+import { OcpReport, OcpReportType } from 'api/ocpReports';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { ocpReportsActions, ocpReportsSelectors } from 'store/ocpReports';
+import { GetComputedOcpReportItemsParams } from 'utils/getComputedOcpReportItems';
+import { styles } from './filterBy.styles';
+
+interface FilterByOwnProps {
+  groupBy?: string;
+  onItemClicked(value: string);
+  queryString?: string;
+}
+
+interface FilterByStateProps {
+  report?: OcpReport;
+  reportFetchStatus?: FetchStatus;
+}
+
+interface FilterByDispatchProps {
+  fetchReport?: typeof ocpReportsActions.fetchReport;
+}
+
+interface FilterByState {
+  currentItem?: any;
+  currentTagItem?: any;
+  isFilterByOpen: boolean;
+  isFilterByTagOpen: boolean;
+}
+
+type FilterByProps = FilterByOwnProps &
+  FilterByStateProps &
+  FilterByDispatchProps &
+  InjectedTranslateProps;
+
+const filterByOptions: {
+  label: string;
+  value: GetComputedOcpReportItemsParams['idKey'];
+}[] = [
+  { label: 'cluster', value: 'cluster' },
+  { label: 'node', value: 'node' },
+  { label: 'project', value: 'project' },
+  { label: 'tags', value: 'tags' },
+];
+
+const reportType = OcpReportType.tag;
+const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
+
+class FilterByBase extends React.Component<FilterByProps> {
+  protected defaultState: FilterByState = {
+    isFilterByOpen: false,
+    isFilterByTagOpen: false,
+  };
+  public state: FilterByState = { ...this.defaultState };
+
+  constructor(stateProps, dispatchProps) {
+    super(stateProps, dispatchProps);
+    this.handleFilterBySelect = this.handleFilterBySelect.bind(this);
+    this.handleFilterByTagSelect = this.handleFilterByTagSelect.bind(this);
+    this.handleFilterByTagToggle = this.handleFilterByTagToggle.bind(this);
+    this.handleFilterByToggle = this.handleFilterByToggle.bind(this);
+  }
+
+  public componentDidMount() {
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
+    this.setState({
+      currentItem: this.getFilterBy(),
+      currentTagItem: this.getFilterByTag(),
+    });
+  }
+
+  public componentDidUpdate(prevProps: FilterByProps) {
+    const { fetchReport, reportFetchStatus, groupBy, queryString } = this.props;
+    if (
+      prevProps.groupBy !== groupBy ||
+      prevProps.queryString !== queryString
+    ) {
+      fetchReport(reportType, queryString);
+    }
+    if (
+      prevProps.groupBy !== groupBy ||
+      prevProps.queryString !== queryString ||
+      prevProps.reportFetchStatus !== reportFetchStatus
+    ) {
+      this.setState({
+        currentItem: this.getFilterBy(),
+        currentTagItem: this.getFilterByTag(),
+      });
+    }
+  }
+
+  private getFilterBy = () => {
+    const { groupBy } = this.props;
+
+    // Find i18n string
+    const items = this.getSelectOptions();
+    for (const item of items) {
+      if (
+        groupBy === item.id ||
+        (groupBy.indexOf(tagKey) !== -1 && item.id === 'tags')
+      ) {
+        return item;
+      }
+    }
+    return null;
+  };
+
+  private getFilterByTag = () => {
+    const { groupBy } = this.props;
+
+    // Find i18n string
+    const items = this.getSelectTagOptions();
+    for (const item of items) {
+      if (groupBy === item.id) {
+        return item;
+      }
+    }
+    return items[0];
+  };
+
+  private getSelectOption = (id, label) => {
+    return {
+      id,
+      toString: () => label,
+    };
+  };
+
+  private getSelectItems = () => {
+    return this.getSelectOptions().map(option => (
+      <SelectOption key={option.id} value={option} />
+    ));
+  };
+
+  private getSelectTagItems = () => {
+    return this.getSelectTagOptions().map(option => (
+      <SelectOption key={option.id} value={option} />
+    ));
+  };
+
+  private getSelectOptions = () => {
+    const { t } = this.props;
+
+    return filterByOptions.map(option => {
+      return this.getSelectOption(
+        `${option.value}`,
+        t(`group_by.values.${option.label}`)
+      );
+    });
+  };
+
+  private getSelectTagOptions = () => {
+    const { report, t } = this.props;
+
+    if (report && report.data) {
+      const data = [...new Set([...report.data])]; // prune duplicates
+      return data.map(val => {
+        return this.getSelectOption(
+          `${tagKey}${val}`,
+          t('group_by.tag', { key: val, interpolation: { escapeValue: false } })
+        );
+      });
+    } else {
+      return [];
+    }
+  };
+
+  private handleFilterBySelect = (event, selection, isPlaceholder) => {
+    const { groupBy, onItemClicked } = this.props;
+    let selected = selection;
+
+    if (selection.id === 'tags') {
+      const items = this.getSelectTagOptions();
+      if (groupBy.indexOf(tagKey) !== -1) {
+        for (const item of items) {
+          if (groupBy === item.id) {
+            selected = item;
+          }
+        }
+      } else {
+        selected = items[0];
+      }
+    }
+    if (onItemClicked) {
+      onItemClicked(selected.id);
+    }
+    this.setState({
+      currentItem: selection,
+      isFilterByOpen: false,
+    });
+  };
+
+  private handleFilterByTagSelect = (event, selection, isPlaceholder) => {
+    const { onItemClicked } = this.props;
+    if (onItemClicked) {
+      onItemClicked(selection.id);
+    }
+    this.setState({
+      currentTagItem: selection,
+      isFilterByTagOpen: false,
+    });
+  };
+
+  private handleFilterByToggle = isFilterByOpen => {
+    this.setState({
+      isFilterByOpen,
+    });
+  };
+
+  private handleFilterByTagToggle = isFilterByTagOpen => {
+    this.setState({
+      isFilterByTagOpen,
+    });
+  };
+
+  public render() {
+    const { t } = this.props;
+    const {
+      currentItem,
+      currentTagItem,
+      isFilterByOpen,
+      isFilterByTagOpen,
+    } = this.state;
+    const filterByTag =
+      currentItem && currentItem.id ? currentItem.id === 'tags' : false;
+
+    return (
+      <div className={css(styles.filterContainer)}>
+        <Select
+          aria-label={t('ocp_details.toolbar.filter_type_aria_label')}
+          onSelect={this.handleFilterBySelect}
+          onToggle={this.handleFilterByToggle}
+          isExpanded={isFilterByOpen}
+          selections={currentItem}
+          variant={SelectVariant.single}
+        >
+          {this.getSelectItems()}
+        </Select>
+        {Boolean(filterByTag) && (
+          <Select
+            aria-label={t('ocp_details.toolbar.filter_tag_type_aria_label')}
+            onSelect={this.handleFilterByTagSelect}
+            onToggle={this.handleFilterByTagToggle}
+            isExpanded={isFilterByTagOpen}
+            selections={currentTagItem}
+            variant={SelectVariant.single}
+          >
+            {this.getSelectTagItems()}
+          </Select>
+        )}
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  FilterByOwnProps,
+  FilterByStateProps
+>(state => {
+  const queryString = getQuery({
+    filter: {
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
+    },
+    key_only: true,
+  });
+  const report = ocpReportsSelectors.selectReport(
+    state,
+    reportType,
+    queryString
+  );
+  const reportFetchStatus = ocpReportsSelectors.selectReportFetchStatus(
+    state,
+    reportType,
+    queryString
+  );
+  return {
+    queryString,
+    report,
+    reportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: FilterByDispatchProps = {
+  fetchReport: ocpReportsActions.fetchReport,
+};
+
+const FilterBy = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(FilterByBase)
+);
+
+export { FilterBy, FilterByProps };

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -1,6 +1,6 @@
 import { Pagination, PaginationVariant } from '@patternfly/react-core';
 import { css } from '@patternfly/react-styles';
-import { getQuery, OcpQuery, parseQuery } from 'api/ocpQuery';
+import { getQuery, getQueryRoute, OcpQuery, parseQuery } from 'api/ocpQuery';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
 import { Providers, ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/providersQuery';
@@ -67,6 +67,7 @@ const baseQuery: OcpQuery = {
     time_scope_units: 'month',
     time_scope_value: -1,
   },
+  filter_by: {},
   group_by: {
     project: '*',
   },
@@ -136,53 +137,6 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     );
   };
 
-  private getFilterFields = (groupById: string): any[] => {
-    const { t } = this.props;
-    if (groupById === 'cluster') {
-      return [
-        {
-          id: 'cluster',
-          label: t('ocp_details.filter.name'),
-          title: t('ocp_details.filter.cluster_select'),
-          placeholder: t('ocp_details.filter.cluster_placeholder'),
-          filterType: 'text',
-        },
-      ];
-    } else if (groupById === 'node') {
-      return [
-        {
-          id: 'node',
-          label: t('ocp_details.filter.name'),
-          title: t('ocp_details.filter.node_select'),
-          placeholder: t('ocp_details.filter.node_placeholder'),
-          filterType: 'text',
-        },
-      ];
-    } else if (groupById === 'project') {
-      return [
-        {
-          id: 'project',
-          label: t('ocp_details.filter.name'),
-          title: t('ocp_details.filter.project_select'),
-          placeholder: t('ocp_details.filter.project_placeholder'),
-          filterType: 'text',
-        },
-      ];
-    } else {
-      // Default for group by project tags
-      return [
-        {
-          id: 'tag',
-          label: t('ocp_details.filter.name'),
-          title: t('ocp_details.filter.tag_select'),
-          placeholder: t('ocp_details.filter.tag_placeholder'),
-          filterType: 'text',
-        },
-      ];
-    }
-    return [];
-  };
-
   private getGroupByTagKey = () => {
     const { query } = this.props;
     let groupByTagKey;
@@ -232,7 +186,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
         offset: baseQuery.filter.offset,
       };
     }
-    return `/ocp?${getQuery(query)}`;
+    return `/ocp?${getQueryRoute(query)}`;
   }
 
   private getTable = () => {
@@ -258,14 +212,11 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByTagKey = this.getGroupByTagKey();
-    const filterFields = this.getFilterFields(
-      groupByTagKey ? 'tag' : groupById
-    );
 
     return (
       <DetailsToolbar
         exportText={t('ocp_details.export_link')}
-        filterFields={filterFields}
+        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
         isExportDisabled={selectedItems.length === 0}
         onExportClicked={this.handleExportModalOpen}
         onFilterAdded={this.handleFilterAdded}
@@ -294,17 +245,32 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     const newFilterType =
       filterType === 'tag' ? `${tagKey}${groupByTagKey}` : filterType;
 
-    if (newQuery.group_by[newFilterType]) {
-      if (newQuery.group_by[newFilterType] === '*') {
-        newQuery.group_by[newFilterType] = filterValue;
-      } else if (!newQuery.group_by[newFilterType].includes(filterValue)) {
-        newQuery.group_by[newFilterType] = [
-          newQuery.group_by[newFilterType],
+    // Filter by * won't generate a new request if group_by * already exists
+    if (filterValue === '*' && newQuery.group_by[newFilterType] === '*') {
+      return;
+    }
+
+    if (newQuery.filter_by[newFilterType]) {
+      let found = false;
+      const filters = newQuery.filter_by[newFilterType];
+      if (!Array.isArray(filters)) {
+        found = filterValue === newQuery.filter_by[newFilterType];
+      } else {
+        for (const filter of filters) {
+          if (filter === filterValue) {
+            found = true;
+            break;
+          }
+        }
+      }
+      if (!found) {
+        newQuery.filter_by[newFilterType] = [
+          newQuery.filter_by[newFilterType],
           filterValue,
         ];
       }
     } else {
-      newQuery.group_by[filterType] = [filterValue];
+      newQuery.filter_by[filterType] = [filterValue];
     }
     const filteredQuery = this.getRouteForQuery(newQuery, true);
     history.replace(filteredQuery);
@@ -319,17 +285,15 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
       filterType === 'tag' ? `${tagKey}${groupByTagKey}` : filterType;
 
     if (filterValue === '') {
-      newQuery.group_by = {
-        [newFilterType]: '*',
-      };
-    } else if (!Array.isArray(newQuery.group_by[newFilterType])) {
-      newQuery.group_by[newFilterType] = '*';
+      newQuery.filter_by = undefined; // Clear all
+    } else if (!Array.isArray(newQuery.filter_by[newFilterType])) {
+      newQuery.filter_by[newFilterType] = undefined;
     } else {
-      const index = newQuery.group_by[newFilterType].indexOf(filterValue);
+      const index = newQuery.filter_by[newFilterType].indexOf(filterValue);
       if (index > -1) {
-        newQuery.group_by[newFilterType] = [
-          ...query.group_by[newFilterType].slice(0, index),
-          ...query.group_by[newFilterType].slice(index + 1),
+        newQuery.filter_by[newFilterType] = [
+          ...query.filter_by[newFilterType].slice(0, index),
+          ...query.filter_by[newFilterType].slice(index + 1),
         ];
       }
     }
@@ -342,6 +306,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     const groupByKey: keyof OcpQuery['group_by'] = groupBy as any;
     const newQuery = {
       ...JSON.parse(JSON.stringify(query)),
+      filter_by: undefined,
       group_by: {
         [groupByKey]: '*',
       },
@@ -398,6 +363,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     if (!location.search) {
       history.replace(
         this.getRouteForQuery({
+          filter_by: query.filter_by,
           group_by: query.group_by,
           order_by: { cost: 'desc' },
         })
@@ -470,6 +436,7 @@ const mapStateToProps = createMapStateToProps<
       ...baseQuery.filter,
       ...queryFromRoute.filter,
     },
+    filter_by: queryFromRoute.filter_by || baseQuery.filter_by,
     group_by: queryFromRoute.group_by || baseQuery.group_by,
     order_by: queryFromRoute.order_by || baseQuery.order_by,
   };

--- a/src/utils/getComputedOcpReportItems.ts
+++ b/src/utils/getComputedOcpReportItems.ts
@@ -164,5 +164,8 @@ export function getIdKeyForGroupBy(
   if (groupBy.node) {
     return 'node';
   }
+  if (groupBy.tags) {
+    return 'tags';
+  }
   return 'date';
 }


### PR DESCRIPTION
Filter by many things in details (not only the main dimension). 

Users want the ability to filter on additional projects, clusters, nodes, and tag keys. Although, the table results do not show tags in its columns, this hack will provide the requested functionality.

Fixes https://github.com/project-koku/koku-ui/issues/1219

Mock: https://user-images.githubusercontent.com/17481322/69057929-a1cb4900-09e0-11ea-8ecd-8205e9c3c0f2.png

Demo:
![chrome-capture (1)](https://user-images.githubusercontent.com/17481322/72263943-dfff7600-35e7-11ea-9c6d-dffbbad01bee.gif)

Note: The following issues will need to be addressed server-side
project-koku/koku#1589
project-koku/koku#1596