### PR TITLE
Updated not authorized message

### DIFF
--- a/src/components/state/errorState/errorState.tsx
+++ b/src/components/state/errorState/errorState.tsx
@@ -4,7 +4,7 @@ import {
   EmptyStateIcon,
   Title,
 } from '@patternfly/react-core';
-import { BanIcon, ErrorCircleOIcon } from '@patternfly/react-icons';
+import { ErrorCircleOIcon, LockIcon } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
 import { AxiosError } from 'axios';
 import React from 'react';
@@ -25,7 +25,7 @@ const ErrorStateBase: React.SFC<ErrorStateProps> = ({
   let subTitle = t('error_state.unexpected_desc');
 
   if (error && error.response && error.response.status === 401) {
-    icon = BanIcon;
+    icon = LockIcon;
     title = t('error_state.unauthorized_title');
     subTitle = t('error_state.unauthorized_desc');
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -363,8 +363,8 @@
     "title": "No match found"
   },
   "error_state": {
-    "unauthorized_desc": "You do not have permission to access cost data. Contact your administrator.",
-    "unauthorized_title": "Unauthorized!",
+    "unauthorized_desc": "Contact the cost management administrator to provide access to this application",
+    "unauthorized_title": "You don't have access to the Cost management application",
     "unexpected_desc": "We encountered an unexpected error. Contact your administrator.",
     "unexpected_title": "Oops!"
   },


### PR DESCRIPTION
We already handle the not authorized state. However, I've updated the icon and message per the latest mock.

https://github.com/project-koku/koku-ui/issues/885

![Screen Shot 2020-02-03 at 10 13 37 AM](https://user-images.githubusercontent.com/17481322/73664954-4e2adc00-466e-11ea-9173-dba35b862029.png)
