### PR TITLE
feat(costmodels): add Azure type to cost model

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -323,6 +323,7 @@
       "caption": "Select from the following {{ type }} sources:",
       "sub_title": "Select one or more source(s) to assign to this cost model. If the source already has a cost model assigned to it, this selection will override that assignment. You can also assign sources to your cost model at a later time.",
       "title_AWS": "Assign Amazon Web Service source(s) (optional)",
+      "title_AZURE": "Assign Microsoft Azure source(s) (optional)",
       "title_OCP": "Assign Red Hat OpenShift source(s) (optional)"
     },
     "source_table": {

--- a/src/pages/costModelsDetails/addSourceWizard.tsx
+++ b/src/pages/costModelsDetails/addSourceWizard.tsx
@@ -39,14 +39,21 @@ interface Props extends InjectedTranslateProps {
   updateApiError: string;
 }
 
+const sourceTypeMap = {
+  'OpenShift Container Platform': 'OCP',
+  'Microsoft Azure': 'AZURE',
+  'Amazon Web Services': 'AWS',
+};
+
 class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
   public state = { checked: {} };
   public componentDidMount() {
-    const sourceType =
-      this.props.costModel.source_type === 'OpenShift Container Platform'
-        ? 'OCP'
-        : 'AWS';
-    this.props.fetch(`type=${sourceType}&limit=10&offset=0`);
+    const {
+      costModel: { source_type },
+      fetch,
+    } = this.props;
+    const sourceType = sourceTypeMap[source_type];
+    fetch(`type=${sourceType}&limit=10&offset=0`);
   }
   public componentDidUpdate(prevProps) {
     if (

--- a/src/pages/createCostModelWizard/generalInformation.tsx
+++ b/src/pages/createCostModelWizard/generalInformation.tsx
@@ -82,6 +82,10 @@ const GeneralInformation: React.SFC<InjectedTranslateProps> = ({ t }) => {
                     label={t('onboarding.type_options.aws')}
                   />
                   <FormSelectOption
+                    value="AZURE"
+                    label={t('onboarding.type_options.azure')}
+                  />
+                  <FormSelectOption
                     value="OCP"
                     label={t('onboarding.type_options.ocp')}
                   />

--- a/src/pages/createCostModelWizard/steps.tsx
+++ b/src/pages/createCostModelWizard/steps.tsx
@@ -13,6 +13,28 @@ export const stepsHash = (t: (text: string) => string) => ({
       component: <GeneralInformation />,
     },
   ],
+  AZURE: [
+    {
+      id: 1,
+      name: t('cost_models_wizard.steps.general_info'),
+      component: <GeneralInformation />,
+    },
+    {
+      id: 2,
+      name: t('cost_models_wizard.steps.markup'),
+      component: <Markup />,
+    },
+    {
+      id: 3,
+      name: t('cost_models_wizard.steps.sources'),
+      component: <Sources />,
+    },
+    {
+      id: 4,
+      name: t('cost_models_wizard.steps.review'),
+      component: <Review />,
+    },
+  ],
   AWS: [
     {
       id: 1,
@@ -67,6 +89,12 @@ export const stepsHash = (t: (text: string) => string) => ({
 export const validatorsHash = {
   '': [ctx => false],
   AWS: [
+    ctx => ctx.name !== '' && ctx.type !== '',
+    ctx => ctx.markup !== '' && !isNaN(Number(ctx.markup)),
+    ctx => true,
+    ctx => true,
+  ],
+  AZURE: [
     ctx => ctx.name !== '' && ctx.type !== '',
     ctx => ctx.markup !== '' && !isNaN(Number(ctx.markup)),
     ctx => true,


### PR DESCRIPTION
closes #1222 

- [x] in Create Cost Model wizard - Add Microsoft Azure:
  - [x] Select Azure from "Source type"
  - [x] Set markup for Microsoft Azure
  - [x] Assign the cost model to Azure sources
  - [x] Be able to create Microsoft Azure cost model by the end of the wizard
- [x] Cost model view details - Add Microsoft Azure:
  - [x] Re-assign Microsoft Azure sources
  - [x] Update the markup
