### PR TITLE
fix(api): in assign sources step fetch data from /providers/

### DIFF
--- a/src/api/costModelsProviders.test.ts
+++ b/src/api/costModelsProviders.test.ts
@@ -1,0 +1,9 @@
+jest.mock('axios');
+
+import axios from 'axios';
+import { fetchProviders } from './costModelsProviders';
+
+test('api get provider calls axios.get', () => {
+  fetchProviders('type=AWS');
+  expect(axios.get).toBeCalledWith('providers/?type=AWS');
+});

--- a/src/api/costModelsProviders.ts
+++ b/src/api/costModelsProviders.ts
@@ -1,0 +1,42 @@
+import axios from 'axios';
+import { PagedLinks, PagedMetaData } from './api';
+import {
+  ProviderAuthentication,
+  ProviderBillingSource,
+  ProviderCreatedBy,
+  ProviderCustomer,
+} from './providers';
+
+export interface ProviderCostModel {
+  name: string;
+  uuid: string;
+}
+
+export interface Provider {
+  uuid?: string;
+  name?: string;
+  type?: string;
+  authentication?: ProviderAuthentication;
+  billing_source?: ProviderBillingSource;
+  customer?: ProviderCustomer;
+  created_by?: ProviderCreatedBy;
+  created_timestamp?: Date;
+  cost_models?: ProviderCostModel[];
+}
+
+export interface Providers {
+  meta: PagedMetaData;
+  links?: PagedLinks;
+  data: Provider[];
+}
+
+export const enum ProviderType {
+  aws = 'aws',
+  azure = 'azure',
+  ocp = 'ocp',
+}
+
+export function fetchProviders(query: string) {
+  const queryString = query ? `?${query}` : '';
+  return axios.get<Providers>(`providers/${queryString}`);
+}

--- a/src/api/providers.ts
+++ b/src/api/providers.ts
@@ -3,12 +3,12 @@ import { PagedLinks, PagedMetaData } from './api';
 
 export interface ProviderAuthentication {
   uuid?: string;
-  provider_resource_name: string;
+  provider_resource_name?: string;
 }
 
 export interface ProviderBillingSource {
   uuid?: string;
-  bucket: string;
+  bucket?: string;
 }
 
 export interface ProviderCreatedBy {
@@ -45,7 +45,6 @@ export interface Provider {
   customer?: ProviderCustomer;
   created_by?: ProviderCreatedBy;
   created_timestamp?: Date;
-  cost_models?: ProviderCostModel[];
 }
 
 export interface Providers {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -366,7 +366,7 @@
       "caption": "Select from the following {{ type }} sources:",
       "sub_title": "Select the source(s) you want to assign the cost model to. Assigning a new cost model will overwrite any previous cost model assignments. You can also save your cost model and assign it to a source later.",
       "title_AWS": "Assign Amazon Web Service source(s) (optional)",
-      "title_Azure": "Assign Microsoft Azure source(s) (optional)",
+      "title_AZURE": "Assign Microsoft Azure source(s) (optional)",
       "title_OCP": "Assign Red Hat OpenShift source(s) (optional)"
     },
     "source_table": {

--- a/src/pages/costModelsDetails/addSourceStep.tsx
+++ b/src/pages/costModelsDetails/addSourceStep.tsx
@@ -7,7 +7,7 @@ import {
 } from '@patternfly/react-core';
 import { Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { CostModel } from 'api/costModels';
-import { Provider } from 'api/providers';
+import { Provider } from 'api/costModelsProviders';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import { ErrorState } from 'components/state/errorState/errorState';
 import { LoadingState } from 'components/state/loadingState/loadingState';

--- a/src/pages/createCostModelWizard/api.ts
+++ b/src/pages/createCostModelWizard/api.ts
@@ -1,4 +1,4 @@
-import { fetchProviders } from 'api/providers';
+import { fetchProviders } from 'api/costModelsProviders';
 
 export const fetchSources = ({ type, page, perPage, query }) => {
   const offset = (page - 1) * perPage;


### PR DESCRIPTION
related to #1306 

commit https://github.com/project-koku/koku-ui/commit/77fd9c5c38c62c84b167f6db3301202d959bd476#diff-132bb7faa9075ed055ab813e4d80bb39 changed the endpoint that is used to fetch providers/sources.
The new endpoint doesn't have "cost_models" in its response and that's what caused the failure.