### PR TITLE
fix(costmodel): add missing translation in the review step

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -310,6 +310,7 @@
       "close_button": "Close",
       "create_button": "Create",
       "markup": "Markup/discount",
+      "sources": "Assigned sources",
       "sub_title_details": "Review and confirm your cost model configuration and assignments. Click {{create}} to create the cost model, or {{back}} to revise.",
       "sub_title_success": "Costs for resources connected to the assigned sources will now be calculated using the newly created {{ cost_model }} cost model.",
       "title_details": "Review details",
@@ -340,7 +341,7 @@
     "steps": {
       "general_info": "Enter information",
       "markup": "Set markup or discount",
-      "price_list": "Create price list",
+      "price_list": "Price list",
       "review": "Review details",
       "sources": "Assign a source to the cost model"
     },


### PR DESCRIPTION
related to #1321 

Added the missing "source" key in en.json.