### PR TITLE
Remove tooltip from Infrastructure overview

### DIFF
--- a/src/components/reports/reportSummary/reportSummaryDetails.tsx
+++ b/src/components/reports/reportSummary/reportSummaryDetails.tsx
@@ -4,10 +4,7 @@ import { Report } from 'api/reports/report';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
-import {
-  DashboardChartType,
-  DashboardPerspective,
-} from 'store/dashboard/common/dashboardCommon';
+import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
   FormatOptions,
   unitLookupKey,
@@ -20,10 +17,10 @@ interface ReportSummaryDetailsProps extends InjectedTranslateProps {
   costLabel?: string;
   formatValue?: ValueFormatter;
   formatOptions?: FormatOptions;
-  perspective: DashboardPerspective;
   report: Report;
   requestFormatOptions?: FormatOptions;
   requestLabel?: string;
+  showTooltip?: boolean;
   showUnits?: boolean;
   showUsageFirst?: boolean;
   units?: string;
@@ -36,10 +33,10 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
   costLabel,
   formatValue,
   formatOptions,
-  perspective,
   report,
   requestFormatOptions,
   requestLabel,
+  showTooltip = false,
   showUnits = false,
   showUsageFirst = false,
   t,
@@ -54,7 +51,8 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
   let usage: string | React.ReactNode = <EmptyValueState />;
 
   const hasTotal = report && report.meta && report.meta.total;
-  const hasCost = hasTotal && report.meta.total.cost;
+  const hasCost =
+    hasTotal && report.meta.total.cost && report.meta.total.cost.total;
   const hasCount = hasTotal && report.meta.total.count;
   const hasSupplementaryCost =
     hasTotal &&
@@ -113,17 +111,12 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
 
   const getCostLayout = () => (
     <div className={css(styles.valueContainer)}>
-      {Boolean(
-        perspective === DashboardPerspective.ocp ||
-          perspective === DashboardPerspective.ocpCloud
-      ) ? (
+      {Boolean(showTooltip) ? (
         <Tooltip
-          content={t(
-            `${perspective}_dashboard.total_cost_tooltip`,
-            perspective === DashboardPerspective.ocp
-              ? { infrastructureCost, supplementaryCost }
-              : { infrastructureCost, supplementaryCost }
-          )}
+          content={t('dashboard.total_cost_tooltip', {
+            infrastructureCost,
+            supplementaryCost,
+          })}
           enableFlip
         >
           <div className={css(styles.value)}>{cost}</div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -373,6 +373,9 @@
     "warning_override_source": "This selection will override the assignment of the {{ cost_model }} cost model",
     "warning_override_sources": "This selection will override the assignment of some cost models"
   },
+  "dashboard": {
+    "total_cost_tooltip": "This total cost is the sum of the infrastructure cost {{infrastructureCost}} and supplementary cost {{supplementaryCost}}"
+  },
   "details": {
     "clusters_modal_title": "$t(group_by.values.{{groupBy}}) {{name}} clusters",
     "more_clusters": ", {{value}} more...",
@@ -620,7 +623,6 @@
     "requests_label": "Requests",
     "storage_title": "Storage services usage",
     "storage_trend_title": "Daily usage comparison ({{units}})",
-    "total_cost_tooltip": "This total cost is the sum of the infrastructure cost: {{infrastructureCost}} and markup: {{markupCost}}",
     "usage_label": "Usage",
     "volume_title": "OpenShift volume usage and requests",
     "volume_trend_title": "Daily usage and requests comparison ({{units}})",
@@ -691,7 +693,7 @@
     "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}} related tags",
     "title": "OpenShift cloud infrastructure details",
     "total_cost": "Total cost",
-    "total_cost_tooltip": "This total cost is the sum of the infrastructure cost: {{infrastructureCost}} and markup: {{markupCost}}",
+    "total_cost_tooltip": "This total cost is the sum of the infrastructure cost {{infrastructureCost}} and supplementary cost {{supplementaryCost}}",
     "view_all": "View all {{value}}s",
     "widget_modal_title": "{{name}} {{groupBy}}s"
   },
@@ -704,7 +706,6 @@
     "memory_title": "Memory usage and requests",
     "memory_trend_title": "Daily usage and requests comparison ({{units}})",
     "requests_label": "Requests",
-    "total_cost_tooltip": "This total cost is the sum of the infrastructure cost {{infrastructureCost}} and supplementary cost {{supplementaryCost}}",
     "usage_label": "Usage",
     "volume_title": "Volume usage and requests",
     "volume_trend_title": "Daily usage and requests comparison ({{units}})",
@@ -818,7 +819,6 @@
     "memory_title": "Memory usage and requests",
     "memory_trend_title": "Daily usage and requests comparison ({{units}})",
     "requests_label": "Requests",
-    "total_cost_tooltip": "This total cost is the sum of the infrastructure cost {{infrastructureCost}} and supplementary cost {{supplementaryCost}}",
     "usage_label": "Usage",
     "volume_title": "Volume usage and requests",
     "volume_trend_title": "Daily usage and requests comparison ({{units}})",
@@ -843,7 +843,6 @@
     "requests_label": "Requests",
     "storage_title": "Storage services usage",
     "storage_trend_title": "Daily usage comparison ({{units}})",
-    "total_cost_tooltip": "This total cost is the sum of the infrastructure cost: {{infrastructureCost}} and markup: {{markupCost}}",
     "usage_label": "Usage",
     "volume_title": "OpenShift volume usage and requests",
     "volume_trend_title": "Daily usage and requests comparison ({{units}})",

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -245,13 +245,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   };
 
   private getDetails = () => {
-    const {
-      chartType,
-      currentReport,
-      details,
-      isUsageFirst,
-      perspective,
-    } = this.props;
+    const { chartType, currentReport, details, isUsageFirst } = this.props;
     const units = this.getUnits();
     return (
       <ReportSummaryDetails
@@ -259,9 +253,9 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         costLabel={this.getDetailsLabel(details.costKey, units)}
         formatOptions={details.formatOptions}
         formatValue={formatValue}
-        perspective={perspective}
         report={currentReport}
         requestLabel={this.getDetailsLabel(details.requestKey, units)}
+        showTooltip={details.showTooltip}
         showUnits={details.showUnits}
         showUsageFirst={isUsageFirst}
         usageFormatOptions={details.usageFormatOptions}
@@ -379,7 +373,10 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
       const hasUsage = hasTotal && tabsReport.meta.total.usage;
       totalValue = hasUsage ? tabsReport.meta.total.usage.value : undefined;
     } else {
-      const hasCost = hasTotal && tabsReport.meta.total.cost;
+      const hasCost =
+        hasTotal &&
+        tabsReport.meta.total.cost &&
+        tabsReport.meta.total.cost.total;
       totalValue = hasCost ? tabsReport.meta.total.cost.total.value : undefined;
     }
 
@@ -447,7 +444,10 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         ? unitLookupKey(currentReport.meta.total.usage.units)
         : '';
     } else {
-      const hasCost = hasTotal && currentReport.meta.total.cost;
+      const hasCost =
+        hasTotal &&
+        currentReport.meta.total.cost &&
+        currentReport.meta.total.cost.total;
       units = hasCost
         ? unitLookupKey(currentReport.meta.total.cost.total.units)
         : '';

--- a/src/pages/details/awsDetails/detailsHeader.tsx
+++ b/src/pages/details/awsDetails/detailsHeader.tsx
@@ -90,6 +90,13 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       providers.meta &&
       providers.meta.count > 0;
 
+    const hasCost =
+      report &&
+      report.meta &&
+      report.meta.total &&
+      report.meta.total.cost &&
+      report.meta.total.cost.total;
+
     return (
       <header className={css(styles.header)}>
         <div>
@@ -106,7 +113,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
         {Boolean(showContent) && (
           <div className={css(styles.cost)}>
             <Title className={css(styles.costValue)} size="4xl">
-              {formatCurrency(report.meta.total.cost.total.value)}
+              {formatCurrency(hasCost ? report.meta.total.cost.total.value : 0)}
             </Title>
             <div className={css(styles.costLabel)}>
               <div className={css(styles.costLabelUnit)}>

--- a/src/pages/details/awsDetails/detailsTable.tsx
+++ b/src/pages/details/awsDetails/detailsTable.tsx
@@ -97,7 +97,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const groupByTagKey = this.getGroupByTagKey();
 
     const total = formatCurrency(
-      report && report.meta && report.meta.total
+      report &&
+        report.meta &&
+        report.meta.total &&
+        report.meta.total.cost &&
+        report.meta.total.cost.total
         ? report.meta.total.cost.total.value
         : 0
     );
@@ -334,7 +338,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
   private getTotalCost = (item: ComputedReportItem, index: number) => {
     const { report, t } = this.props;
-    const cost = report.meta.total.cost.total.value;
+    const cost =
+      report &&
+      report.meta &&
+      report.meta.total &&
+      report.meta.total.cost &&
+      report.meta.total.cost.total
+        ? report.meta.total.cost.total.value
+        : 0;
 
     return (
       <>

--- a/src/pages/details/azureDetails/detailsHeader.tsx
+++ b/src/pages/details/azureDetails/detailsHeader.tsx
@@ -90,6 +90,13 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       providers.meta &&
       providers.meta.count > 0;
 
+    const hasCost =
+      report &&
+      report.meta &&
+      report.meta.total &&
+      report.meta.total.cost &&
+      report.meta.total.cost.total;
+
     return (
       <header className={css(styles.header)}>
         <div>
@@ -106,7 +113,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
         {Boolean(showContent) && (
           <div className={css(styles.cost)}>
             <Title className={css(styles.costValue)} size="4xl">
-              {formatCurrency(report.meta.total.cost.total.value)}
+              {formatCurrency(hasCost ? report.meta.total.cost.total.value : 0)}
             </Title>
             <div className={css(styles.costLabel)}>
               <div className={css(styles.costLabelUnit)}>

--- a/src/pages/details/azureDetails/detailsTable.tsx
+++ b/src/pages/details/azureDetails/detailsTable.tsx
@@ -97,7 +97,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const groupByTagKey = this.getGroupByTagKey();
 
     const total = formatCurrency(
-      report && report.meta && report.meta.total
+      report &&
+        report.meta &&
+        report.meta.total &&
+        report.meta.total.cost &&
+        report.meta.total.cost.total
         ? report.meta.total.cost.total.value
         : 0
     );
@@ -334,7 +338,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
   private getTotalCost = (item: ComputedReportItem, index: number) => {
     const { report, t } = this.props;
-    const cost = report.meta.total.cost.total.value;
+    const cost =
+      report &&
+      report.meta &&
+      report.meta.total &&
+      report.meta.total.cost &&
+      report.meta.total.cost.total
+        ? report.meta.total.cost.total.value
+        : 0;
 
     return (
       <>

--- a/src/pages/details/ocpCloudDetails/detailsHeader.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsHeader.tsx
@@ -107,19 +107,19 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     let infrastructureCost: string | React.ReactNode = <EmptyValueState />;
 
     if (report && report.meta && report.meta.total) {
+      const hasCost = report.meta.total.cost && report.meta.total.cost.total;
+      const hasInfrastructureCost =
+        report.meta.total.infrastructure &&
+        report.meta.total.infrastructure.total;
       cost = formatValue(
-        report.meta.total.cost.total.value
-          ? report.meta.total.cost.total.value
-          : 0,
-        report.meta.total.cost.total.units
-          ? report.meta.total.cost.total.units
-          : 'USD'
+        hasCost ? report.meta.total.cost.total.value : 0,
+        hasCost ? report.meta.total.cost.total.units : 'USD'
       );
       infrastructureCost = formatValue(
-        report.meta.total.infrastructure.total.value
+        hasInfrastructureCost
           ? report.meta.total.infrastructure.total.value
           : 0,
-        report.meta.total.infrastructure.total.units
+        hasInfrastructureCost
           ? report.meta.total.infrastructure.total.units
           : 'USD'
       );

--- a/src/pages/details/ocpCloudDetails/detailsTable.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsTable.tsx
@@ -97,7 +97,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const groupByTagKey = this.getGroupByTagKey();
 
     const total = formatCurrency(
-      report && report.meta && report.meta.total && report.meta.total.cost
+      report &&
+        report.meta &&
+        report.meta.total &&
+        report.meta.total.cost &&
+        report.meta.total.cost.total
         ? report.meta.total.cost.total.value
         : 0
     );
@@ -336,7 +340,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
   private getTotalCost = (item: ComputedReportItem, index: number) => {
     const { report, t } = this.props;
-    const total = report.meta.total.cost.total.value;
+    const cost =
+      report &&
+      report.meta &&
+      report.meta.total &&
+      report.meta.total.cost &&
+      report.meta.total.cost.total
+        ? report.meta.total.cost.total.value
+        : 0;
 
     return (
       <>
@@ -346,7 +357,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           key={`total-cost-${index}`}
         >
           {t('percent_of_cost', {
-            value: ((item.cost / total) * 100).toFixed(2),
+            value: ((item.cost / cost) * 100).toFixed(2),
           })}
         </div>
       </>

--- a/src/pages/details/ocpDetails/detailsHeader.tsx
+++ b/src/pages/details/ocpDetails/detailsHeader.tsx
@@ -108,25 +108,28 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     let infrastructureCost: string | React.ReactNode = <EmptyValueState />;
 
     if (report && report.meta && report.meta.total) {
+      const hasCost = report.meta.total.cost && report.meta.total.cost.total;
+      const hasSupplementaryCost =
+        report.meta.total.supplementary &&
+        report.meta.total.supplementary.total;
+      const hasInfrastructureCost =
+        report.meta.total.infrastructure &&
+        report.meta.total.infrastructure.total;
       cost = formatValue(
-        report.meta.total.cost.total ? report.meta.total.cost.total.value : 0,
-        report.meta.total.cost.total
-          ? report.meta.total.cost.total.units
-          : 'USD'
+        hasCost ? report.meta.total.cost.total.value : 0,
+        hasCost ? report.meta.total.cost.total.units : 'USD'
       );
       supplementaryCost = formatValue(
-        report.meta.total.supplementary.total
-          ? report.meta.total.supplementary.total.value
-          : 0,
-        report.meta.total.supplementary.total
+        hasSupplementaryCost ? report.meta.total.supplementary.total.value : 0,
+        hasSupplementaryCost
           ? report.meta.total.supplementary.total.units
           : 'USD'
       );
       infrastructureCost = formatValue(
-        report.meta.total.infrastructure.total.value
+        hasInfrastructureCost
           ? report.meta.total.infrastructure.total.value
           : 0,
-        report.meta.total.infrastructure.total.units
+        hasInfrastructureCost
           ? report.meta.total.infrastructure.total.units
           : 'USD'
       );

--- a/src/pages/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/details/ocpDetails/detailsTable.tsx
@@ -97,7 +97,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const groupByTagKey = this.getGroupByTagKey();
 
     const total = formatCurrency(
-      report && report.meta && report.meta.total
+      report &&
+        report.meta &&
+        report.meta.total &&
+        report.meta.total.cost &&
+        report.meta.total.cost.total
         ? report.meta.total.cost.total.value
         : 0
     );
@@ -412,7 +416,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
   private getTotalCost = (item: ComputedReportItem, index: number) => {
     const { report, t } = this.props;
-    const total = report.meta.total.cost.total.value;
+    const cost =
+      report &&
+      report.meta &&
+      report.meta.total &&
+      report.meta.total.cost &&
+      report.meta.total.cost.total
+        ? report.meta.total.cost.total.value
+        : 0;
 
     return (
       <>
@@ -422,7 +433,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           key={`total-cost-${index}`}
         >
           {t('percent_of_cost', {
-            value: ((item.cost / total) * 100).toFixed(2),
+            value: ((item.cost / cost) * 100).toFixed(2),
           })}
         </div>
       </>

--- a/src/store/dashboard/awsCloudDashboard/awsCloudDashboardWidgets.ts
+++ b/src/store/dashboard/awsCloudDashboard/awsCloudDashboardWidgets.ts
@@ -3,10 +3,7 @@ import {
   ChartComparison,
   ChartType,
 } from 'components/charts/common/chartUtils';
-import {
-  DashboardChartType,
-  DashboardPerspective,
-} from 'store/dashboard/common/dashboardCommon';
+import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
   AwsCloudDashboardTab,
   AwsCloudDashboardWidget,
@@ -56,7 +53,6 @@ export const computeWidget: AwsCloudDashboardWidget = {
   // ],
   chartType: DashboardChartType.trend,
   currentTab: AwsCloudDashboardTab.instanceType,
-  perspective: DashboardPerspective.awsCloud,
 };
 
 export const costSummaryWidget: AwsCloudDashboardWidget = {
@@ -90,7 +86,6 @@ export const costSummaryWidget: AwsCloudDashboardWidget = {
   ],
   chartType: DashboardChartType.trend,
   currentTab: AwsCloudDashboardTab.services,
-  perspective: DashboardPerspective.awsCloud,
 };
 
 export const databaseWidget: AwsCloudDashboardWidget = {
@@ -128,7 +123,6 @@ export const databaseWidget: AwsCloudDashboardWidget = {
   // ],
   chartType: DashboardChartType.trend,
   currentTab: AwsCloudDashboardTab.services,
-  perspective: DashboardPerspective.awsCloud,
 };
 
 export const networkWidget: AwsCloudDashboardWidget = {
@@ -164,7 +158,6 @@ export const networkWidget: AwsCloudDashboardWidget = {
   // ],
   chartType: DashboardChartType.trend,
   currentTab: AwsCloudDashboardTab.services,
-  perspective: DashboardPerspective.awsCloud,
 };
 
 export const storageWidget: AwsCloudDashboardWidget = {
@@ -202,5 +195,4 @@ export const storageWidget: AwsCloudDashboardWidget = {
   // ],
   chartType: DashboardChartType.trend,
   currentTab: AwsCloudDashboardTab.accounts,
-  perspective: DashboardPerspective.awsCloud,
 };

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -3,10 +3,7 @@ import {
   ChartComparison,
   ChartType,
 } from 'components/charts/common/chartUtils';
-import {
-  DashboardChartType,
-  DashboardPerspective,
-} from 'store/dashboard/common/dashboardCommon';
+import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { AwsDashboardTab, AwsDashboardWidget } from './awsDashboardCommon';
 
 let currrentId = 0;
@@ -53,7 +50,6 @@ export const computeWidget: AwsDashboardWidget = {
   // ],
   chartType: DashboardChartType.trend,
   currentTab: AwsDashboardTab.instanceType,
-  perspective: DashboardPerspective.aws,
 };
 
 export const costSummaryWidget: AwsDashboardWidget = {
@@ -87,7 +83,6 @@ export const costSummaryWidget: AwsDashboardWidget = {
   ],
   chartType: DashboardChartType.trend,
   currentTab: AwsDashboardTab.services,
-  perspective: DashboardPerspective.aws,
 };
 
 export const databaseWidget: AwsDashboardWidget = {
@@ -125,7 +120,6 @@ export const databaseWidget: AwsDashboardWidget = {
   // ],
   chartType: DashboardChartType.trend,
   currentTab: AwsDashboardTab.services,
-  perspective: DashboardPerspective.aws,
 };
 
 export const networkWidget: AwsDashboardWidget = {
@@ -161,7 +155,6 @@ export const networkWidget: AwsDashboardWidget = {
   // ],
   chartType: DashboardChartType.trend,
   currentTab: AwsDashboardTab.services,
-  perspective: DashboardPerspective.aws,
 };
 
 export const storageWidget: AwsDashboardWidget = {
@@ -199,5 +192,4 @@ export const storageWidget: AwsDashboardWidget = {
   // ],
   chartType: DashboardChartType.trend,
   currentTab: AwsDashboardTab.accounts,
-  perspective: DashboardPerspective.aws,
 };

--- a/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
+++ b/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
@@ -3,10 +3,7 @@ import {
   ChartComparison,
   ChartType,
 } from 'components/charts/common/chartUtils';
-import {
-  DashboardChartType,
-  DashboardPerspective,
-} from 'store/dashboard/common/dashboardCommon';
+import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
   AzureCloudDashboardTab,
   AzureCloudDashboardWidget,
@@ -46,7 +43,6 @@ export const costSummaryWidget: AzureCloudDashboardWidget = {
   ],
   chartType: DashboardChartType.trend,
   currentTab: AzureCloudDashboardTab.service_names,
-  perspective: DashboardPerspective.azureCloud,
 };
 
 export const databaseWidget: AzureCloudDashboardWidget = {
@@ -82,7 +78,6 @@ export const databaseWidget: AzureCloudDashboardWidget = {
   // ],
   chartType: DashboardChartType.trend,
   currentTab: AzureCloudDashboardTab.service_names,
-  perspective: DashboardPerspective.azureCloud,
 };
 
 export const networkWidget: AzureCloudDashboardWidget = {
@@ -120,7 +115,6 @@ export const networkWidget: AzureCloudDashboardWidget = {
   // ],
   chartType: DashboardChartType.trend,
   currentTab: AzureCloudDashboardTab.service_names,
-  perspective: DashboardPerspective.azureCloud,
 };
 
 export const storageWidget: AzureCloudDashboardWidget = {
@@ -165,7 +159,6 @@ export const storageWidget: AzureCloudDashboardWidget = {
   // ],
   chartType: DashboardChartType.trend,
   currentTab: AzureCloudDashboardTab.subscription_guids,
-  perspective: DashboardPerspective.azureCloud,
 };
 
 export const virtualMachineWidget: AzureCloudDashboardWidget = {
@@ -210,5 +203,4 @@ export const virtualMachineWidget: AzureCloudDashboardWidget = {
   // ],
   chartType: DashboardChartType.trend,
   currentTab: AzureCloudDashboardTab.instanceType,
-  perspective: DashboardPerspective.azureCloud,
 };

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -3,10 +3,7 @@ import {
   ChartComparison,
   ChartType,
 } from 'components/charts/common/chartUtils';
-import {
-  DashboardChartType,
-  DashboardPerspective,
-} from 'store/dashboard/common/dashboardCommon';
+import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
   AzureDashboardTab,
   AzureDashboardWidget,
@@ -46,7 +43,6 @@ export const costSummaryWidget: AzureDashboardWidget = {
   ],
   chartType: DashboardChartType.trend,
   currentTab: AzureDashboardTab.service_names,
-  perspective: DashboardPerspective.azure,
 };
 
 export const databaseWidget: AzureDashboardWidget = {
@@ -82,7 +78,6 @@ export const databaseWidget: AzureDashboardWidget = {
   // ],
   chartType: DashboardChartType.trend,
   currentTab: AzureDashboardTab.service_names,
-  perspective: DashboardPerspective.azure,
 };
 
 export const networkWidget: AzureDashboardWidget = {
@@ -120,7 +115,6 @@ export const networkWidget: AzureDashboardWidget = {
   // ],
   chartType: DashboardChartType.trend,
   currentTab: AzureDashboardTab.service_names,
-  perspective: DashboardPerspective.azure,
 };
 
 export const storageWidget: AzureDashboardWidget = {
@@ -165,7 +159,6 @@ export const storageWidget: AzureDashboardWidget = {
   // ],
   chartType: DashboardChartType.trend,
   currentTab: AzureDashboardTab.subscription_guids,
-  perspective: DashboardPerspective.azure,
 };
 
 export const virtualMachineWidget: AzureDashboardWidget = {
@@ -210,5 +203,4 @@ export const virtualMachineWidget: AzureDashboardWidget = {
   // ],
   chartType: DashboardChartType.trend,
   currentTab: AzureDashboardTab.instanceType,
-  perspective: DashboardPerspective.azure,
 };

--- a/src/store/dashboard/common/dashboardCommon.ts
+++ b/src/store/dashboard/common/dashboardCommon.ts
@@ -6,17 +6,6 @@ export const enum DashboardChartType {
   usage = 'usage',
 }
 
-export const enum DashboardPerspective {
-  aws = 'aws',
-  awsCloud = 'aws_cloud', // Aws filtered by Ocp
-  azure = 'azure',
-  azureCloud = 'azure_cloud', // Azure filtered by Ocp
-  ocp = 'ocp',
-  ocpCloud = 'ocp_cloud', // All filtered by Ocp
-  ocpUsage = 'ocp_usage',
-  ocpSupplementary = 'ocp_supplementary',
-}
-
 export interface ValueFormatOptions {
   fractionDigits?: number;
 }
@@ -33,6 +22,7 @@ export interface DashboardWidget<T> {
       fractionDigits?: number;
     };
     requestKey?: string;
+    showTooltip?: boolean;
     showUnits?: boolean;
     showUsageLegendLabel?: boolean;
     units?: string;
@@ -48,7 +38,6 @@ export interface DashboardWidget<T> {
   isDetailsLink?: boolean;
   isHorizontal?: boolean;
   isUsageFirst?: boolean;
-  perspective?: DashboardPerspective;
   reportType: ReportType;
   /** i18n key for the title. passed { startDate, endDate, month, time } */
   titleKey: string;

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
@@ -3,10 +3,7 @@ import {
   ChartComparison,
   ChartType,
 } from 'components/charts/common/chartUtils';
-import {
-  DashboardChartType,
-  DashboardPerspective,
-} from 'store/dashboard/common/dashboardCommon';
+import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
   OcpCloudDashboardTab,
   OcpCloudDashboardWidget,
@@ -46,7 +43,6 @@ export const costSummaryWidget: OcpCloudDashboardWidget = {
   ],
   chartType: DashboardChartType.trend,
   currentTab: OcpCloudDashboardTab.services,
-  perspective: DashboardPerspective.ocpCloud,
 };
 
 // Cloud widgets
@@ -80,7 +76,6 @@ export const computeWidget: OcpCloudDashboardWidget = {
     type: ChartType.daily,
   },
   chartType: DashboardChartType.trend,
-  perspective: DashboardPerspective.ocpCloud,
 };
 
 export const databaseWidget: OcpCloudDashboardWidget = {
@@ -106,7 +101,6 @@ export const databaseWidget: OcpCloudDashboardWidget = {
     type: ChartType.rolling,
   },
   chartType: DashboardChartType.trend,
-  perspective: DashboardPerspective.ocpCloud,
 };
 
 export const networkWidget: OcpCloudDashboardWidget = {
@@ -132,7 +126,6 @@ export const networkWidget: OcpCloudDashboardWidget = {
     type: ChartType.rolling,
   },
   chartType: DashboardChartType.trend,
-  perspective: DashboardPerspective.ocpCloud,
 };
 
 export const storageWidget: OcpCloudDashboardWidget = {
@@ -161,5 +154,4 @@ export const storageWidget: OcpCloudDashboardWidget = {
     type: ChartType.daily,
   },
   chartType: DashboardChartType.trend,
-  perspective: DashboardPerspective.ocpCloud,
 };

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -3,10 +3,7 @@ import {
   ChartComparison,
   ChartType,
 } from 'components/charts/common/chartUtils';
-import {
-  DashboardChartType,
-  DashboardPerspective,
-} from 'store/dashboard/common/dashboardCommon';
+import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { OcpDashboardTab, OcpDashboardWidget } from './ocpDashboardCommon';
 
 let currrentId = 0;
@@ -21,6 +18,7 @@ export const costSummaryWidget: OcpDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
+    showTooltip: true,
   },
   isDetailsLink: true,
   isHorizontal: true,
@@ -39,7 +37,6 @@ export const costSummaryWidget: OcpDashboardWidget = {
   availableTabs: [OcpDashboardTab.projects, OcpDashboardTab.clusters],
   chartType: DashboardChartType.cost,
   currentTab: OcpDashboardTab.projects,
-  perspective: DashboardPerspective.ocp,
 };
 
 export const cpuWidget: OcpDashboardWidget = {
@@ -75,7 +72,6 @@ export const cpuWidget: OcpDashboardWidget = {
   // availableTabs: [OcpDashboardTab.projects, OcpDashboardTab.clusters],
   chartType: DashboardChartType.usage,
   currentTab: OcpDashboardTab.projects,
-  perspective: DashboardPerspective.ocp,
 };
 
 export const memoryWidget: OcpDashboardWidget = {
@@ -111,7 +107,6 @@ export const memoryWidget: OcpDashboardWidget = {
   // availableTabs: [OcpDashboardTab.projects, OcpDashboardTab.clusters],
   chartType: DashboardChartType.usage,
   currentTab: OcpDashboardTab.projects,
-  perspective: DashboardPerspective.ocp,
 };
 
 export const volumeWidget: OcpDashboardWidget = {
@@ -147,5 +142,4 @@ export const volumeWidget: OcpDashboardWidget = {
   // availableTabs: [OcpDashboardTab.projects, OcpDashboardTab.clusters],
   chartType: DashboardChartType.usage,
   currentTab: OcpDashboardTab.projects,
-  perspective: DashboardPerspective.ocp,
 };

--- a/src/store/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidgets.ts
+++ b/src/store/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidgets.ts
@@ -3,10 +3,7 @@ import {
   ChartComparison,
   ChartType,
 } from 'components/charts/common/chartUtils';
-import {
-  DashboardChartType,
-  DashboardPerspective,
-} from 'store/dashboard/common/dashboardCommon';
+import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
   OcpSupplementaryDashboardTab,
   OcpSupplementaryDashboardWidget,
@@ -45,7 +42,6 @@ export const costSummaryWidget: OcpSupplementaryDashboardWidget = {
   ],
   chartType: DashboardChartType.cost,
   currentTab: OcpSupplementaryDashboardTab.projects,
-  perspective: DashboardPerspective.ocpSupplementary,
 };
 
 export const cpuWidget: OcpSupplementaryDashboardWidget = {
@@ -84,7 +80,6 @@ export const cpuWidget: OcpSupplementaryDashboardWidget = {
   // ],
   chartType: DashboardChartType.usage,
   currentTab: OcpSupplementaryDashboardTab.projects,
-  perspective: DashboardPerspective.ocpSupplementary,
 };
 
 export const memoryWidget: OcpSupplementaryDashboardWidget = {
@@ -123,7 +118,6 @@ export const memoryWidget: OcpSupplementaryDashboardWidget = {
   // ],
   chartType: DashboardChartType.usage,
   currentTab: OcpSupplementaryDashboardTab.projects,
-  perspective: DashboardPerspective.ocpSupplementary,
 };
 
 export const volumeWidget: OcpSupplementaryDashboardWidget = {
@@ -162,5 +156,4 @@ export const volumeWidget: OcpSupplementaryDashboardWidget = {
   // ],
   chartType: DashboardChartType.usage,
   currentTab: OcpSupplementaryDashboardTab.projects,
-  perspective: DashboardPerspective.ocpSupplementary,
 };

--- a/src/store/dashboard/ocpUsageDashboard/ocpUsageDashboardWidgets.ts
+++ b/src/store/dashboard/ocpUsageDashboard/ocpUsageDashboardWidgets.ts
@@ -3,10 +3,7 @@ import {
   ChartComparison,
   ChartType,
 } from 'components/charts/common/chartUtils';
-import {
-  DashboardChartType,
-  DashboardPerspective,
-} from 'store/dashboard/common/dashboardCommon';
+import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
   OcpUsageDashboardTab,
   OcpUsageDashboardWidget,
@@ -42,7 +39,6 @@ export const costSummaryWidget: OcpUsageDashboardWidget = {
   availableTabs: [OcpUsageDashboardTab.projects, OcpUsageDashboardTab.clusters],
   chartType: DashboardChartType.trend,
   currentTab: OcpUsageDashboardTab.projects,
-  perspective: DashboardPerspective.ocpUsage,
 };
 
 export const cpuWidget: OcpUsageDashboardWidget = {
@@ -70,7 +66,6 @@ export const cpuWidget: OcpUsageDashboardWidget = {
     type: ChartType.daily,
   },
   chartType: DashboardChartType.usage,
-  perspective: DashboardPerspective.ocpUsage,
 };
 
 export const memoryWidget: OcpUsageDashboardWidget = {
@@ -101,7 +96,6 @@ export const memoryWidget: OcpUsageDashboardWidget = {
     type: ChartType.daily,
   },
   chartType: DashboardChartType.usage,
-  perspective: DashboardPerspective.ocpUsage,
 };
 
 export const volumeWidget: OcpUsageDashboardWidget = {
@@ -132,5 +126,4 @@ export const volumeWidget: OcpUsageDashboardWidget = {
     type: ChartType.daily,
   },
   chartType: DashboardChartType.usage,
-  perspective: DashboardPerspective.ocpUsage,
 };


### PR DESCRIPTION
Removed the cumulative cost tooltip from Infrastructure overview. The only cumulative cost tooltip that should be displayed is for the Ocp overview.

Also added better testing for the new `report.meta.total.cost.total` object -- that change caused the UI to crash while APIs are being updated.