### PR TITLE
Details: Toolbar fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "i18next-json-sync": "2.2.0",
     "i18next-xhr-backend": "1.5.1",
     "js-file-download": "0.4.4",
+    "lodash": "^4.17.15",
     "mini-css-extract-plugin": "0.4.5",
     "qs": "6.5.2",
     "react-bootstrap": "0.32.4",

--- a/src/pages/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/details/awsDetails/detailsToolbar.tsx
@@ -50,14 +50,17 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   private getCategoryOptions = () => {
-    const { t } = this.props;
+    const { report, t } = this.props;
 
-    return [
+    const options = [
       { label: t('filter_by.values.account'), value: 'account' },
       { label: t('filter_by.values.service'), value: 'service' },
       { label: t('filter_by.values.region'), value: 'region' },
       { label: t('filter_by.values.tag'), value: 'tag' },
     ];
+    return report && report.data && report.data.length
+      ? options
+      : options.filter(option => option.value !== 'tag');
   };
 
   public render() {

--- a/src/pages/details/awsDetails/groupBy.tsx
+++ b/src/pages/details/awsDetails/groupBy.tsx
@@ -4,6 +4,7 @@ import { AwsQuery, getQuery } from 'api/awsQuery';
 import { parseQuery } from 'api/awsQuery';
 import { AwsReport, AwsReportType } from 'api/awsReports';
 import { tagKeyPrefix } from 'api/query';
+import { uniqBy } from 'lodash';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -110,7 +111,11 @@ class GroupByBase extends React.Component<GroupByProps> {
     const { report, t } = this.props;
 
     if (report && report.data) {
-      const data = [...new Set([...report.data])]; // prune duplicates
+      // Workaround for https://github.com/project-koku/koku/issues/1797
+      const keepData = report.data.map(
+        ({ type, ...keepProps }: any) => keepProps
+      );
+      const data = uniqBy(keepData, 'key'); // prune duplicates
       return data.map(tag => (
         <DropdownItem
           component="button"

--- a/src/pages/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/details/azureDetails/detailsToolbar.tsx
@@ -50,9 +50,9 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   private getCategoryOptions = () => {
-    const { t } = this.props;
+    const { report, t } = this.props;
 
-    return [
+    const options = [
       {
         label: t('filter_by.values.subscription_guid'),
         value: 'subscription_guid',
@@ -64,6 +64,9 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       },
       { label: t('filter_by.values.tag'), value: 'tag' },
     ];
+    return report && report.data && report.data.length
+      ? options
+      : options.filter(option => option.value !== 'tag');
   };
 
   public render() {

--- a/src/pages/details/azureDetails/groupBy.tsx
+++ b/src/pages/details/azureDetails/groupBy.tsx
@@ -4,6 +4,7 @@ import { AzureQuery, getQuery } from 'api/azureQuery';
 import { parseQuery } from 'api/azureQuery';
 import { AzureReport, AzureReportType } from 'api/azureReports';
 import { tagKeyPrefix } from 'api/query';
+import { uniqBy } from 'lodash';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -110,7 +111,11 @@ class GroupByBase extends React.Component<GroupByProps> {
     const { report, t } = this.props;
 
     if (report && report.data) {
-      const data = [...new Set([...report.data])]; // prune duplicates
+      // Workaround for https://github.com/project-koku/koku/issues/1797
+      const keepData = report.data.map(
+        ({ type, ...keepProps }: any) => keepProps
+      );
+      const data = uniqBy(keepData, 'key'); // prune duplicates
       return data.map(tag => (
         <DropdownItem
           component="button"

--- a/src/pages/details/components/toolbar/toolbar.tsx
+++ b/src/pages/details/components/toolbar/toolbar.tsx
@@ -27,6 +27,7 @@ import {
 import { css } from '@patternfly/react-styles';
 import { Query, tagKeyPrefix } from 'api/query';
 import { cloneDeep } from 'lodash';
+import { uniqBy } from 'lodash';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -288,9 +289,7 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
         chips={filters[categoryOption.value]}
         deleteChip={this.onDelete}
         key={categoryOption.value}
-        showToolbarItem={
-          currentCategory !== 'tag' && currentCategory === categoryOption.value
-        }
+        showToolbarItem={currentCategory === categoryOption.value}
       >
         <InputGroup>
           <TextInput
@@ -398,7 +397,9 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
 
     let data = [];
     if (report && report.data) {
-      data = [...new Set([...report.data])]; // prune duplicates
+      // Workaround for https://github.com/project-koku/koku/issues/1797
+      const keepData = report.data.map(({ type, ...keepProps }) => keepProps);
+      data = uniqBy(keepData, 'key');
     }
 
     let options = [];
@@ -449,8 +450,14 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
       );
     });
 
+    // Workaround for https://github.com/patternfly/patternfly-react/issues/3770
     if (
-      !(currentCategory === 'tag' && currentTagKey === tagKeyPrefixOption.value)
+      !(
+        (filters.tag[tagKeyPrefixOption.value] &&
+          filters.tag[tagKeyPrefixOption.value].length) ||
+        (currentCategory === 'tag' &&
+          currentTagKey === tagKeyPrefixOption.value)
+      )
     ) {
       return null;
     }

--- a/src/pages/details/ocpCloudDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsToolbar.tsx
@@ -53,14 +53,17 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   private getCategoryOptions = () => {
-    const { t } = this.props;
+    const { report, t } = this.props;
 
-    return [
+    const options = [
       { label: t('filter_by.values.cluster'), value: 'cluster' },
       { label: t('filter_by.values.node'), value: 'node' },
       { label: t('filter_by.values.project'), value: 'project' },
       { label: t('filter_by.values.tag'), value: 'tag' },
     ];
+    return report && report.data && report.data.length
+      ? options
+      : options.filter(option => option.value !== 'tag');
   };
 
   public render() {

--- a/src/pages/details/ocpCloudDetails/groupBy.tsx
+++ b/src/pages/details/ocpCloudDetails/groupBy.tsx
@@ -4,6 +4,7 @@ import { getQuery, OcpCloudQuery } from 'api/ocpCloudQuery';
 import { parseQuery } from 'api/ocpCloudQuery';
 import { OcpCloudReport, OcpCloudReportType } from 'api/ocpCloudReports';
 import { tagKeyPrefix } from 'api/query';
+import { uniqBy } from 'lodash';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -113,7 +114,11 @@ class GroupByBase extends React.Component<GroupByProps> {
     const { report, t } = this.props;
 
     if (report && report.data) {
-      const data = [...new Set([...report.data])]; // prune duplicates
+      // Workaround for https://github.com/project-koku/koku/issues/1797
+      const keepData = report.data.map(
+        ({ type, ...keepProps }: any) => keepProps
+      );
+      const data = uniqBy(keepData, 'key'); // prune duplicates
       return data.map(tag => (
         <DropdownItem
           component="button"

--- a/src/pages/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpDetails/detailsToolbar.tsx
@@ -50,14 +50,17 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   private getCategoryOptions = () => {
-    const { t } = this.props;
+    const { report, t } = this.props;
 
-    return [
+    const options = [
       { label: t('filter_by.values.cluster'), value: 'cluster' },
       { label: t('filter_by.values.node'), value: 'node' },
       { label: t('filter_by.values.project'), value: 'project' },
       { label: t('filter_by.values.tag'), value: 'tag' },
     ];
+    return report && report.data && report.data.length
+      ? options
+      : options.filter(option => option.value !== 'tag');
   };
 
   public render() {

--- a/src/pages/details/ocpDetails/groupBy.tsx
+++ b/src/pages/details/ocpDetails/groupBy.tsx
@@ -4,6 +4,7 @@ import { getQuery, OcpQuery } from 'api/ocpQuery';
 import { parseQuery } from 'api/ocpQuery';
 import { OcpReport, OcpReportType } from 'api/ocpReports';
 import { tagKeyPrefix } from 'api/query';
+import { uniqBy } from 'lodash';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -110,7 +111,11 @@ class GroupByBase extends React.Component<GroupByProps> {
     const { report, t } = this.props;
 
     if (report && report.data) {
-      const data = [...new Set([...report.data])]; // prune duplicates
+      // Workaround for https://github.com/project-koku/koku/issues/1797
+      const keepData = report.data.map(
+        ({ type, ...keepProps }: any) => keepProps
+      );
+      const data = uniqBy(keepData, 'key'); // prune duplicates
       return data.map(tag => (
         <DropdownItem
           component="button"


### PR DESCRIPTION
This fixes a couple issues with the details toolbar.

1. Don't show a tags category when there are no tags
2. The tag filter chips should remain visible when a new category is selected

https://github.com/project-koku/koku-ui/issues/1334
https://github.com/project-koku/koku-ui/issues/1335

![chrome-capture](https://user-images.githubusercontent.com/17481322/75054357-ee6f6600-54a0-11ea-8747-d34671b82899.gif)

Note: the "clear all filters" link may remain in view, due to the workaround for https://github.com/patternfly/patternfly-react/issues/3770#issuecomment-589071250

![Screen Shot 2020-02-21 at 11 58 21 AM](https://user-images.githubusercontent.com/17481322/75054676-8a00d680-54a1-11ea-9f56-2b9b56349aa0.png)
