### PR TITLE
Remove HTML escape for filter option label

### DIFF
--- a/src/pages/azureDetails/filterBy.tsx
+++ b/src/pages/azureDetails/filterBy.tsx
@@ -161,7 +161,7 @@ class FilterByBase extends React.Component<FilterByProps> {
       return data.map(val => {
         return this.getSelectOption(
           `${tagKey}${val}`,
-          t('group_by.tag', { key: val, interpolation: { escapeValue: false } })
+          t('group_by.tag', { key: val })
         );
       });
     } else {

--- a/src/pages/azureDetails/groupBy.tsx
+++ b/src/pages/azureDetails/groupBy.tsx
@@ -113,10 +113,7 @@ class GroupByBase extends React.Component<GroupByProps> {
           key={`${tagKey}${val}`}
           onClick={() => this.handleGroupByClick(`${tagKey}${val}`)}
         >
-          {t('group_by.tag', {
-            key: val,
-            interpolation: { escapeValue: false }, // Todo: temporary fix
-          })}
+          {t('group_by.tag', { key: val })}
         </DropdownItem>
       ));
     } else {
@@ -166,10 +163,7 @@ class GroupByBase extends React.Component<GroupByProps> {
     const index = currentItem ? currentItem.indexOf(tagKey) : -1;
     const label =
       index !== -1
-        ? t('group_by.tag', {
-            key: currentItem.slice(tagKey.length),
-            interpolation: { escapeValue: false }, // Todo: temporary fix
-          })
+        ? t('group_by.tag', { key: currentItem.slice(tagKey.length) })
         : t(`group_by.values.${currentItem}`);
 
     return (

--- a/src/pages/ocpCloudDetails/filterBy.tsx
+++ b/src/pages/ocpCloudDetails/filterBy.tsx
@@ -164,7 +164,7 @@ class FilterByBase extends React.Component<FilterByProps> {
       return data.map(val => {
         return this.getSelectOption(
           `${tagKey}${val}`,
-          t('group_by.tag', { key: val, interpolation: { escapeValue: false } })
+          t('group_by.tag', { key: val })
         );
       });
     } else {

--- a/src/pages/ocpCloudDetails/groupBy.tsx
+++ b/src/pages/ocpCloudDetails/groupBy.tsx
@@ -116,10 +116,7 @@ class GroupByBase extends React.Component<GroupByProps> {
           key={`${tagKey}${val}`}
           onClick={() => this.handleGroupByClick(`${tagKey}${val}`)}
         >
-          {t('group_by.tag', {
-            key: val,
-            interpolation: { escapeValue: false }, // Todo: temporary fix
-          })}
+          {t('group_by.tag', { key: val })}
         </DropdownItem>
       ));
     } else {
@@ -169,10 +166,7 @@ class GroupByBase extends React.Component<GroupByProps> {
     const index = currentItem ? currentItem.indexOf(tagKey) : -1;
     const label =
       index !== -1
-        ? t('group_by.tag', {
-            key: currentItem.slice(tagKey.length),
-            interpolation: { escapeValue: false }, // Todo: temporary fix
-          })
+        ? t('group_by.tag', { key: currentItem.slice(tagKey.length) })
         : t(`group_by.values.${currentItem}`);
 
     return (


### PR DESCRIPTION
Currently we HTML escape the filter / group_by option labels on the AWS details and Ocp cloud details pages.

This was a workaround for:
project-koku/nise#169

Fixes https://github.com/project-koku/koku-ui/issues/1233