### PR TITLE
feat(costmodels): add source_type sortable column to the table

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -265,6 +265,7 @@
         "desc": "Description",
         "last_modified": "Last modified",
         "name": "Name",
+        "source_type": "Source type",
         "sources": "Sources"
       }
     }

--- a/src/pages/costModelsDetails/costModelsDetails.tsx
+++ b/src/pages/costModelsDetails/costModelsDetails.tsx
@@ -160,6 +160,7 @@ class CostModelsDetails extends React.Component<Props, State> {
     const columns = [
       t('cost_models_details.table.columns.name'),
       t('cost_models_details.table.columns.desc'),
+      t('cost_models_details.table.columns.source_type'),
       t('cost_models_details.table.columns.sources'),
       t('cost_models_details.table.columns.last_modified'),
       '',

--- a/src/pages/costModelsDetails/costModelsTable.tsx
+++ b/src/pages/costModelsDetails/costModelsTable.tsx
@@ -64,6 +64,7 @@ class CostModelsTable extends React.Component<TableProps, TableState> {
             ),
           },
           row.description,
+          row.source_type,
           String(row.providers.length),
           relativeTime(row.updated_timestamp),
         ],
@@ -147,6 +148,7 @@ class CostModelsTable extends React.Component<TableProps, TableState> {
               if (
                 [
                   t('cost_models_details.table.columns.name'),
+                  t('cost_models_details.table.columns.source_type'),
                   t('cost_models_details.table.columns.last_modified'),
                 ].includes(cell)
               ) {

--- a/src/pages/costModelsDetails/sort.test.ts
+++ b/src/pages/costModelsDetails/sort.test.ts
@@ -4,7 +4,8 @@ import { costModelsTableMap, getSortByData, reverseMap } from './sort';
 test('reverseMap', () => {
   expect(reverseMap(costModelsTableMap)).toEqual({
     0: 'name',
-    3: 'updated_timestamp',
+    2: 'source_type',
+    4: 'updated_timestamp',
   });
 });
 
@@ -17,7 +18,7 @@ describe('getSortByData', () => {
   });
   test('updated_timestamp', () => {
     expect(getSortByData('updated_timestamp', costModelsTableMap)).toEqual({
-      index: 3,
+      index: 4,
       direction: SortByDirection.asc,
     });
   });

--- a/src/pages/costModelsDetails/sort.ts
+++ b/src/pages/costModelsDetails/sort.ts
@@ -1,8 +1,9 @@
 import { SortByDirection } from '@patternfly/react-table';
 
 export const costModelsTableMap = {
-  updated_timestamp: 3,
+  updated_timestamp: 4,
   name: 0,
+  source_type: 2,
 };
 
 interface SortMap {


### PR DESCRIPTION
closes #1226 

- [x] Have "Source type" column in the table
![image](https://user-images.githubusercontent.com/2453279/72388912-cbc69080-372f-11ea-90f4-e27b9b329fe8.png)

- [x] Be able to sort (asc/desc) by that attribute
![image](https://user-images.githubusercontent.com/2453279/72388937-d97c1600-372f-11ea-85c9-bcdaede86d6e.png)
