### PR TITLE
Infrastructure overview to show top services, accounts, & regions

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -13,12 +13,6 @@
     "network_trend_title": "Cumulative cost comparison ({{units}})",
     "storage_title": "Storage services usage",
     "storage_trend_title": "Daily usage comparison ({{units}})",
-    "tabs": {
-      "accounts": "Top accounts",
-      "instance_types": "Top types",
-      "regions": "Top regions",
-      "services": "Top services"
-    },
     "usage_label": "Usage",
     "widget_subtitle": "{{startDate}} $t(months.{{month}})",
     "widget_subtitle_plural": "{{startDate}}-{{endDate}} $t(months.{{month}})"
@@ -36,12 +30,6 @@
     "network_trend_title": "Cumulative cost comparison ({{units}})",
     "storage_title": "Storage services usage",
     "storage_trend_title": "Daily usage comparison ({{units}})",
-    "tabs": {
-      "accounts": "Top accounts",
-      "instance_types": "Top types",
-      "regions": "Top regions",
-      "services": "Top services"
-    },
     "usage_label": "Usage",
     "widget_subtitle": "{{startDate}} $t(months.{{month}})",
     "widget_subtitle_plural": "{{startDate}}-{{endDate}} $t(months.{{month}})"
@@ -106,12 +94,6 @@
     "network_trend_title": "Cumulative cost comparison ({{units}})",
     "storage_title": "Storage services usage",
     "storage_trend_title": "Daily usage comparison ({{units}})",
-    "tabs": {
-      "instance_types": "Top types",
-      "resource_locations": "Top regions",
-      "service_names": "Top services",
-      "subscription_guids": "Top accounts"
-    },
     "usage_label": "Usage",
     "widget_subtitle": "{{startDate}} $t(months.{{month}})",
     "widget_subtitle_plural": "{{startDate}}-{{endDate}} $t(months.{{month}})"
@@ -129,12 +111,6 @@
     "network_trend_title": "Cumulative cost comparison ({{units}})",
     "storage_title": "Storage services usage",
     "storage_trend_title": "Daily usage comparison ({{units}})",
-    "tabs": {
-      "instance_types": "Top types",
-      "resource_locations": "Top regions",
-      "service_names": "Top services",
-      "subscription_guids": "Top accounts"
-    },
     "usage_label": "Usage",
     "widget_subtitle": "{{startDate}} $t(months.{{month}})",
     "widget_subtitle_plural": "{{startDate}}-{{endDate}} $t(months.{{month}})"
@@ -728,12 +704,6 @@
     "memory_title": "Memory usage and requests",
     "memory_trend_title": "Daily usage and requests comparison ({{units}})",
     "requests_label": "Requests",
-    "tabs": {
-      "clusters": "Top clusters",
-      "nodes": "Top nodes",
-      "pods": "Top pods",
-      "projects": "Top projects"
-    },
     "total_cost_tooltip": "This total cost is the sum of the infrastructure cost {{infrastructureCost}} and derived cost {{derivedCost}}",
     "usage_label": "Usage",
     "volume_title": "Volume usage and requests",
@@ -848,12 +818,6 @@
     "memory_title": "Memory usage and requests",
     "memory_trend_title": "Daily usage and requests comparison ({{units}})",
     "requests_label": "Requests",
-    "tabs": {
-      "clusters": "Top clusters",
-      "nodes": "Top nodes",
-      "pods": "Top pods",
-      "projects": "Top projects"
-    },
     "total_cost_tooltip": "This total cost is the sum of the infrastructure cost {{infrastructureCost}} and derived cost {{derivedCost}}",
     "usage_label": "Usage",
     "volume_title": "Volume usage and requests",

--- a/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboardWidget.test.tsx
+++ b/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboardWidget.test.tsx
@@ -27,12 +27,12 @@ beforeEach(() => {
 
 test('id key for dashboard tab is the tab name in singular form', () => {
   [
-    OcpCloudDashboardTab.clusters,
-    OcpCloudDashboardTab.nodes,
-    OcpCloudDashboardTab.projects,
+    OcpCloudDashboardTab.accounts,
+    OcpCloudDashboardTab.regions,
+    OcpCloudDashboardTab.services,
   ].forEach(value => {
     expect(getIdKeyForTab(value)).toEqual(value.slice(0, -1));
   });
 
-  expect(getIdKeyForTab(OcpCloudDashboardTab.projects)).toEqual('project');
+  expect(getIdKeyForTab(OcpCloudDashboardTab.accounts)).toEqual('account');
 });

--- a/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboardWidget.tsx
@@ -40,12 +40,12 @@ export const getIdKeyForTab = (
   tab: OcpCloudDashboardTab
 ): ComputedOcpCloudReportItemsParams['idKey'] => {
   switch (tab) {
-    case OcpCloudDashboardTab.clusters:
-      return 'cluster';
-    case OcpCloudDashboardTab.nodes:
-      return 'node';
-    case OcpCloudDashboardTab.projects:
-      return 'project';
+    case OcpCloudDashboardTab.accounts:
+      return 'account';
+    case OcpCloudDashboardTab.regions:
+      return 'region';
+    case OcpCloudDashboardTab.services:
+      return 'service';
   }
 };
 

--- a/src/store/dashboard/ocpCloudDashboard/__snapshots__/ocpCloudDashboard.test.ts.snap
+++ b/src/store/dashboard/ocpCloudDashboard/__snapshots__/ocpCloudDashboard.test.ts.snap
@@ -12,27 +12,15 @@ Array [
   ],
   Array [
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[project]=*",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[service]=*",
   ],
 ]
 `;
 
-exports[`getGroupByForTab clusters tab 1`] = `
-Object {
-  "cluster": "*",
-}
-`;
+exports[`getGroupByForTab accounts tab 1`] = `Object {}`;
 
-exports[`getGroupByForTab nodes tab 1`] = `
-Object {
-  "node": "*",
-}
-`;
+exports[`getGroupByForTab regions tab 1`] = `Object {}`;
 
-exports[`getGroupByForTab projects tab 1`] = `
-Object {
-  "project": "*",
-}
-`;
+exports[`getGroupByForTab services tab 1`] = `Object {}`;
 
 exports[`getGroupByForTab unknown tab 1`] = `Object {}`;

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboard.test.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboard.test.ts
@@ -58,24 +58,24 @@ test('fetch widget reports', () => {
 test('changeWidgetTab', () => {
   const store = createOcpCloudDashboardStore();
   store.dispatch(
-    actions.changeWidgetTab(costSummaryWidget.id, OcpCloudDashboardTab.projects)
+    actions.changeWidgetTab(costSummaryWidget.id, OcpCloudDashboardTab.regions)
   );
   const widget = selectors.selectWidget(store.getState(), costSummaryWidget.id);
-  expect(widget.currentTab).toBe(OcpCloudDashboardTab.projects);
+  expect(widget.currentTab).toBe(OcpCloudDashboardTab.regions);
   expect(fetchReportMock).toHaveBeenCalledTimes(3);
 });
 
 describe('getGroupByForTab', () => {
-  test('clusters tab', () => {
-    expect(getGroupByForTab(OcpCloudDashboardTab.clusters)).toMatchSnapshot();
+  test('services tab', () => {
+    expect(getGroupByForTab(OcpCloudDashboardTab.services)).toMatchSnapshot();
   });
 
-  test('nodes tab', () => {
-    expect(getGroupByForTab(OcpCloudDashboardTab.nodes)).toMatchSnapshot();
+  test('accounts tab', () => {
+    expect(getGroupByForTab(OcpCloudDashboardTab.accounts)).toMatchSnapshot();
   });
 
-  test('projects tab', () => {
-    expect(getGroupByForTab(OcpCloudDashboardTab.projects)).toMatchSnapshot();
+  test('regions tab', () => {
+    expect(getGroupByForTab(OcpCloudDashboardTab.regions)).toMatchSnapshot();
   });
 
   test('unknown tab', () => {
@@ -88,8 +88,8 @@ test('getQueryForWidget', () => {
     id: 1,
     titleKey: '',
     reportType: ReportType.cost,
-    availableTabs: [OcpCloudDashboardTab.projects],
-    currentTab: OcpCloudDashboardTab.projects,
+    availableTabs: [OcpCloudDashboardTab.accounts],
+    currentTab: OcpCloudDashboardTab.accounts,
     details: { labelKey: '', formatOptions: {} },
     trend: {
       comparison: ChartComparison.cost,
@@ -105,10 +105,10 @@ test('getQueryForWidget', () => {
   [
     [
       undefined,
-      'filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&group_by[project]=*',
+      'filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&group_by[account]=*',
     ],
-    [{}, 'group_by[project]=*'],
-    [{ limit: 3 }, 'filter[limit]=3&group_by[project]=*'],
+    [{}, 'group_by[account]=*'],
+    [{ limit: 3 }, 'filter[limit]=3&group_by[account]=*'],
   ].forEach(value => {
     expect(getQueryForWidgetTabs(widget, value[0])).toEqual(value[1]);
   });

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
@@ -39,9 +39,13 @@ export const costSummaryWidget: OcpCloudDashboardWidget = {
   topItems: {
     formatOptions: {},
   },
-  availableTabs: [OcpCloudDashboardTab.projects, OcpCloudDashboardTab.clusters],
+  availableTabs: [
+    OcpCloudDashboardTab.services,
+    OcpCloudDashboardTab.accounts,
+    OcpCloudDashboardTab.regions,
+  ],
   chartType: DashboardChartType.trend,
-  currentTab: OcpCloudDashboardTab.projects,
+  currentTab: OcpCloudDashboardTab.services,
   perspective: DashboardPerspective.ocpCloud,
 };
 


### PR DESCRIPTION
For the infrastructure overview (i.e., the "All filtered by OpenShift" view), we want to show top services, accounts, and regions in the cost card instead of projects, nodes, & clusters.

https://github.com/project-koku/koku-ui/issues/1387