### PR TITLE
Azure details filtering localized strings

### DIFF
--- a/src/pages/azureDetails/detailsToolbar.tsx
+++ b/src/pages/azureDetails/detailsToolbar.tsx
@@ -110,13 +110,13 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       // Normalize account, region, and service filters
       switch (field) {
         case 'resource_location':
-          filterText = t('azure_details.filter.region_select');
+          filterText = t('azure_details.filter.resource_location_select');
           break;
         case 'subscription_guid':
-          filterText = t('azure_details.filter.account_select');
+          filterText = t('azure_details.filter.subscription_guid_select');
           break;
         case 'service_name':
-          filterText = t('azure_details.filter.service_select');
+          filterText = t('azure_details.filter.service_name_select');
           break;
         default:
           filterText = field;


### PR DESCRIPTION
Fixed typo with the localized strings used for Azure's filtering chips

Fixes https://github.com/project-koku/koku-ui/issues/1254

<img width="611" alt="Screen Shot 2020-01-16 at 9 01 33 AM" src="https://user-images.githubusercontent.com/17481322/72531358-4500d900-383f-11ea-959a-713156a771bb.png">
