### PR TITLE
Data toolbar must wrap Select with DataToolbarItem

### DIFF
--- a/src/components/details/detailsDataToolbar.tsx
+++ b/src/components/details/detailsDataToolbar.tsx
@@ -377,18 +377,20 @@ export class DetailsDataToolbarBase extends React.Component<
     });
 
     return (
-      <Select
-        variant={SelectVariant.typeahead}
-        aria-label={t('filter_by.tag_key_aria_label')}
-        onClear={this.onTagKeyClear}
-        onToggle={this.onTagKeyToggle}
-        onSelect={this.onTagKeySelect}
-        isExpanded={isTagKeySelectExpanded}
-        placeholderText={t('filter_by.tag_key_placeholder')}
-        selections={currentTagKey}
-      >
-        {selectOptions}
-      </Select>
+      <DataToolbarItem>
+        <Select
+          variant={SelectVariant.typeahead}
+          aria-label={t('filter_by.tag_key_aria_label')}
+          onClear={this.onTagKeyClear}
+          onToggle={this.onTagKeyToggle}
+          onSelect={this.onTagKeySelect}
+          isExpanded={isTagKeySelectExpanded}
+          placeholderText={t('filter_by.tag_key_placeholder')}
+          selections={currentTagKey}
+        >
+          {selectOptions}
+        </Select>
+      </DataToolbarItem>
     );
   };
 
@@ -448,7 +450,6 @@ export class DetailsDataToolbarBase extends React.Component<
       );
     });
 
-    // Width prop is a workaround for https://github.com/patternfly/patternfly-react/issues/3574
     return (
       <DataToolbarFilter
         categoryName={tagKeyOption.value}
@@ -471,7 +472,6 @@ export class DetailsDataToolbarBase extends React.Component<
           }
           isExpanded={isTagValueSelectExpanded}
           placeholderText={t('filter_by.tag_value_placeholder')}
-          width={200}
         >
           {selectOptions}
         </Select>


### PR DESCRIPTION
As a workaround, we set the width for the PatternFly Select component. We just need to wrap the select menu with `DataToolbarItem` and the `width` prop can be removed.

https://github.com/project-koku/koku-ui/issues/1292