### PR TITLE
Aws details: Filter by many things

### DIFF
--- a/src/api/awsQuery.ts
+++ b/src/api/awsQuery.ts
@@ -17,6 +17,7 @@ interface AwsGroupBys {
   account?: AwsGroupByValue;
   instance_type?: AwsGroupByValue;
   region?: AwsGroupByValue;
+  tags?: AwsGroupByValue;
 }
 
 interface AwsOrderBys {
@@ -30,16 +31,18 @@ interface AwsOrderBys {
 export interface AwsQuery {
   delta?: string;
   filter?: AwsFilters;
+  filter_by?: AwsGroupBys;
   group_by?: AwsGroupBys;
   order_by?: AwsOrderBys;
   key_only?: boolean;
 }
 
 const groupByAnd = 'and:';
+const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 // Adds logical AND to group_by -- https://github.com/project-koku/koku-ui/issues/704
-export function getGroupByAnd(query: AwsQuery) {
-  if (!(query && query.group_by) || skipGroupByAnd(query)) {
+export function getLogicalAnd(query: AwsQuery) {
+  if (!(query && query.group_by)) {
     return query;
   }
   const newQuery = {
@@ -47,23 +50,72 @@ export function getGroupByAnd(query: AwsQuery) {
     group_by: {},
   };
   for (const key of Object.keys(query.group_by)) {
-    if (query.group_by[key] === '*') {
-      newQuery.group_by[key] = query.group_by[key];
-    } else {
-      newQuery.group_by[`${groupByAnd}${key}`] = query.group_by[key];
-    }
+    newQuery.group_by[`${groupByAnd}${key}`] = query.group_by[key];
+    newQuery.group_by[key] = undefined;
   }
   return newQuery;
 }
 
+// Converts filter_by to group_by
+export function getGroupBy(query: AwsQuery) {
+  if (!(query && query.filter_by)) {
+    return query;
+  }
+  const newQuery = {
+    ...JSON.parse(JSON.stringify(query)),
+    filter_by: {},
+  };
+  for (const key of Object.keys(query.filter_by)) {
+    newQuery.group_by[key] = query.filter_by[key];
+  }
+  return newQuery;
+}
+
+// Skip adding logical AND
+export function getQueryRoute(query: AwsQuery) {
+  return stringify(query, { encode: false, indices: false });
+}
+
+// Adds logical AND
 export function getQuery(query: AwsQuery) {
-  const newQuery = getGroupByAnd(query);
-  return stringify(newQuery, { encode: false, indices: false });
+  const newQuery = getGroupBy(query);
+  const groupByKeys = newQuery.group_by ? Object.keys(newQuery.group_by) : [];
+
+  // Workaround for https://github.com/project-koku/koku/issues/1596
+  let isGroupByAnd = false;
+  if (groupByKeys.length === 1) {
+    for (const key of groupByKeys) {
+      isGroupByAnd = key.indexOf(tagKey) !== -1;
+    }
+  }
+
+  // Skip logical AND for single group_by
+  const q =
+    groupByKeys.length > 1 || isGroupByAnd ? getLogicalAnd(newQuery) : newQuery;
+  return stringify(q, { encode: false, indices: false });
+}
+
+// Removes logical AND from filter_by
+export function parseFilterByAnd(query: AwsQuery) {
+  if (!(query && query.filter_by)) {
+    return query;
+  }
+  const newQuery = {
+    ...JSON.parse(JSON.stringify(query)),
+    filter_by: {},
+  };
+  for (const key of Object.keys(query.filter_by)) {
+    const index = key.indexOf(groupByAnd);
+    const filterByKey =
+      index !== -1 ? key.substring(index + groupByAnd.length) : key;
+    newQuery.filter_by[filterByKey] = query.filter_by[key];
+  }
+  return newQuery;
 }
 
 // Removes logical AND from group_by -- https://github.com/project-koku/koku-ui/issues/704
 export function parseGroupByAnd(query: AwsQuery) {
-  if (!(query && query.group_by) || skipGroupByAnd(query)) {
+  if (!(query && query.group_by)) {
     return query;
   }
   const newQuery = {
@@ -81,20 +133,5 @@ export function parseGroupByAnd(query: AwsQuery) {
 
 export function parseQuery<T = any>(query: string): T {
   const newQuery = parse(query, { ignoreQueryPrefix: true });
-  return parseGroupByAnd(newQuery);
-}
-
-export function skipGroupByAnd(query: AwsQuery) {
-  let result = true;
-
-  if (query && query.group_by) {
-    for (const key of Object.keys(query.group_by)) {
-      const groupBy = query.group_by[key];
-      if (groupBy instanceof Array && groupBy.length > 1) {
-        result = false;
-        break;
-      }
-    }
-  }
-  return result;
+  return parseFilterByAnd(parseGroupByAnd(newQuery));
 }

--- a/src/api/awsReports.ts
+++ b/src/api/awsReports.ts
@@ -19,6 +19,7 @@ export interface AwsReportValue {
   instance_type?: string;
   region?: string;
   service?: string;
+  tags?: string;
   usage?: AwsDatum;
 }
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -40,12 +40,12 @@
     "export_link": "Export",
     "filter": {
       "account_placeholder": "Filter by account",
-      "account_select": "Account",
-      "name": "Name",
+      "account_select": "Account name",
       "region_placeholder": "Filter by region",
-      "region_select": "Region",
+      "region_select": "Region name",
       "service_placeholder": "Filter by service",
-      "service_select": "Service",
+      "service_select": "Service name",
+      "tag_name": "Tags",
       "tag_placeholder": "Filter by tag",
       "tag_select": "Tag"
     },

--- a/src/pages/awsDetails/filterBy.styles.ts
+++ b/src/pages/awsDetails/filterBy.styles.ts
@@ -1,0 +1,7 @@
+import { StyleSheet } from '@patternfly/react-styles';
+
+export const styles = StyleSheet.create({
+  filterContainer: {
+    display: 'inline-flex',
+  },
+});

--- a/src/pages/awsDetails/filterBy.tsx
+++ b/src/pages/awsDetails/filterBy.tsx
@@ -1,0 +1,300 @@
+import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
+import { css } from '@patternfly/react-styles';
+import { getQuery } from 'api/awsQuery';
+import { AwsReport, AwsReportType } from 'api/awsReports';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { awsReportsActions, awsReportsSelectors } from 'store/awsReports';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { GetComputedAwsReportItemsParams } from 'utils/getComputedAwsReportItems';
+import { styles } from './filterBy.styles';
+
+interface FilterByOwnProps {
+  groupBy?: string;
+  onItemClicked(value: string);
+  queryString?: string;
+}
+
+interface FilterByStateProps {
+  report?: AwsReport;
+  reportFetchStatus?: FetchStatus;
+}
+
+interface FilterByDispatchProps {
+  fetchReport?: typeof awsReportsActions.fetchReport;
+}
+
+interface FilterByState {
+  currentItem?: any;
+  currentTagItem?: any;
+  isFilterByOpen: boolean;
+  isFilterByTagOpen: boolean;
+}
+
+type FilterByProps = FilterByOwnProps &
+  FilterByStateProps &
+  FilterByDispatchProps &
+  InjectedTranslateProps;
+
+const filterByOptions: {
+  label: string;
+  value: GetComputedAwsReportItemsParams['idKey'];
+}[] = [
+  { label: 'account', value: 'account' },
+  { label: 'service', value: 'service' },
+  { label: 'region', value: 'region' },
+  { label: 'tags', value: 'tags' },
+];
+
+const reportType = AwsReportType.tag;
+const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
+
+class FilterByBase extends React.Component<FilterByProps> {
+  protected defaultState: FilterByState = {
+    isFilterByOpen: false,
+    isFilterByTagOpen: false,
+  };
+  public state: FilterByState = { ...this.defaultState };
+
+  constructor(stateProps, dispatchProps) {
+    super(stateProps, dispatchProps);
+    this.handleFilterBySelect = this.handleFilterBySelect.bind(this);
+    this.handleFilterByTagSelect = this.handleFilterByTagSelect.bind(this);
+    this.handleFilterByTagToggle = this.handleFilterByTagToggle.bind(this);
+    this.handleFilterByToggle = this.handleFilterByToggle.bind(this);
+  }
+
+  public componentDidMount() {
+    const { fetchReport, queryString } = this.props;
+    fetchReport(reportType, queryString);
+    this.setState({
+      currentItem: this.getFilterBy(),
+      currentTagItem: this.getFilterByTag(),
+    });
+  }
+
+  public componentDidUpdate(prevProps: FilterByProps) {
+    const { fetchReport, reportFetchStatus, groupBy, queryString } = this.props;
+    if (
+      prevProps.groupBy !== groupBy ||
+      prevProps.queryString !== queryString
+    ) {
+      fetchReport(reportType, queryString);
+    }
+    if (
+      prevProps.groupBy !== groupBy ||
+      prevProps.queryString !== queryString ||
+      prevProps.reportFetchStatus !== reportFetchStatus
+    ) {
+      this.setState({
+        currentItem: this.getFilterBy(),
+        currentTagItem: this.getFilterByTag(),
+      });
+    }
+  }
+
+  private getFilterBy = () => {
+    const { groupBy } = this.props;
+
+    // Find i18n string
+    const items = this.getSelectOptions();
+    for (const item of items) {
+      if (
+        groupBy === item.id ||
+        (groupBy.indexOf(tagKey) !== -1 && item.id === 'tags')
+      ) {
+        return item;
+      }
+    }
+    return null;
+  };
+
+  private getFilterByTag = () => {
+    const { groupBy } = this.props;
+
+    // Find i18n string
+    const items = this.getSelectTagOptions();
+    for (const item of items) {
+      if (groupBy === item.id) {
+        return item;
+      }
+    }
+    return items[0];
+  };
+
+  private getSelectOption = (id, label) => {
+    return {
+      id,
+      toString: () => label,
+    };
+  };
+
+  private getSelectItems = () => {
+    return this.getSelectOptions().map(option => (
+      <SelectOption key={option.id} value={option} />
+    ));
+  };
+
+  private getSelectTagItems = () => {
+    return this.getSelectTagOptions().map(option => (
+      <SelectOption key={option.id} value={option} />
+    ));
+  };
+
+  private getSelectOptions = () => {
+    const { t } = this.props;
+
+    return filterByOptions.map(option => {
+      return this.getSelectOption(
+        `${option.value}`,
+        t(`group_by.values.${option.label}`)
+      );
+    });
+  };
+
+  private getSelectTagOptions = () => {
+    const { report, t } = this.props;
+
+    if (report && report.data) {
+      const data = [...new Set([...report.data])]; // prune duplicates
+      return data.map(val => {
+        return this.getSelectOption(
+          `${tagKey}${val}`,
+          t('group_by.tag', { key: val, interpolation: { escapeValue: false } })
+        );
+      });
+    } else {
+      return [];
+    }
+  };
+
+  private handleFilterBySelect = (event, selection, isPlaceholder) => {
+    const { groupBy, onItemClicked } = this.props;
+    let selected = selection;
+
+    if (selection.id === 'tags') {
+      const items = this.getSelectTagOptions();
+      if (groupBy.indexOf(tagKey) !== -1) {
+        for (const item of items) {
+          if (groupBy === item.id) {
+            selected = item;
+          }
+        }
+      } else {
+        selected = items[0];
+      }
+    }
+    if (onItemClicked) {
+      onItemClicked(selected.id);
+    }
+    this.setState({
+      currentItem: selection,
+      isFilterByOpen: false,
+    });
+  };
+
+  private handleFilterByTagSelect = (event, selection, isPlaceholder) => {
+    const { onItemClicked } = this.props;
+    if (onItemClicked) {
+      onItemClicked(selection.id);
+    }
+    this.setState({
+      currentTagItem: selection,
+      isFilterByTagOpen: false,
+    });
+  };
+
+  private handleFilterByToggle = isFilterByOpen => {
+    this.setState({
+      isFilterByOpen,
+    });
+  };
+
+  private handleFilterByTagToggle = isFilterByTagOpen => {
+    this.setState({
+      isFilterByTagOpen,
+    });
+  };
+
+  public render() {
+    const { t } = this.props;
+    const {
+      currentItem,
+      currentTagItem,
+      isFilterByOpen,
+      isFilterByTagOpen,
+    } = this.state;
+    const filterByTag =
+      currentItem && currentItem.id ? currentItem.id === 'tags' : false;
+
+    return (
+      <div className={css(styles.filterContainer)}>
+        <Select
+          aria-label={t('aws_details.toolbar.filter_type_aria_label')}
+          onSelect={this.handleFilterBySelect}
+          onToggle={this.handleFilterByToggle}
+          isExpanded={isFilterByOpen}
+          selections={currentItem}
+          variant={SelectVariant.single}
+        >
+          {this.getSelectItems()}
+        </Select>
+        {Boolean(filterByTag) && (
+          <Select
+            aria-label={t('aws_details.toolbar.filter_tag_type_aria_label')}
+            onSelect={this.handleFilterByTagSelect}
+            onToggle={this.handleFilterByTagToggle}
+            isExpanded={isFilterByTagOpen}
+            selections={currentTagItem}
+            variant={SelectVariant.single}
+          >
+            {this.getSelectTagItems()}
+          </Select>
+        )}
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  FilterByOwnProps,
+  FilterByStateProps
+>(state => {
+  const queryString = getQuery({
+    filter: {
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
+    },
+    key_only: true,
+  });
+  const report = awsReportsSelectors.selectReport(
+    state,
+    reportType,
+    queryString
+  );
+  const reportFetchStatus = awsReportsSelectors.selectReportFetchStatus(
+    state,
+    reportType,
+    queryString
+  );
+  return {
+    queryString,
+    report,
+    reportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: FilterByDispatchProps = {
+  fetchReport: awsReportsActions.fetchReport,
+};
+
+const FilterBy = translate()(
+  connect(
+    mapStateToProps,
+    mapDispatchToProps
+  )(FilterByBase)
+);
+
+export { FilterBy, FilterByProps };

--- a/src/utils/getComputedAwsReportItems.ts
+++ b/src/utils/getComputedAwsReportItems.ts
@@ -134,5 +134,8 @@ export function getIdKeyForGroupBy(
   if (groupBy.service) {
     return 'service';
   }
+  if (groupBy.tags) {
+    return 'tags';
+  }
   return 'date';
 }


### PR DESCRIPTION
Filter by many things in details (not only the main dimension). 

Users want the ability to filter on additional projects, clusters, nodes, and tag keys. Although, the table results do not show tags in its columns, this hack will provide the requested functionality.

Fixes https://github.com/project-koku/koku-ui/issues/1220

Mock: https://user-images.githubusercontent.com/17481322/69057929-a1cb4900-09e0-11ea-8ecd-8205e9c3c0f2.png

Demo:
![chrome-capture (2)](https://user-images.githubusercontent.com/17481322/72267408-032d2400-35ee-11ea-874f-df67f198a0c7.gif)

Note: The following issues will need to be addressed server-side
project-koku/koku#1589
project-koku/koku#1596