### PR TITLE
fix(costmodels): wrap description text in the header

### DIFF
--- a/src/pages/costModelsDetails/costModelInfo/header.tsx
+++ b/src/pages/costModelsDetails/costModelInfo/header.tsx
@@ -116,7 +116,7 @@ class Header extends React.Component<Props> {
             <BreadcrumbItem isActive>{current.name}</BreadcrumbItem>
           </Breadcrumb>
           <Split>
-            <SplitItem>
+            <SplitItem className={css(styles.headerDescription)}>
               <Title className={css(styles.title)} size="2xl">
                 {current.name}
               </Title>

--- a/src/pages/costModelsDetails/costModelsDetails.styles.ts
+++ b/src/pages/costModelsDetails/costModelsDetails.styles.ts
@@ -9,6 +9,10 @@ import {
 } from '@patternfly/react-tokens';
 
 export const styles = StyleSheet.create({
+  headerDescription: {
+    width: '97%',
+    wordWrap: 'break-word',
+  },
   sourceSettings: {
     backgroundColor: global_BackgroundColor_300.var,
   },


### PR DESCRIPTION
related #1257 and https://github.com/patternfly/patternfly-react/issues/3598

This is a workaround to a long description in the header (in the cost model info page).
Setting width to 97% and wrapping the text in the description part fixes this.

![image](https://user-images.githubusercontent.com/2453279/73353557-43ea9580-429c-11ea-94ea-7730632c831c.png)
