### PR TITLE
Overview card tooltips missing usage/request info

### DIFF
--- a/src/pages/awsDetails/detailsTable.tsx
+++ b/src/pages/awsDetails/detailsTable.tsx
@@ -228,30 +228,38 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
+    const showPercentage = percentage !== '0.00';
 
-    let iconOverride = percentage !== 0 ? 'iconOverride' : undefined;
-    if (item.deltaPercent !== null && item.deltaValue < 0) {
-      iconOverride += ' decrease';
-    }
-    if (item.deltaPercent !== null && item.deltaValue > 0) {
-      iconOverride += ' increase';
+    let iconOverride;
+    if (showPercentage) {
+      iconOverride = 'iconOverride';
+      if (item.deltaPercent !== null && item.deltaValue < 0) {
+        iconOverride += ' decrease';
+      }
+      if (item.deltaPercent !== null && item.deltaValue > 0) {
+        iconOverride += ' increase';
+      }
     }
 
     return (
       <div className={monthOverMonthOverride}>
         <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-          {Boolean(percentage > 0) ? (
+          {Boolean(showPercentage) ? (
             t('percent', { value: percentage })
           ) : (
             <EmptyValueState />
           )}
-          {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
+          {Boolean(
+            showPercentage && item.deltaPercent !== null && item.deltaValue > 0
+          ) && (
             <span
               className={css('fa fa-sort-up', styles.infoArrow)}
               key={`month-over-month-icon-${index}`}
             />
           )}
-          {Boolean(item.deltaPercent !== null && item.deltaValue < 0) && (
+          {Boolean(
+            showPercentage && item.deltaPercent !== null && item.deltaValue < 0
+          ) && (
             <span
               className={css(
                 'fa fa-sort-down',

--- a/src/pages/azureDetails/detailsTable.tsx
+++ b/src/pages/azureDetails/detailsTable.tsx
@@ -228,30 +228,38 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
+    const showPercentage = percentage !== '0.00';
 
-    let iconOverride = percentage !== 0 ? 'iconOverride' : undefined;
-    if (item.deltaPercent !== null && item.deltaValue < 0) {
-      iconOverride += ' decrease';
-    }
-    if (item.deltaPercent !== null && item.deltaValue > 0) {
-      iconOverride += ' increase';
+    let iconOverride;
+    if (showPercentage) {
+      iconOverride = 'iconOverride';
+      if (item.deltaPercent !== null && item.deltaValue < 0) {
+        iconOverride += ' decrease';
+      }
+      if (item.deltaPercent !== null && item.deltaValue > 0) {
+        iconOverride += ' increase';
+      }
     }
 
     return (
       <div className={monthOverMonthOverride}>
         <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-          {Boolean(percentage > 0) ? (
+          {Boolean(showPercentage) ? (
             t('percent', { value: percentage })
           ) : (
             <EmptyValueState />
           )}
-          {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
+          {Boolean(
+            showPercentage && item.deltaPercent !== null && item.deltaValue > 0
+          ) && (
             <span
               className={css('fa fa-sort-up', styles.infoArrow)}
               key={`month-over-month-icon-${index}`}
             />
           )}
-          {Boolean(item.deltaPercent !== null && item.deltaValue < 0) && (
+          {Boolean(
+            showPercentage && item.deltaPercent !== null && item.deltaValue < 0
+          ) && (
             <span
               className={css(
                 'fa fa-sort-down',

--- a/src/pages/ocpCloudDetails/detailsTable.tsx
+++ b/src/pages/ocpCloudDetails/detailsTable.tsx
@@ -230,30 +230,38 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
+    const showPercentage = percentage !== '0.00';
 
-    let iconOverride = percentage !== 0 ? 'iconOverride' : undefined;
-    if (item.deltaPercent !== null && item.deltaValue < 0) {
-      iconOverride += ' decrease';
-    }
-    if (item.deltaPercent !== null && item.deltaValue > 0) {
-      iconOverride += ' increase';
+    let iconOverride;
+    if (showPercentage) {
+      iconOverride = 'iconOverride';
+      if (item.deltaPercent !== null && item.deltaValue < 0) {
+        iconOverride += ' decrease';
+      }
+      if (item.deltaPercent !== null && item.deltaValue > 0) {
+        iconOverride += ' increase';
+      }
     }
 
     return (
       <div className={monthOverMonthOverride}>
         <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-          {Boolean(percentage > 0) ? (
+          {Boolean(showPercentage) ? (
             t('percent', { value: percentage })
           ) : (
             <EmptyValueState />
           )}
-          {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
+          {Boolean(
+            showPercentage && item.deltaPercent !== null && item.deltaValue > 0
+          ) && (
             <span
               className={css('fa fa-sort-up', styles.infoArrow)}
               key={`month-over-month-icon-${index}`}
             />
           )}
-          {Boolean(item.deltaPercent !== null && item.deltaValue < 0) && (
+          {Boolean(
+            showPercentage && item.deltaPercent !== null && item.deltaValue < 0
+          ) && (
             <span
               className={css(
                 'fa fa-sort-down',

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -305,30 +305,38 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
+    const showPercentage = percentage !== '0.00';
 
-    let iconOverride = percentage !== 0 ? 'iconOverride' : undefined;
-    if (item.deltaPercent !== null && item.deltaValue < 0) {
-      iconOverride += ' decrease';
-    }
-    if (item.deltaPercent !== null && item.deltaValue > 0) {
-      iconOverride += ' increase';
+    let iconOverride;
+    if (showPercentage) {
+      iconOverride = 'iconOverride';
+      if (item.deltaPercent !== null && item.deltaValue < 0) {
+        iconOverride += ' decrease';
+      }
+      if (item.deltaPercent !== null && item.deltaValue > 0) {
+        iconOverride += ' increase';
+      }
     }
 
     return (
       <div className={monthOverMonthOverride}>
         <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-          {Boolean(percentage > 0) ? (
+          {Boolean(showPercentage) ? (
             t('percent', { value: percentage })
           ) : (
             <EmptyValueState />
           )}
-          {Boolean(item.deltaPercent !== null && item.deltaValue > 0) && (
+          {Boolean(
+            showPercentage && item.deltaPercent !== null && item.deltaValue > 0
+          ) && (
             <span
               className={css('fa fa-sort-up', styles.infoArrow)}
               key={`month-over-month-icon-${index}`}
             />
           )}
-          {Boolean(item.deltaPercent !== null && item.deltaValue < 0) && (
+          {Boolean(
+            showPercentage && item.deltaPercent !== null && item.deltaValue < 0
+          ) && (
             <span
               className={css(
                 'fa fa-sort-down',


### PR DESCRIPTION
Show item empty state based on percentage string

Fixes https://github.com/project-koku/koku-ui/issues/1241

<img width="971" alt="Screen Shot 2020-01-14 at 11 19 40 AM" src="https://user-images.githubusercontent.com/17481322/72362316-f5949e80-36c0-11ea-9cb8-78451efa492c.png">
