### PR TITLE
Update overview "view all..." links

### DIFF
--- a/src/pages/dashboard/awsCloudDashboard/awsCloudDashboardWidget.tsx
+++ b/src/pages/dashboard/awsCloudDashboard/awsCloudDashboardWidget.tsx
@@ -46,8 +46,6 @@ const mapStateToProps = createMapStateToProps<
   return {
     ...widget,
     getIdKeyForTab,
-    appNavPath: 'aws',
-    detailsPath: '/aws-cloud',
     currentQuery: queries.current,
     previousQuery: queries.previous,
     tabsQuery: queries.tabs,

--- a/src/pages/dashboard/awsDashboard/awsDashboardWidget.tsx
+++ b/src/pages/dashboard/awsDashboard/awsDashboardWidget.tsx
@@ -43,8 +43,6 @@ const mapStateToProps = createMapStateToProps<
   return {
     ...widget,
     getIdKeyForTab,
-    appNavPath: 'aws',
-    detailsPath: '/aws',
     currentQuery: queries.current,
     previousQuery: queries.previous,
     tabsQuery: queries.tabs,

--- a/src/pages/dashboard/azureCloudDashboard/azureCloudDashboardWidget.tsx
+++ b/src/pages/dashboard/azureCloudDashboard/azureCloudDashboardWidget.tsx
@@ -46,8 +46,6 @@ const mapStateToProps = createMapStateToProps<
   return {
     ...widget,
     getIdKeyForTab,
-    appNavPath: 'azure',
-    detailsPath: '/azure-cloud',
     currentQuery: queries.current,
     previousQuery: queries.previous,
     tabsQuery: queries.tabs,

--- a/src/pages/dashboard/azureDashboard/azureDashboardWidget.tsx
+++ b/src/pages/dashboard/azureDashboard/azureDashboardWidget.tsx
@@ -43,8 +43,6 @@ const mapStateToProps = createMapStateToProps<
   return {
     ...widget,
     getIdKeyForTab,
-    appNavPath: 'azure',
-    detailsPath: '/azure',
     currentQuery: queries.current,
     previousQuery: queries.previous,
     tabsQuery: queries.tabs,

--- a/src/pages/dashboard/components/dashboardBase.tsx
+++ b/src/pages/dashboard/components/dashboardBase.tsx
@@ -26,7 +26,7 @@ const DashboardBase: React.SFC<DashboardProps> = ({
     <Grid gutter="md">
       {widgets.map(widgetId => {
         const widget = selectWidgets[widgetId];
-        return Boolean(widget.isHorizontal) ? (
+        return Boolean(widget.details.showHorizontal) ? (
           <GridItem sm={12} key={widgetId}>
             <DashboardWidget widgetId={widgetId} />
           </GridItem>

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -31,10 +31,8 @@ import { formatValue, unitLookupKey } from 'utils/formatValue';
 import { chartStyles, styles } from './dashboardWidget.styles';
 
 interface DashboardWidgetOwnProps {
-  appNavPath: string;
   chartAltHeight?: number;
   containerAltHeight?: number;
-  detailsPath: string;
   getIdKeyForTab: <T extends DashboardWidget<any>>(tab: T) => string;
   widgetId: number;
 }
@@ -74,9 +72,9 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   }
 
   private buildDetailsLink = <T extends DashboardWidget<any>>(tab: T) => {
-    const { detailsPath, getIdKeyForTab } = this.props;
+    const { details, getIdKeyForTab } = this.props;
     const currentTab = getIdKeyForTab(tab);
-    return `${detailsPath}?${getQuery({
+    return `${details.viewAllPath}?${getQuery({
       group_by: {
         [currentTab]: '*',
       },
@@ -245,7 +243,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   };
 
   private getDetails = () => {
-    const { chartType, currentReport, details, isUsageFirst } = this.props;
+    const { chartType, currentReport, details } = this.props;
     const units = this.getUnits();
     return (
       <ReportSummaryDetails
@@ -257,7 +255,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         requestLabel={this.getDetailsLabel(details.requestKey, units)}
         showTooltip={details.showTooltip}
         showUnits={details.showUnits}
-        showUsageFirst={isUsageFirst}
+        showUsageFirst={details.showUsageFirst}
         usageFormatOptions={details.usageFormatOptions}
         usageLabel={this.getDetailsLabel(details.usageKey, units)}
       />
@@ -270,17 +268,19 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   };
 
   private getDetailsLink = () => {
-    const { currentTab, isDetailsLink } = this.props;
-    return (
-      isDetailsLink && (
+    const { currentTab, details } = this.props;
+
+    if (details.viewAllPath) {
+      return (
         <Link
           to={this.buildDetailsLink(currentTab)}
           onClick={this.handleInsightsNavClick}
         >
           {this.getDetailsLinkTitle(currentTab)}
         </Link>
-      )
-    );
+      );
+    }
+    return null;
   };
 
   private getDetailsLinkTitle = <T extends DashboardWidget<any>>(tab: T) => {
@@ -478,8 +478,13 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   };
 
   private handleInsightsNavClick = () => {
-    const { appNavPath } = this.props;
-    insights.chrome.appNavClick({ id: appNavPath, secondaryNav: true });
+    const { details } = this.props;
+    if (details.appNavPath) {
+      insights.chrome.appNavClick({
+        id: details.appNavPath,
+        secondaryNav: true,
+      });
+    }
   };
 
   private handleTabClick = (event, tabIndex) => {
@@ -493,8 +498,8 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   };
 
   public render() {
-    const { isHorizontal = false } = this.props;
-    return Boolean(isHorizontal)
+    const { details } = this.props;
+    return details.showHorizontal
       ? this.getHorizontalLayout()
       : this.getVerticalLayout();
   }

--- a/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboardWidget.tsx
@@ -44,8 +44,6 @@ const mapStateToProps = createMapStateToProps<
   return {
     ...widget,
     getIdKeyForTab,
-    appNavPath: 'ocp-cloud',
-    detailsPath: '/ocp-cloud',
     currentQuery: queries.current,
     previousQuery: queries.previous,
     tabsQuery: queries.tabs,

--- a/src/pages/dashboard/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpDashboard/ocpDashboardWidget.tsx
@@ -42,8 +42,6 @@ const mapStateToProps = createMapStateToProps<
   return {
     ...widget,
     getIdKeyForTab,
-    appNavPath: 'ocp-cloud',
-    detailsPath: '/ocp-cloud',
     chartAltHeight: chartStyles.chartAltHeight,
     containerAltHeight: chartStyles.containerAltHeight,
     currentQuery: queries.current,

--- a/src/pages/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidget.tsx
@@ -48,8 +48,6 @@ const mapStateToProps = createMapStateToProps<
   return {
     ...widget,
     getIdKeyForTab,
-    appNavPath: 'ocp-supplementary',
-    detailsPath: '/ocp-supplementary',
     chartAltHeight: chartStyles.chartAltHeight,
     containerAltHeight: chartStyles.containerAltHeight,
     currentQuery: queries.current,

--- a/src/pages/dashboard/ocpUsageDashboard/ocpUsageDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpUsageDashboard/ocpUsageDashboardWidget.tsx
@@ -44,8 +44,6 @@ const mapStateToProps = createMapStateToProps<
   return {
     ...widget,
     getIdKeyForTab,
-    appNavPath: 'ocp-usage',
-    detailsPath: '/ocp-usage',
     currentQuery: queries.current,
     previousQuery: queries.previous,
     tabsQuery: queries.tabs,

--- a/src/store/dashboard/awsCloudDashboard/awsCloudDashboardWidgets.ts
+++ b/src/store/dashboard/awsCloudDashboard/awsCloudDashboardWidgets.ts
@@ -23,6 +23,7 @@ export const computeWidget: AwsCloudDashboardWidget = {
       fractionDigits: 2,
     },
     showUnits: true,
+    showUsageFirst: true,
     showUsageLegendLabel: true,
     usageFormatOptions: {
       fractionDigits: 0,
@@ -32,7 +33,6 @@ export const computeWidget: AwsCloudDashboardWidget = {
   filter: {
     service: 'AmazonEC2',
   },
-  isUsageFirst: true,
   tabsFilter: {
     service: 'AmazonEC2',
   },
@@ -66,9 +66,8 @@ export const costSummaryWidget: AwsCloudDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
+    showHorizontal: true,
   },
-  isDetailsLink: true,
-  isHorizontal: true,
   tabsFilter: {
     limit: 3,
   },
@@ -175,13 +174,13 @@ export const storageWidget: AwsCloudDashboardWidget = {
       fractionDigits: 2,
     },
     showUnits: true,
+    showUsageFirst: true,
     showUsageLegendLabel: true,
     usageFormatOptions: {
       fractionDigits: 0,
     },
     usageKey: 'aws_cloud_dashboard.usage_label',
   },
-  isUsageFirst: true,
   trend: {
     comparison: ChartComparison.usage,
     formatOptions: {

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -20,6 +20,7 @@ export const computeWidget: AwsDashboardWidget = {
       fractionDigits: 2,
     },
     showUnits: true,
+    showUsageFirst: true,
     showUsageLegendLabel: true,
     usageFormatOptions: {
       fractionDigits: 0,
@@ -29,7 +30,6 @@ export const computeWidget: AwsDashboardWidget = {
   filter: {
     service: 'AmazonEC2',
   },
-  isUsageFirst: true,
   tabsFilter: {
     service: 'AmazonEC2',
   },
@@ -59,13 +59,14 @@ export const costSummaryWidget: AwsDashboardWidget = {
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.cost,
   details: {
+    appNavPath: 'aws',
     costKey: 'aws_dashboard.cumulative_cost_label',
     formatOptions: {
       fractionDigits: 2,
     },
+    showHorizontal: true,
+    viewAllPath: '/aws',
   },
-  isDetailsLink: true,
-  isHorizontal: true,
   tabsFilter: {
     limit: 3,
   },
@@ -172,13 +173,13 @@ export const storageWidget: AwsDashboardWidget = {
       fractionDigits: 2,
     },
     showUnits: true,
+    showUsageFirst: true,
     showUsageLegendLabel: true,
     usageFormatOptions: {
       fractionDigits: 0,
     },
     usageKey: 'aws_dashboard.usage_label',
   },
-  isUsageFirst: true,
   trend: {
     comparison: ChartComparison.usage,
     formatOptions: {

--- a/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
+++ b/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
@@ -22,9 +22,8 @@ export const costSummaryWidget: AzureCloudDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
+    showHorizontal: true,
   },
-  isDetailsLink: true,
-  isHorizontal: true,
   tabsFilter: {
     limit: 3,
   },
@@ -131,6 +130,7 @@ export const storageWidget: AzureCloudDashboardWidget = {
       fractionDigits: 2,
     },
     showUnits: true,
+    showUsageFirst: true,
     showUsageLegendLabel: true,
     units: 'gb-mo',
     usageFormatOptions: {
@@ -141,7 +141,6 @@ export const storageWidget: AzureCloudDashboardWidget = {
   filter: {
     service_name: 'Storage',
   },
-  isUsageFirst: true,
   tabsFilter: {
     service_name: 'Storage',
   },
@@ -176,6 +175,7 @@ export const virtualMachineWidget: AzureCloudDashboardWidget = {
       fractionDigits: 2,
     },
     showUnits: true,
+    showUsageFirst: true,
     showUsageLegendLabel: true,
     usageFormatOptions: {
       fractionDigits: 0,
@@ -186,7 +186,6 @@ export const virtualMachineWidget: AzureCloudDashboardWidget = {
   filter: {
     service_name: 'Virtual Machines',
   },
-  isUsageFirst: true,
   tabsFilter: {
     service_name: 'Virtual Machines',
   },

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -18,13 +18,14 @@ export const costSummaryWidget: AzureDashboardWidget = {
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.cost,
   details: {
+    appNavPath: 'aws',
     costKey: 'aws_dashboard.cumulative_cost_label',
     formatOptions: {
       fractionDigits: 2,
     },
+    showHorizontal: true,
+    viewAllPath: '/azure',
   },
-  isDetailsLink: true,
-  isHorizontal: true,
   tabsFilter: {
     limit: 3,
   },
@@ -131,6 +132,7 @@ export const storageWidget: AzureDashboardWidget = {
       fractionDigits: 2,
     },
     showUnits: true,
+    showUsageFirst: true,
     showUsageLegendLabel: true,
     units: 'gb-mo',
     usageFormatOptions: {
@@ -141,7 +143,6 @@ export const storageWidget: AzureDashboardWidget = {
   filter: {
     service_name: 'Storage',
   },
-  isUsageFirst: true,
   tabsFilter: {
     service_name: 'Storage',
   },
@@ -176,6 +177,7 @@ export const virtualMachineWidget: AzureDashboardWidget = {
       fractionDigits: 2,
     },
     showUnits: true,
+    showUsageFirst: true,
     showUsageLegendLabel: true,
     usageFormatOptions: {
       fractionDigits: 0,
@@ -186,7 +188,6 @@ export const virtualMachineWidget: AzureDashboardWidget = {
   filter: {
     service_name: 'Virtual Machines',
   },
-  isUsageFirst: true,
   tabsFilter: {
     service_name: 'Virtual Machines',
   },

--- a/src/store/dashboard/common/dashboardCommon.ts
+++ b/src/store/dashboard/common/dashboardCommon.ts
@@ -15,19 +15,23 @@ export interface DashboardWidget<T> {
   chartType?: DashboardChartType;
   currentTab?: T;
   details: {
-    costKey?: string /** i18n key */;
+    appNavPath?: string; // Highlights Insights nav-item when view all link is clicked
+    costKey?: string; // i18n key
     formatOptions: ValueFormatOptions;
-    labelKey?: string /** i18n key */;
+    labelKey?: string; // i18n key
     requestFormatOptions?: {
       fractionDigits?: number;
     };
     requestKey?: string;
-    showTooltip?: boolean;
-    showUnits?: boolean;
+    showHorizontal?: boolean; // Show horizontal layout
+    showTooltip?: boolean; // Show cost tooltip
+    showUnits?: boolean; // Show units
+    showUsageFirst?: boolean; // Show usage before cost
     showUsageLegendLabel?: boolean;
-    units?: string;
+    units?: string; // Override units shown as workaround for missing Azure API units
     usageFormatOptions?: ValueFormatOptions;
-    usageKey?: string /** i18n key */;
+    usageKey?: string; // i18n key
+    viewAllPath?: string; // View all link to details page
   };
   filter?: {
     limit?: number;
@@ -35,9 +39,6 @@ export interface DashboardWidget<T> {
     service_name?: string;
   };
   id: number;
-  isDetailsLink?: boolean;
-  isHorizontal?: boolean;
-  isUsageFirst?: boolean;
   reportPathsType: ReportPathsType;
   reportType: ReportType;
   /** i18n key for the title. passed { startDate, endDate, month, time } */

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
@@ -22,9 +22,8 @@ export const costSummaryWidget: OcpCloudDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
+    showHorizontal: true,
   },
-  isDetailsLink: true,
-  isHorizontal: true,
   tabsFilter: {
     limit: 3,
   },
@@ -59,13 +58,13 @@ export const computeWidget: OcpCloudDashboardWidget = {
       fractionDigits: 2,
     },
     showUnits: true,
+    showUsageFirst: true,
     showUsageLegendLabel: true,
     usageFormatOptions: {
       fractionDigits: 0,
     },
     usageKey: 'ocp_cloud_dashboard.usage_label',
   },
-  isUsageFirst: true,
   filter: {
     service: 'AmazonEC2',
   },
@@ -143,13 +142,13 @@ export const storageWidget: OcpCloudDashboardWidget = {
       fractionDigits: 2,
     },
     showUnits: true,
+    showUsageFirst: true,
     showUsageLegendLabel: true,
     usageFormatOptions: {
       fractionDigits: 0,
     },
     usageKey: 'ocp_cloud_dashboard.usage_label',
   },
-  isUsageFirst: true,
   trend: {
     comparison: ChartComparison.usage,
     formatOptions: {

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -15,14 +15,15 @@ export const costSummaryWidget: OcpDashboardWidget = {
   reportPathsType: ReportPathsType.ocp,
   reportType: ReportType.cost,
   details: {
+    appNavPath: 'ocp',
     costKey: 'ocp_dashboard.cumulative_cost_label',
     formatOptions: {
       fractionDigits: 2,
     },
+    showHorizontal: true,
     showTooltip: true,
+    viewAllPath: '/ocp',
   },
-  isDetailsLink: true,
-  isHorizontal: true,
   trend: {
     comparison: ChartComparison.cost,
     formatOptions: {},
@@ -54,12 +55,12 @@ export const cpuWidget: OcpDashboardWidget = {
     },
     requestKey: 'ocp_dashboard.requests_label',
     showUnits: true,
+    showUsageFirst: true,
     usageFormatOptions: {
       fractionDigits: 0,
     },
     usageKey: 'ocp_dashboard.usage_label',
   },
-  isUsageFirst: true,
   trend: {
     comparison: ChartComparison.usage,
     formatOptions: {
@@ -90,12 +91,12 @@ export const memoryWidget: OcpDashboardWidget = {
     },
     requestKey: 'ocp_dashboard.requests_label',
     showUnits: true,
+    showUsageFirst: true,
     usageFormatOptions: {
       fractionDigits: 0,
     },
     usageKey: 'ocp_dashboard.usage_label',
   },
-  isUsageFirst: true,
   trend: {
     comparison: ChartComparison.usage,
     formatOptions: {
@@ -126,12 +127,12 @@ export const volumeWidget: OcpDashboardWidget = {
     },
     requestKey: 'ocp_dashboard.requests_label',
     showUnits: true,
+    showUsageFirst: true,
     usageFormatOptions: {
       fractionDigits: 0,
     },
     usageKey: 'ocp_dashboard.usage_label',
   },
-  isUsageFirst: true,
   trend: {
     comparison: ChartComparison.usage,
     formatOptions: {

--- a/src/store/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidgets.ts
+++ b/src/store/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidgets.ts
@@ -22,9 +22,8 @@ export const costSummaryWidget: OcpSupplementaryDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
+    showHorizontal: true,
   },
-  isDetailsLink: true,
-  isHorizontal: true,
   trend: {
     comparison: ChartComparison.cost,
     formatOptions: {},
@@ -59,12 +58,12 @@ export const cpuWidget: OcpSupplementaryDashboardWidget = {
     },
     requestKey: 'ocp_supplementary_dashboard.requests_label',
     showUnits: true,
+    showUsageFirst: true,
     usageFormatOptions: {
       fractionDigits: 0,
     },
     usageKey: 'ocp_supplementary_dashboard.usage_label',
   },
-  isUsageFirst: true,
   trend: {
     comparison: ChartComparison.usage,
     formatOptions: {
@@ -98,12 +97,12 @@ export const memoryWidget: OcpSupplementaryDashboardWidget = {
     },
     requestKey: 'ocp_supplementary_dashboard.requests_label',
     showUnits: true,
+    showUsageFirst: true,
     usageFormatOptions: {
       fractionDigits: 0,
     },
     usageKey: 'ocp_supplementary_dashboard.usage_label',
   },
-  isUsageFirst: true,
   trend: {
     comparison: ChartComparison.usage,
     formatOptions: {
@@ -137,12 +136,12 @@ export const volumeWidget: OcpSupplementaryDashboardWidget = {
     },
     requestKey: 'ocp_supplementary_dashboard.requests_label',
     showUnits: true,
+    showUsageFirst: true,
     usageFormatOptions: {
       fractionDigits: 0,
     },
     usageKey: 'ocp_supplementary_dashboard.usage_label',
   },
-  isUsageFirst: true,
   trend: {
     comparison: ChartComparison.usage,
     formatOptions: {

--- a/src/store/dashboard/ocpUsageDashboard/ocpUsageDashboardWidgets.ts
+++ b/src/store/dashboard/ocpUsageDashboard/ocpUsageDashboardWidgets.ts
@@ -22,9 +22,8 @@ export const costSummaryWidget: OcpUsageDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
+    showHorizontal: true,
   },
-  isDetailsLink: true,
-  isHorizontal: true,
   tabsFilter: {
     limit: 3,
   },
@@ -53,12 +52,13 @@ export const cpuWidget: OcpUsageDashboardWidget = {
     },
     requestKey: 'ocp_usage_dashboard.requests_label',
     showUnits: true,
+    showUsageFirst: true,
     usageFormatOptions: {
       fractionDigits: 0,
     },
     usageKey: 'ocp_usage_dashboard.usage_label',
   },
-  isUsageFirst: true,
+
   trend: {
     comparison: ChartComparison.usage,
     formatOptions: {
@@ -84,12 +84,12 @@ export const memoryWidget: OcpUsageDashboardWidget = {
     },
     requestKey: 'ocp_usage_dashboard.requests_label',
     showUnits: true,
+    showUsageFirst: true,
     usageFormatOptions: {
       fractionDigits: 0,
     },
     usageKey: 'ocp_usage_dashboard.usage_label',
   },
-  isUsageFirst: true,
   trend: {
     comparison: ChartComparison.usage,
     formatOptions: {
@@ -115,12 +115,12 @@ export const volumeWidget: OcpUsageDashboardWidget = {
     },
     requestKey: 'ocp_usage_dashboard.requests_label',
     showUnits: true,
+    showUsageFirst: true,
     usageFormatOptions: {
       fractionDigits: 0,
     },
     usageKey: 'ocp_usage_dashboard.usage_label',
   },
-  isUsageFirst: true,
   trend: {
     comparison: ChartComparison.usage,
     formatOptions: {


### PR DESCRIPTION
Ensure all overview "view all..." links navigate correctly.

Also omit the "view all" links from the "filtered by OpenShift" overview pages. Only the following overview pages should show links.

- OpenShift > All
- Infrastructure > AWS
- Infrastructure > Azure

https://github.com/project-koku/koku-ui/issues/1406