### PR TITLE
Rename overview perspective as "All cloud filtered by OpenShift"

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1033,7 +1033,7 @@
     "ocp_desc": "Total cost for OpenShift Container Platform, comprising the infrastructure cost and cost calculated from metrics.",
     "perspective": {
       "all": "All",
-      "all_cloud": "All filtered by OpenShift",
+      "all_cloud": "All cloud filtered by OpenShift",
       "aws": "Amazon Web Services",
       "aws_cloud": "Amazon Web Services filtered by OpenShift",
       "azure": "Microsoft Azure",


### PR DESCRIPTION
Renamed the "All filtered by OpenShift" overview perspective as "All cloud filtered by OpenShift"

<img width="425" alt="Screen Shot 2020-03-20 at 2 13 39 PM" src="https://user-images.githubusercontent.com/17481322/77193674-04c70c80-6ab5-11ea-84c6-6176cee054f5.png">

https://github.com/project-koku/koku-ui/issues/1404