### PR TITLE
Details report query: Logical AND prefix not applied

### DIFF
--- a/src/api/awsQuery.ts
+++ b/src/api/awsQuery.ts
@@ -1,4 +1,5 @@
 import { parse, stringify } from 'qs';
+import { OcpCloudQuery } from './ocpCloudQuery';
 
 export interface AwsFilters {
   account?: string | number;
@@ -77,21 +78,31 @@ export function getQueryRoute(query: AwsQuery) {
 }
 
 // Adds logical AND
-export function getQuery(query: AwsQuery) {
+export function getQuery(query: OcpCloudQuery) {
   const newQuery = getGroupBy(query);
-  const groupByKeys = newQuery.group_by ? Object.keys(newQuery.group_by) : [];
+  let isGroupByAnd = false;
 
   // Workaround for https://github.com/project-koku/koku/issues/1596
-  let isGroupByAnd = false;
-  if (groupByKeys.length === 1) {
-    for (const key of groupByKeys) {
-      isGroupByAnd = key.indexOf(tagKey) !== -1;
+  if (newQuery && newQuery.group_by) {
+    const keys = Object.keys(newQuery.group_by);
+    if (keys && keys.length > 1) {
+      isGroupByAnd = true;
+    } else {
+      // Find a tag (#1596) or group_by with multiple keys
+      for (const key of keys) {
+        if (
+          (Array.isArray(newQuery.group_by[key]) &&
+            newQuery.group_by[key].length > 1) ||
+          key.indexOf(tagKey) !== -1
+        ) {
+          isGroupByAnd = true;
+        }
+      }
     }
   }
 
   // Skip logical AND for single group_by
-  const q =
-    groupByKeys.length > 1 || isGroupByAnd ? getLogicalAnd(newQuery) : newQuery;
+  const q = isGroupByAnd ? getLogicalAnd(newQuery) : newQuery;
   return stringify(q, { encode: false, indices: false });
 }
 

--- a/src/api/awsQuery.ts
+++ b/src/api/awsQuery.ts
@@ -1,5 +1,4 @@
 import { parse, stringify } from 'qs';
-import { OcpCloudQuery } from './ocpCloudQuery';
 
 export interface AwsFilters {
   account?: string | number;
@@ -78,7 +77,7 @@ export function getQueryRoute(query: AwsQuery) {
 }
 
 // Adds logical AND
-export function getQuery(query: OcpCloudQuery) {
+export function getQuery(query: AwsQuery) {
   const newQuery = getGroupBy(query);
   let isGroupByAnd = false;
 

--- a/src/api/azureQuery.ts
+++ b/src/api/azureQuery.ts
@@ -1,5 +1,4 @@
 import { parse, stringify } from 'qs';
-import { OcpCloudQuery } from './ocpCloudQuery';
 
 export interface AzureFilters {
   subscription_guid?: string | number;
@@ -78,7 +77,7 @@ export function getQueryRoute(query: AzureQuery) {
 }
 
 // Adds logical AND
-export function getQuery(query: OcpCloudQuery) {
+export function getQuery(query: AzureQuery) {
   const newQuery = getGroupBy(query);
   let isGroupByAnd = false;
 

--- a/src/api/azureQuery.ts
+++ b/src/api/azureQuery.ts
@@ -1,4 +1,5 @@
 import { parse, stringify } from 'qs';
+import { OcpCloudQuery } from './ocpCloudQuery';
 
 export interface AzureFilters {
   subscription_guid?: string | number;
@@ -77,21 +78,31 @@ export function getQueryRoute(query: AzureQuery) {
 }
 
 // Adds logical AND
-export function getQuery(query: AzureQuery) {
+export function getQuery(query: OcpCloudQuery) {
   const newQuery = getGroupBy(query);
-  const groupByKeys = newQuery.group_by ? Object.keys(newQuery.group_by) : [];
+  let isGroupByAnd = false;
 
   // Workaround for https://github.com/project-koku/koku/issues/1596
-  let isGroupByAnd = false;
-  if (groupByKeys.length === 1) {
-    for (const key of groupByKeys) {
-      isGroupByAnd = key.indexOf(tagKey) !== -1;
+  if (newQuery && newQuery.group_by) {
+    const keys = Object.keys(newQuery.group_by);
+    if (keys && keys.length > 1) {
+      isGroupByAnd = true;
+    } else {
+      // Find a tag (#1596) or group_by with multiple keys
+      for (const key of keys) {
+        if (
+          (Array.isArray(newQuery.group_by[key]) &&
+            newQuery.group_by[key].length > 1) ||
+          key.indexOf(tagKey) !== -1
+        ) {
+          isGroupByAnd = true;
+        }
+      }
     }
   }
 
   // Skip logical AND for single group_by
-  const q =
-    groupByKeys.length > 1 || isGroupByAnd ? getLogicalAnd(newQuery) : newQuery;
+  const q = isGroupByAnd ? getLogicalAnd(newQuery) : newQuery;
   return stringify(q, { encode: false, indices: false });
 }
 

--- a/src/api/ocpCloudQuery.ts
+++ b/src/api/ocpCloudQuery.ts
@@ -80,19 +80,29 @@ export function getQueryRoute(query: OcpCloudQuery) {
 // Adds logical AND
 export function getQuery(query: OcpCloudQuery) {
   const newQuery = getGroupBy(query);
-  const groupByKeys = newQuery.group_by ? Object.keys(newQuery.group_by) : [];
+  let isGroupByAnd = false;
 
   // Workaround for https://github.com/project-koku/koku/issues/1596
-  let isGroupByAnd = false;
-  if (groupByKeys.length === 1) {
-    for (const key of groupByKeys) {
-      isGroupByAnd = key.indexOf(tagKey) !== -1;
+  if (newQuery && newQuery.group_by) {
+    const keys = Object.keys(newQuery.group_by);
+    if (keys && keys.length > 1) {
+      isGroupByAnd = true;
+    } else {
+      // Find a tag (#1596) or group_by with multiple keys
+      for (const key of keys) {
+        if (
+          (Array.isArray(newQuery.group_by[key]) &&
+            newQuery.group_by[key].length > 1) ||
+          key.indexOf(tagKey) !== -1
+        ) {
+          isGroupByAnd = true;
+        }
+      }
     }
   }
 
   // Skip logical AND for single group_by
-  const q =
-    groupByKeys.length > 1 || isGroupByAnd ? getLogicalAnd(newQuery) : newQuery;
+  const q = isGroupByAnd ? getLogicalAnd(newQuery) : newQuery;
   return stringify(q, { encode: false, indices: false });
 }
 

--- a/src/api/ocpQuery.ts
+++ b/src/api/ocpQuery.ts
@@ -1,5 +1,4 @@
 import { parse, stringify } from 'qs';
-import { OcpCloudQuery } from './ocpCloudQuery';
 
 export interface OcpFilters {
   limit?: number;
@@ -76,7 +75,7 @@ export function getQueryRoute(query: OcpQuery) {
 }
 
 // Adds logical AND
-export function getQuery(query: OcpCloudQuery) {
+export function getQuery(query: OcpQuery) {
   const newQuery = getGroupBy(query);
   let isGroupByAnd = false;
 

--- a/src/api/ocpQuery.ts
+++ b/src/api/ocpQuery.ts
@@ -1,4 +1,5 @@
 import { parse, stringify } from 'qs';
+import { OcpCloudQuery } from './ocpCloudQuery';
 
 export interface OcpFilters {
   limit?: number;
@@ -75,21 +76,31 @@ export function getQueryRoute(query: OcpQuery) {
 }
 
 // Adds logical AND
-export function getQuery(query: OcpQuery) {
+export function getQuery(query: OcpCloudQuery) {
   const newQuery = getGroupBy(query);
-  const groupByKeys = newQuery.group_by ? Object.keys(newQuery.group_by) : [];
+  let isGroupByAnd = false;
 
   // Workaround for https://github.com/project-koku/koku/issues/1596
-  let isGroupByAnd = false;
-  if (groupByKeys.length === 1) {
-    for (const key of groupByKeys) {
-      isGroupByAnd = key.indexOf(tagKey) !== -1;
+  if (newQuery && newQuery.group_by) {
+    const keys = Object.keys(newQuery.group_by);
+    if (keys && keys.length > 1) {
+      isGroupByAnd = true;
+    } else {
+      // Find a tag (#1596) or group_by with multiple keys
+      for (const key of keys) {
+        if (
+          (Array.isArray(newQuery.group_by[key]) &&
+            newQuery.group_by[key].length > 1) ||
+          key.indexOf(tagKey) !== -1
+        ) {
+          isGroupByAnd = true;
+        }
+      }
     }
   }
 
   // Skip logical AND for single group_by
-  const q =
-    groupByKeys.length > 1 || isGroupByAnd ? getLogicalAnd(newQuery) : newQuery;
+  const q = isGroupByAnd ? getLogicalAnd(newQuery) : newQuery;
   return stringify(q, { encode: false, indices: false });
 }
 


### PR DESCRIPTION
For the details report query, the logical AND prefix is not being applied to multiple keys within the same group_by.

`group_by[and:project]=cost&group_by[and:project]=management`

Fixes https://github.com/project-koku/koku-ui/issues/1245