### PR TITLE
Add "no data available" text

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -527,6 +527,8 @@
     "source_settings": "Cost management sources"
   },
   "navigation_toggle": "navigation toggle",
+  "no_data_for_date": "No data available for {{startDate}} $t(months_abbr.{{month}})",
+  "no_data_for_date_plural": "No data available for {{startDate}}-{{endDate}} $t(months_abbr.{{month}})",
   "no_match_found_state": {
     "desc": "Sorry, no source with the given filter was found.",
     "title": "No match found"

--- a/src/pages/awsDetails/detailsTable.tsx
+++ b/src/pages/awsDetails/detailsTable.tsx
@@ -19,7 +19,10 @@ import { EmptyValueState } from 'components/state/emptyValueState/emptyValueStat
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
-import { getForDateRangeString } from 'utils/dateRange';
+import {
+  getForDateRangeString,
+  getNoDataForDateRangeString,
+} from 'utils/dateRange';
 import { formatCurrency } from 'utils/formatValue';
 import {
   getIdKeyForGroupBy,
@@ -228,7 +231,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
+
     const showPercentage = !(percentage === 0 || percentage === '0.00');
+    const showValue = item.deltaPercent !== null; // Workaround for https://github.com/project-koku/koku/issues/1395
 
     let iconOverride;
     if (showPercentage) {
@@ -241,43 +246,51 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       }
     }
 
-    return (
-      <div className={monthOverMonthOverride}>
-        <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-          {Boolean(showPercentage) ? (
-            t('percent', { value: percentage })
-          ) : (
-            <EmptyValueState />
-          )}
-          {Boolean(
-            showPercentage && item.deltaPercent !== null && item.deltaValue > 0
-          ) && (
-            <span
-              className={css('fa fa-sort-up', styles.infoArrow)}
-              key={`month-over-month-icon-${index}`}
-            />
-          )}
-          {Boolean(
-            showPercentage && item.deltaPercent !== null && item.deltaValue < 0
-          ) && (
-            <span
-              className={css(
-                'fa fa-sort-down',
-                styles.infoArrow,
-                styles.infoArrowDesc
-              )}
-              key={`month-over-month-icon-${index}`}
-            />
-          )}
+    if (!showValue) {
+      return getNoDataForDateRangeString();
+    } else {
+      return (
+        <div className={monthOverMonthOverride}>
+          <div className={iconOverride} key={`month-over-month-cost-${index}`}>
+            {Boolean(showPercentage) ? (
+              t('percent', { value: percentage })
+            ) : (
+              <EmptyValueState />
+            )}
+            {Boolean(
+              showPercentage &&
+                item.deltaPercent !== null &&
+                item.deltaValue > 0
+            ) && (
+              <span
+                className={css('fa fa-sort-up', styles.infoArrow)}
+                key={`month-over-month-icon-${index}`}
+              />
+            )}
+            {Boolean(
+              showPercentage &&
+                item.deltaPercent !== null &&
+                item.deltaValue < 0
+            ) && (
+              <span
+                className={css(
+                  'fa fa-sort-down',
+                  styles.infoArrow,
+                  styles.infoArrowDesc
+                )}
+                key={`month-over-month-icon-${index}`}
+              />
+            )}
+          </div>
+          <div
+            className={css(styles.infoDescription)}
+            key={`month-over-month-info-${index}`}
+          >
+            {getForDateRangeString(value)}
+          </div>
         </div>
-        <div
-          className={css(styles.infoDescription)}
-          key={`month-over-month-info-${index}`}
-        >
-          {getForDateRangeString(value)}
-        </div>
-      </div>
-    );
+      );
+    }
   };
 
   public getSortBy = () => {

--- a/src/pages/azureDetails/detailsTable.tsx
+++ b/src/pages/azureDetails/detailsTable.tsx
@@ -19,7 +19,10 @@ import { EmptyValueState } from 'components/state/emptyValueState/emptyValueStat
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
-import { getForDateRangeString } from 'utils/dateRange';
+import {
+  getForDateRangeString,
+  getNoDataForDateRangeString,
+} from 'utils/dateRange';
 import { formatCurrency } from 'utils/formatValue';
 import {
   getIdKeyForGroupBy,
@@ -228,7 +231,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
+
     const showPercentage = !(percentage === 0 || percentage === '0.00');
+    const showValue = item.deltaPercent !== null; // Workaround for https://github.com/project-koku/koku/issues/1395
 
     let iconOverride;
     if (showPercentage) {
@@ -241,43 +246,51 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       }
     }
 
-    return (
-      <div className={monthOverMonthOverride}>
-        <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-          {Boolean(showPercentage) ? (
-            t('percent', { value: percentage })
-          ) : (
-            <EmptyValueState />
-          )}
-          {Boolean(
-            showPercentage && item.deltaPercent !== null && item.deltaValue > 0
-          ) && (
-            <span
-              className={css('fa fa-sort-up', styles.infoArrow)}
-              key={`month-over-month-icon-${index}`}
-            />
-          )}
-          {Boolean(
-            showPercentage && item.deltaPercent !== null && item.deltaValue < 0
-          ) && (
-            <span
-              className={css(
-                'fa fa-sort-down',
-                styles.infoArrow,
-                styles.infoArrowDesc
-              )}
-              key={`month-over-month-icon-${index}`}
-            />
-          )}
+    if (!showValue) {
+      return getNoDataForDateRangeString();
+    } else {
+      return (
+        <div className={monthOverMonthOverride}>
+          <div className={iconOverride} key={`month-over-month-cost-${index}`}>
+            {Boolean(showPercentage) ? (
+              t('percent', { value: percentage })
+            ) : (
+              <EmptyValueState />
+            )}
+            {Boolean(
+              showPercentage &&
+                item.deltaPercent !== null &&
+                item.deltaValue > 0
+            ) && (
+              <span
+                className={css('fa fa-sort-up', styles.infoArrow)}
+                key={`month-over-month-icon-${index}`}
+              />
+            )}
+            {Boolean(
+              showPercentage &&
+                item.deltaPercent !== null &&
+                item.deltaValue < 0
+            ) && (
+              <span
+                className={css(
+                  'fa fa-sort-down',
+                  styles.infoArrow,
+                  styles.infoArrowDesc
+                )}
+                key={`month-over-month-icon-${index}`}
+              />
+            )}
+          </div>
+          <div
+            className={css(styles.infoDescription)}
+            key={`month-over-month-info-${index}`}
+          >
+            {getForDateRangeString(value)}
+          </div>
         </div>
-        <div
-          className={css(styles.infoDescription)}
-          key={`month-over-month-info-${index}`}
-        >
-          {getForDateRangeString(value)}
-        </div>
-      </div>
-    );
+      );
+    }
   };
 
   public getSortBy = () => {

--- a/src/pages/ocpCloudDetails/detailsTable.tsx
+++ b/src/pages/ocpCloudDetails/detailsTable.tsx
@@ -19,7 +19,10 @@ import { EmptyValueState } from 'components/state/emptyValueState/emptyValueStat
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
-import { getForDateRangeString } from 'utils/dateRange';
+import {
+  getForDateRangeString,
+  getNoDataForDateRangeString,
+} from 'utils/dateRange';
 import { formatCurrency } from 'utils/formatValue';
 import {
   getIdKeyForGroupBy,
@@ -230,7 +233,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
+
     const showPercentage = !(percentage === 0 || percentage === '0.00');
+    const showValue = item.deltaPercent !== null; // Workaround for https://github.com/project-koku/koku/issues/1395
 
     let iconOverride;
     if (showPercentage) {
@@ -243,43 +248,51 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       }
     }
 
-    return (
-      <div className={monthOverMonthOverride}>
-        <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-          {Boolean(showPercentage) ? (
-            t('percent', { value: percentage })
-          ) : (
-            <EmptyValueState />
-          )}
-          {Boolean(
-            showPercentage && item.deltaPercent !== null && item.deltaValue > 0
-          ) && (
-            <span
-              className={css('fa fa-sort-up', styles.infoArrow)}
-              key={`month-over-month-icon-${index}`}
-            />
-          )}
-          {Boolean(
-            showPercentage && item.deltaPercent !== null && item.deltaValue < 0
-          ) && (
-            <span
-              className={css(
-                'fa fa-sort-down',
-                styles.infoArrow,
-                styles.infoArrowDesc
-              )}
-              key={`month-over-month-icon-${index}`}
-            />
-          )}
+    if (!showValue) {
+      return getNoDataForDateRangeString();
+    } else {
+      return (
+        <div className={monthOverMonthOverride}>
+          <div className={iconOverride} key={`month-over-month-cost-${index}`}>
+            {Boolean(showPercentage) ? (
+              t('percent', { value: percentage })
+            ) : (
+              <EmptyValueState />
+            )}
+            {Boolean(
+              showPercentage &&
+                item.deltaPercent !== null &&
+                item.deltaValue > 0
+            ) && (
+              <span
+                className={css('fa fa-sort-up', styles.infoArrow)}
+                key={`month-over-month-icon-${index}`}
+              />
+            )}
+            {Boolean(
+              showPercentage &&
+                item.deltaPercent !== null &&
+                item.deltaValue < 0
+            ) && (
+              <span
+                className={css(
+                  'fa fa-sort-down',
+                  styles.infoArrow,
+                  styles.infoArrowDesc
+                )}
+                key={`month-over-month-icon-${index}`}
+              />
+            )}
+          </div>
+          <div
+            className={css(styles.infoDescription)}
+            key={`month-over-month-info-${index}`}
+          >
+            {getForDateRangeString(value)}
+          </div>
         </div>
-        <div
-          className={css(styles.infoDescription)}
-          key={`month-over-month-info-${index}`}
-        >
-          {getForDateRangeString(value)}
-        </div>
-      </div>
-    );
+      );
+    }
   };
 
   private getSortBy = () => {

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -19,7 +19,10 @@ import { EmptyValueState } from 'components/state/emptyValueState/emptyValueStat
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
-import { getForDateRangeString } from 'utils/dateRange';
+import {
+  getForDateRangeString,
+  getNoDataForDateRangeString,
+} from 'utils/dateRange';
 import { formatCurrency } from 'utils/formatValue';
 import {
   getIdKeyForGroupBy,
@@ -305,7 +308,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
     const percentage =
       item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
+
     const showPercentage = !(percentage === 0 || percentage === '0.00');
+    const showValue = item.deltaPercent !== null; // Workaround for https://github.com/project-koku/koku/issues/1395
 
     let iconOverride;
     if (showPercentage) {
@@ -318,43 +323,51 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       }
     }
 
-    return (
-      <div className={monthOverMonthOverride}>
-        <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-          {Boolean(showPercentage) ? (
-            t('percent', { value: percentage })
-          ) : (
-            <EmptyValueState />
-          )}
-          {Boolean(
-            showPercentage && item.deltaPercent !== null && item.deltaValue > 0
-          ) && (
-            <span
-              className={css('fa fa-sort-up', styles.infoArrow)}
-              key={`month-over-month-icon-${index}`}
-            />
-          )}
-          {Boolean(
-            showPercentage && item.deltaPercent !== null && item.deltaValue < 0
-          ) && (
-            <span
-              className={css(
-                'fa fa-sort-down',
-                styles.infoArrow,
-                styles.infoArrowDesc
-              )}
-              key={`month-over-month-icon-${index}`}
-            />
-          )}
+    if (!showValue) {
+      return getNoDataForDateRangeString();
+    } else {
+      return (
+        <div className={monthOverMonthOverride}>
+          <div className={iconOverride} key={`month-over-month-cost-${index}`}>
+            {Boolean(showPercentage) ? (
+              t('percent', { value: percentage })
+            ) : (
+              <EmptyValueState />
+            )}
+            {Boolean(
+              showPercentage &&
+                item.deltaPercent !== null &&
+                item.deltaValue > 0
+            ) && (
+              <span
+                className={css('fa fa-sort-up', styles.infoArrow)}
+                key={`month-over-month-icon-${index}`}
+              />
+            )}
+            {Boolean(
+              showPercentage &&
+                item.deltaPercent !== null &&
+                item.deltaValue < 0
+            ) && (
+              <span
+                className={css(
+                  'fa fa-sort-down',
+                  styles.infoArrow,
+                  styles.infoArrowDesc
+                )}
+                key={`month-over-month-icon-${index}`}
+              />
+            )}
+          </div>
+          <div
+            className={css(styles.infoDescription)}
+            key={`month-over-month-info-${index}`}
+          >
+            {getForDateRangeString(value)}
+          </div>
         </div>
-        <div
-          className={css(styles.infoDescription)}
-          key={`month-over-month-info-${index}`}
-        >
-          {getForDateRangeString(value)}
-        </div>
-      </div>
-    );
+      );
+    }
   };
 
   private getSortBy = () => {

--- a/src/utils/dateRange.ts
+++ b/src/utils/dateRange.ts
@@ -4,6 +4,27 @@ import getMonth from 'date-fns/get_month';
 import startOfMonth from 'date-fns/start_of_month';
 import i18next from 'i18next';
 
+export function getNoDataForDateRangeString(
+  key: string = 'no_data_for_date',
+  offset: number = 1
+) {
+  const today = new Date();
+  if (offset) {
+    today.setMonth(today.getMonth() - offset);
+  }
+
+  const month = getMonth(today);
+  const endDate = formatDate(today, 'D');
+  const startDate = formatDate(startOfMonth(today), 'D');
+
+  return i18next.t(key, {
+    count: getDate(today),
+    endDate,
+    month,
+    startDate,
+  });
+}
+
 export function getForDateRangeString(
   value: string | number,
   key: string = 'for_date',


### PR DESCRIPTION
When the "month over month change" delta is null, we want to show "No data available for 1-20 Dec", instead of "$0.00 for 1-20 Dec".

Azure
![Screen Shot 2020-01-20 at 1 25 22 PM](https://user-images.githubusercontent.com/17481322/72749841-1f4e3980-3b89-11ea-9377-7c51e33e78f0.png)

Ocp details
![Screen Shot 2020-01-20 at 1 24 40 PM](https://user-images.githubusercontent.com/17481322/72749851-25dcb100-3b89-11ea-9bce-eb19f3a20029.png)
