### PR TITLE
Update details to use clusters array

### DIFF
--- a/src/api/ocpCloudReports.ts
+++ b/src/api/ocpCloudReports.ts
@@ -12,7 +12,7 @@ export interface OcpCloudReportValue {
   account_alias?: string;
   capacity?: OcpCloudDatum;
   cluster?: string;
-  cluster_alias?: string;
+  clusters?: string[];
   cost?: OcpCloudDatum;
   count?: OcpCloudDatum;
   date: string;

--- a/src/api/ocpReports.ts
+++ b/src/api/ocpReports.ts
@@ -10,7 +10,7 @@ export interface OcpReportValue {
   capacity?: OcpDatum;
   cost?: OcpDatum;
   cluster?: string;
-  cluster_alias?: string;
+  clusters?: string[];
   count?: OcpDatum;
   date: string;
   delta_percent?: number;

--- a/src/utils/getComputedOcpCloudReportItems.ts
+++ b/src/utils/getComputedOcpCloudReportItems.ts
@@ -12,6 +12,7 @@ import { sort, SortDirection } from './sort';
 export interface ComputedOcpCloudReportItem {
   capacity?: number;
   cluster?: string | number;
+  clusters?: string[];
   cost: number;
   deltaPercent: number;
   deltaValue: number;
@@ -81,10 +82,13 @@ export function getUnsortedComputedOcpCloudReportItems({
   const visitDataPoint = (dataPoint: OcpCloudReportData) => {
     if (dataPoint.values) {
       dataPoint.values.forEach(value => {
+        // clusters will either contain the cluster alias or default to cluster ID
+        const cluster_alias =
+          value.clusters && value.clusters.length > 0
+            ? value.clusters[0]
+            : undefined;
+        const cluster = cluster_alias || value.cluster;
         const capacity = value.capacity ? value.capacity.value : 0;
-        const cluster = value.cluster_alias
-          ? value.cluster_alias
-          : value.cluster;
         const cost = value.cost ? value.cost.value : 0;
         const derivedCost = value.derived_cost ? value.derived_cost.value : 0;
         const infrastructureCost = value.infrastructure_cost
@@ -98,8 +102,8 @@ export function getUnsortedComputedOcpCloudReportItems({
             : '';
         const id = `${value[idKey]}${idSuffix}`;
         let label;
-        if (labelKey === 'cluster' && value.cluster_alias) {
-          label = value.cluster_alias;
+        if (labelKey === 'cluster' && cluster_alias) {
+          label = cluster_alias;
         } else if (value[labelKey] instanceof Object) {
           label = (value[labelKey] as OcpCloudDatum).value;
         } else {
@@ -120,6 +124,7 @@ export function getUnsortedComputedOcpCloudReportItems({
           itemMap.set(id, {
             capacity,
             cluster,
+            clusters: value.clusters,
             cost,
             deltaPercent: value.delta_percent,
             deltaValue: value.delta_value,

--- a/src/utils/getComputedOcpReportItems.ts
+++ b/src/utils/getComputedOcpReportItems.ts
@@ -11,6 +11,7 @@ import { sort, SortDirection } from './sort';
 export interface ComputedOcpReportItem {
   capacity?: number;
   cluster?: string | number;
+  clusters?: string[];
   cost: number;
   deltaPercent: number;
   deltaValue: number;
@@ -78,10 +79,13 @@ export function getUnsortedComputedOcpReportItems({
   const visitDataPoint = (dataPoint: OcpReportData) => {
     if (dataPoint.values) {
       dataPoint.values.forEach(value => {
+        // clusters will either contain the cluster alias or default to cluster ID
+        const cluster_alias =
+          value.clusters && value.clusters.length > 0
+            ? value.clusters[0]
+            : undefined;
+        const cluster = cluster_alias || value.cluster;
         const capacity = value.capacity ? value.capacity.value : 0;
-        const cluster = value.cluster_alias
-          ? value.cluster_alias
-          : value.cluster;
         const cost = value.cost ? value.cost.value : 0;
         const derivedCost = value.derived_cost ? value.derived_cost.value : 0;
         const infrastructureCost = value.infrastructure_cost
@@ -94,8 +98,8 @@ export function getUnsortedComputedOcpReportItems({
             : '';
         const id = `${value[idKey]}${idSuffix}`;
         let label;
-        if (labelKey === 'cluster' && value.cluster_alias) {
-          label = value.cluster_alias;
+        if (labelKey === 'cluster' && cluster_alias) {
+          label = cluster_alias;
         } else if (value[labelKey] instanceof Object) {
           label = (value[labelKey] as OcpDatum).value;
         } else {
@@ -113,6 +117,7 @@ export function getUnsortedComputedOcpReportItems({
           itemMap.set(id, {
             capacity,
             cluster,
+            clusters: value.clusters,
             cost,
             deltaPercent: value.delta_percent,
             deltaValue: value.delta_value,


### PR DESCRIPTION
As a first step to fixing the cluster names, I'm updating the details pages to use new clusters array instead of deprecated cluster_alias.

https://github.com/project-koku/koku-ui/issues/1294