### PR TITLE
Overview list items for cost don't show currency

### DIFF
--- a/src/components/charts/historicalTrendChart/__snapshots__/historicalTrendChart.test.tsx.snap
+++ b/src/components/charts/historicalTrendChart/__snapshots__/historicalTrendChart.test.tsx.snap
@@ -5,7 +5,7 @@ Array [
   Object {
     "key": "1-15-18",
     "name": "1-15-18",
-    "units": "unit",
+    "units": "USD",
     "x": 15,
     "y": 0,
   },
@@ -17,7 +17,7 @@ Array [
   Object {
     "key": "12-15-17",
     "name": "12-15-17",
-    "units": "unit",
+    "units": "USD",
     "x": 15,
     "y": 0,
   },
@@ -29,14 +29,14 @@ Array [
   Object {
     "key": "1-15-18",
     "name": "1-15-18",
-    "units": "unit",
+    "units": "USD",
     "x": 15,
     "y": 0,
   },
   Object {
     "key": "1-16-18",
     "name": "1-16-18",
-    "units": "unit",
+    "units": "USD",
     "x": 16,
     "y": 0,
   },
@@ -48,14 +48,14 @@ Array [
   Object {
     "key": "1-15-18",
     "name": "1-15-18",
-    "units": "unit",
+    "units": "USD",
     "x": 15,
     "y": 0,
   },
   Object {
     "key": "1-16-18",
     "name": "1-16-18",
-    "units": "unit",
+    "units": "USD",
     "x": 16,
     "y": 0,
   },

--- a/src/components/charts/trendChart/__snapshots__/trendChart.test.tsx.snap
+++ b/src/components/charts/trendChart/__snapshots__/trendChart.test.tsx.snap
@@ -5,7 +5,7 @@ Array [
   Object {
     "key": "1-15-18",
     "name": "1-15-18",
-    "units": "unit",
+    "units": "USD",
     "x": 15,
     "y": 0,
   },
@@ -17,7 +17,7 @@ Array [
   Object {
     "key": "12-15-17",
     "name": "12-15-17",
-    "units": "unit",
+    "units": "USD",
     "x": 15,
     "y": 0,
   },
@@ -29,14 +29,14 @@ Array [
   Object {
     "key": "1-15-18",
     "name": "1-15-18",
-    "units": "unit",
+    "units": "USD",
     "x": 15,
     "y": 0,
   },
   Object {
     "key": "1-16-18",
     "name": "1-16-18",
-    "units": "unit",
+    "units": "USD",
     "x": 16,
     "y": 0,
   },
@@ -48,14 +48,14 @@ Array [
   Object {
     "key": "1-15-18",
     "name": "1-15-18",
-    "units": "unit",
+    "units": "USD",
     "x": 15,
     "y": 0,
   },
   Object {
     "key": "1-16-18",
     "name": "1-16-18",
-    "units": "unit",
+    "units": "USD",
     "x": 16,
     "y": 0,
   },

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -370,14 +370,17 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     let totalValue;
     const hasTotal = tabsReport && tabsReport.meta && tabsReport.meta.total;
     if (trend.comparison === ChartComparison.usage) {
-      const hasUsage = hasTotal && tabsReport.meta.total.usage;
-      totalValue = hasUsage ? tabsReport.meta.total.usage.value : undefined;
+      if (hasTotal && tabsReport.meta.total.usage) {
+        totalValue = tabsReport.meta.total.usage.value;
+      }
     } else {
-      const hasCost =
+      if (
         hasTotal &&
         tabsReport.meta.total.cost &&
-        tabsReport.meta.total.cost.total;
-      totalValue = hasCost ? tabsReport.meta.total.cost.total.value : undefined;
+        tabsReport.meta.total.cost.total
+      ) {
+        totalValue = tabsReport.meta.total.cost.total.value;
+      }
     }
 
     if (activeTab === currentTab) {
@@ -388,7 +391,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
           formatValue={formatValue}
           label={reportItem.label ? reportItem.label.toString() : ''}
           totalValue={totalValue}
-          units={details.units ? details.units : reportItem.units}
+          units={details.units ? details.units : this.getUnits()}
           value={reportItem.cost}
         />
       );

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -16,7 +16,7 @@ export interface ComputedReportItem {
   label: string | number;
   limit?: number;
   request?: number;
-  units: string;
+  units?: string;
   usage?: number;
 }
 
@@ -77,19 +77,13 @@ export function getUnsortedComputedReportItems<
         const cluster = cluster_alias || value.cluster;
         const capacity = value.capacity ? value.capacity.value : 0;
         const cost =
-          value.cost && value.cost.total && value.cost.total.value
-            ? value.cost.total.value
-            : 0;
+          value.cost && value.cost.total ? value.cost.total.value : 0;
         const supplementaryCost =
-          value.supplementary &&
-          value.supplementary.total &&
-          value.supplementary.total.value
+          value.supplementary && value.supplementary.total
             ? value.supplementary.total.value
             : 0;
         const infrastructureCost =
-          value.infrastructure &&
-          value.infrastructure.total &&
-          value.infrastructure.total.value
+          value.infrastructure && value.infrastructure.total
             ? value.infrastructure.total.value
             : 0;
         // Ensure unique IDs -- https://github.com/project-koku/koku-ui/issues/706
@@ -115,8 +109,8 @@ export function getUnsortedComputedReportItems<
         const usage = value.usage ? value.usage.value : 0;
         const units = value.usage
           ? value.usage.units
-          : value.cost
-          ? value.cost.units
+          : value.cost && value.cost.total
+          ? value.cost.total.units
           : 'USD';
         if (!itemMap.get(id)) {
           itemMap.set(id, {


### PR DESCRIPTION
Due to the recent supplementary API changes, we're not obtaining units correctly in the computed report items, used by the charts.

<img width="1856" alt="Screen Shot 2020-03-20 at 12 26 47 PM" src="https://user-images.githubusercontent.com/17481322/77184356-1654e800-6aa6-11ea-981c-c1f48f35c1f8.png">

https://github.com/project-koku/koku-ui/issues/1402