### PR TITLE
"View all tags" title does not fit into the dialog

### DIFF
--- a/src/pages/awsDetails/detailsTagModal.tsx
+++ b/src/pages/awsDetails/detailsTagModal.tsx
@@ -37,13 +37,13 @@ class DetailsTagModalBase extends React.Component<DetailsTagModalProps> {
     return (
       <Modal
         className={`${modalOverride} ${css(styles.modal)}`}
-        isLarge
         isOpen={isOpen}
         onClose={this.handleClose}
         title={t('aws_details.tags_modal_title', {
           groupBy,
           name: item.label,
         })}
+        width={'50%'}
       >
         <DetailsTagView
           account={item.label || item.id}

--- a/src/pages/azureDetails/detailsTagModal.tsx
+++ b/src/pages/azureDetails/detailsTagModal.tsx
@@ -37,13 +37,13 @@ class DetailsTagModalBase extends React.Component<DetailsTagModalProps> {
     return (
       <Modal
         className={`${modalOverride} ${css(styles.modal)}`}
-        isLarge
         isOpen={isOpen}
         onClose={this.handleClose}
         title={t('azure_details.tags_modal_title', {
           groupBy,
           name: item.label,
         })}
+        width={'50%'}
       >
         <DetailsTagView
           account={item.label || item.id}

--- a/src/pages/ocpCloudDetails/detailsTagModal.tsx
+++ b/src/pages/ocpCloudDetails/detailsTagModal.tsx
@@ -37,13 +37,13 @@ class DetailsTagModalBase extends React.Component<DetailsTagModalProps> {
     return (
       <Modal
         className={`${modalOverride} ${css(styles.modal)}`}
-        isLarge
         isOpen={isOpen}
         onClose={this.handleClose}
         title={t('ocp_cloud_details.tags_modal_title', {
           groupBy,
           name: item.label,
         })}
+        width={'50%'}
       >
         <DetailsTagView
           groupBy={groupBy}

--- a/src/pages/ocpDetails/detailsTagModal.tsx
+++ b/src/pages/ocpDetails/detailsTagModal.tsx
@@ -37,13 +37,13 @@ class DetailsTagModalBase extends React.Component<DetailsTagModalProps> {
     return (
       <Modal
         className={`${modalOverride} ${css(styles.modal)}`}
-        isLarge
         isOpen={isOpen}
         onClose={this.handleClose}
         title={t('ocp_details.tags_modal_title', {
           groupBy,
           name: item.label,
         })}
+        width={'50%'}
       >
         <DetailsTagView
           groupBy={groupBy}


### PR DESCRIPTION
Modified the modal width to use 50% of window.

Fixes https://github.com/project-koku/koku-ui/issues/1239

<img width="875" alt="Screen Shot 2020-01-14 at 9 14 58 AM" src="https://user-images.githubusercontent.com/17481322/72352242-e2c59e00-36af-11ea-8c23-5cf7467198c5.png">
