### PR TITLE
Overview card tooltips missing usage/request info

### DIFF
--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -48,6 +48,7 @@ interface TrendChartLegendItem {
 }
 
 interface TrendChartSeries {
+  childName?: string;
   data?: [TrendChartData];
   legendItem?: TrendChartLegendItem;
   style?: VictoryStyleInterface;
@@ -109,6 +110,7 @@ class CostChart extends React.Component<CostChartProps, State> {
     this.setState({
       series: [
         {
+          childName: 'previousCost',
           data: previousCostData,
           legendItem: {
             name: getCostRangeString(previousCostData, costKey, true, true, 1),
@@ -119,6 +121,7 @@ class CostChart extends React.Component<CostChartProps, State> {
           style: chartStyles.previousCostData,
         },
         {
+          childName: 'currentCost',
           data: currentCostData,
           legendItem: {
             name: getCostRangeString(currentCostData, costKey, true, false),
@@ -129,6 +132,7 @@ class CostChart extends React.Component<CostChartProps, State> {
           style: chartStyles.currentCostData,
         },
         {
+          childName: 'previousInfrastructureCost',
           data: previousInfrastructureCostData,
           legendItem: {
             name: getCostRangeString(
@@ -145,6 +149,7 @@ class CostChart extends React.Component<CostChartProps, State> {
           style: chartStyles.previousInfrastructureCostData,
         },
         {
+          childName: 'currentInfrastructureCost',
           data: currentInfrastructureCostData,
           legendItem: {
             name: getCostRangeString(
@@ -175,8 +180,8 @@ class CostChart extends React.Component<CostChartProps, State> {
       <ChartArea
         data={!hiddenSeries.has(index) ? series.data : [{ y: null }]}
         interpolation="monotoneX"
-        key={'area-' + index}
-        name={'area-' + index}
+        key={series.childName}
+        name={series.childName}
         style={series.style}
       />
     );
@@ -333,9 +338,9 @@ class CostChart extends React.Component<CostChartProps, State> {
     const { series } = this.state;
     const result = [];
     if (series) {
-      series.map((_, index) => {
+      series.map((serie, index) => {
         // Each group of chart names are hidden / shown together
-        result.push(`area-${index}`);
+        result.push(serie.childName);
       });
     }
     return result as any;

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -49,6 +49,7 @@ interface HistoricalTrendChartLegendItem {
 }
 
 interface HistoricalTrendChartSeries {
+  childName?: string;
   data?: [HistoricalTrendChartData];
   legendItem?: HistoricalTrendChartLegendItem;
   style?: VictoryStyleInterface;
@@ -113,6 +114,7 @@ class HistoricalCostChart extends React.Component<
     this.setState({
       series: [
         {
+          childName: 'previousCost',
           data: previousCostData,
           legendItem: {
             name: getCostRangeString(previousCostData, costKey, true, true, 1),
@@ -123,6 +125,7 @@ class HistoricalCostChart extends React.Component<
           style: chartStyles.previousCostData,
         },
         {
+          childName: 'currentCost',
           data: currentCostData,
           legendItem: {
             name: getCostRangeString(currentCostData, costKey, true, false),
@@ -133,6 +136,7 @@ class HistoricalCostChart extends React.Component<
           style: chartStyles.currentCostData,
         },
         {
+          childName: 'previousInfrastructureCost',
           data: previousInfrastructureCostData,
           legendItem: {
             name: getCostRangeString(
@@ -149,6 +153,7 @@ class HistoricalCostChart extends React.Component<
           style: chartStyles.previousInfrastructureCostData,
         },
         {
+          childName: 'currentInfrastructureCost',
           data: currentInfrastructureCostData,
           legendItem: {
             name: getCostRangeString(
@@ -179,8 +184,8 @@ class HistoricalCostChart extends React.Component<
       <ChartArea
         data={!hiddenSeries.has(index) ? series.data : [{ y: null }]}
         interpolation="monotoneX"
-        key={'area-' + index}
-        name={'area-' + index}
+        key={series.childName}
+        name={series.childName}
         style={series.style}
       />
     );
@@ -319,9 +324,9 @@ class HistoricalCostChart extends React.Component<
     const { series } = this.state;
     const result = [];
     if (series) {
-      series.map((_, index) => {
+      series.map((serie, index) => {
         // Each group of chart names are hidden / shown together
-        result.push(`area-${index}`);
+        result.push(serie.childName);
       });
     }
     return result as any;

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -47,6 +47,7 @@ interface HistoricalTrendChartLegendItem {
 }
 
 interface HistoricalTrendChartSeries {
+  childName?: string;
   data?: [HistoricalTrendChartData];
   legendItem?: HistoricalTrendChartLegendItem;
   style?: VictoryStyleInterface;
@@ -107,6 +108,7 @@ class HistoricalTrendChart extends React.Component<
     this.setState({
       series: [
         {
+          childName: 'previousCost',
           data: previousData,
           legendItem: {
             name: getCostRangeString(previousData, key, true, true, 1),
@@ -117,6 +119,7 @@ class HistoricalTrendChart extends React.Component<
           style: chartStyles.previousMonth,
         },
         {
+          childName: 'currentCost',
           data: currentData,
           legendItem: {
             name: getCostRangeString(currentData, key, true, false),
@@ -142,8 +145,8 @@ class HistoricalTrendChart extends React.Component<
       <ChartArea
         data={!hiddenSeries.has(index) ? series.data : [{ y: null }]}
         interpolation="monotoneX"
-        key={'area-' + index}
-        name={'area-' + index}
+        key={series.childName}
+        name={series.childName}
         style={series.style}
       />
     );
@@ -241,9 +244,9 @@ class HistoricalTrendChart extends React.Component<
     const { series } = this.state;
     const result = [];
     if (series) {
-      series.map((_, index) => {
+      series.map((serie, index) => {
         // Each group of chart names are hidden / shown together
-        result.push(`area-${index}`);
+        result.push(serie.childName);
       });
     }
     return result as any;

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -51,6 +51,7 @@ interface HistoricalTrendChartLegendItem {
 }
 
 interface HistoricalTrendChartSeries {
+  childName?: string;
   data?: [HistoricalTrendChartData];
   legendItem?: HistoricalTrendChartLegendItem;
   style?: VictoryStyleInterface;
@@ -118,6 +119,7 @@ class HistoricalUsageChart extends React.Component<
     this.setState({
       series: [
         {
+          childName: 'previousUsage',
           data: previousUsageData,
           legendItem: {
             name: getUsageRangeString(
@@ -134,6 +136,7 @@ class HistoricalUsageChart extends React.Component<
           style: chartStyles.previousUsageData,
         },
         {
+          childName: 'currentUsage',
           data: currentUsageData,
           legendItem: {
             name: getUsageRangeString(currentUsageData, usageKey, true, false),
@@ -144,6 +147,7 @@ class HistoricalUsageChart extends React.Component<
           style: chartStyles.currentUsageData,
         },
         {
+          childName: 'previousRequest',
           data: previousRequestData,
           legendItem: {
             name: getUsageRangeString(
@@ -160,6 +164,7 @@ class HistoricalUsageChart extends React.Component<
           style: chartStyles.previousRequestData,
         },
         {
+          childName: 'currentRequest',
           data: currentRequestData,
           legendItem: {
             name: getUsageRangeString(
@@ -175,6 +180,7 @@ class HistoricalUsageChart extends React.Component<
           style: chartStyles.currentRequestData,
         },
         {
+          childName: 'previousLimit',
           data: previousLimitData,
           legendItem: {
             name: getUsageRangeString(
@@ -191,6 +197,7 @@ class HistoricalUsageChart extends React.Component<
           style: chartStyles.previousLimitData,
         },
         {
+          childName: 'currentLimit',
           data: currentLimitData,
           legendItem: {
             name: getUsageRangeString(currentLimitData, limitKey, true, false),
@@ -216,8 +223,8 @@ class HistoricalUsageChart extends React.Component<
       <ChartArea
         data={!hiddenSeries.has(index) ? series.data : [{ y: null }]}
         interpolation="monotoneX"
-        key={'area-' + index}
-        name={'area-' + index}
+        key={series.childName}
+        name={series.childName}
         style={series.style}
       />
     );
@@ -388,9 +395,9 @@ class HistoricalUsageChart extends React.Component<
     const { series } = this.state;
     const result = [];
     if (series) {
-      series.map((_, index) => {
+      series.map((serie, index) => {
         // Each group of chart names are hidden / shown together
-        result.push(`area-${index}`);
+        result.push(serie.childName);
       });
     }
     return result as any;

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -46,6 +46,7 @@ interface TrendChartLegendItem {
 }
 
 interface TrendChartSeries {
+  childName?: string;
   data?: [TrendChartData];
   legendItem?: TrendChartLegendItem;
   style?: VictoryStyleInterface;
@@ -103,6 +104,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     this.setState({
       series: [
         {
+          childName: 'previousCost',
           data: previousData,
           legendItem: {
             name: getCostRangeString(previousData, key, true, true, 1),
@@ -113,6 +115,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
           style: chartStyles.previousMonth,
         },
         {
+          childName: 'currentCost',
           data: currentData,
           legendItem: {
             name: getCostRangeString(currentData, key, true, false),
@@ -138,8 +141,8 @@ class TrendChart extends React.Component<TrendChartProps, State> {
       <ChartArea
         data={!hiddenSeries.has(index) ? series.data : [{ y: null }]}
         interpolation="monotoneX"
-        key={'area-' + index}
-        name={'area-' + index}
+        key={series.childName}
+        name={series.childName}
         style={series.style}
       />
     );
@@ -239,9 +242,9 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     const { series } = this.state;
     const result = [];
     if (series) {
-      series.map((_, index) => {
+      series.map((serie, index) => {
         // Each group of chart names are hidden / shown together
-        result.push(`area-${index}`);
+        result.push(serie.childName);
       });
     }
     return result as any;

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -48,6 +48,7 @@ interface TrendChartLegendItem {
 }
 
 interface TrendChartSeries {
+  childName?: string;
   data?: [TrendChartData];
   legendItem?: TrendChartLegendItem;
   style?: VictoryStyleInterface;
@@ -107,6 +108,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
     this.setState({
       series: [
         {
+          childName: 'previousUsage',
           data: previousUsageData,
           legendItem: {
             name: getUsageRangeString(
@@ -120,9 +122,11 @@ class UsageChart extends React.Component<UsageChartProps, State> {
               type: 'minus',
             },
           },
+
           style: chartStyles.previousUsageData,
         },
         {
+          childName: 'currentUsage',
           data: currentUsageData,
           legendItem: {
             name: getUsageRangeString(currentUsageData, usageKey, true, false),
@@ -133,6 +137,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
           style: chartStyles.currentUsageData,
         },
         {
+          childName: 'previousRequest',
           data: previousRequestData,
           legendItem: {
             name: getUsageRangeString(
@@ -149,6 +154,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
           style: chartStyles.previousRequestData,
         },
         {
+          childName: 'currentRequest',
           data: currentRequestData,
           legendItem: {
             name: getUsageRangeString(
@@ -179,8 +185,8 @@ class UsageChart extends React.Component<UsageChartProps, State> {
       <ChartArea
         data={!hiddenSeries.has(index) ? series.data : [{ y: null }]}
         interpolation="monotoneX"
-        key={'area-' + index}
-        name={'area-' + index}
+        key={series.childName}
+        name={series.childName}
         style={series.style}
       />
     );
@@ -338,9 +344,9 @@ class UsageChart extends React.Component<UsageChartProps, State> {
     const { series } = this.state;
     const result = [];
     if (series) {
-      series.map((_, index) => {
+      series.map((serie, index) => {
         // Each group of chart names are hidden / shown together
-        result.push(`area-${index}`);
+        result.push(serie.childName);
       });
     }
     return result as any;


### PR DESCRIPTION
Fixed chart names in order to display the correct custom tooltips.

Fixes #1238

Overview usage chart
<img width="476" alt="Screen Shot 2020-01-14 at 10 15 11 AM" src="https://user-images.githubusercontent.com/17481322/72356828-ebba6d80-36b7-11ea-809f-b5994cdad62d.png">

Historical charts
<img width="917" alt="Screen Shot 2020-01-14 at 10 16 28 AM" src="https://user-images.githubusercontent.com/17481322/72356818-e78e5000-36b7-11ea-8400-3a602b67ce1c.png">
