### PR TITLE
Disable dropCurrentMonthData util

### DIFF
--- a/src/store/awsReports/awsReportsActions.ts
+++ b/src/store/awsReports/awsReportsActions.ts
@@ -4,7 +4,6 @@ import { ThunkAction } from 'redux-thunk';
 import { FetchStatus } from 'store/common';
 import { RootState } from 'store/rootReducer';
 import { createStandardAction } from 'typesafe-actions';
-import { dropCurrentMonthData } from 'utils/dropCurrentMonthData';
 import { getReportId } from './awsReportsCommon';
 import { selectReport, selectReportFetchStatus } from './awsReportsSelectors';
 
@@ -42,8 +41,9 @@ export function fetchReport(
     dispatch(fetchAwsReportRequest(meta));
     runReport(reportType, query)
       .then(res => {
-        const repsonseData = dropCurrentMonthData(res, query);
-        dispatch(fetchAwsReportSuccess(repsonseData, meta));
+        // See https://github.com/project-koku/koku-ui/pull/580
+        // const repsonseData = dropCurrentMonthData(res, query);
+        dispatch(fetchAwsReportSuccess(res.data, meta));
       })
       .catch(err => {
         dispatch(fetchAwsReportFailure(err, meta));

--- a/src/store/azureReports/azureReportsActions.ts
+++ b/src/store/azureReports/azureReportsActions.ts
@@ -4,7 +4,6 @@ import { ThunkAction } from 'redux-thunk';
 import { FetchStatus } from 'store/common';
 import { RootState } from 'store/rootReducer';
 import { createStandardAction } from 'typesafe-actions';
-import { dropCurrentMonthData } from 'utils/dropCurrentMonthData';
 import { getReportId } from './azureReportsCommon';
 import { selectReport, selectReportFetchStatus } from './azureReportsSelectors';
 
@@ -40,8 +39,9 @@ export function fetchReport(
     dispatch(fetchAzureReportRequest(meta));
     runReport(reportType, query)
       .then(res => {
-        const repsonseData = dropCurrentMonthData(res, query);
-        dispatch(fetchAzureReportSuccess(repsonseData, meta));
+        // See https://github.com/project-koku/koku-ui/pull/580
+        // const repsonseData = dropCurrentMonthData(res, query);
+        dispatch(fetchAzureReportSuccess(res.data, meta));
       })
       .catch(err => {
         dispatch(fetchAzureReportFailure(err, meta));

--- a/src/store/ocpCloudReports/ocpCloudReportsActions.ts
+++ b/src/store/ocpCloudReports/ocpCloudReportsActions.ts
@@ -8,7 +8,6 @@ import { ThunkAction } from 'redux-thunk';
 import { FetchStatus } from 'store/common';
 import { RootState } from 'store/rootReducer';
 import { createStandardAction } from 'typesafe-actions';
-import { dropCurrentMonthData } from 'utils/dropCurrentMonthData';
 import { getReportId } from './ocpCloudReportsCommon';
 import {
   selectReport,
@@ -47,8 +46,9 @@ export function fetchReport(
     dispatch(fetchOcpCloudReportRequest(meta));
     runReport(reportType, query)
       .then(res => {
-        const repsonseData = dropCurrentMonthData(res, query);
-        dispatch(fetchOcpCloudReportSuccess(repsonseData, meta));
+        // See https://github.com/project-koku/koku-ui/pull/580
+        // const repsonseData = dropCurrentMonthData(res, query);
+        dispatch(fetchOcpCloudReportSuccess(res.data, meta));
       })
       .catch(err => {
         dispatch(fetchOcpCloudReportFailure(err, meta));

--- a/src/store/ocpReports/ocpReportsActions.ts
+++ b/src/store/ocpReports/ocpReportsActions.ts
@@ -4,7 +4,6 @@ import { ThunkAction } from 'redux-thunk';
 import { expirationMS, FetchStatus } from 'store/common';
 import { RootState } from 'store/rootReducer';
 import { createStandardAction } from 'typesafe-actions';
-import { dropCurrentMonthData } from 'utils/dropCurrentMonthData';
 import { getReportId } from './ocpReportsCommon';
 import { selectReport, selectReportFetchStatus } from './ocpReportsSelectors';
 
@@ -42,8 +41,10 @@ export function fetchReport(
       .then(res => {
         // Todo: For testing purposes
         // dispatch(fetchOcpReportSuccess(test as any, meta));
-        const repsonseData = dropCurrentMonthData(res, query);
-        dispatch(fetchOcpReportSuccess(repsonseData, meta));
+
+        // See https://github.com/project-koku/koku-ui/pull/580
+        // const repsonseData = dropCurrentMonthData(res, query);
+        dispatch(fetchOcpReportSuccess(res.data, meta));
       })
       .catch(err => {
         dispatch(fetchOcpReportFailure(err, meta));


### PR DESCRIPTION
The API cost reports no longer return multiple months of data. Thus, we can omit calling the dropCurrentMonthData util to remove unused data for now.

https://github.com/project-koku/koku-ui/issues/1312