### PR TITLE
Updated the supplementary cost description in Ocp details

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -799,7 +799,7 @@
     },
     "supplementary_aria_label": "A description of infrastructure and supplementary cost",
     "supplementary_cost_column_title": "Supplementary cost",
-    "supplementary_cost_desc": "The cost based on the user’s defined price list specified as supplementary.",
+    "supplementary_cost_desc": "All costs not directly attributed to the infrastructure. These costs are determined by applying a price list within a cost model to OpenShift cluster metrics.",
     "supplementary_cost_title": "Supplementary cost",
     "tag_column_title": "Tag names",
     "tags_label": "Related tags:",


### PR DESCRIPTION
Updated the supplementary cost description in the info popup, shown in Ocp details.

<img width="372" alt="Screen Shot 2020-03-19 at 1 16 32 PM" src="https://user-images.githubusercontent.com/17481322/77095309-1a203600-69e4-11ea-86bb-f1e79f659ae8.png">

https://github.com/project-koku/koku-ui/issues/1396