### PR TITLE
Simplify calculation for unused requested capacity

### DIFF
--- a/src/pages/ocpCloudDetails/detailsChart.tsx
+++ b/src/pages/ocpCloudDetails/detailsChart.tsx
@@ -308,20 +308,11 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
       `units.${unitLookupKey(hasUsage ? report.meta.total.usage.units : '')}`
     );
 
-    // Show negative values https://github.com/project-koku/koku-ui/issues/1214
+    // Note: Unused won't be negative since Kubernetes doesn't allow requests to exceed capacity -- see #1232
     const unusedRequestCapacity = capacity - request;
+    const unusedRequestCapacityPercentage = (request / capacity) * 100;
     const unusedUsageCapacity = capacity - usage;
-
-    let unusedRequestCapacityPercentage =
-      request > 0 ? (request / capacity) * 100 : 0;
-    if (unusedRequestCapacityPercentage > 100) {
-      unusedRequestCapacityPercentage = 100 - unusedRequestCapacityPercentage;
-    }
-    let unusedUsageCapacityPercentage =
-      capacity > usage ? (usage / capacity) * 100 : 0;
-    if (unusedUsageCapacityPercentage > 100) {
-      unusedUsageCapacityPercentage = 100 - unusedUsageCapacityPercentage;
-    }
+    const unusedUsageCapacityPercentage = (usage / capacity) * 100;
 
     return (
       <TextContent className={css(styles.freeSpace)}>


### PR DESCRIPTION
Removes special code showing negative numbers for unused requested capacity.

Kubernetes won't allow the number of requests to exceed capacity; thus, this calculation can be simplified.

Fixes https://github.com/project-koku/koku-ui/issues/1232

<img width="603" alt="Screen Shot 2020-01-13 at 11 07 45 PM" src="https://user-images.githubusercontent.com/17481322/72313494-8c2d7500-3659-11ea-9bfa-27a3e1e2cc35.png">
