### PR TITLE
Removed AWS prefix from Ocp cloud infrastructure details widget

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -447,17 +447,6 @@
     "details": "$t(group_by.values.{{groupBy}}, { 'count': 3 })",
     "tag_key": "Tag Key: {{value}}",
     "top": "Top $t(group_by.top_values.{{groupBy}}, { 'count': 5 })",
-    "top_ocp_cloud": "$t(group_by.top_ocp_cloud_values.{{groupBy}}, { 'count': 3 })",
-    "top_ocp_cloud_values": {
-      "account": "AWS account",
-      "account_plural": "AWS accounts",
-      "project": "OpenShift project",
-      "project_plural": "OpenShift projects",
-      "region": "AWS region",
-      "region_plural": "AWS regions",
-      "service": "AWS service",
-      "service_plural": "AWS services"
-    },
     "top_values": {
       "account": "account",
       "account_plural": "accounts",

--- a/src/pages/ocpCloudDetails/detailsWidget.tsx
+++ b/src/pages/ocpCloudDetails/detailsWidget.tsx
@@ -126,7 +126,7 @@ class DetailsWidgetBase extends React.Component<DetailsWidgetProps> {
     const { t } = this.props;
     const key = getIdKeyForTab(tab) || '';
 
-    return t('group_by.top_ocp_cloud', { groupBy: key });
+    return t('group_by.details', { groupBy: key });
   };
 
   public render() {


### PR DESCRIPTION
Since the Ocp cloud infrastructure details page now includes AWS and Azure data, we need to remove the "AWS" prefix from the "top projects/services/accounts" widget.

https://github.com/project-koku/koku-ui/issues/1283

![Screen Shot 2020-01-28 at 6 37 40 PM](https://user-images.githubusercontent.com/17481322/73315167-6679a180-41fd-11ea-9c15-57c57e565617.png)
