### PR TITLE
Bullet chart: Invalid prop type warning

### DIFF
--- a/src/pages/ocpCloudDetails/detailsChart.tsx
+++ b/src/pages/ocpCloudDetails/detailsChart.tsx
@@ -411,6 +411,8 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
                   labels={({ datum }) => `${datum.tooltip}`}
                   legendPosition="bottom-left"
                   legendItemsPerRow={itemsPerRow}
+                  maxDomain={!cpuReport ? 100 : undefined}
+                  minDomain={0}
                   padding={{
                     bottom: 75,
                     left: 10,
@@ -487,6 +489,8 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
                   labels={({ datum }) => `${datum.tooltip}`}
                   legendPosition="bottom-left"
                   legendItemsPerRow={itemsPerRow}
+                  maxDomain={!memoryReport ? 100 : undefined}
+                  minDomain={0}
                   padding={{
                     bottom: 75,
                     left: 10,

--- a/src/pages/ocpDetails/detailsChart.tsx
+++ b/src/pages/ocpDetails/detailsChart.tsx
@@ -415,6 +415,8 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
                   labels={({ datum }) => `${datum.tooltip}`}
                   legendPosition="bottom-left"
                   legendItemsPerRow={itemsPerRow}
+                  maxDomain={!cpuReport ? 100 : undefined}
+                  minDomain={0}
                   padding={{
                     bottom: 75,
                     left: 10,
@@ -491,6 +493,8 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
                   labels={({ datum }) => `${datum.tooltip}`}
                   legendPosition="bottom-left"
                   legendItemsPerRow={itemsPerRow}
+                  maxDomain={!memoryReport ? 100 : undefined}
+                  minDomain={0}
                   padding={{
                     bottom: 75,
                     left: 10,


### PR DESCRIPTION
The bullet chart invalid prop warning, in the browser console, is eliminated by adding a default domain.

Fixes https://github.com/project-koku/koku-ui/issues/1251