### PR TITLE
Replace logical AND with OR

### DIFF
--- a/src/api/awsQuery.ts
+++ b/src/api/awsQuery.ts
@@ -1,5 +1,4 @@
-import { parse, stringify } from 'qs';
-import { groupByAnd, Query, tagKey } from './query';
+import * as utils from './query';
 
 export interface AwsFilters {
   account?: string | number;
@@ -28,7 +27,7 @@ interface AwsOrderBys {
   usage?: string;
 }
 
-export interface AwsQuery extends Query {
+export interface AwsQuery extends utils.Query {
   delta?: string;
   filter?: AwsFilters;
   group_by?: AwsGroupBys;
@@ -36,108 +35,14 @@ export interface AwsQuery extends Query {
   key_only?: boolean;
 }
 
-// Adds logical AND to group_by -- https://github.com/project-koku/koku-ui/issues/704
-export function getLogicalAnd(query: AwsQuery) {
-  if (!(query && query.group_by)) {
-    return query;
-  }
-  const newQuery = {
-    ...JSON.parse(JSON.stringify(query)),
-    group_by: {},
-  };
-  for (const key of Object.keys(query.group_by)) {
-    newQuery.group_by[`${groupByAnd}${key}`] = query.group_by[key];
-    newQuery.group_by[key] = undefined;
-  }
-  return newQuery;
-}
-
-// Converts filter_by to group_by
-export function getGroupBy(query: AwsQuery) {
-  if (!(query && query.filter_by)) {
-    return query;
-  }
-  const newQuery = {
-    ...JSON.parse(JSON.stringify(query)),
-    filter_by: {},
-  };
-  for (const key of Object.keys(query.filter_by)) {
-    newQuery.group_by[key] = query.filter_by[key];
-  }
-  return newQuery;
-}
-
-// Skip adding logical AND
 export function getQueryRoute(query: AwsQuery) {
-  return stringify(query, { encode: false, indices: false });
+  return utils.getQueryRoute(query);
 }
 
-// Adds logical AND
 export function getQuery(query: AwsQuery) {
-  const newQuery = getGroupBy(query);
-  let isGroupByAnd = false;
-
-  // Workaround for https://github.com/project-koku/koku/issues/1596
-  if (newQuery && newQuery.group_by) {
-    const keys = Object.keys(newQuery.group_by);
-    if (keys && keys.length > 1) {
-      isGroupByAnd = true;
-    } else {
-      // Find a tag (#1596) or group_by with multiple keys
-      for (const key of keys) {
-        if (
-          (Array.isArray(newQuery.group_by[key]) &&
-            newQuery.group_by[key].length > 1) ||
-          key.indexOf(tagKey) !== -1
-        ) {
-          isGroupByAnd = true;
-        }
-      }
-    }
-  }
-
-  // Skip logical AND for single group_by
-  const q = isGroupByAnd ? getLogicalAnd(newQuery) : newQuery;
-  return stringify(q, { encode: false, indices: false });
-}
-
-// Removes logical AND from filter_by
-export function parseFilterByAnd(query: AwsQuery) {
-  if (!(query && query.filter_by)) {
-    return query;
-  }
-  const newQuery = {
-    ...JSON.parse(JSON.stringify(query)),
-    filter_by: {},
-  };
-  for (const key of Object.keys(query.filter_by)) {
-    const index = key.indexOf(groupByAnd);
-    const filterByKey =
-      index !== -1 ? key.substring(index + groupByAnd.length) : key;
-    newQuery.filter_by[filterByKey] = query.filter_by[key];
-  }
-  return newQuery;
-}
-
-// Removes logical AND from group_by -- https://github.com/project-koku/koku-ui/issues/704
-export function parseGroupByAnd(query: AwsQuery) {
-  if (!(query && query.group_by)) {
-    return query;
-  }
-  const newQuery = {
-    ...JSON.parse(JSON.stringify(query)),
-    group_by: {},
-  };
-  for (const key of Object.keys(query.group_by)) {
-    const index = key.indexOf(groupByAnd);
-    const groupByKey =
-      index !== -1 ? key.substring(index + groupByAnd.length) : key;
-    newQuery.group_by[groupByKey] = query.group_by[key];
-  }
-  return newQuery;
+  return utils.getQuery(query);
 }
 
 export function parseQuery<T = any>(query: string): T {
-  const newQuery = parse(query, { ignoreQueryPrefix: true });
-  return parseFilterByAnd(parseGroupByAnd(newQuery));
+  return utils.parseQuery(query);
 }

--- a/src/api/azureQuery.ts
+++ b/src/api/azureQuery.ts
@@ -1,5 +1,4 @@
-import { parse, stringify } from 'qs';
-import { groupByAnd, Query, tagKey } from './query';
+import * as utils from './query';
 
 export interface AzureFilters {
   subscription_guid?: string | number;
@@ -28,7 +27,7 @@ interface AzureOrderBys {
   usage?: string;
 }
 
-export interface AzureQuery extends Query {
+export interface AzureQuery extends utils.Query {
   delta?: string;
   filter?: AzureFilters;
   group_by?: AzureGroupBys;
@@ -36,108 +35,14 @@ export interface AzureQuery extends Query {
   key_only?: boolean;
 }
 
-// Adds logical AND to group_by -- https://github.com/project-koku/koku-ui/issues/704
-export function getLogicalAnd(query: AzureQuery) {
-  if (!(query && query.group_by)) {
-    return query;
-  }
-  const newQuery = {
-    ...JSON.parse(JSON.stringify(query)),
-    group_by: {},
-  };
-  for (const key of Object.keys(query.group_by)) {
-    newQuery.group_by[`${groupByAnd}${key}`] = query.group_by[key];
-    newQuery.group_by[key] = undefined;
-  }
-  return newQuery;
-}
-
-// Converts filter_by to group_by
-export function getGroupBy(query: AzureQuery) {
-  if (!(query && query.filter_by)) {
-    return query;
-  }
-  const newQuery = {
-    ...JSON.parse(JSON.stringify(query)),
-    filter_by: {},
-  };
-  for (const key of Object.keys(query.filter_by)) {
-    newQuery.group_by[key] = query.filter_by[key];
-  }
-  return newQuery;
-}
-
-// Skip adding logical AND
 export function getQueryRoute(query: AzureQuery) {
-  return stringify(query, { encode: false, indices: false });
+  return utils.getQueryRoute(query);
 }
 
-// Adds logical AND
 export function getQuery(query: AzureQuery) {
-  const newQuery = getGroupBy(query);
-  let isGroupByAnd = false;
-
-  // Workaround for https://github.com/project-koku/koku/issues/1596
-  if (newQuery && newQuery.group_by) {
-    const keys = Object.keys(newQuery.group_by);
-    if (keys && keys.length > 1) {
-      isGroupByAnd = true;
-    } else {
-      // Find a tag (#1596) or group_by with multiple keys
-      for (const key of keys) {
-        if (
-          (Array.isArray(newQuery.group_by[key]) &&
-            newQuery.group_by[key].length > 1) ||
-          key.indexOf(tagKey) !== -1
-        ) {
-          isGroupByAnd = true;
-        }
-      }
-    }
-  }
-
-  // Skip logical AND for single group_by
-  const q = isGroupByAnd ? getLogicalAnd(newQuery) : newQuery;
-  return stringify(q, { encode: false, indices: false });
-}
-
-// Removes logical AND from filter_by
-export function parseFilterByAnd(query: AzureQuery) {
-  if (!(query && query.filter_by)) {
-    return query;
-  }
-  const newQuery = {
-    ...JSON.parse(JSON.stringify(query)),
-    filter_by: {},
-  };
-  for (const key of Object.keys(query.filter_by)) {
-    const index = key.indexOf(groupByAnd);
-    const filterByKey =
-      index !== -1 ? key.substring(index + groupByAnd.length) : key;
-    newQuery.filter_by[filterByKey] = query.filter_by[key];
-  }
-  return newQuery;
-}
-
-// Removes logical AND from group_by -- https://github.com/project-koku/koku-ui/issues/704
-export function parseGroupByAnd(query: AzureQuery) {
-  if (!(query && query.group_by)) {
-    return query;
-  }
-  const newQuery = {
-    ...JSON.parse(JSON.stringify(query)),
-    group_by: {},
-  };
-  for (const key of Object.keys(query.group_by)) {
-    const index = key.indexOf(groupByAnd);
-    const groupByKey =
-      index !== -1 ? key.substring(index + groupByAnd.length) : key;
-    newQuery.group_by[groupByKey] = query.group_by[key];
-  }
-  return newQuery;
+  return utils.getQuery(query);
 }
 
 export function parseQuery<T = any>(query: string): T {
-  const newQuery = parse(query, { ignoreQueryPrefix: true });
-  return parseFilterByAnd(parseGroupByAnd(newQuery));
+  return utils.parseQuery(query);
 }

--- a/src/api/ocpCloudQuery.ts
+++ b/src/api/ocpCloudQuery.ts
@@ -1,5 +1,4 @@
-import { parse, stringify } from 'qs';
-import { groupByAnd, Query, tagKey } from './query';
+import * as utils from './query';
 
 export interface OcpCloudFilters {
   limit?: number;
@@ -29,7 +28,7 @@ interface OcpCloudOrderBys {
   project?: string;
 }
 
-export interface OcpCloudQuery extends Query {
+export interface OcpCloudQuery extends utils.Query {
   delta?: string;
   filter?: OcpCloudFilters;
   group_by?: OcpCloudGroupBys;
@@ -37,108 +36,14 @@ export interface OcpCloudQuery extends Query {
   key_only?: boolean;
 }
 
-// Adds logical AND to group_by -- https://github.com/project-koku/koku-ui/issues/704
-export function getLogicalAnd(query: OcpCloudQuery) {
-  if (!(query && query.group_by)) {
-    return query;
-  }
-  const newQuery = {
-    ...JSON.parse(JSON.stringify(query)),
-    group_by: {},
-  };
-  for (const key of Object.keys(query.group_by)) {
-    newQuery.group_by[`${groupByAnd}${key}`] = query.group_by[key];
-    newQuery.group_by[key] = undefined;
-  }
-  return newQuery;
-}
-
-// Converts filter_by to group_by
-export function getGroupBy(query: OcpCloudQuery) {
-  if (!(query && query.filter_by)) {
-    return query;
-  }
-  const newQuery = {
-    ...JSON.parse(JSON.stringify(query)),
-    filter_by: {},
-  };
-  for (const key of Object.keys(query.filter_by)) {
-    newQuery.group_by[key] = query.filter_by[key];
-  }
-  return newQuery;
-}
-
-// Skip adding logical AND
 export function getQueryRoute(query: OcpCloudQuery) {
-  return stringify(query, { encode: false, indices: false });
+  return utils.getQueryRoute(query);
 }
 
-// Adds logical AND
 export function getQuery(query: OcpCloudQuery) {
-  const newQuery = getGroupBy(query);
-  let isGroupByAnd = false;
-
-  // Workaround for https://github.com/project-koku/koku/issues/1596
-  if (newQuery && newQuery.group_by) {
-    const keys = Object.keys(newQuery.group_by);
-    if (keys && keys.length > 1) {
-      isGroupByAnd = true;
-    } else {
-      // Find a tag (#1596) or group_by with multiple keys
-      for (const key of keys) {
-        if (
-          (Array.isArray(newQuery.group_by[key]) &&
-            newQuery.group_by[key].length > 1) ||
-          key.indexOf(tagKey) !== -1
-        ) {
-          isGroupByAnd = true;
-        }
-      }
-    }
-  }
-
-  // Skip logical AND for single group_by
-  const q = isGroupByAnd ? getLogicalAnd(newQuery) : newQuery;
-  return stringify(q, { encode: false, indices: false });
-}
-
-// Removes logical AND from filter_by
-export function parseFilterByAnd(query: OcpCloudQuery) {
-  if (!(query && query.filter_by)) {
-    return query;
-  }
-  const newQuery = {
-    ...JSON.parse(JSON.stringify(query)),
-    filter_by: {},
-  };
-  for (const key of Object.keys(query.filter_by)) {
-    const index = key.indexOf(groupByAnd);
-    const filterByKey =
-      index !== -1 ? key.substring(index + groupByAnd.length) : key;
-    newQuery.filter_by[filterByKey] = query.filter_by[key];
-  }
-  return newQuery;
-}
-
-// Removes logical AND from group_by -- https://github.com/project-koku/koku-ui/issues/704
-export function parseGroupByAnd(query: OcpCloudQuery) {
-  if (!(query && query.group_by)) {
-    return query;
-  }
-  const newQuery = {
-    ...JSON.parse(JSON.stringify(query)),
-    group_by: {},
-  };
-  for (const key of Object.keys(query.group_by)) {
-    const index = key.indexOf(groupByAnd);
-    const groupByKey =
-      index !== -1 ? key.substring(index + groupByAnd.length) : key;
-    newQuery.group_by[groupByKey] = query.group_by[key];
-  }
-  return newQuery;
+  return utils.getQuery(query);
 }
 
 export function parseQuery<T = any>(query: string): T {
-  const newQuery = parse(query, { ignoreQueryPrefix: true });
-  return parseFilterByAnd(parseGroupByAnd(newQuery));
+  return utils.parseQuery(query);
 }

--- a/src/api/ocpQuery.ts
+++ b/src/api/ocpQuery.ts
@@ -1,5 +1,4 @@
-import { parse, stringify } from 'qs';
-import { groupByAnd, Query, tagKey } from './query';
+import * as utils from './query';
 
 export interface OcpFilters {
   limit?: number;
@@ -26,7 +25,7 @@ interface OcpOrderBys {
   project?: string;
 }
 
-export interface OcpQuery extends Query {
+export interface OcpQuery extends utils.Query {
   delta?: string;
   filter?: OcpFilters;
   group_by?: OcpGroupBys;
@@ -34,108 +33,14 @@ export interface OcpQuery extends Query {
   key_only?: boolean;
 }
 
-// Adds logical AND to group_by -- https://github.com/project-koku/koku-ui/issues/704
-export function getLogicalAnd(query: OcpQuery) {
-  if (!(query && query.group_by)) {
-    return query;
-  }
-  const newQuery = {
-    ...JSON.parse(JSON.stringify(query)),
-    group_by: {},
-  };
-  for (const key of Object.keys(query.group_by)) {
-    newQuery.group_by[`${groupByAnd}${key}`] = query.group_by[key];
-    newQuery.group_by[key] = undefined;
-  }
-  return newQuery;
-}
-
-// Converts filter_by to group_by
-export function getGroupBy(query: OcpQuery) {
-  if (!(query && query.filter_by)) {
-    return query;
-  }
-  const newQuery = {
-    ...JSON.parse(JSON.stringify(query)),
-    filter_by: {},
-  };
-  for (const key of Object.keys(query.filter_by)) {
-    newQuery.group_by[key] = query.filter_by[key];
-  }
-  return newQuery;
-}
-
-// Skip adding logical AND
 export function getQueryRoute(query: OcpQuery) {
-  return stringify(query, { encode: false, indices: false });
+  return utils.getQueryRoute(query);
 }
 
-// Adds logical AND
 export function getQuery(query: OcpQuery) {
-  const newQuery = getGroupBy(query);
-  let isGroupByAnd = false;
-
-  // Workaround for https://github.com/project-koku/koku/issues/1596
-  if (newQuery && newQuery.group_by) {
-    const keys = Object.keys(newQuery.group_by);
-    if (keys && keys.length > 1) {
-      isGroupByAnd = true;
-    } else {
-      // Find a tag (#1596) or group_by with multiple keys
-      for (const key of keys) {
-        if (
-          (Array.isArray(newQuery.group_by[key]) &&
-            newQuery.group_by[key].length > 1) ||
-          key.indexOf(tagKey) !== -1
-        ) {
-          isGroupByAnd = true;
-        }
-      }
-    }
-  }
-
-  // Skip logical AND for single group_by
-  const q = isGroupByAnd ? getLogicalAnd(newQuery) : newQuery;
-  return stringify(q, { encode: false, indices: false });
-}
-
-// Removes logical AND from filter_by
-export function parseFilterByAnd(query: OcpQuery) {
-  if (!(query && query.filter_by)) {
-    return query;
-  }
-  const newQuery = {
-    ...JSON.parse(JSON.stringify(query)),
-    filter_by: {},
-  };
-  for (const key of Object.keys(query.filter_by)) {
-    const index = key.indexOf(groupByAnd);
-    const filterByKey =
-      index !== -1 ? key.substring(index + groupByAnd.length) : key;
-    newQuery.filter_by[filterByKey] = query.filter_by[key];
-  }
-  return newQuery;
-}
-
-// Removes logical AND from group_by -- https://github.com/project-koku/koku-ui/issues/704
-export function parseGroupByAnd(query: OcpQuery) {
-  if (!(query && query.group_by)) {
-    return query;
-  }
-  const newQuery = {
-    ...JSON.parse(JSON.stringify(query)),
-    group_by: {},
-  };
-  for (const key of Object.keys(query.group_by)) {
-    const index = key.indexOf(groupByAnd);
-    const groupByKey =
-      index !== -1 ? key.substring(index + groupByAnd.length) : key;
-    newQuery.group_by[groupByKey] = query.group_by[key];
-  }
-  return newQuery;
+  return utils.getQuery(query);
 }
 
 export function parseQuery<T = any>(query: string): T {
-  const newQuery = parse(query, { ignoreQueryPrefix: true });
-  return parseFilterByAnd(parseGroupByAnd(newQuery));
+  return utils.parseQuery(query);
 }

--- a/src/api/query.ts
+++ b/src/api/query.ts
@@ -1,7 +1,9 @@
-type FilterByValue = string | string[];
+import { parse, stringify } from 'qs';
 
-export const groupByAnd = 'and:';
-export const tagKey = 'tag:'; // Show 'others' with group_by https://github.com/project-koku/koku-ui/issues/1090
+export const groupByPrefix = 'or:'; // logical OR ('or:') or AND ('and:') prefix for group_by
+export const tagKeyPrefix = 'tag:'; // Tag key prefix for group_by
+
+type FilterByValue = string | string[];
 
 interface FilterBys {
   tag?: FilterByValue;
@@ -9,4 +11,110 @@ interface FilterBys {
 
 export interface Query {
   filter_by?: FilterBys;
+  group_by?: any;
+}
+
+// Adds group_by prefix -- https://github.com/project-koku/koku-ui/issues/704
+export function addGroupByPrifix(query: Query) {
+  if (!(query && query.group_by)) {
+    return query;
+  }
+  const newQuery = {
+    ...JSON.parse(JSON.stringify(query)),
+    group_by: {},
+  };
+  for (const key of Object.keys(query.group_by)) {
+    newQuery.group_by[`${groupByPrefix}${key}`] = query.group_by[key];
+  }
+  return newQuery;
+}
+
+// Converts filter_by props to group_by
+export function convertFilterByToGroupBy(query: Query) {
+  if (!(query && query.filter_by)) {
+    return query;
+  }
+  const newQuery = {
+    ...JSON.parse(JSON.stringify(query)),
+    filter_by: {},
+  };
+  for (const key of Object.keys(query.filter_by)) {
+    newQuery.group_by[key] = query.filter_by[key];
+  }
+  return newQuery;
+}
+
+// Returns query without group_by prefix
+export function getQueryRoute(query: Query) {
+  return stringify(query, { encode: false, indices: false });
+}
+
+// Returns query and adds group_by prefix
+export function getQuery(query: Query) {
+  const newQuery = convertFilterByToGroupBy(query);
+  let addGroupByPrefix = false;
+
+  // Workaround for https://github.com/project-koku/koku/issues/1596
+  if (newQuery && newQuery.group_by) {
+    const keys = Object.keys(newQuery.group_by);
+    if (keys && keys.length > 1) {
+      addGroupByPrefix = true;
+    } else {
+      // Find a tag (#1596) or group_by with multiple keys
+      for (const key of keys) {
+        if (
+          (Array.isArray(newQuery.group_by[key]) &&
+            newQuery.group_by[key].length > 1) ||
+          key.indexOf(tagKeyPrefix) !== -1
+        ) {
+          addGroupByPrefix = true;
+        }
+      }
+    }
+  }
+
+  // Skip adding group_by prefix for a single group_by
+  const q = addGroupByPrefix ? addGroupByPrifix(newQuery) : newQuery;
+  return stringify(q, { encode: false, indices: false });
+}
+
+// Returns query without filter_by prefix
+export function parseFilterByPrefix(query: Query) {
+  if (!(query && query.filter_by)) {
+    return query;
+  }
+  const newQuery = {
+    ...JSON.parse(JSON.stringify(query)),
+    filter_by: {},
+  };
+  for (const key of Object.keys(query.filter_by)) {
+    const index = key.indexOf(groupByPrefix);
+    const filterByKey =
+      index !== -1 ? key.substring(index + groupByPrefix.length) : key;
+    newQuery.filter_by[filterByKey] = query.filter_by[key];
+  }
+  return newQuery;
+}
+
+// Returns query without group_by prefix -- https://github.com/project-koku/koku-ui/issues/704
+export function parseGroupByPrefix(query: Query) {
+  if (!(query && query.group_by)) {
+    return query;
+  }
+  const newQuery = {
+    ...JSON.parse(JSON.stringify(query)),
+    group_by: {},
+  };
+  for (const key of Object.keys(query.group_by)) {
+    const index = key.indexOf(groupByPrefix);
+    const groupByKey =
+      index !== -1 ? key.substring(index + groupByPrefix.length) : key;
+    newQuery.group_by[groupByKey] = query.group_by[key];
+  }
+  return newQuery;
+}
+
+export function parseQuery<T = any>(query: string): T {
+  const newQuery = parse(query, { ignoreQueryPrefix: true });
+  return parseFilterByPrefix(parseGroupByPrefix(newQuery));
 }

--- a/src/components/details/detailsDataToolbar.tsx
+++ b/src/components/details/detailsDataToolbar.tsx
@@ -25,7 +25,7 @@ import {
   SearchIcon,
 } from '@patternfly/react-icons';
 import { css } from '@patternfly/react-styles';
-import { Query, tagKey } from 'api/query';
+import { Query, tagKeyPrefix } from 'api/query';
 import { cloneDeep } from 'lodash';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -121,7 +121,9 @@ export class DetailsDataToolbarBase extends React.Component<
     for (const option of categoryOptions) {
       if (
         groupBy === option.value ||
-        (groupBy && groupBy.indexOf(tagKey) !== -1 && option.value === 'tag')
+        (groupBy &&
+          groupBy.indexOf(tagKeyPrefix) !== -1 &&
+          option.value === 'tag')
       ) {
         return option.value;
       }
@@ -138,8 +140,8 @@ export class DetailsDataToolbarBase extends React.Component<
           ? [...query.filter_by[key]]
           : [query.filter_by[key]];
 
-        if (key.indexOf(tagKey) !== -1) {
-          filters.tag[key.substring(tagKey.length)] = values;
+        if (key.indexOf(tagKeyPrefix) !== -1) {
+          filters.tag[key.substring(tagKeyPrefix.length)] = values;
         } else {
           filters[key] = values;
         }
@@ -185,7 +187,7 @@ export class DetailsDataToolbarBase extends React.Component<
         () => {
           const { filters } = this.state;
           const _filterType = filters.tag[filterType]
-            ? `${tagKey}${filterType}`
+            ? `${tagKeyPrefix}${filterType}`
             : filterType; // Todo: use ID
           this.props.onFilterRemoved(_filterType, id);
         }
@@ -435,7 +437,7 @@ export class DetailsDataToolbarBase extends React.Component<
 
   // Tag value select
 
-  public getTagValueSelect = tagKeyOption => {
+  public getTagValueSelect = tagKeyPrefixOption => {
     const { t } = this.props;
     const {
       currentCategory,
@@ -452,12 +454,13 @@ export class DetailsDataToolbarBase extends React.Component<
 
     return (
       <DataToolbarFilter
-        categoryName={tagKeyOption.value}
-        chips={filters.tag[tagKeyOption.value]}
+        categoryName={tagKeyPrefixOption.value}
+        chips={filters.tag[tagKeyPrefixOption.value]}
         deleteChip={this.onDelete}
-        key={tagKeyOption.value}
+        key={tagKeyPrefixOption.value}
         showToolbarItem={
-          currentCategory === 'tag' && currentTagKey === tagKeyOption.value
+          currentCategory === 'tag' &&
+          currentTagKey === tagKeyPrefixOption.value
         }
       >
         <Select
@@ -466,8 +469,8 @@ export class DetailsDataToolbarBase extends React.Component<
           onToggle={this.onTagValueToggle}
           onSelect={this.onTagValueSelect}
           selections={
-            filters.tag[tagKeyOption.value]
-              ? filters.tag[tagKeyOption.value]
+            filters.tag[tagKeyPrefixOption.value]
+              ? filters.tag[tagKeyPrefixOption.value]
               : []
           }
           isExpanded={isTagValueSelectExpanded}
@@ -527,7 +530,10 @@ export class DetailsDataToolbarBase extends React.Component<
       },
       () => {
         if (checked) {
-          this.props.onFilterAdded(`${tagKey}${currentTagKey}`, selection);
+          this.props.onFilterAdded(
+            `${tagKeyPrefix}${currentTagKey}`,
+            selection
+          );
         } else {
           this.onDelete(currentTagKey, selection);
         }

--- a/src/pages/awsDetails/awsDetails.tsx
+++ b/src/pages/awsDetails/awsDetails.tsx
@@ -4,7 +4,7 @@ import { AwsQuery, getQuery, getQueryRoute, parseQuery } from 'api/awsQuery';
 import { AwsReport, AwsReportType } from 'api/awsReports';
 import { Providers, ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/providersQuery';
-import { tagKey } from 'api/query';
+import { tagKeyPrefix } from 'api/query';
 import { AxiosError } from 'axios';
 import { ErrorState } from 'components/state/errorState/errorState';
 import { LoadingState } from 'components/state/loadingState/loadingState';
@@ -127,7 +127,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     return (
       <ExportModal
         isAllItems={selectedItems.length === computedItems.length}
-        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKeyPrefix}${groupByTagKey}` : groupById}
         isOpen={isExportModalOpen}
         items={selectedItems}
         onClose={this.handleExportModalClose}
@@ -141,9 +141,9 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     let groupByTag;
 
     for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf(tagKey);
+      const tagIndex = groupBy.indexOf(tagKeyPrefix);
       if (tagIndex !== -1) {
-        groupByTag = groupBy.substring(tagIndex + tagKey.length) as any;
+        groupByTag = groupBy.substring(tagIndex + tagKeyPrefix.length) as any;
         break;
       }
     }
@@ -197,7 +197,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 
     return (
       <DetailsTable
-        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKeyPrefix}${groupByTagKey}` : groupById}
         onSelected={this.handleSelected}
         onSort={this.handleSort}
         query={query}
@@ -215,7 +215,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 
     return (
       <DetailsToolbar
-        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKeyPrefix}${groupByTagKey}` : groupById}
         isExportDisabled={selectedItems.length === 0}
         onExportClicked={this.handleExportModalOpen}
         onFilterAdded={this.handleFilterAdded}
@@ -501,8 +501,5 @@ const mapDispatchToProps: AwsDetailsDispatchProps = {
 };
 
 export default translate()(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(AwsDetails)
+  connect(mapStateToProps, mapDispatchToProps)(AwsDetails)
 );

--- a/src/pages/awsDetails/detailsTable.tsx
+++ b/src/pages/awsDetails/detailsTable.tsx
@@ -14,7 +14,7 @@ import {
 } from '@patternfly/react-table';
 import { AwsQuery, getQuery } from 'api/awsQuery';
 import { AwsReport } from 'api/awsReports';
-import { tagKey } from 'api/query';
+import { tagKeyPrefix } from 'api/query';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
@@ -162,7 +162,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           isOpen: false,
           item,
           tableItem: {
-            groupBy: groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById,
+            groupBy: groupByTagKey
+              ? `${tagKeyPrefix}${groupByTagKey}`
+              : groupById,
             index,
             item,
             query,
@@ -213,9 +215,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     let groupByTagKey;
 
     for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf(tagKey);
+      const tagIndex = groupBy.indexOf(tagKeyPrefix);
       if (tagIndex !== -1) {
-        groupByTagKey = groupBy.substring(tagIndex + tagKey.length) as any;
+        groupByTagKey = groupBy.substring(
+          tagIndex + tagKeyPrefix.length
+        ) as any;
         break;
       }
     }

--- a/src/pages/awsDetails/exportModal.tsx
+++ b/src/pages/awsDetails/exportModal.tsx
@@ -10,7 +10,7 @@ import {
 import { css } from '@patternfly/react-styles';
 import { AwsQuery, getQuery } from 'api/awsQuery';
 import { AwsReportType } from 'api/awsReports';
-import { tagKey } from 'api/query';
+import { tagKeyPrefix } from 'api/query';
 import { AxiosError } from 'axios';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -134,7 +134,7 @@ export class ExportModalBase extends React.Component<
     }
 
     let selectedLabel = t('export.selected', { groupBy });
-    if (groupBy.indexOf(tagKey) !== -1) {
+    if (groupBy.indexOf(tagKeyPrefix) !== -1) {
       selectedLabel = t('export.selected_tags');
     }
 
@@ -218,10 +218,7 @@ const mapDispatchToProps: ExportModalDispatchProps = {
 };
 
 const ExportModal = translate()(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(ExportModalBase)
+  connect(mapStateToProps, mapDispatchToProps)(ExportModalBase)
 );
 
 export { ExportModal, ExportModalProps };

--- a/src/pages/awsDetails/groupBy.tsx
+++ b/src/pages/awsDetails/groupBy.tsx
@@ -3,7 +3,7 @@ import { css } from '@patternfly/react-styles';
 import { AwsQuery, getQuery } from 'api/awsQuery';
 import { parseQuery } from 'api/awsQuery';
 import { AwsReport, AwsReportType } from 'api/awsReports';
-import { tagKey } from 'api/query';
+import { tagKeyPrefix } from 'api/query';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -114,8 +114,8 @@ class GroupByBase extends React.Component<GroupByProps> {
       return data.map(tag => (
         <DropdownItem
           component="button"
-          key={`${tagKey}${tag.key}`}
-          onClick={() => this.handleGroupByClick(`${tagKey}${tag.key}`)}
+          key={`${tagKeyPrefix}${tag.key}`}
+          onClick={() => this.handleGroupByClick(`${tagKeyPrefix}${tag.key}`)}
         >
           {t('group_by.tag_key', { value: tag.key })}
         </DropdownItem>
@@ -134,7 +134,7 @@ class GroupByBase extends React.Component<GroupByProps> {
         : [];
 
     for (const key of groupByKeys) {
-      const index = key.indexOf(tagKey);
+      const index = key.indexOf(tagKeyPrefix);
       if (index !== -1) {
         groupBy = key;
         break;
@@ -164,10 +164,12 @@ class GroupByBase extends React.Component<GroupByProps> {
       ...this.getDropDownTags(),
     ];
 
-    const index = currentItem ? currentItem.indexOf(tagKey) : -1;
+    const index = currentItem ? currentItem.indexOf(tagKeyPrefix) : -1;
     const label =
       index !== -1
-        ? t('group_by.tag_key', { value: currentItem.slice(tagKey.length) })
+        ? t('group_by.tag_key', {
+            value: currentItem.slice(tagKeyPrefix.length),
+          })
         : t(`group_by.values.${currentItem}`);
 
     return (
@@ -223,10 +225,7 @@ const mapDispatchToProps: GroupByDispatchProps = {
 };
 
 const GroupBy = translate()(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(GroupByBase)
+  connect(mapStateToProps, mapDispatchToProps)(GroupByBase)
 );
 
 export { GroupBy, GroupByProps };

--- a/src/pages/azureDetails/azureDetails.tsx
+++ b/src/pages/azureDetails/azureDetails.tsx
@@ -9,7 +9,7 @@ import {
 import { AzureReport, AzureReportType } from 'api/azureReports';
 import { Providers, ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/providersQuery';
-import { tagKey } from 'api/query';
+import { tagKeyPrefix } from 'api/query';
 import { AxiosError } from 'axios';
 import { ErrorState } from 'components/state/errorState/errorState';
 import { LoadingState } from 'components/state/loadingState/loadingState';
@@ -132,7 +132,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     return (
       <ExportModal
         isAllItems={selectedItems.length === computedItems.length}
-        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKeyPrefix}${groupByTagKey}` : groupById}
         isOpen={isExportModalOpen}
         items={selectedItems}
         onClose={this.handleExportModalClose}
@@ -146,9 +146,9 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     let groupByTag;
 
     for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf(tagKey);
+      const tagIndex = groupBy.indexOf(tagKeyPrefix);
       if (tagIndex !== -1) {
-        groupByTag = groupBy.substring(tagIndex + tagKey.length) as any;
+        groupByTag = groupBy.substring(tagIndex + tagKeyPrefix.length) as any;
         break;
       }
     }
@@ -202,7 +202,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
 
     return (
       <DetailsTable
-        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKeyPrefix}${groupByTagKey}` : groupById}
         onSelected={this.handleSelected}
         onSort={this.handleSort}
         query={query}
@@ -220,7 +220,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
 
     return (
       <DetailsToolbar
-        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKeyPrefix}${groupByTagKey}` : groupById}
         isExportDisabled={selectedItems.length === 0}
         onExportClicked={this.handleExportModalOpen}
         onFilterAdded={this.handleFilterAdded}
@@ -246,7 +246,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
 
     const groupByTagKey = this.getGroupByTagKey();
     const newFilterType =
-      filterType === 'tag' ? `${tagKey}${groupByTagKey}` : filterType;
+      filterType === 'tag' ? `${tagKeyPrefix}${groupByTagKey}` : filterType;
 
     // Filter by * won't generate a new request if group_by * already exists
     if (filterValue === '*' && newQuery.group_by[newFilterType] === '*') {
@@ -285,7 +285,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
 
     const groupByTagKey = this.getGroupByTagKey();
     const newFilterType =
-      filterType === 'tag' ? `${tagKey}${groupByTagKey}` : filterType;
+      filterType === 'tag' ? `${tagKeyPrefix}${groupByTagKey}` : filterType;
 
     if (filterValue === '') {
       newQuery.filter_by = undefined; // Clear all
@@ -512,8 +512,5 @@ const mapDispatchToProps: AzureDetailsDispatchProps = {
 };
 
 export default translate()(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(AzureDetails)
+  connect(mapStateToProps, mapDispatchToProps)(AzureDetails)
 );

--- a/src/pages/azureDetails/detailsTable.tsx
+++ b/src/pages/azureDetails/detailsTable.tsx
@@ -14,7 +14,7 @@ import {
 } from '@patternfly/react-table';
 import { AzureQuery, getQuery } from 'api/azureQuery';
 import { AzureReport } from 'api/azureReports';
-import { tagKey } from 'api/query';
+import { tagKeyPrefix } from 'api/query';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
@@ -162,7 +162,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           isOpen: false,
           item,
           tableItem: {
-            groupBy: groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById,
+            groupBy: groupByTagKey
+              ? `${tagKeyPrefix}${groupByTagKey}`
+              : groupById,
             index,
             item,
             query,
@@ -213,9 +215,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     let groupByTagKey;
 
     for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf(tagKey);
+      const tagIndex = groupBy.indexOf(tagKeyPrefix);
       if (tagIndex !== -1) {
-        groupByTagKey = groupBy.substring(tagIndex + tagKey.length) as any;
+        groupByTagKey = groupBy.substring(
+          tagIndex + tagKeyPrefix.length
+        ) as any;
         break;
       }
     }

--- a/src/pages/azureDetails/exportModal.tsx
+++ b/src/pages/azureDetails/exportModal.tsx
@@ -10,7 +10,7 @@ import {
 import { css } from '@patternfly/react-styles';
 import { AzureQuery, getQuery } from 'api/azureQuery';
 import { AzureReportType } from 'api/azureReports';
-import { tagKey } from 'api/query';
+import { tagKeyPrefix } from 'api/query';
 import { AxiosError } from 'axios';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -134,7 +134,7 @@ export class ExportModalBase extends React.Component<
     }
 
     let selectedLabel = t('export.selected', { groupBy });
-    if (groupBy.indexOf(tagKey) !== -1) {
+    if (groupBy.indexOf(tagKeyPrefix) !== -1) {
       selectedLabel = t('export.selected_tags');
     }
 
@@ -218,10 +218,7 @@ const mapDispatchToProps: ExportModalDispatchProps = {
 };
 
 const ExportModal = translate()(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(ExportModalBase)
+  connect(mapStateToProps, mapDispatchToProps)(ExportModalBase)
 );
 
 export { ExportModal, ExportModalProps };

--- a/src/pages/azureDetails/groupBy.tsx
+++ b/src/pages/azureDetails/groupBy.tsx
@@ -3,7 +3,7 @@ import { css } from '@patternfly/react-styles';
 import { AzureQuery, getQuery } from 'api/azureQuery';
 import { parseQuery } from 'api/azureQuery';
 import { AzureReport, AzureReportType } from 'api/azureReports';
-import { tagKey } from 'api/query';
+import { tagKeyPrefix } from 'api/query';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -114,8 +114,8 @@ class GroupByBase extends React.Component<GroupByProps> {
       return data.map(tag => (
         <DropdownItem
           component="button"
-          key={`${tagKey}${tag.key}`}
-          onClick={() => this.handleGroupByClick(`${tagKey}${tag.key}`)}
+          key={`${tagKeyPrefix}${tag.key}`}
+          onClick={() => this.handleGroupByClick(`${tagKeyPrefix}${tag.key}`)}
         >
           {t('group_by.tag_key', { value: tag.key })}
         </DropdownItem>
@@ -134,7 +134,7 @@ class GroupByBase extends React.Component<GroupByProps> {
         : [];
 
     for (const key of groupByKeys) {
-      const index = key.indexOf(tagKey);
+      const index = key.indexOf(tagKeyPrefix);
       if (index !== -1) {
         groupBy = key;
         break;
@@ -164,10 +164,12 @@ class GroupByBase extends React.Component<GroupByProps> {
       ...this.getDropDownTags(),
     ];
 
-    const index = currentItem ? currentItem.indexOf(tagKey) : -1;
+    const index = currentItem ? currentItem.indexOf(tagKeyPrefix) : -1;
     const label =
       index !== -1
-        ? t('group_by.tag_key', { value: currentItem.slice(tagKey.length) })
+        ? t('group_by.tag_key', {
+            value: currentItem.slice(tagKeyPrefix.length),
+          })
         : t(`group_by.values.${currentItem}`);
 
     return (
@@ -223,10 +225,7 @@ const mapDispatchToProps: GroupByDispatchProps = {
 };
 
 const GroupBy = translate()(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(GroupByBase)
+  connect(mapStateToProps, mapDispatchToProps)(GroupByBase)
 );
 
 export { GroupBy, GroupByProps };

--- a/src/pages/ocpCloudDetails/detailsTable.tsx
+++ b/src/pages/ocpCloudDetails/detailsTable.tsx
@@ -14,7 +14,7 @@ import {
 } from '@patternfly/react-table';
 import { getQuery, OcpCloudQuery } from 'api/ocpCloudQuery';
 import { OcpCloudReport } from 'api/ocpCloudReports';
-import { tagKey } from 'api/query';
+import { tagKeyPrefix } from 'api/query';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
@@ -164,7 +164,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           isOpen: false,
           item,
           tableItem: {
-            groupBy: groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById,
+            groupBy: groupByTagKey
+              ? `${tagKeyPrefix}${groupByTagKey}`
+              : groupById,
             index,
             item,
             query,
@@ -215,9 +217,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     let groupByTagKey;
 
     for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf(tagKey);
+      const tagIndex = groupBy.indexOf(tagKeyPrefix);
       if (tagIndex !== -1) {
-        groupByTagKey = groupBy.substring(tagIndex + tagKey.length) as any;
+        groupByTagKey = groupBy.substring(
+          tagIndex + tagKeyPrefix.length
+        ) as any;
         break;
       }
     }

--- a/src/pages/ocpCloudDetails/exportModal.tsx
+++ b/src/pages/ocpCloudDetails/exportModal.tsx
@@ -10,7 +10,7 @@ import {
 import { css } from '@patternfly/react-styles';
 import { getQuery, OcpCloudQuery } from 'api/ocpCloudQuery';
 import { OcpCloudReportType } from 'api/ocpCloudReports';
-import { tagKey } from 'api/query';
+import { tagKeyPrefix } from 'api/query';
 import { AxiosError } from 'axios';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -137,7 +137,7 @@ export class ExportModalBase extends React.Component<
     }
 
     let selectedLabel = t('export.selected', { groupBy });
-    if (groupBy.indexOf(tagKey) !== -1) {
+    if (groupBy.indexOf(tagKeyPrefix) !== -1) {
       selectedLabel = t('export.selected_tags');
     }
 
@@ -221,10 +221,7 @@ const mapDispatchToProps: ExportModalDispatchProps = {
 };
 
 const ExportModal = translate()(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(ExportModalBase)
+  connect(mapStateToProps, mapDispatchToProps)(ExportModalBase)
 );
 
 export { ExportModal, ExportModalProps };

--- a/src/pages/ocpCloudDetails/groupBy.tsx
+++ b/src/pages/ocpCloudDetails/groupBy.tsx
@@ -3,7 +3,7 @@ import { css } from '@patternfly/react-styles';
 import { getQuery, OcpCloudQuery } from 'api/ocpCloudQuery';
 import { parseQuery } from 'api/ocpCloudQuery';
 import { OcpCloudReport, OcpCloudReportType } from 'api/ocpCloudReports';
-import { tagKey } from 'api/query';
+import { tagKeyPrefix } from 'api/query';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -117,8 +117,8 @@ class GroupByBase extends React.Component<GroupByProps> {
       return data.map(tag => (
         <DropdownItem
           component="button"
-          key={`${tagKey}${tag.key}`}
-          onClick={() => this.handleGroupByClick(`${tagKey}${tag.key}`)}
+          key={`${tagKeyPrefix}${tag.key}`}
+          onClick={() => this.handleGroupByClick(`${tagKeyPrefix}${tag.key}`)}
         >
           {t('group_by.tag_key', { value: tag.key })}
         </DropdownItem>
@@ -137,7 +137,7 @@ class GroupByBase extends React.Component<GroupByProps> {
         : [];
 
     for (const key of groupByKeys) {
-      const index = key.indexOf(tagKey);
+      const index = key.indexOf(tagKeyPrefix);
       if (index !== -1) {
         groupBy = key;
         break;
@@ -167,10 +167,12 @@ class GroupByBase extends React.Component<GroupByProps> {
       ...this.getDropDownTags(),
     ];
 
-    const index = currentItem ? currentItem.indexOf(tagKey) : -1;
+    const index = currentItem ? currentItem.indexOf(tagKeyPrefix) : -1;
     const label =
       index !== -1
-        ? t('group_by.tag_key', { value: currentItem.slice(tagKey.length) })
+        ? t('group_by.tag_key', {
+            value: currentItem.slice(tagKeyPrefix.length),
+          })
         : t(`group_by.values.${currentItem}`);
 
     return (
@@ -226,10 +228,7 @@ const mapDispatchToProps: GroupByDispatchProps = {
 };
 
 const GroupBy = translate()(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(GroupByBase)
+  connect(mapStateToProps, mapDispatchToProps)(GroupByBase)
 );
 
 export { GroupBy, GroupByProps };

--- a/src/pages/ocpCloudDetails/ocpCloudDetails.tsx
+++ b/src/pages/ocpCloudDetails/ocpCloudDetails.tsx
@@ -9,7 +9,7 @@ import {
 import { OcpCloudReport, OcpCloudReportType } from 'api/ocpCloudReports';
 import { Providers, ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/providersQuery';
-import { tagKey } from 'api/query';
+import { tagKeyPrefix } from 'api/query';
 import { AxiosError } from 'axios';
 import { ErrorState } from 'components/state/errorState/errorState';
 import { LoadingState } from 'components/state/loadingState/loadingState';
@@ -136,7 +136,7 @@ class OcpCloudDetails extends React.Component<OcpCloudDetailsProps> {
     return (
       <ExportModal
         isAllItems={selectedItems.length === computedItems.length}
-        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKeyPrefix}${groupByTagKey}` : groupById}
         isOpen={isExportModalOpen}
         items={selectedItems}
         onClose={this.handleExportModalClose}
@@ -150,9 +150,11 @@ class OcpCloudDetails extends React.Component<OcpCloudDetailsProps> {
     let groupByTagKey;
 
     for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf(tagKey);
+      const tagIndex = groupBy.indexOf(tagKeyPrefix);
       if (tagIndex !== -1) {
-        groupByTagKey = groupBy.substring(tagIndex + tagKey.length) as any;
+        groupByTagKey = groupBy.substring(
+          tagIndex + tagKeyPrefix.length
+        ) as any;
         break;
       }
     }
@@ -206,7 +208,7 @@ class OcpCloudDetails extends React.Component<OcpCloudDetailsProps> {
 
     return (
       <DetailsTable
-        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKeyPrefix}${groupByTagKey}` : groupById}
         onSelected={this.handleSelected}
         onSort={this.handleSort}
         query={query}
@@ -224,7 +226,7 @@ class OcpCloudDetails extends React.Component<OcpCloudDetailsProps> {
 
     return (
       <DetailsToolbar
-        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKeyPrefix}${groupByTagKey}` : groupById}
         isExportDisabled={selectedItems.length === 0}
         onExportClicked={this.handleExportModalOpen}
         onFilterAdded={this.handleFilterAdded}
@@ -495,8 +497,5 @@ const mapDispatchToProps: OcpCloudDetailsDispatchProps = {
 };
 
 export default translate()(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(OcpCloudDetails)
+  connect(mapStateToProps, mapDispatchToProps)(OcpCloudDetails)
 );

--- a/src/pages/ocpDetails/detailsActions.tsx
+++ b/src/pages/ocpDetails/detailsActions.tsx
@@ -1,6 +1,6 @@
 import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
 import { OcpQuery } from 'api/ocpQuery';
-import { tagKey } from 'api/query';
+import { tagKeyPrefix } from 'api/query';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { ComputedOcpReportItem } from 'utils/getComputedOcpReportItems';
@@ -194,7 +194,7 @@ class DetailsActionsBase extends React.Component<DetailsActionsProps> {
             <DropdownItem
               component="button"
               key="price-list-action"
-              isDisabled={groupBy.includes(tagKey)}
+              isDisabled={groupBy.includes(tagKeyPrefix)}
               onClick={this.handlePriceListModalOpen}
             >
               {t('ocp_details.actions.price_list')}

--- a/src/pages/ocpDetails/detailsTable.tsx
+++ b/src/pages/ocpDetails/detailsTable.tsx
@@ -14,7 +14,7 @@ import {
 } from '@patternfly/react-table';
 import { getQuery, OcpQuery } from 'api/ocpQuery';
 import { OcpReport } from 'api/ocpReports';
-import { tagKey } from 'api/query';
+import { tagKeyPrefix } from 'api/query';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
@@ -186,7 +186,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           isOpen: false,
           item,
           tableItem: {
-            groupBy: groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById,
+            groupBy: groupByTagKey
+              ? `${tagKeyPrefix}${groupByTagKey}`
+              : groupById,
             index,
             item,
             query,
@@ -262,9 +264,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     let groupByTagKey;
 
     for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf(tagKey);
+      const tagIndex = groupBy.indexOf(tagKeyPrefix);
       if (tagIndex !== -1) {
-        groupByTagKey = groupBy.substring(tagIndex + tagKey.length) as any;
+        groupByTagKey = groupBy.substring(
+          tagIndex + tagKeyPrefix.length
+        ) as any;
         break;
       }
     }

--- a/src/pages/ocpDetails/exportModal.tsx
+++ b/src/pages/ocpDetails/exportModal.tsx
@@ -10,7 +10,7 @@ import {
 import { css } from '@patternfly/react-styles';
 import { getQuery, OcpQuery } from 'api/ocpQuery';
 import { OcpReportType } from 'api/ocpReports';
-import { tagKey } from 'api/query';
+import { tagKeyPrefix } from 'api/query';
 import { AxiosError } from 'axios';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -134,7 +134,7 @@ export class ExportModalBase extends React.Component<
     }
 
     let selectedLabel = t('export.selected', { groupBy });
-    if (groupBy.indexOf(tagKey) !== -1) {
+    if (groupBy.indexOf(tagKeyPrefix) !== -1) {
       selectedLabel = t('export.selected_tags');
     }
 
@@ -218,10 +218,7 @@ const mapDispatchToProps: ExportModalDispatchProps = {
 };
 
 const ExportModal = translate()(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(ExportModalBase)
+  connect(mapStateToProps, mapDispatchToProps)(ExportModalBase)
 );
 
 export { ExportModal, ExportModalProps };

--- a/src/pages/ocpDetails/groupBy.tsx
+++ b/src/pages/ocpDetails/groupBy.tsx
@@ -3,7 +3,7 @@ import { css } from '@patternfly/react-styles';
 import { getQuery, OcpQuery } from 'api/ocpQuery';
 import { parseQuery } from 'api/ocpQuery';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
-import { tagKey } from 'api/query';
+import { tagKeyPrefix } from 'api/query';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -114,8 +114,8 @@ class GroupByBase extends React.Component<GroupByProps> {
       return data.map(tag => (
         <DropdownItem
           component="button"
-          key={`${tagKey}${tag.key}`}
-          onClick={() => this.handleGroupByClick(`${tagKey}${tag.key}`)}
+          key={`${tagKeyPrefix}${tag.key}`}
+          onClick={() => this.handleGroupByClick(`${tagKeyPrefix}${tag.key}`)}
         >
           {t('group_by.tag_key', { value: tag.key })}
         </DropdownItem>
@@ -134,7 +134,7 @@ class GroupByBase extends React.Component<GroupByProps> {
         : [];
 
     for (const key of groupByKeys) {
-      const index = key.indexOf(tagKey);
+      const index = key.indexOf(tagKeyPrefix);
       if (index !== -1) {
         groupBy = key;
         break;
@@ -164,10 +164,12 @@ class GroupByBase extends React.Component<GroupByProps> {
       ...this.getDropDownTags(),
     ];
 
-    const index = currentItem ? currentItem.indexOf(tagKey) : -1;
+    const index = currentItem ? currentItem.indexOf(tagKeyPrefix) : -1;
     const label =
       index !== -1
-        ? t('group_by.tag_key', { value: currentItem.slice(tagKey.length) })
+        ? t('group_by.tag_key', {
+            value: currentItem.slice(tagKeyPrefix.length),
+          })
         : t(`group_by.values.${currentItem}`);
 
     return (
@@ -223,10 +225,7 @@ const mapDispatchToProps: GroupByDispatchProps = {
 };
 
 const GroupBy = translate()(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(GroupByBase)
+  connect(mapStateToProps, mapDispatchToProps)(GroupByBase)
 );
 
 export { GroupBy, GroupByProps };

--- a/src/pages/ocpDetails/ocpDetails.tsx
+++ b/src/pages/ocpDetails/ocpDetails.tsx
@@ -4,7 +4,7 @@ import { getQuery, getQueryRoute, OcpQuery, parseQuery } from 'api/ocpQuery';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
 import { Providers, ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/providersQuery';
-import { tagKey } from 'api/query';
+import { tagKeyPrefix } from 'api/query';
 import { AxiosError } from 'axios';
 import { ErrorState } from 'components/state/errorState/errorState';
 import { LoadingState } from 'components/state/loadingState/loadingState';
@@ -127,7 +127,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     return (
       <ExportModal
         isAllItems={selectedItems.length === computedItems.length}
-        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKeyPrefix}${groupByTagKey}` : groupById}
         isOpen={isExportModalOpen}
         items={selectedItems}
         onClose={this.handleExportModalClose}
@@ -141,9 +141,11 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     let groupByTagKey;
 
     for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf(tagKey);
+      const tagIndex = groupBy.indexOf(tagKeyPrefix);
       if (tagIndex !== -1) {
-        groupByTagKey = groupBy.substring(tagIndex + tagKey.length) as any;
+        groupByTagKey = groupBy.substring(
+          tagIndex + tagKeyPrefix.length
+        ) as any;
         break;
       }
     }
@@ -197,7 +199,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
     return (
       <DetailsTable
-        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKeyPrefix}${groupByTagKey}` : groupById}
         onSelected={this.handleSelected}
         onSort={this.handleSort}
         query={query}
@@ -215,7 +217,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
     return (
       <DetailsToolbar
-        groupBy={groupByTagKey ? `${tagKey}${groupByTagKey}` : groupById}
+        groupBy={groupByTagKey ? `${tagKeyPrefix}${groupByTagKey}` : groupById}
         isExportDisabled={selectedItems.length === 0}
         onExportClicked={this.handleExportModalOpen}
         onFilterAdded={this.handleFilterAdded}
@@ -486,8 +488,5 @@ const mapDispatchToProps: OcpDetailsDispatchProps = {
 };
 
 export default translate()(
-  connect(
-    mapStateToProps,
-    mapDispatchToProps
-  )(OcpDetails)
+  connect(mapStateToProps, mapDispatchToProps)(OcpDetails)
 );

--- a/src/utils/getItemLabel.ts
+++ b/src/utils/getItemLabel.ts
@@ -1,4 +1,4 @@
-import { tagKey } from '../api/query';
+import { tagKeyPrefix } from '../api/query';
 
 export interface GetItemLabelParams {
   report: any;
@@ -11,8 +11,8 @@ export function getItemLabel({ report, labelKey, value }: GetItemLabelParams) {
   if (report.meta && report.meta.group_by) {
     const group_by = report.meta.group_by;
     for (const key of Object.keys(group_by)) {
-      if (key.indexOf(tagKey)) {
-        const tagPrefixKey = tagKey + labelKey;
+      if (key.indexOf(tagKeyPrefix)) {
+        const tagPrefixKey = tagKeyPrefix + labelKey;
         if (value.hasOwnProperty(tagPrefixKey)) {
           itemLabelKey = tagPrefixKey;
         }


### PR DESCRIPTION
Replaced logical AND with OR when generating group_by query params. Also renamed tagKey as tagKeyPrefix.

This should allow us to filter by any group_by combination.

Note: API functionality already exists to apply logical AND between unique group_by categories.

https://github.com/project-koku/koku-ui/issues/1298