### PR TITLE
DataToolbarFilter: Maximum update depth exceeded

### DIFF
--- a/src/pages/details/components/toolbar/toolbar.tsx
+++ b/src/pages/details/components/toolbar/toolbar.tsx
@@ -449,6 +449,11 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
       );
     });
 
+    if (
+      !(currentCategory === 'tag' && currentTagKey === tagKeyPrefixOption.value)
+    ) {
+      return null;
+    }
     return (
       <DataToolbarFilter
         categoryName={tagKeyPrefixOption.value}


### PR DESCRIPTION
Added workaround is to return `null` instead of relying on the `showToolbarItem` prop of `DataToolbarFilter`. This resolves the "maximum update depth exceeded" issue by lazily rendering each `DataToolbarFilter`.

https://github.com/project-koku/koku-ui/issues/1326

Note: While testing this fix, I discovered a separate API issue when grouping by tag. See https://github.com/project-koku/koku/issues/1773