### PR TITLE
Filter fails if filter field is empty

### DIFF
--- a/src/components/details/detailsDataToolbar.tsx
+++ b/src/components/details/detailsDataToolbar.tsx
@@ -314,7 +314,7 @@ export class DetailsDataToolbarBase extends React.Component<
   public onCategoryInput = (event, key) => {
     const { categoryInput, currentCategory } = this.state;
 
-    if (event.key && event.key !== 'Enter') {
+    if ((event.key && event.key !== 'Enter') || categoryInput.trim() === '') {
       return;
     }
     this.setState(


### PR DESCRIPTION
The data toolbar filter should not accept empty strings.

https://github.com/project-koku/koku-ui/issues/1282