### PR TITLE
Reuse DashboardWidgetOwnProps & DashboardWidgetStateProps interfaces

### DIFF
--- a/src/pages/dashboard/awsCloudDashboard/awsCloudDashboardWidget.tsx
+++ b/src/pages/dashboard/awsCloudDashboard/awsCloudDashboardWidget.tsx
@@ -1,5 +1,8 @@
-import { AwsReport } from 'api/reports/awsReports';
-import { DashboardWidgetBase } from 'pages/dashboard/components/dashboardWidgetBase';
+import {
+  DashboardWidgetBase,
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps,
+} from 'pages/dashboard/components/dashboardWidgetBase';
 import { translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
@@ -7,29 +10,9 @@ import {
   awsCloudDashboardActions,
   awsCloudDashboardSelectors,
   AwsCloudDashboardTab,
-  AwsCloudDashboardWidget as AwsCloudDashboardWidgetStatic,
 } from 'store/dashboard/awsCloudDashboard';
 import { awsReportsSelectors } from 'store/reports/awsReports';
 import { ComputedAwsReportItemsParams } from 'utils/computedReport/getComputedAwsReportItems';
-
-interface AwsCloudDashboardWidgetOwnProps {
-  appNavPath: string;
-  detailsPath: string;
-  getIdKeyForTab: (tab: AwsCloudDashboardTab) => string;
-  widgetId: number;
-}
-
-interface AwsCloudDashboardWidgetStateProps
-  extends AwsCloudDashboardWidgetStatic {
-  currentQuery: string;
-  currentReport: AwsReport;
-  currentReportFetchStatus: number;
-  previousQuery: string;
-  previousReport: AwsReport;
-  tabsQuery: string;
-  tabsReport: AwsReport;
-  tabsReportFetchStatus: number;
-}
 
 interface AwsCloudDashboardWidgetDispatchProps {
   fetchReports: typeof awsCloudDashboardActions.fetchWidgetReports;
@@ -52,8 +35,8 @@ export const getIdKeyForTab = (
 };
 
 const mapStateToProps = createMapStateToProps<
-  AwsCloudDashboardWidgetOwnProps,
-  AwsCloudDashboardWidgetStateProps
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps
 >((state, { widgetId }) => {
   const widget = awsCloudDashboardSelectors.selectWidget(state, widgetId);
   const queries = awsCloudDashboardSelectors.selectWidgetQueries(

--- a/src/pages/dashboard/awsDashboard/awsDashboardWidget.tsx
+++ b/src/pages/dashboard/awsDashboard/awsDashboardWidget.tsx
@@ -1,5 +1,8 @@
-import { AwsReport } from 'api/reports/awsReports';
-import { DashboardWidgetBase } from 'pages/dashboard/components/dashboardWidgetBase';
+import {
+  DashboardWidgetBase,
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps,
+} from 'pages/dashboard/components/dashboardWidgetBase';
 import { translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
@@ -7,28 +10,9 @@ import {
   awsDashboardActions,
   awsDashboardSelectors,
   AwsDashboardTab,
-  AwsDashboardWidget as AwsDashboardWidgetStatic,
 } from 'store/dashboard/awsDashboard';
 import { awsReportsSelectors } from 'store/reports/awsReports';
 import { ComputedAwsReportItemsParams } from 'utils/computedReport/getComputedAwsReportItems';
-
-interface AwsDashboardWidgetOwnProps {
-  appNavPath: string;
-  detailsPath: string;
-  getIdKeyForTab: (tab: AwsDashboardTab) => string;
-  widgetId: number;
-}
-
-interface AwsDashboardWidgetStateProps extends AwsDashboardWidgetStatic {
-  currentQuery: string;
-  currentReport: AwsReport;
-  currentReportFetchStatus: number;
-  previousQuery: string;
-  previousReport: AwsReport;
-  tabsQuery: string;
-  tabsReport: AwsReport;
-  tabsReportFetchStatus: number;
-}
 
 interface AwsDashboardWidgetDispatchProps {
   fetchReports: typeof awsDashboardActions.fetchWidgetReports;
@@ -51,8 +35,8 @@ export const getIdKeyForTab = (
 };
 
 const mapStateToProps = createMapStateToProps<
-  AwsDashboardWidgetOwnProps,
-  AwsDashboardWidgetStateProps
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps
 >((state, { widgetId }) => {
   const widget = awsDashboardSelectors.selectWidget(state, widgetId);
   const queries = awsDashboardSelectors.selectWidgetQueries(state, widgetId);

--- a/src/pages/dashboard/azureCloudDashboard/azureCloudDashboardWidget.tsx
+++ b/src/pages/dashboard/azureCloudDashboard/azureCloudDashboardWidget.tsx
@@ -1,5 +1,8 @@
-import { AzureReport } from 'api/reports/azureReports';
-import { DashboardWidgetBase } from 'pages/dashboard/components/dashboardWidgetBase';
+import {
+  DashboardWidgetBase,
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps,
+} from 'pages/dashboard/components/dashboardWidgetBase';
 import { translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
@@ -7,29 +10,9 @@ import {
   azureCloudDashboardActions,
   azureCloudDashboardSelectors,
   AzureCloudDashboardTab,
-  AzureCloudDashboardWidget as AzureCloudDashboardWidgetStatic,
 } from 'store/dashboard/azureCloudDashboard';
 import { azureReportsSelectors } from 'store/reports/azureReports';
 import { ComputedAzureReportItemsParams } from 'utils/computedReport/getComputedAzureReportItems';
-
-interface AzureCloudDashboardWidgetOwnProps {
-  appNavPath: string;
-  detailsPath: string;
-  getIdKeyForTab: (tab: AzureCloudDashboardTab) => string;
-  widgetId: number;
-}
-
-interface AzureCloudDashboardWidgetStateProps
-  extends AzureCloudDashboardWidgetStatic {
-  currentQuery: string;
-  currentReport: AzureReport;
-  currentReportFetchStatus: number;
-  previousQuery: string;
-  previousReport: AzureReport;
-  tabsQuery: string;
-  tabsReport: AzureReport;
-  tabsReportFetchStatus: number;
-}
 
 interface AzureCloudDashboardWidgetDispatchProps {
   fetchReports: typeof azureCloudDashboardActions.fetchWidgetReports;
@@ -52,8 +35,8 @@ export const getIdKeyForTab = (
 };
 
 const mapStateToProps = createMapStateToProps<
-  AzureCloudDashboardWidgetOwnProps,
-  AzureCloudDashboardWidgetStateProps
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps
 >((state, { widgetId }) => {
   const widget = azureCloudDashboardSelectors.selectWidget(state, widgetId);
   const queries = azureCloudDashboardSelectors.selectWidgetQueries(

--- a/src/pages/dashboard/azureDashboard/azureDashboardWidget.tsx
+++ b/src/pages/dashboard/azureDashboard/azureDashboardWidget.tsx
@@ -1,5 +1,8 @@
-import { AzureReport } from 'api/reports/azureReports';
-import { DashboardWidgetBase } from 'pages/dashboard/components/dashboardWidgetBase';
+import {
+  DashboardWidgetBase,
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps,
+} from 'pages/dashboard/components/dashboardWidgetBase';
 import { translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
@@ -7,28 +10,9 @@ import {
   azureDashboardActions,
   azureDashboardSelectors,
   AzureDashboardTab,
-  AzureDashboardWidget as AzureDashboardWidgetStatic,
 } from 'store/dashboard/azureDashboard';
 import { azureReportsSelectors } from 'store/reports/azureReports';
 import { ComputedAzureReportItemsParams } from 'utils/computedReport/getComputedAzureReportItems';
-
-interface AzureDashboardWidgetOwnProps {
-  appNavPath: string;
-  detailsPath: string;
-  getIdKeyForTab: (tab: AzureDashboardTab) => string;
-  widgetId: number;
-}
-
-interface AzureDashboardWidgetStateProps extends AzureDashboardWidgetStatic {
-  currentQuery: string;
-  currentReport: AzureReport;
-  currentReportFetchStatus: number;
-  previousQuery: string;
-  previousReport: AzureReport;
-  tabsQuery: string;
-  tabsReport: AzureReport;
-  tabsReportFetchStatus: number;
-}
 
 interface AzureDashboardWidgetDispatchProps {
   fetchReports: typeof azureDashboardActions.fetchWidgetReports;
@@ -51,8 +35,8 @@ export const getIdKeyForTab = (
 };
 
 const mapStateToProps = createMapStateToProps<
-  AzureDashboardWidgetOwnProps,
-  AzureDashboardWidgetStateProps
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps
 >((state, { widgetId }) => {
   const widget = azureDashboardSelectors.selectWidget(state, widgetId);
   const queries = azureDashboardSelectors.selectWidgetQueries(state, widgetId);

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -500,4 +500,9 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   }
 }
 
-export { DashboardWidgetBase, DashboardWidgetProps };
+export {
+  DashboardWidgetBase,
+  DashboardWidgetProps,
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps,
+};

--- a/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboardWidget.tsx
@@ -1,5 +1,8 @@
-import { OcpCloudReport } from 'api/reports/ocpCloudReports';
-import { DashboardWidgetBase } from 'pages/dashboard/components/dashboardWidgetBase';
+import {
+  DashboardWidgetBase,
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps,
+} from 'pages/dashboard/components/dashboardWidgetBase';
 import { translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
@@ -7,29 +10,9 @@ import {
   ocpCloudDashboardActions,
   ocpCloudDashboardSelectors,
   OcpCloudDashboardTab,
-  OcpCloudDashboardWidget as OcpCloudDashboardWidgetStatic,
 } from 'store/dashboard/ocpCloudDashboard';
 import { ocpCloudReportsSelectors } from 'store/reports/ocpCloudReports';
 import { ComputedOcpCloudReportItemsParams } from 'utils/computedReport/getComputedOcpCloudReportItems';
-
-interface OcpCloudDashboardWidgetOwnProps {
-  appNavPath: string;
-  detailsPath: string;
-  getIdKeyForTab: (tab: OcpCloudDashboardTab) => string;
-  widgetId: number;
-}
-
-interface OcpCloudDashboardWidgetStateProps
-  extends OcpCloudDashboardWidgetStatic {
-  currentQuery: string;
-  currentReport: OcpCloudReport;
-  currentReportFetchStatus: number;
-  previousQuery: string;
-  previousReport: OcpCloudReport;
-  tabsQuery: string;
-  tabsReport: OcpCloudReport;
-  tabsReportFetchStatus: number;
-}
 
 interface OcpCloudDashboardWidgetDispatchProps {
   fetchReports: typeof ocpCloudDashboardActions.fetchWidgetReports;
@@ -50,8 +33,8 @@ export const getIdKeyForTab = (
 };
 
 const mapStateToProps = createMapStateToProps<
-  OcpCloudDashboardWidgetOwnProps,
-  OcpCloudDashboardWidgetStateProps
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps
 >((state, { widgetId }) => {
   const widget = ocpCloudDashboardSelectors.selectWidget(state, widgetId);
   const queries = ocpCloudDashboardSelectors.selectWidgetQueries(

--- a/src/pages/dashboard/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpDashboard/ocpDashboardWidget.tsx
@@ -1,5 +1,8 @@
-import { OcpReport } from 'api/reports/ocpReports';
-import { DashboardWidgetBase } from 'pages/dashboard/components/dashboardWidgetBase';
+import {
+  DashboardWidgetBase,
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps,
+} from 'pages/dashboard/components/dashboardWidgetBase';
 import { translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
@@ -7,31 +10,10 @@ import {
   ocpDashboardActions,
   ocpDashboardSelectors,
   OcpDashboardTab,
-  OcpDashboardWidget as OcpDashboardWidgetStatic,
 } from 'store/dashboard/ocpDashboard';
 import { ocpReportsSelectors } from 'store/reports/ocpReports';
 import { ComputedOcpReportItemsParams } from 'utils/computedReport/getComputedOcpReportItems';
 import { chartStyles } from './ocpDashboardWidget.styles';
-
-interface OcpDashboardWidgetOwnProps {
-  chartAltHeight?: number;
-  containerAltHeight?: number;
-  appNavPath: string;
-  detailsPath: string;
-  getIdKeyForTab: (tab: OcpDashboardTab) => string;
-  widgetId: number;
-}
-
-interface OcpDashboardWidgetStateProps extends OcpDashboardWidgetStatic {
-  currentQuery: string;
-  currentReport: OcpReport;
-  currentReportFetchStatus: number;
-  previousQuery: string;
-  previousReport: OcpReport;
-  tabsQuery: string;
-  tabsReport: OcpReport;
-  tabsReportFetchStatus: number;
-}
 
 interface OcpDashboardWidgetDispatchProps {
   fetchReports: typeof ocpDashboardActions.fetchWidgetReports;
@@ -52,8 +34,8 @@ export const getIdKeyForTab = (
 };
 
 const mapStateToProps = createMapStateToProps<
-  OcpDashboardWidgetOwnProps,
-  OcpDashboardWidgetStateProps
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps
 >((state, { widgetId }) => {
   const widget = ocpDashboardSelectors.selectWidget(state, widgetId);
   const queries = ocpDashboardSelectors.selectWidgetQueries(state, widgetId);

--- a/src/pages/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidget.tsx
@@ -1,5 +1,8 @@
-import { OcpReport } from 'api/reports/ocpReports';
-import { DashboardWidgetBase } from 'pages/dashboard/components/dashboardWidgetBase';
+import {
+  DashboardWidgetBase,
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps,
+} from 'pages/dashboard/components/dashboardWidgetBase';
 import { translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
@@ -7,32 +10,10 @@ import {
   ocpSupplementaryDashboardActions,
   ocpSupplementaryDashboardSelectors,
   OcpSupplementaryDashboardTab,
-  OcpSupplementaryDashboardWidget as OcpSupplementaryDashboardWidgetStatic,
 } from 'store/dashboard/ocpSupplementaryDashboard';
 import { ocpReportsSelectors } from 'store/reports/ocpReports';
 import { ComputedOcpReportItemsParams } from 'utils/computedReport/getComputedOcpReportItems';
 import { chartStyles } from './ocpSupplementaryDashboardWidget.styles';
-
-interface OcpSupplementaryDashboardWidgetOwnProps {
-  chartAltHeight?: number;
-  containerAltHeight?: number;
-  appNavPath: string;
-  detailsPath: string;
-  getIdKeyForTab: (tab: OcpSupplementaryDashboardTab) => string;
-  widgetId: number;
-}
-
-interface OcpSupplementaryDashboardWidgetStateProps
-  extends OcpSupplementaryDashboardWidgetStatic {
-  currentQuery: string;
-  currentReport: OcpReport;
-  currentReportFetchStatus: number;
-  previousQuery: string;
-  previousReport: OcpReport;
-  tabsQuery: string;
-  tabsReport: OcpReport;
-  tabsReportFetchStatus: number;
-}
 
 interface OcpSupplementaryDashboardWidgetDispatchProps {
   fetchReports: typeof ocpSupplementaryDashboardActions.fetchWidgetReports;
@@ -53,8 +34,8 @@ export const getIdKeyForTab = (
 };
 
 const mapStateToProps = createMapStateToProps<
-  OcpSupplementaryDashboardWidgetOwnProps,
-  OcpSupplementaryDashboardWidgetStateProps
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps
 >((state, { widgetId }) => {
   const widget = ocpSupplementaryDashboardSelectors.selectWidget(
     state,

--- a/src/pages/dashboard/ocpUsageDashboard/ocpUsageDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpUsageDashboard/ocpUsageDashboardWidget.tsx
@@ -1,5 +1,8 @@
-import { OcpCloudReport } from 'api/reports/ocpCloudReports';
-import { DashboardWidgetBase } from 'pages/dashboard/components/dashboardWidgetBase';
+import {
+  DashboardWidgetBase,
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps,
+} from 'pages/dashboard/components/dashboardWidgetBase';
 import { translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
@@ -7,29 +10,9 @@ import {
   ocpUsageDashboardActions,
   ocpUsageDashboardSelectors,
   OcpUsageDashboardTab,
-  OcpUsageDashboardWidget as OcpUsageDashboardWidgetStatic,
 } from 'store/dashboard/ocpUsageDashboard';
 import { ocpCloudReportsSelectors } from 'store/reports/ocpCloudReports';
 import { ComputedOcpCloudReportItemsParams } from 'utils/computedReport/getComputedOcpCloudReportItems';
-
-interface OcpUsageDashboardWidgetOwnProps {
-  appNavPath: string;
-  detailsPath: string;
-  getIdKeyForTab: (tab: OcpUsageDashboardTab) => string;
-  widgetId: number;
-}
-
-interface OcpUsageDashboardWidgetStateProps
-  extends OcpUsageDashboardWidgetStatic {
-  currentQuery: string;
-  currentReport: OcpCloudReport;
-  currentReportFetchStatus: number;
-  previousQuery: string;
-  previousReport: OcpCloudReport;
-  tabsQuery: string;
-  tabsReport: OcpCloudReport;
-  tabsReportFetchStatus: number;
-}
 
 interface OcpUsageDashboardWidgetDispatchProps {
   fetchReports: typeof ocpUsageDashboardActions.fetchWidgetReports;
@@ -50,8 +33,8 @@ export const getIdKeyForTab = (
 };
 
 const mapStateToProps = createMapStateToProps<
-  OcpUsageDashboardWidgetOwnProps,
-  OcpUsageDashboardWidgetStateProps
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps
 >((state, { widgetId }) => {
   const widget = ocpUsageDashboardSelectors.selectWidget(state, widgetId);
   const queries = ocpUsageDashboardSelectors.selectWidgetQueries(


### PR DESCRIPTION
Reusing the existing DashboardWidgetOwnProps & DashboardWidgetStateProps interfaces for each dashboard widget -- cleans things up a bit

https://github.com/project-koku/koku-ui/issues/1400