### PR TITLE
Bullet chart: Invalid prop domain

### DIFF
--- a/src/api/awsQuery.ts
+++ b/src/api/awsQuery.ts
@@ -1,5 +1,5 @@
 import { parse, stringify } from 'qs';
-import { Query } from './query';
+import { groupByAnd, Query, tagKey } from './query';
 
 export interface AwsFilters {
   account?: string | number;
@@ -35,9 +35,6 @@ export interface AwsQuery extends Query {
   order_by?: AwsOrderBys;
   key_only?: boolean;
 }
-
-const groupByAnd = 'and:';
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 // Adds logical AND to group_by -- https://github.com/project-koku/koku-ui/issues/704
 export function getLogicalAnd(query: AwsQuery) {

--- a/src/api/azureQuery.ts
+++ b/src/api/azureQuery.ts
@@ -1,5 +1,5 @@
 import { parse, stringify } from 'qs';
-import { Query } from './query';
+import { groupByAnd, Query, tagKey } from './query';
 
 export interface AzureFilters {
   subscription_guid?: string | number;
@@ -35,9 +35,6 @@ export interface AzureQuery extends Query {
   order_by?: AzureOrderBys;
   key_only?: boolean;
 }
-
-const groupByAnd = 'and:';
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 // Adds logical AND to group_by -- https://github.com/project-koku/koku-ui/issues/704
 export function getLogicalAnd(query: AzureQuery) {

--- a/src/api/ocpCloudQuery.ts
+++ b/src/api/ocpCloudQuery.ts
@@ -1,5 +1,5 @@
 import { parse, stringify } from 'qs';
-import { Query } from './query';
+import { groupByAnd, Query, tagKey } from './query';
 
 export interface OcpCloudFilters {
   limit?: number;
@@ -36,9 +36,6 @@ export interface OcpCloudQuery extends Query {
   order_by?: OcpCloudOrderBys;
   key_only?: boolean;
 }
-
-const groupByAnd = 'and:';
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 // Adds logical AND to group_by -- https://github.com/project-koku/koku-ui/issues/704
 export function getLogicalAnd(query: OcpCloudQuery) {

--- a/src/api/ocpQuery.ts
+++ b/src/api/ocpQuery.ts
@@ -1,5 +1,5 @@
 import { parse, stringify } from 'qs';
-import { Query } from './query';
+import { groupByAnd, Query, tagKey } from './query';
 
 export interface OcpFilters {
   limit?: number;
@@ -33,9 +33,6 @@ export interface OcpQuery extends Query {
   order_by?: OcpOrderBys;
   key_only?: boolean;
 }
-
-const groupByAnd = 'and:';
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 // Adds logical AND to group_by -- https://github.com/project-koku/koku-ui/issues/704
 export function getLogicalAnd(query: OcpQuery) {

--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -1,5 +1,8 @@
 type FilterByValue = string | string[];
 
+export const groupByAnd = 'and:';
+export const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
+
 interface FilterBys {
   tag?: FilterByValue;
 }

--- a/src/components/details/detailsDataToolbar.tsx
+++ b/src/components/details/detailsDataToolbar.tsx
@@ -25,7 +25,7 @@ import {
   SearchIcon,
 } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
-import { Query } from 'api/query';
+import { Query, tagKey } from 'api/query';
 import { cloneDeep } from 'lodash';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -68,7 +68,6 @@ interface DetailsDataToolbarState {
 type DetailsDataToolbarProps = DetailsDataToolbarOwnProps &
   InjectedTranslateProps;
 
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 const defaultFilters = {
   tag: {},
 };

--- a/src/pages/awsDetails/awsDetails.tsx
+++ b/src/pages/awsDetails/awsDetails.tsx
@@ -4,6 +4,7 @@ import { AwsQuery, getQuery, getQueryRoute, parseQuery } from 'api/awsQuery';
 import { AwsReport, AwsReportType } from 'api/awsReports';
 import { Providers, ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/providersQuery';
+import { tagKey } from 'api/query';
 import { AxiosError } from 'axios';
 import { ErrorState } from 'components/state/errorState/errorState';
 import { LoadingState } from 'components/state/loadingState/loadingState';
@@ -73,8 +74,6 @@ const baseQuery: AwsQuery = {
     cost: 'desc',
   },
 };
-
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 class AwsDetails extends React.Component<AwsDetailsProps> {
   protected defaultState: AwsDetailsState = {

--- a/src/pages/awsDetails/detailsTable.tsx
+++ b/src/pages/awsDetails/detailsTable.tsx
@@ -14,6 +14,7 @@ import {
 } from '@patternfly/react-table';
 import { AwsQuery, getQuery } from 'api/awsQuery';
 import { AwsReport } from 'api/awsReports';
+import { tagKey } from 'api/query';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
@@ -52,8 +53,6 @@ interface DetailsTableState {
 }
 
 type DetailsTableProps = DetailsTableOwnProps & InjectedTranslateProps;
-
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 class DetailsTableBase extends React.Component<DetailsTableProps> {
   public state: DetailsTableState = {

--- a/src/pages/awsDetails/exportModal.tsx
+++ b/src/pages/awsDetails/exportModal.tsx
@@ -10,6 +10,7 @@ import {
 import { css } from '@patternfly/react-styles';
 import { AwsQuery, getQuery } from 'api/awsQuery';
 import { AwsReportType } from 'api/awsReports';
+import { tagKey } from 'api/query';
 import { AxiosError } from 'axios';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -57,8 +58,6 @@ const resolutionOptions: {
   { label: 'Daily', value: 'daily' },
   { label: 'Monthly', value: 'monthly' },
 ];
-
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 export class ExportModalBase extends React.Component<
   ExportModalProps,

--- a/src/pages/awsDetails/groupBy.tsx
+++ b/src/pages/awsDetails/groupBy.tsx
@@ -3,6 +3,7 @@ import { css } from '@patternfly/react-styles';
 import { AwsQuery, getQuery } from 'api/awsQuery';
 import { parseQuery } from 'api/awsQuery';
 import { AwsReport, AwsReportType } from 'api/awsReports';
+import { tagKey } from 'api/query';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -47,8 +48,6 @@ const groupByOptions: {
 ];
 
 const reportType = AwsReportType.tag;
-
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 class GroupByBase extends React.Component<GroupByProps> {
   protected defaultState: GroupByState = {

--- a/src/pages/azureDetails/azureDetails.tsx
+++ b/src/pages/azureDetails/azureDetails.tsx
@@ -9,6 +9,7 @@ import {
 import { AzureReport, AzureReportType } from 'api/azureReports';
 import { Providers, ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/providersQuery';
+import { tagKey } from 'api/query';
 import { AxiosError } from 'axios';
 import { ErrorState } from 'components/state/errorState/errorState';
 import { LoadingState } from 'components/state/loadingState/loadingState';
@@ -78,8 +79,6 @@ const baseQuery: AzureQuery = {
     cost: 'desc',
   },
 };
-
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 class AzureDetails extends React.Component<AzureDetailsProps> {
   protected defaultState: AzureDetailsState = {

--- a/src/pages/azureDetails/detailsTable.tsx
+++ b/src/pages/azureDetails/detailsTable.tsx
@@ -14,6 +14,7 @@ import {
 } from '@patternfly/react-table';
 import { AzureQuery, getQuery } from 'api/azureQuery';
 import { AzureReport } from 'api/azureReports';
+import { tagKey } from 'api/query';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
@@ -52,8 +53,6 @@ interface DetailsTableState {
 }
 
 type DetailsTableProps = DetailsTableOwnProps & InjectedTranslateProps;
-
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 class DetailsTableBase extends React.Component<DetailsTableProps> {
   public state: DetailsTableState = {

--- a/src/pages/azureDetails/exportModal.tsx
+++ b/src/pages/azureDetails/exportModal.tsx
@@ -10,6 +10,7 @@ import {
 import { css } from '@patternfly/react-styles';
 import { AzureQuery, getQuery } from 'api/azureQuery';
 import { AzureReportType } from 'api/azureReports';
+import { tagKey } from 'api/query';
 import { AxiosError } from 'axios';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -57,8 +58,6 @@ const resolutionOptions: {
   { label: 'Daily', value: 'daily' },
   { label: 'Monthly', value: 'monthly' },
 ];
-
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 export class ExportModalBase extends React.Component<
   ExportModalProps,

--- a/src/pages/azureDetails/groupBy.tsx
+++ b/src/pages/azureDetails/groupBy.tsx
@@ -3,6 +3,7 @@ import { css } from '@patternfly/react-styles';
 import { AzureQuery, getQuery } from 'api/azureQuery';
 import { parseQuery } from 'api/azureQuery';
 import { AzureReport, AzureReportType } from 'api/azureReports';
+import { tagKey } from 'api/query';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -47,8 +48,6 @@ const groupByOptions: {
 ];
 
 const reportType = AzureReportType.tag;
-
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 class GroupByBase extends React.Component<GroupByProps> {
   protected defaultState: GroupByState = {

--- a/src/pages/ocpCloudDetails/detailsChart.tsx
+++ b/src/pages/ocpCloudDetails/detailsChart.tsx
@@ -278,6 +278,97 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
     return datum;
   }
 
+  private getCpuChart = () => {
+    const { cpuReportFetchStatus, cpuReport, groupBy, t } = this.props;
+    const { width } = this.state;
+
+    const cpuDatum =
+      groupBy === 'cluster'
+        ? this.getChartDatumWithCapacity(cpuReport, 'cpu')
+        : this.getChartDatum(cpuReport, 'cpu');
+
+    if (!cpuReport || cpuDatum.usage.length === 0) {
+      return null;
+    }
+
+    return (
+      <div>
+        {cpuReportFetchStatus === FetchStatus.inProgress ? (
+          this.getSkeleton()
+        ) : (
+          <>
+            <ChartBullet
+              comparativeErrorMeasureData={
+                cpuDatum.limit.value
+                  ? [
+                      {
+                        tooltip: cpuDatum.limit.tooltip,
+                        y: cpuDatum.limit.value,
+                      },
+                    ]
+                  : []
+              }
+              comparativeErrorMeasureLegendData={
+                cpuDatum.limit.value ? [{ name: cpuDatum.limit.legend }] : []
+              }
+              height={200}
+              labels={({ datum }) => `${datum.tooltip}`}
+              legendPosition="bottom-left"
+              legendItemsPerRow={this.getItemsPerRow()}
+              maxDomain={this.isDatumEmpty(cpuDatum) ? 100 : undefined}
+              minDomain={0}
+              padding={{
+                bottom: 75,
+                left: 10,
+                right: 50,
+                top: 50,
+              }}
+              primarySegmentedMeasureData={
+                cpuDatum.usage.length
+                  ? cpuDatum.usage.map(datum => {
+                      return {
+                        tooltip: datum.tooltip,
+                        y: datum.value,
+                      };
+                    })
+                  : []
+              }
+              primarySegmentedMeasureLegendData={
+                cpuDatum.usage.length
+                  ? cpuDatum.usage.map(datum => {
+                      return {
+                        name: datum.legend,
+                      };
+                    })
+                  : []
+              }
+              qualitativeRangeData={
+                cpuDatum.ranges.length
+                  ? [
+                      {
+                        tooltip: cpuDatum.ranges[0].tooltip,
+                        y: cpuDatum.ranges[0].value,
+                      },
+                    ]
+                  : []
+              }
+              qualitativeRangeLegendData={
+                cpuDatum.ranges.length
+                  ? [{ name: cpuDatum.ranges[0].legend }]
+                  : []
+              }
+              title={t('ocp_details.bullet.cpu_label')}
+              titlePosition="top-left"
+              width={width}
+            />
+            {Boolean(groupBy === 'cluster') &&
+              this.getFreeSpace(cpuReport, 'cpu')}
+          </>
+        )}
+      </div>
+    );
+  };
+
   private getFreeSpace(report: OcpCloudReport, labelKey: string) {
     const { t } = this.props;
     const hasTotal = report && report.meta && report.meta.total;
@@ -348,6 +439,104 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
     );
   }
 
+  private getItemsPerRow = () => {
+    const { width } = this.state;
+    return width > 600 ? 3 : width > 450 ? 2 : 1;
+  };
+
+  private getMemoryChart = () => {
+    const { memoryReportFetchStatus, memoryReport, groupBy, t } = this.props;
+    const { width } = this.state;
+
+    const memoryDatum =
+      groupBy === 'cluster'
+        ? this.getChartDatumWithCapacity(memoryReport, 'memory')
+        : this.getChartDatum(memoryReport, 'memory');
+
+    if (!memoryReport || memoryDatum.usage.length === 0) {
+      return null;
+    }
+
+    return (
+      <div>
+        {memoryReportFetchStatus === FetchStatus.inProgress ? (
+          this.getSkeleton()
+        ) : (
+          <>
+            <ChartBullet
+              comparativeErrorMeasureData={
+                memoryDatum.limit.value
+                  ? [
+                      {
+                        tooltip: memoryDatum.limit.tooltip,
+                        y: memoryDatum.limit.value,
+                      },
+                    ]
+                  : []
+              }
+              comparativeErrorMeasureLegendData={
+                memoryDatum.limit.value
+                  ? [{ name: memoryDatum.limit.legend }]
+                  : []
+              }
+              height={200}
+              labels={({ datum }) => `${datum.tooltip}`}
+              legendPosition="bottom-left"
+              legendItemsPerRow={this.getItemsPerRow()}
+              maxDomain={this.isDatumEmpty(memoryDatum) ? 100 : undefined}
+              minDomain={0}
+              padding={{
+                bottom: 75,
+                left: 10,
+                right: 50,
+                top: 50,
+              }}
+              primarySegmentedMeasureData={
+                memoryDatum.usage.length
+                  ? memoryDatum.usage.map(datum => {
+                      return {
+                        tooltip: datum.tooltip,
+                        y: datum.value,
+                      };
+                    })
+                  : []
+              }
+              primarySegmentedMeasureLegendData={
+                memoryDatum.usage.length
+                  ? memoryDatum.usage.map(datum => {
+                      return {
+                        name: datum.legend,
+                      };
+                    })
+                  : []
+              }
+              qualitativeRangeData={
+                memoryDatum.ranges.length
+                  ? [
+                      {
+                        tooltip: memoryDatum.ranges[0].tooltip,
+                        y: memoryDatum.ranges[0].value,
+                      },
+                    ]
+                  : []
+              }
+              qualitativeRangeLegendData={
+                memoryDatum.ranges.length
+                  ? [{ name: memoryDatum.ranges[0].legend }]
+                  : []
+              }
+              title={t('ocp_details.bullet.memory_label')}
+              titlePosition="top-left"
+              width={width}
+            />
+            {Boolean(groupBy === 'cluster') &&
+              this.getFreeSpace(memoryReport, 'memory')}
+          </>
+        )}
+      </div>
+    );
+  };
+
   private getSkeleton = () => {
     return (
       <>
@@ -363,184 +552,29 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
     );
   };
 
-  public render() {
-    const {
-      cpuReport,
-      cpuReportFetchStatus,
-      groupBy,
-      memoryReport,
-      memoryReportFetchStatus,
-      t,
-    } = this.props;
-    const { width } = this.state;
-    const cpuDatum =
-      groupBy === 'cluster'
-        ? this.getChartDatumWithCapacity(cpuReport, 'cpu')
-        : this.getChartDatum(cpuReport, 'cpu');
-    const memoryDatum =
-      groupBy === 'cluster'
-        ? this.getChartDatumWithCapacity(memoryReport, 'memory')
-        : this.getChartDatum(memoryReport, 'memory');
-    const itemsPerRow = width > 600 ? 3 : width > 450 ? 2 : 1;
+  private isDatumEmpty = (datum: ChartDatum) => {
+    let hasRange = false;
+    for (const range of datum.ranges) {
+      if (range.value) {
+        hasRange = true;
+        break;
+      }
+    }
+    let hasUsage = false;
+    for (const usage of datum.usage) {
+      if (usage.value) {
+        hasUsage = true;
+        break;
+      }
+    }
+    return !(datum.limit.value || hasRange || hasUsage);
+  };
 
+  public render() {
     return (
       <div ref={this.containerRef}>
-        {Boolean(cpuDatum && cpuDatum.usage.length) && (
-          <div>
-            {cpuReportFetchStatus === FetchStatus.inProgress ? (
-              this.getSkeleton()
-            ) : (
-              <>
-                <ChartBullet
-                  comparativeErrorMeasureData={
-                    cpuDatum.limit.value
-                      ? [
-                          {
-                            tooltip: cpuDatum.limit.tooltip,
-                            y: cpuDatum.limit.value,
-                          },
-                        ]
-                      : []
-                  }
-                  comparativeErrorMeasureLegendData={
-                    cpuDatum.limit.value
-                      ? [{ name: cpuDatum.limit.legend }]
-                      : []
-                  }
-                  height={200}
-                  labels={({ datum }) => `${datum.tooltip}`}
-                  legendPosition="bottom-left"
-                  legendItemsPerRow={itemsPerRow}
-                  maxDomain={!cpuReport ? 100 : undefined}
-                  minDomain={0}
-                  padding={{
-                    bottom: 75,
-                    left: 10,
-                    right: 50,
-                    top: 50,
-                  }}
-                  primarySegmentedMeasureData={
-                    cpuDatum.usage.length
-                      ? cpuDatum.usage.map(datum => {
-                          return {
-                            tooltip: datum.tooltip,
-                            y: datum.value,
-                          };
-                        })
-                      : []
-                  }
-                  primarySegmentedMeasureLegendData={
-                    cpuDatum.usage.length
-                      ? cpuDatum.usage.map(datum => {
-                          return {
-                            name: datum.legend,
-                          };
-                        })
-                      : []
-                  }
-                  qualitativeRangeData={
-                    cpuDatum.ranges.length
-                      ? [
-                          {
-                            tooltip: cpuDatum.ranges[0].tooltip,
-                            y: cpuDatum.ranges[0].value,
-                          },
-                        ]
-                      : []
-                  }
-                  qualitativeRangeLegendData={
-                    cpuDatum.ranges.length
-                      ? [{ name: cpuDatum.ranges[0].legend }]
-                      : []
-                  }
-                  title={t('ocp_details.bullet.cpu_label')}
-                  titlePosition="top-left"
-                  width={width}
-                />
-                {Boolean(groupBy === 'cluster') &&
-                  this.getFreeSpace(cpuReport, 'cpu')}
-              </>
-            )}
-          </div>
-        )}
-        {Boolean(memoryDatum && memoryDatum.usage.length) && (
-          <div>
-            {memoryReportFetchStatus === FetchStatus.inProgress ? (
-              this.getSkeleton()
-            ) : (
-              <>
-                <ChartBullet
-                  comparativeErrorMeasureData={
-                    memoryDatum.limit.value
-                      ? [
-                          {
-                            tooltip: memoryDatum.limit.tooltip,
-                            y: memoryDatum.limit.value,
-                          },
-                        ]
-                      : []
-                  }
-                  comparativeErrorMeasureLegendData={
-                    memoryDatum.limit.value
-                      ? [{ name: memoryDatum.limit.legend }]
-                      : []
-                  }
-                  height={200}
-                  labels={({ datum }) => `${datum.tooltip}`}
-                  legendPosition="bottom-left"
-                  legendItemsPerRow={itemsPerRow}
-                  maxDomain={!memoryReport ? 100 : undefined}
-                  minDomain={0}
-                  padding={{
-                    bottom: 75,
-                    left: 10,
-                    right: 50,
-                    top: 50,
-                  }}
-                  primarySegmentedMeasureData={
-                    memoryDatum.usage.length
-                      ? memoryDatum.usage.map(datum => {
-                          return {
-                            tooltip: datum.tooltip,
-                            y: datum.value,
-                          };
-                        })
-                      : []
-                  }
-                  primarySegmentedMeasureLegendData={
-                    memoryDatum.usage.length
-                      ? memoryDatum.usage.map(datum => {
-                          return {
-                            name: datum.legend,
-                          };
-                        })
-                      : []
-                  }
-                  qualitativeRangeData={
-                    memoryDatum.ranges.length
-                      ? [
-                          {
-                            tooltip: memoryDatum.ranges[0].tooltip,
-                            y: memoryDatum.ranges[0].value,
-                          },
-                        ]
-                      : []
-                  }
-                  qualitativeRangeLegendData={
-                    memoryDatum.ranges.length
-                      ? [{ name: memoryDatum.ranges[0].legend }]
-                      : []
-                  }
-                  title={t('ocp_details.bullet.memory_label')}
-                  titlePosition="top-left"
-                  width={width}
-                />
-                {Boolean(groupBy === 'cluster') &&
-                  this.getFreeSpace(memoryReport, 'memory')}
-              </>
-            )}
-          </div>
-        )}
+        {this.getCpuChart()}
+        {this.getMemoryChart()}
       </div>
     );
   }

--- a/src/pages/ocpCloudDetails/detailsTable.tsx
+++ b/src/pages/ocpCloudDetails/detailsTable.tsx
@@ -14,6 +14,7 @@ import {
 } from '@patternfly/react-table';
 import { getQuery, OcpCloudQuery } from 'api/ocpCloudQuery';
 import { OcpCloudReport } from 'api/ocpCloudReports';
+import { tagKey } from 'api/query';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
@@ -52,8 +53,6 @@ interface DetailsTableState {
 }
 
 type DetailsTableProps = DetailsTableOwnProps & InjectedTranslateProps;
-
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 class DetailsTableBase extends React.Component<DetailsTableProps> {
   public state: DetailsTableState = {

--- a/src/pages/ocpCloudDetails/exportModal.tsx
+++ b/src/pages/ocpCloudDetails/exportModal.tsx
@@ -10,6 +10,7 @@ import {
 import { css } from '@patternfly/react-styles';
 import { getQuery, OcpCloudQuery } from 'api/ocpCloudQuery';
 import { OcpCloudReportType } from 'api/ocpCloudReports';
+import { tagKey } from 'api/query';
 import { AxiosError } from 'axios';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -60,8 +61,6 @@ const resolutionOptions: {
   { label: 'Daily', value: 'daily' },
   { label: 'Monthly', value: 'monthly' },
 ];
-
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 export class ExportModalBase extends React.Component<
   ExportModalProps,

--- a/src/pages/ocpCloudDetails/groupBy.tsx
+++ b/src/pages/ocpCloudDetails/groupBy.tsx
@@ -3,6 +3,7 @@ import { css } from '@patternfly/react-styles';
 import { getQuery, OcpCloudQuery } from 'api/ocpCloudQuery';
 import { parseQuery } from 'api/ocpCloudQuery';
 import { OcpCloudReport, OcpCloudReportType } from 'api/ocpCloudReports';
+import { tagKey } from 'api/query';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -50,8 +51,6 @@ const groupByOptions: {
 ];
 
 const reportType = OcpCloudReportType.tag;
-
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 class GroupByBase extends React.Component<GroupByProps> {
   protected defaultState: GroupByState = {

--- a/src/pages/ocpCloudDetails/ocpCloudDetails.tsx
+++ b/src/pages/ocpCloudDetails/ocpCloudDetails.tsx
@@ -9,6 +9,7 @@ import {
 import { OcpCloudReport, OcpCloudReportType } from 'api/ocpCloudReports';
 import { Providers, ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/providersQuery';
+import { tagKey } from 'api/query';
 import { AxiosError } from 'axios';
 import { ErrorState } from 'components/state/errorState/errorState';
 import { LoadingState } from 'components/state/loadingState/loadingState';
@@ -64,8 +65,6 @@ type OcpCloudDetailsProps = OcpCloudDetailsStateProps &
   OcpCloudDetailsDispatchProps;
 
 const reportType = OcpCloudReportType.cost;
-
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 const baseQuery: OcpCloudQuery = {
   delta: 'cost',

--- a/src/pages/ocpDetails/detailsActions.tsx
+++ b/src/pages/ocpDetails/detailsActions.tsx
@@ -1,5 +1,6 @@
 import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
 import { OcpQuery } from 'api/ocpQuery';
+import { tagKey } from 'api/query';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { ComputedOcpReportItem } from 'utils/getComputedOcpReportItems';
@@ -25,8 +26,6 @@ interface DetailsActionsState {
 }
 
 type DetailsActionsProps = DetailsActionsOwnProps & InjectedTranslateProps;
-
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 class DetailsActionsBase extends React.Component<DetailsActionsProps> {
   protected defaultState: DetailsActionsState = {

--- a/src/pages/ocpDetails/detailsChart.tsx
+++ b/src/pages/ocpDetails/detailsChart.tsx
@@ -273,6 +273,97 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
     return datum;
   }
 
+  private getCpuChart = () => {
+    const { cpuReportFetchStatus, cpuReport, groupBy, t } = this.props;
+    const { width } = this.state;
+
+    const cpuDatum =
+      groupBy === 'cluster'
+        ? this.getChartDatumWithCapacity(cpuReport, 'cpu')
+        : this.getChartDatum(cpuReport, 'cpu');
+
+    if (!cpuReport || cpuDatum.usage.length === 0) {
+      return null;
+    }
+
+    return (
+      <div>
+        {cpuReportFetchStatus === FetchStatus.inProgress ? (
+          this.getSkeleton()
+        ) : (
+          <>
+            <ChartBullet
+              comparativeErrorMeasureData={
+                cpuDatum.limit.value
+                  ? [
+                      {
+                        tooltip: cpuDatum.limit.tooltip,
+                        y: cpuDatum.limit.value,
+                      },
+                    ]
+                  : []
+              }
+              comparativeErrorMeasureLegendData={
+                cpuDatum.limit.value ? [{ name: cpuDatum.limit.legend }] : []
+              }
+              height={200}
+              labels={({ datum }) => `${datum.tooltip}`}
+              legendPosition="bottom-left"
+              legendItemsPerRow={this.getItemsPerRow()}
+              maxDomain={this.isDatumEmpty(cpuDatum) ? 100 : undefined}
+              minDomain={0}
+              padding={{
+                bottom: 75,
+                left: 10,
+                right: 50,
+                top: 50,
+              }}
+              primarySegmentedMeasureData={
+                cpuDatum.usage.length
+                  ? cpuDatum.usage.map(datum => {
+                      return {
+                        tooltip: datum.tooltip,
+                        y: datum.value,
+                      };
+                    })
+                  : []
+              }
+              primarySegmentedMeasureLegendData={
+                cpuDatum.usage.length
+                  ? cpuDatum.usage.map(datum => {
+                      return {
+                        name: datum.legend,
+                      };
+                    })
+                  : []
+              }
+              qualitativeRangeData={
+                cpuDatum.ranges.length
+                  ? [
+                      {
+                        tooltip: cpuDatum.ranges[0].tooltip,
+                        y: cpuDatum.ranges[0].value,
+                      },
+                    ]
+                  : []
+              }
+              qualitativeRangeLegendData={
+                cpuDatum.ranges.length
+                  ? [{ name: cpuDatum.ranges[0].legend }]
+                  : []
+              }
+              title={t('ocp_details.bullet.cpu_label')}
+              titlePosition="top-left"
+              width={width}
+            />
+            {Boolean(groupBy === 'cluster') &&
+              this.getFreeSpace(cpuReport, 'cpu')}
+          </>
+        )}
+      </div>
+    );
+  };
+
   private getFreeSpace(report: OcpReport, labelKey: string) {
     const { t } = this.props;
     const hasTotal = report && report.meta && report.meta.total;
@@ -352,6 +443,104 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
     );
   }
 
+  private getItemsPerRow = () => {
+    const { width } = this.state;
+    return width > 600 ? 3 : width > 450 ? 2 : 1;
+  };
+
+  private getMemoryChart = () => {
+    const { memoryReportFetchStatus, memoryReport, groupBy, t } = this.props;
+    const { width } = this.state;
+
+    const memoryDatum =
+      groupBy === 'cluster'
+        ? this.getChartDatumWithCapacity(memoryReport, 'memory')
+        : this.getChartDatum(memoryReport, 'memory');
+
+    if (!memoryReport || memoryDatum.usage.length === 0) {
+      return null;
+    }
+
+    return (
+      <div>
+        {memoryReportFetchStatus === FetchStatus.inProgress ? (
+          this.getSkeleton()
+        ) : (
+          <>
+            <ChartBullet
+              comparativeErrorMeasureData={
+                memoryDatum.limit.value
+                  ? [
+                      {
+                        tooltip: memoryDatum.limit.tooltip,
+                        y: memoryDatum.limit.value,
+                      },
+                    ]
+                  : []
+              }
+              comparativeErrorMeasureLegendData={
+                memoryDatum.limit.value
+                  ? [{ name: memoryDatum.limit.legend }]
+                  : []
+              }
+              height={200}
+              labels={({ datum }) => `${datum.tooltip}`}
+              legendPosition="bottom-left"
+              legendItemsPerRow={this.getItemsPerRow()}
+              maxDomain={this.isDatumEmpty(memoryDatum) ? 100 : undefined}
+              minDomain={0}
+              padding={{
+                bottom: 75,
+                left: 10,
+                right: 50,
+                top: 50,
+              }}
+              primarySegmentedMeasureData={
+                memoryDatum.usage.length
+                  ? memoryDatum.usage.map(datum => {
+                      return {
+                        tooltip: datum.tooltip,
+                        y: datum.value,
+                      };
+                    })
+                  : []
+              }
+              primarySegmentedMeasureLegendData={
+                memoryDatum.usage.length
+                  ? memoryDatum.usage.map(datum => {
+                      return {
+                        name: datum.legend,
+                      };
+                    })
+                  : []
+              }
+              qualitativeRangeData={
+                memoryDatum.ranges.length
+                  ? [
+                      {
+                        tooltip: memoryDatum.ranges[0].tooltip,
+                        y: memoryDatum.ranges[0].value,
+                      },
+                    ]
+                  : []
+              }
+              qualitativeRangeLegendData={
+                memoryDatum.ranges.length
+                  ? [{ name: memoryDatum.ranges[0].legend }]
+                  : []
+              }
+              title={t('ocp_details.bullet.memory_label')}
+              titlePosition="top-left"
+              width={width}
+            />
+            {Boolean(groupBy === 'cluster') &&
+              this.getFreeSpace(memoryReport, 'memory')}
+          </>
+        )}
+      </div>
+    );
+  };
+
   private getSkeleton = () => {
     return (
       <>
@@ -367,184 +556,29 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
     );
   };
 
-  public render() {
-    const {
-      cpuReport,
-      cpuReportFetchStatus,
-      groupBy,
-      memoryReport,
-      memoryReportFetchStatus,
-      t,
-    } = this.props;
-    const { width } = this.state;
-    const cpuDatum =
-      groupBy === 'cluster'
-        ? this.getChartDatumWithCapacity(cpuReport, 'cpu')
-        : this.getChartDatum(cpuReport, 'cpu');
-    const memoryDatum =
-      groupBy === 'cluster'
-        ? this.getChartDatumWithCapacity(memoryReport, 'memory')
-        : this.getChartDatum(memoryReport, 'memory');
-    const itemsPerRow = width > 600 ? 3 : width > 450 ? 2 : 1;
+  private isDatumEmpty = (datum: ChartDatum) => {
+    let hasRange = false;
+    for (const range of datum.ranges) {
+      if (range.value) {
+        hasRange = true;
+        break;
+      }
+    }
+    let hasUsage = false;
+    for (const usage of datum.usage) {
+      if (usage.value) {
+        hasUsage = true;
+        break;
+      }
+    }
+    return !(datum.limit.value || hasRange || hasUsage);
+  };
 
+  public render() {
     return (
       <div ref={this.containerRef}>
-        {Boolean(cpuDatum && cpuDatum.usage.length) && (
-          <div>
-            {cpuReportFetchStatus === FetchStatus.inProgress ? (
-              this.getSkeleton()
-            ) : (
-              <>
-                <ChartBullet
-                  comparativeErrorMeasureData={
-                    cpuDatum.limit.value
-                      ? [
-                          {
-                            tooltip: cpuDatum.limit.tooltip,
-                            y: cpuDatum.limit.value,
-                          },
-                        ]
-                      : []
-                  }
-                  comparativeErrorMeasureLegendData={
-                    cpuDatum.limit.value
-                      ? [{ name: cpuDatum.limit.legend }]
-                      : []
-                  }
-                  height={200}
-                  labels={({ datum }) => `${datum.tooltip}`}
-                  legendPosition="bottom-left"
-                  legendItemsPerRow={itemsPerRow}
-                  maxDomain={!cpuReport ? 100 : undefined}
-                  minDomain={0}
-                  padding={{
-                    bottom: 75,
-                    left: 10,
-                    right: 50,
-                    top: 50,
-                  }}
-                  primarySegmentedMeasureData={
-                    cpuDatum.usage.length
-                      ? cpuDatum.usage.map(datum => {
-                          return {
-                            tooltip: datum.tooltip,
-                            y: datum.value,
-                          };
-                        })
-                      : []
-                  }
-                  primarySegmentedMeasureLegendData={
-                    cpuDatum.usage.length
-                      ? cpuDatum.usage.map(datum => {
-                          return {
-                            name: datum.legend,
-                          };
-                        })
-                      : []
-                  }
-                  qualitativeRangeData={
-                    cpuDatum.ranges.length
-                      ? [
-                          {
-                            tooltip: cpuDatum.ranges[0].tooltip,
-                            y: cpuDatum.ranges[0].value,
-                          },
-                        ]
-                      : []
-                  }
-                  qualitativeRangeLegendData={
-                    cpuDatum.ranges.length
-                      ? [{ name: cpuDatum.ranges[0].legend }]
-                      : []
-                  }
-                  title={t('ocp_details.bullet.cpu_label')}
-                  titlePosition="top-left"
-                  width={width}
-                />
-                {Boolean(groupBy === 'cluster') &&
-                  this.getFreeSpace(cpuReport, 'cpu')}
-              </>
-            )}
-          </div>
-        )}
-        {Boolean(memoryDatum && memoryDatum.usage.length) && (
-          <div>
-            {memoryReportFetchStatus === FetchStatus.inProgress ? (
-              this.getSkeleton()
-            ) : (
-              <>
-                <ChartBullet
-                  comparativeErrorMeasureData={
-                    memoryDatum.limit.value
-                      ? [
-                          {
-                            tooltip: memoryDatum.limit.tooltip,
-                            y: memoryDatum.limit.value,
-                          },
-                        ]
-                      : []
-                  }
-                  comparativeErrorMeasureLegendData={
-                    memoryDatum.limit.value
-                      ? [{ name: memoryDatum.limit.legend }]
-                      : []
-                  }
-                  height={200}
-                  labels={({ datum }) => `${datum.tooltip}`}
-                  legendPosition="bottom-left"
-                  legendItemsPerRow={itemsPerRow}
-                  maxDomain={!memoryReport ? 100 : undefined}
-                  minDomain={0}
-                  padding={{
-                    bottom: 75,
-                    left: 10,
-                    right: 50,
-                    top: 50,
-                  }}
-                  primarySegmentedMeasureData={
-                    memoryDatum.usage.length
-                      ? memoryDatum.usage.map(datum => {
-                          return {
-                            tooltip: datum.tooltip,
-                            y: datum.value,
-                          };
-                        })
-                      : []
-                  }
-                  primarySegmentedMeasureLegendData={
-                    memoryDatum.usage.length
-                      ? memoryDatum.usage.map(datum => {
-                          return {
-                            name: datum.legend,
-                          };
-                        })
-                      : []
-                  }
-                  qualitativeRangeData={
-                    memoryDatum.ranges.length
-                      ? [
-                          {
-                            tooltip: memoryDatum.ranges[0].tooltip,
-                            y: memoryDatum.ranges[0].value,
-                          },
-                        ]
-                      : []
-                  }
-                  qualitativeRangeLegendData={
-                    memoryDatum.ranges.length
-                      ? [{ name: memoryDatum.ranges[0].legend }]
-                      : []
-                  }
-                  title={t('ocp_details.bullet.memory_label')}
-                  titlePosition="top-left"
-                  width={width}
-                />
-                {Boolean(groupBy === 'cluster') &&
-                  this.getFreeSpace(memoryReport, 'memory')}
-              </>
-            )}
-          </div>
-        )}
+        {this.getCpuChart()}
+        {this.getMemoryChart()}
       </div>
     );
   }

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -14,6 +14,7 @@ import {
 } from '@patternfly/react-table';
 import { getQuery, OcpQuery } from 'api/ocpQuery';
 import { OcpReport } from 'api/ocpReports';
+import { tagKey } from 'api/query';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
@@ -51,8 +52,6 @@ interface DetailsTableState {
 }
 
 type DetailsTableProps = DetailsTableOwnProps & InjectedTranslateProps;
-
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 class DetailsTableBase extends React.Component<DetailsTableProps> {
   public state: DetailsTableState = {

--- a/src/pages/ocpDetails/exportModal.tsx
+++ b/src/pages/ocpDetails/exportModal.tsx
@@ -10,6 +10,7 @@ import {
 import { css } from '@patternfly/react-styles';
 import { getQuery, OcpQuery } from 'api/ocpQuery';
 import { OcpReportType } from 'api/ocpReports';
+import { tagKey } from 'api/query';
 import { AxiosError } from 'axios';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -57,8 +58,6 @@ const resolutionOptions: {
   { label: 'Daily', value: 'daily' },
   { label: 'Monthly', value: 'monthly' },
 ];
-
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 export class ExportModalBase extends React.Component<
   ExportModalProps,

--- a/src/pages/ocpDetails/groupBy.tsx
+++ b/src/pages/ocpDetails/groupBy.tsx
@@ -3,6 +3,7 @@ import { css } from '@patternfly/react-styles';
 import { getQuery, OcpQuery } from 'api/ocpQuery';
 import { parseQuery } from 'api/ocpQuery';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
+import { tagKey } from 'api/query';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -47,8 +48,6 @@ const groupByOptions: {
 ];
 
 const reportType = OcpReportType.tag;
-
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 class GroupByBase extends React.Component<GroupByProps> {
   protected defaultState: GroupByState = {

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -4,6 +4,7 @@ import { getQuery, getQueryRoute, OcpQuery, parseQuery } from 'api/ocpQuery';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
 import { Providers, ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/providersQuery';
+import { tagKey } from 'api/query';
 import { AxiosError } from 'axios';
 import { ErrorState } from 'components/state/errorState/errorState';
 import { LoadingState } from 'components/state/loadingState/loadingState';
@@ -55,8 +56,6 @@ type OcpDetailsProps = OcpDetailsStateProps &
   OcpDetailsDispatchProps;
 
 const reportType = OcpReportType.cost;
-
-const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
 
 const baseQuery: OcpQuery = {
   delta: 'cost',


### PR DESCRIPTION
This eliminates the "invalid prop domain" error with bullet chart when there is no data (i.e., when all values are zero). 

This is best seen when grouping by tag, then expand the others category (e.g., "no-app"). There should be no errors in the browser console.

https://github.com/project-koku/koku-ui/issues/1284

![Screen Shot 2020-01-28 at 6 20 55 PM](https://user-images.githubusercontent.com/17481322/73314112-f833df80-41fa-11ea-8f87-eb1e289d8c77.png)
