### PR TITLE
fix(costmodels): kebab option stays on the right corner if desc long

### DIFF
--- a/src/pages/costModelsDetails/costModelInfo/header.tsx
+++ b/src/pages/costModelsDetails/costModelInfo/header.tsx
@@ -3,10 +3,10 @@ import {
   BreadcrumbItem,
   Button,
   DropdownItem,
-  Flex,
-  FlexItem,
   List,
   ListItem,
+  Split,
+  SplitItem,
   Tab,
   Tabs,
   Title,
@@ -115,8 +115,8 @@ class Header extends React.Component<Props> {
             </BreadcrumbItem>
             <BreadcrumbItem isActive>{current.name}</BreadcrumbItem>
           </Breadcrumb>
-          <Flex className="pf-m-justify-content-space-between example-border">
-            <FlexItem>
+          <Split>
+            <SplitItem>
               <Title className={css(styles.title)} size="2xl">
                 {current.name}
               </Title>
@@ -175,8 +175,8 @@ class Header extends React.Component<Props> {
                   />
                 </Tabs>
               )}
-            </FlexItem>
-            <FlexItem>
+            </SplitItem>
+            <SplitItem>
               <Dropdown
                 isPlain
                 position="right"
@@ -206,8 +206,8 @@ class Header extends React.Component<Props> {
                   </DropdownItem>,
                 ]}
               />
-            </FlexItem>
-          </Flex>
+            </SplitItem>
+          </Split>
         </header>
       </>
     );


### PR DESCRIPTION
bugfix #1257 

Replace the `Flex` layout by `Split` to make sure the kebab option and the description are going to be on the same row.

![image](https://user-images.githubusercontent.com/2453279/72782661-fd0df780-3c2c-11ea-81b7-462c2368f495.png)
