### PR TITLE
fix(costmodel): add unit test to price list data toolbar

### DIFF
--- a/src/pages/createCostModelWizard/Datatoolbar.test.tsx
+++ b/src/pages/createCostModelWizard/Datatoolbar.test.tsx
@@ -1,0 +1,85 @@
+import { fireEvent, render } from '@testing-library/react';
+import { createModel } from '@xstate/test';
+import React from 'react';
+import { PriceListToolbar, toolbarMachine } from './Datatoolbar';
+
+describe('price list toolbar base', () => {
+  const onUpdateSelection = jest.fn();
+  const machine = toolbarMachine(onUpdateSelection);
+
+  const model = createModel(machine).withEvents({
+    TOGGLE_METRICS: {
+      exec: ({ getByText }) => {
+        fireEvent.click(getByText('Metric'));
+      },
+    },
+    TOGGLE_MEASUREMENTS: {
+      exec: ({ getByText }) => {
+        fireEvent.click(getByText('Measurement'));
+      },
+    },
+    SELECT_METRICS: {
+      exec: ({ getByText }) => {
+        fireEvent.click(getByText('Memory'));
+      },
+    },
+    SELECT_MEASUREMENTS: {
+      exec: ({ getByText }) => {
+        fireEvent.click(getByText('Request'));
+      },
+    },
+  });
+
+  const plans = model.getSimplePathPlans();
+  plans.forEach(plan => {
+    describe(plan.description, () => {
+      plan.paths.forEach(path => {
+        it(path.description, () => {
+          path.test(
+            render(
+              <PriceListToolbar
+                metricProps={{
+                  options: [
+                    { label: 'CPU', value: 'CPU' },
+                    { label: 'Memory', value: 'Memory' },
+                    { label: 'Storage', value: 'Storage' },
+                  ],
+                  selection: [],
+                  placeholder: 'Metric',
+                }}
+                measurementProps={{
+                  options: [
+                    { label: 'Request', value: 'Request' },
+                    { label: 'Usage', value: 'Usage' },
+                    { label: 'Currency', value: 'Currency' },
+                  ],
+                  selection: [],
+                  placeholder: 'Measurement',
+                }}
+                actionButtonText="Add rate"
+                onSelect={jest.fn()}
+                onClick={jest.fn()}
+                pagination={{
+                  isCompact: true,
+                  itemCount: 10,
+                  perPage: 10,
+                  page: 1,
+                  onSetPage: jest.fn(),
+                  onPerPageSelect: jest.fn(),
+                  perPageOptions: [
+                    { title: '2', value: 2 },
+                    { title: '4', value: 4 },
+                    { title: '6', value: 6 },
+                  ],
+                }}
+                filters={{}}
+                onClear={jest.fn()}
+                onRemoveFilter={jest.fn()}
+              />
+            )
+          );
+        });
+      });
+    });
+  });
+});

--- a/src/pages/createCostModelWizard/Datatoolbar.tsx
+++ b/src/pages/createCostModelWizard/Datatoolbar.tsx
@@ -1,19 +1,17 @@
 import {
   Button,
   ButtonProps,
+  DataToolbar,
+  DataToolbarContent,
+  DataToolbarFilter,
+  DataToolbarItem,
+  DataToolbarItemVariant,
   Pagination,
   PaginationProps,
   Select,
   SelectOption,
   SelectVariant,
 } from '@patternfly/react-core';
-import {
-  DataToolbar,
-  DataToolbarContent,
-  DataToolbarFilter,
-  DataToolbarItem,
-  DataToolbarItemVariant,
-} from '@patternfly/react-core/dist/esm/experimental';
 import { Option } from 'components/priceList/types';
 import React from 'react';
 import { interpret, Machine, State } from 'xstate';
@@ -102,10 +100,7 @@ export const PriceListToolbarBase: React.FC<PriceListToolbarBaseProps> = ({
         <DataToolbarItem>
           <Button {...buttonProps} />
         </DataToolbarItem>
-        <DataToolbarItem
-          variant={DataToolbarItemVariant.pagination}
-          breakpointMods={[{ modifier: 'align-right' }]}
-        >
+        <DataToolbarItem variant={DataToolbarItemVariant.pagination}>
           <Pagination {...paginationProps} />
         </DataToolbarItem>
       </DataToolbarContent>
@@ -136,7 +131,7 @@ type PriceListToolbarMachineEvents =
   | { type: 'SELECT_METRICS'; selection: string }
   | { type: 'SELECT_MEASUREMENTS'; selection: string };
 
-const toolbarMachine = onSelect =>
+export const toolbarMachine = onSelect =>
   Machine<
     undefined,
     PriceListToolbarMachineState,
@@ -146,12 +141,15 @@ const toolbarMachine = onSelect =>
       initial: 'metric',
       type: 'parallel',
       states: {
-        // metric: filterSelectorMachineData('metrics'),
-        // measurement: filterSelectorMachineData('measurements'),
         metric: {
           initial: 'collapsed',
           states: {
             expanded: {
+              meta: {
+                test: ({ queryAllByText }) => {
+                  expect(queryAllByText('CPU').length).toBe(1);
+                },
+              },
               on: {
                 TOGGLE_METRICS: 'collapsed',
                 SELECT_METRICS: {
@@ -160,6 +158,11 @@ const toolbarMachine = onSelect =>
               },
             },
             collapsed: {
+              meta: {
+                test: ({ queryAllByText }) => {
+                  expect(queryAllByText('CPU').length).toBe(0);
+                },
+              },
               on: {
                 TOGGLE_METRICS: 'expanded',
               },
@@ -170,6 +173,11 @@ const toolbarMachine = onSelect =>
           initial: 'collapsed',
           states: {
             expanded: {
+              meta: {
+                test: ({ queryAllByText }) => {
+                  expect(queryAllByText('Request').length).toBe(1);
+                },
+              },
               on: {
                 TOGGLE_MEASUREMENTS: 'collapsed',
                 SELECT_MEASUREMENTS: {
@@ -178,6 +186,11 @@ const toolbarMachine = onSelect =>
               },
             },
             collapsed: {
+              meta: {
+                test: ({ queryAllByText }) => {
+                  expect(queryAllByText('Request').length).toBe(0);
+                },
+              },
               on: {
                 TOGGLE_MEASUREMENTS: 'expanded',
               },


### PR DESCRIPTION

After updating patternfly/react-core - I can test Datatoolbar.
These are tests for price list toolbar.