### PR TITLE
Added webpack stats target

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "precommit": "lint-staged",
     "start": "webpack-dev-server",
     "start:dev": "APP_ENV=proxy yarn start",
+    "stats": "webpack --mode production --profile --json > stats.json",
     "test": "jest",
     "container:test": "docker stop -t 0 koku-ui-test >/dev/null; docker build -t koku-ui-test . && docker run -i --rm -p 8080:8080 --name koku-ui-test koku-ui-test",
     "insights:proxy": "docker stop -t 0 insightsproxy >/dev/null; docker run -e LOCAL_CHROME -e PLATFORM -e PORT -e LOCAL_API -e SPANDX_HOST -e SPANDX_PORT --rm -t --name insightsproxy -p 1337:1337 docker.io/redhatinsights/insights-proxy",


### PR DESCRIPTION
Added webpack stats target to view package structure. 

The generated stats file can be viewed below
http://chrisbateman.github.io/webpack-visualizer/