### PR TITLE
Deltas show incorrectly when there is no change

### DIFF
--- a/src/pages/awsDetails/detailsTable.tsx
+++ b/src/pages/awsDetails/detailsTable.tsx
@@ -228,7 +228,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
-    const showPercentage = percentage !== '0.00';
+    const showPercentage = !(percentage === 0 || percentage === '0.00');
 
     let iconOverride;
     if (showPercentage) {

--- a/src/pages/azureDetails/detailsTable.tsx
+++ b/src/pages/azureDetails/detailsTable.tsx
@@ -228,7 +228,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
-    const showPercentage = percentage !== '0.00';
+    const showPercentage = !(percentage === 0 || percentage === '0.00');
 
     let iconOverride;
     if (showPercentage) {

--- a/src/pages/ocpCloudDetails/detailsTable.tsx
+++ b/src/pages/ocpCloudDetails/detailsTable.tsx
@@ -230,7 +230,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
-    const showPercentage = percentage !== '0.00';
+    const showPercentage = !(percentage === 0 || percentage === '0.00');
 
     let iconOverride;
     if (showPercentage) {

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -305,7 +305,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
-    const showPercentage = percentage !== '0.00';
+    const showPercentage = !(percentage === 0 || percentage === '0.00');
 
     let iconOverride;
     if (showPercentage) {


### PR DESCRIPTION
Show item empty state based on percentage string

Fixes https://github.com/project-koku/koku-ui/issues/1241

<img width="971" alt="Screen Shot 2020-01-14 at 11 19 40 AM" src="https://user-images.githubusercontent.com/17481322/72362316-f5949e80-36c0-11ea-9cb8-78451efa492c.png">