### PR TITLE
fix(costmodel,sources): Update AZURE to Azure

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -324,7 +324,7 @@
       "caption": "Select from the following {{ type }} sources:",
       "sub_title": "Select one or more source(s) to assign to this cost model. If the source already has a cost model assigned to it, this selection will override that assignment. You can also assign sources to your cost model at a later time.",
       "title_AWS": "Assign Amazon Web Service source(s) (optional)",
-      "title_AZURE": "Assign Microsoft Azure source(s) (optional)",
+      "title_Azure": "Assign Microsoft Azure source(s) (optional)",
       "title_OCP": "Assign Red Hat OpenShift source(s) (optional)"
     },
     "source_table": {
@@ -865,7 +865,7 @@
       "title": "Confirmation status details",
       "type": {
         "AWS": "AWS",
-        "AZURE": "Microsoft Azure",
+        "Azure": "Microsoft Azure",
         "OCP": "Red Hat OpenShift",
         "title": "Type"
       }
@@ -1033,7 +1033,7 @@
     "title": "Cost management sources",
     "type": {
       "AWS": "AWS",
-      "AZURE": "Microsoft Azure",
+      "Azure": "Microsoft Azure",
       "OCP": "Red Hat OpenShift"
     }
   },


### PR DESCRIPTION
#1259 and related to https://github.com/project-koku/koku/pull/1592

We use the source type from server to translate text. Since AZURE was changed to Azure, I had to update `en.json`.