### PR TITLE
Update to handle special case where tag key collides with keywords.

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ As a convenience `start:dev` has been provided to work behind the proxy.
 yarn start:dev
 ```
 
-Point your browser to the [Overview page](https://ci.foo.redhat.com:1337/hybrid/cost-management/)
+Point your browser to the [Overview page](https://ci.foo.redhat.com:1337/beta/cost-management/)
 
 ### Building
 ```

--- a/config/spandx.config.local.js
+++ b/config/spandx.config.local.js
@@ -1,8 +1,10 @@
 /* global exports */
 const localhost =
   process.env.PLATFORM === 'linux' ? 'localhost' : 'host.docker.internal';
-const localKoku = 'http://' + localhost + ':8000';
-
+const localKokuPort = process.env.LOCAL_API_PORT
+  ? process.env.LOCAL_API_PORT
+  : '80';
+const localKoku = 'http://' + process.env.LOCAL_API + ':' + localKokuPort;
 exports.routes = {
   '/api/cost-management/': {
     host: localKoku,

--- a/src/utils/getComputedAwsReportItems.ts
+++ b/src/utils/getComputedAwsReportItems.ts
@@ -6,6 +6,7 @@ import {
   AwsReportValue,
 } from 'api/awsReports';
 import { Omit } from 'react-redux';
+import { getItemLabel } from './getItemLabel';
 import { sort, SortDirection } from './sort';
 
 export interface ComputedAwsReportItem {
@@ -73,12 +74,13 @@ export function getUnsortedComputedAwsReportItems({
           : 0;
         const id = value[idKey];
         let label;
-        if (value[labelKey] instanceof Object) {
-          label = (value[labelKey] as AwsDatum).value;
+        const itemLabelKey = getItemLabel({ report, labelKey, value });
+        if (value[itemLabelKey] instanceof Object) {
+          label = (value[itemLabelKey] as AwsDatum).value;
         } else {
-          label = value[labelKey];
+          label = value[itemLabelKey];
         }
-        if (labelKey === 'account' && value.account_alias) {
+        if (itemLabelKey === 'account' && value.account_alias) {
           label = value.account_alias;
         }
         if (!itemMap.get(id)) {

--- a/src/utils/getComputedAzureReportItems.ts
+++ b/src/utils/getComputedAzureReportItems.ts
@@ -6,6 +6,7 @@ import {
   AzureReportValue,
 } from 'api/azureReports';
 import { Omit } from 'react-redux';
+import { getItemLabel } from './getItemLabel';
 import { sort, SortDirection } from './sort';
 
 export interface ComputedAzureReportItem {
@@ -73,10 +74,12 @@ export function getUnsortedComputedAzureReportItems({
           : 0;
         const id = value[idKey];
         let label;
-        if (value[labelKey] instanceof Object) {
-          label = (value[labelKey] as AzureDatum).value;
+        const itemLabelKey = getItemLabel({ report, labelKey, value });
+
+        if (value[itemLabelKey] instanceof Object) {
+          label = (value[itemLabelKey] as AzureDatum).value;
         } else {
-          label = value[labelKey];
+          label = value[itemLabelKey];
         }
         if (!itemMap.get(id)) {
           itemMap.set(id, {

--- a/src/utils/getComputedOcpCloudReportItems.ts
+++ b/src/utils/getComputedOcpCloudReportItems.ts
@@ -7,6 +7,7 @@ import {
 } from 'api/ocpCloudReports';
 import { Omit } from 'react-redux';
 import { ComputedOcpCloudReportItem } from './getComputedOcpCloudReportItems';
+import { getItemLabel } from './getItemLabel';
 import { sort, SortDirection } from './sort';
 
 export interface ComputedOcpCloudReportItem {
@@ -102,14 +103,15 @@ export function getUnsortedComputedOcpCloudReportItems({
             : '';
         const id = `${value[idKey]}${idSuffix}`;
         let label;
-        if (labelKey === 'cluster' && cluster_alias) {
+        const itemLabelKey = getItemLabel({ report, labelKey, value });
+        if (itemLabelKey === 'cluster' && cluster_alias) {
           label = cluster_alias;
-        } else if (value[labelKey] instanceof Object) {
-          label = (value[labelKey] as OcpCloudDatum).value;
+        } else if (value[itemLabelKey] instanceof Object) {
+          label = (value[itemLabelKey] as OcpCloudDatum).value;
         } else {
-          label = value[labelKey];
+          label = value[itemLabelKey];
         }
-        if (labelKey === 'account' && value.account_alias) {
+        if (itemLabelKey === 'account' && value.account_alias) {
           label = value.account_alias;
         }
         const limit = value.limit ? value.limit.value : 0;

--- a/src/utils/getComputedOcpReportItems.ts
+++ b/src/utils/getComputedOcpReportItems.ts
@@ -6,6 +6,7 @@ import {
   OcpReportValue,
 } from 'api/ocpReports';
 import { Omit } from 'react-redux';
+import { getItemLabel } from './getItemLabel';
 import { sort, SortDirection } from './sort';
 
 export interface ComputedOcpReportItem {
@@ -98,12 +99,13 @@ export function getUnsortedComputedOcpReportItems({
             : '';
         const id = `${value[idKey]}${idSuffix}`;
         let label;
-        if (labelKey === 'cluster' && cluster_alias) {
+        const itemLabelKey = getItemLabel({ report, labelKey, value });
+        if (itemLabelKey === 'cluster' && cluster_alias) {
           label = cluster_alias;
-        } else if (value[labelKey] instanceof Object) {
-          label = (value[labelKey] as OcpDatum).value;
+        } else if (value[itemLabelKey] instanceof Object) {
+          label = (value[itemLabelKey] as OcpDatum).value;
         } else {
-          label = value[labelKey];
+          label = value[itemLabelKey];
         }
         const limit = value.limit ? value.limit.value : 0;
         const request = value.request ? value.request.value : 0;

--- a/src/utils/getItemLabel.ts
+++ b/src/utils/getItemLabel.ts
@@ -1,0 +1,21 @@
+export interface GetItemLabelParams {
+  report: any;
+  labelKey: any;
+  value: any;
+}
+
+export function getItemLabel({ report, labelKey, value }: GetItemLabelParams) {
+  let itemLabelKey = String(labelKey);
+  if (report.meta && report.meta.group_by) {
+    const group_by = report.meta.group_by;
+    for (const key of Object.keys(group_by)) {
+      if (key.indexOf('tag:')) {
+        const tagPrefixKey = 'tag:' + labelKey;
+        if (value.hasOwnProperty(tagPrefixKey)) {
+          itemLabelKey = tagPrefixKey;
+        }
+      }
+    }
+  }
+  return itemLabelKey;
+}

--- a/src/utils/getItemLabel.ts
+++ b/src/utils/getItemLabel.ts
@@ -1,3 +1,5 @@
+import { tagKey } from '../api/query';
+
 export interface GetItemLabelParams {
   report: any;
   labelKey: any;
@@ -9,8 +11,8 @@ export function getItemLabel({ report, labelKey, value }: GetItemLabelParams) {
   if (report.meta && report.meta.group_by) {
     const group_by = report.meta.group_by;
     for (const key of Object.keys(group_by)) {
-      if (key.indexOf('tag:')) {
-        const tagPrefixKey = 'tag:' + labelKey;
+      if (key.indexOf(tagKey)) {
+        const tagPrefixKey = tagKey + labelKey;
         if (value.hasOwnProperty(tagPrefixKey)) {
           itemLabelKey = tagPrefixKey;
         }


### PR DESCRIPTION
* Utility function to see if "tag:" prefixed entry exist on tag group_by
* Update report items logic to use utility function
* Update SPANDX config for running local koku with latest insights-proxy
* Update README with overview link

This handles the following special case:
https://github.com/project-koku/koku/pull/1690

![Tag_Special_case](https://user-images.githubusercontent.com/29379759/73941977-39dc1e80-48bc-11ea-8263-d4336a97f9c9.png)
