### PR TITLE
Switch from providers to sources API endpoint as providers will be removed.

### DIFF
--- a/src/api/providers.test.ts
+++ b/src/api/providers.test.ts
@@ -24,5 +24,5 @@ test('api add provider calls axios.post', () => {
 test('api get provider calls axios.get', () => {
   const query = getProvidersQuery(awsProvidersQuery);
   fetchProviders(query);
-  expect(axios.get).toBeCalledWith('providers/?type=AWS');
+  expect(axios.get).toBeCalledWith('sources/?type=AWS');
 });

--- a/src/api/providers.ts
+++ b/src/api/providers.ts
@@ -76,10 +76,10 @@ export function fetchProviders(query: string) {
     insights.chrome.auth.getUser
   ) {
     return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Providers>(`providers/${queryString}`);
+      return axios.get<Providers>(`sources/${queryString}`);
     });
   } else {
-    return axios.get<Providers>(`providers/${queryString}`);
+    return axios.get<Providers>(`sources/${queryString}`);
   }
 }
 


### PR DESCRIPTION
* Removing providers endpoint soon to avoid confusing with sources
* Sources endpoint was updated to provide the same support the providers endpoint had.

Image shows local run with calls to the Sources API
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/29379759/75574607-9c908800-5a2c-11ea-9ae0-55741365fe08.png">
