### PR TITLE
OpenShift supplementary overview

### DIFF
--- a/src/api/reports/ocpReports.ts
+++ b/src/api/reports/ocpReports.ts
@@ -43,9 +43,9 @@ export interface OcpReportMeta extends ReportMeta {
     capacity?: ReportDatum;
     cost: ReportCostTypeDatum;
     infrastructure: ReportCostTypeDatum;
-    supplementary: ReportCostTypeDatum;
     limit?: ReportDatum;
     request?: ReportDatum;
+    supplementary: ReportCostTypeDatum;
     usage?: ReportDatum;
   };
 }

--- a/src/components/charts/common/chartUtils.ts
+++ b/src/components/charts/common/chartUtils.ts
@@ -28,8 +28,9 @@ export interface ChartDatum {
   y: number;
 }
 
-export const enum ChartComparison {
+export const enum ComputedReportItemType {
   cost = 'cost',
+  supplementaryCost = 'supplementaryCost',
   usage = 'usage',
 }
 
@@ -43,7 +44,7 @@ export function transformReport(
   report: Report,
   type: ChartType = ChartType.daily,
   key: any = 'date',
-  reportItem: any = 'cost'
+  reportItem: string = 'cost'
 ): ChartDatum[] {
   if (!report) {
     return [];

--- a/src/store/dashboard/awsCloudDashboard/awsCloudDashboardWidgets.ts
+++ b/src/store/dashboard/awsCloudDashboard/awsCloudDashboardWidgets.ts
@@ -1,7 +1,7 @@
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import {
-  ChartComparison,
   ChartType,
+  ComputedReportItemType,
 } from 'components/charts/common/chartUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
@@ -37,7 +37,7 @@ export const computeWidget: AwsCloudDashboardWidget = {
     service: 'AmazonEC2',
   },
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -72,7 +72,7 @@ export const costSummaryWidget: AwsCloudDashboardWidget = {
     limit: 3,
   },
   trend: {
-    comparison: ChartComparison.cost,
+    computedReportItem: ComputedReportItemType.cost,
     formatOptions: {},
     titleKey: 'aws_cloud_dashboard.cost_trend_title',
     type: ChartType.rolling,
@@ -110,7 +110,7 @@ export const databaseWidget: AwsCloudDashboardWidget = {
       'AmazonRDS,AmazonDynamoDB,AmazonElastiCache,AmazonNeptune,AmazonRedshift,AmazonDocumentDB',
   },
   trend: {
-    comparison: ChartComparison.cost,
+    computedReportItem: ComputedReportItemType.cost,
     formatOptions: {},
     titleKey: 'aws_cloud_dashboard.database_trend_title',
     type: ChartType.rolling,
@@ -146,7 +146,7 @@ export const networkWidget: AwsCloudDashboardWidget = {
     service: 'AmazonVPC,AmazonCloudFront,AmazonRoute53,AmazonAPIGateway',
   },
   trend: {
-    comparison: ChartComparison.cost,
+    computedReportItem: ComputedReportItemType.cost,
     formatOptions: {},
     titleKey: 'aws_cloud_dashboard.network_trend_title',
     type: ChartType.rolling,
@@ -182,7 +182,7 @@ export const storageWidget: AwsCloudDashboardWidget = {
     usageKey: 'aws_cloud_dashboard.usage_label',
   },
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -1,7 +1,7 @@
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import {
-  ChartComparison,
   ChartType,
+  ComputedReportItemType,
 } from 'components/charts/common/chartUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { AwsDashboardTab, AwsDashboardWidget } from './awsDashboardCommon';
@@ -34,7 +34,7 @@ export const computeWidget: AwsDashboardWidget = {
     service: 'AmazonEC2',
   },
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -71,7 +71,7 @@ export const costSummaryWidget: AwsDashboardWidget = {
     limit: 3,
   },
   trend: {
-    comparison: ChartComparison.cost,
+    computedReportItem: ComputedReportItemType.cost,
     formatOptions: {},
     titleKey: 'aws_dashboard.cost_trend_title',
     type: ChartType.rolling,
@@ -109,7 +109,7 @@ export const databaseWidget: AwsDashboardWidget = {
       'AmazonRDS,AmazonDynamoDB,AmazonElastiCache,AmazonNeptune,AmazonRedshift,AmazonDocumentDB',
   },
   trend: {
-    comparison: ChartComparison.cost,
+    computedReportItem: ComputedReportItemType.cost,
     formatOptions: {},
     titleKey: 'aws_dashboard.database_trend_title',
     type: ChartType.rolling,
@@ -145,7 +145,7 @@ export const networkWidget: AwsDashboardWidget = {
     service: 'AmazonVPC,AmazonCloudFront,AmazonRoute53,AmazonAPIGateway',
   },
   trend: {
-    comparison: ChartComparison.cost,
+    computedReportItem: ComputedReportItemType.cost,
     formatOptions: {},
     titleKey: 'aws_dashboard.network_trend_title',
     type: ChartType.rolling,
@@ -181,7 +181,7 @@ export const storageWidget: AwsDashboardWidget = {
     usageKey: 'aws_dashboard.usage_label',
   },
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
+++ b/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
@@ -1,7 +1,7 @@
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import {
-  ChartComparison,
   ChartType,
+  ComputedReportItemType,
 } from 'components/charts/common/chartUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
@@ -28,7 +28,7 @@ export const costSummaryWidget: AzureCloudDashboardWidget = {
     limit: 3,
   },
   trend: {
-    comparison: ChartComparison.cost,
+    computedReportItem: ComputedReportItemType.cost,
     formatOptions: {},
     titleKey: 'azure_cloud_dashboard.cost_trend_title',
     type: ChartType.rolling,
@@ -64,7 +64,7 @@ export const databaseWidget: AzureCloudDashboardWidget = {
     service_name: 'Database,Cosmos DB,Cache for Redis',
   },
   trend: {
-    comparison: ChartComparison.cost,
+    computedReportItem: ComputedReportItemType.cost,
     formatOptions: {},
     titleKey: 'azure_cloud_dashboard.database_trend_title',
     type: ChartType.rolling,
@@ -102,7 +102,7 @@ export const networkWidget: AzureCloudDashboardWidget = {
       'Virtual Network,VPN,DNS,Traffic Manager,ExpressRoute,Load Balancer,Application Gateway',
   },
   trend: {
-    comparison: ChartComparison.cost,
+    computedReportItem: ComputedReportItemType.cost,
     formatOptions: {},
     titleKey: 'azure_cloud_dashboard.network_trend_title',
     type: ChartType.rolling,
@@ -145,7 +145,7 @@ export const storageWidget: AzureCloudDashboardWidget = {
     service_name: 'Storage',
   },
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -190,7 +190,7 @@ export const virtualMachineWidget: AzureCloudDashboardWidget = {
     service_name: 'Virtual Machines',
   },
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -1,7 +1,7 @@
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import {
-  ChartComparison,
   ChartType,
+  ComputedReportItemType,
 } from 'components/charts/common/chartUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
@@ -30,7 +30,7 @@ export const costSummaryWidget: AzureDashboardWidget = {
     limit: 3,
   },
   trend: {
-    comparison: ChartComparison.cost,
+    computedReportItem: ComputedReportItemType.cost,
     formatOptions: {},
     titleKey: 'azure_dashboard.cost_trend_title',
     type: ChartType.rolling,
@@ -66,7 +66,7 @@ export const databaseWidget: AzureDashboardWidget = {
     service_name: 'Database,Cosmos DB,Cache for Redis',
   },
   trend: {
-    comparison: ChartComparison.cost,
+    computedReportItem: ComputedReportItemType.cost,
     formatOptions: {},
     titleKey: 'azure_dashboard.database_trend_title',
     type: ChartType.rolling,
@@ -104,7 +104,7 @@ export const networkWidget: AzureDashboardWidget = {
       'Virtual Network,VPN,DNS,Traffic Manager,ExpressRoute,Load Balancer,Application Gateway',
   },
   trend: {
-    comparison: ChartComparison.cost,
+    computedReportItem: ComputedReportItemType.cost,
     formatOptions: {},
     titleKey: 'azure_dashboard.network_trend_title',
     type: ChartType.rolling,
@@ -147,7 +147,7 @@ export const storageWidget: AzureDashboardWidget = {
     service_name: 'Storage',
   },
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -192,7 +192,7 @@ export const virtualMachineWidget: AzureDashboardWidget = {
     service_name: 'Virtual Machines',
   },
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/common/dashboardCommon.ts
+++ b/src/store/dashboard/common/dashboardCommon.ts
@@ -1,9 +1,9 @@
 import { ReportPathsType, ReportType } from 'api/reports/report';
 
 export const enum DashboardChartType {
-  cost = 'cost',
-  trend = 'trend',
-  usage = 'usage',
+  cost = 'cost', // This type displays cost and infrastructure cost
+  trend = 'trend', // This type displays cost only
+  usage = 'usage', // This type displays usage and requests
 }
 
 export interface ValueFormatOptions {
@@ -49,7 +49,7 @@ export interface DashboardWidget<T> {
     service_name?: string;
   };
   trend: {
-    comparison: string;
+    computedReportItem: string; // The computed report item to use in charts, summary, etc.
     titleKey: string;
     type: number;
     formatOptions: ValueFormatOptions;

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboard.test.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboard.test.ts
@@ -2,8 +2,8 @@ jest.mock('store/reports/ocpCloudReports/ocpCloudReportsActions');
 
 import { ReportType } from 'api/reports/report';
 import {
-  ChartComparison,
   ChartType,
+  ComputedReportItemType,
 } from 'components/charts/common/chartUtils';
 import { createMockStoreCreator } from 'store/mockStore';
 import { ocpCloudReportsActions } from 'store/reports/ocpCloudReports';
@@ -92,7 +92,7 @@ test('getQueryForWidget', () => {
     currentTab: OcpCloudDashboardTab.accounts,
     details: { labelKey: '', formatOptions: {} },
     trend: {
-      comparison: ChartComparison.cost,
+      computedReportItem: ComputedReportItemType.cost,
       titleKey: '',
       type: ChartType.daily,
       formatOptions: {},

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
@@ -1,7 +1,7 @@
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import {
-  ChartComparison,
   ChartType,
+  ComputedReportItemType,
 } from 'components/charts/common/chartUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
@@ -28,7 +28,7 @@ export const costSummaryWidget: OcpCloudDashboardWidget = {
     limit: 3,
   },
   trend: {
-    comparison: ChartComparison.cost,
+    computedReportItem: ComputedReportItemType.cost,
     formatOptions: {},
     titleKey: 'ocp_cloud_dashboard.cost_trend_title',
     type: ChartType.rolling,
@@ -69,7 +69,7 @@ export const computeWidget: OcpCloudDashboardWidget = {
     service: 'AmazonEC2',
   },
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -97,7 +97,7 @@ export const databaseWidget: OcpCloudDashboardWidget = {
       'Database,Cosmos DB,Cache for Redis',
   },
   trend: {
-    comparison: ChartComparison.cost,
+    computedReportItem: ComputedReportItemType.cost,
     formatOptions: {},
     titleKey: 'ocp_cloud_dashboard.database_trend_title',
     type: ChartType.rolling,
@@ -123,7 +123,7 @@ export const networkWidget: OcpCloudDashboardWidget = {
       'Virtual Network,VPN,DNS,Traffic Manager,ExpressRoute,Load Balancer,Application Gateway',
   },
   trend: {
-    comparison: ChartComparison.cost,
+    computedReportItem: ComputedReportItemType.cost,
     formatOptions: {},
     titleKey: 'ocp_cloud_dashboard.network_trend_title',
     type: ChartType.rolling,
@@ -150,7 +150,7 @@ export const storageWidget: OcpCloudDashboardWidget = {
     usageKey: 'ocp_cloud_dashboard.usage_label',
   },
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/ocpDashboard/ocpDashboard.test.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboard.test.ts
@@ -2,8 +2,8 @@ jest.mock('store/reports/ocpReports/ocpReportsActions');
 
 import { ReportType } from 'api/reports/report';
 import {
-  ChartComparison,
   ChartType,
+  ComputedReportItemType,
 } from 'components/charts/common/chartUtils';
 import { createMockStoreCreator } from 'store/mockStore';
 import { ocpReportsActions } from 'store/reports/ocpReports';
@@ -90,7 +90,7 @@ test('getQueryForWidget', () => {
     currentTab: OcpDashboardTab.projects,
     details: { labelKey: '', formatOptions: {} },
     trend: {
-      comparison: ChartComparison.cost,
+      computedReportItem: ComputedReportItemType.cost,
       titleKey: '',
       type: ChartType.daily,
       formatOptions: {},

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -1,7 +1,7 @@
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import {
-  ChartComparison,
   ChartType,
+  ComputedReportItemType,
 } from 'components/charts/common/chartUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { OcpDashboardTab, OcpDashboardWidget } from './ocpDashboardCommon';
@@ -25,7 +25,7 @@ export const costSummaryWidget: OcpDashboardWidget = {
     viewAllPath: '/ocp',
   },
   trend: {
-    comparison: ChartComparison.cost,
+    computedReportItem: ComputedReportItemType.cost,
     formatOptions: {},
     titleKey: 'ocp_dashboard.cost_trend_title',
     type: ChartType.rolling,
@@ -62,7 +62,7 @@ export const cpuWidget: OcpDashboardWidget = {
     usageKey: 'ocp_dashboard.usage_label',
   },
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -98,7 +98,7 @@ export const memoryWidget: OcpDashboardWidget = {
     usageKey: 'ocp_dashboard.usage_label',
   },
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -134,7 +134,7 @@ export const volumeWidget: OcpDashboardWidget = {
     usageKey: 'ocp_dashboard.usage_label',
   },
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidgets.ts
+++ b/src/store/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidgets.ts
@@ -1,7 +1,7 @@
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import {
-  ChartComparison,
   ChartType,
+  ComputedReportItemType,
 } from 'components/charts/common/chartUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
@@ -25,7 +25,7 @@ export const costSummaryWidget: OcpSupplementaryDashboardWidget = {
     showHorizontal: true,
   },
   trend: {
-    comparison: ChartComparison.cost,
+    computedReportItem: ComputedReportItemType.supplementaryCost,
     formatOptions: {},
     titleKey: 'ocp_supplementary_dashboard.cost_trend_title',
     type: ChartType.rolling,
@@ -65,7 +65,7 @@ export const cpuWidget: OcpSupplementaryDashboardWidget = {
     usageKey: 'ocp_supplementary_dashboard.usage_label',
   },
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -104,7 +104,7 @@ export const memoryWidget: OcpSupplementaryDashboardWidget = {
     usageKey: 'ocp_supplementary_dashboard.usage_label',
   },
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -143,7 +143,7 @@ export const volumeWidget: OcpSupplementaryDashboardWidget = {
     usageKey: 'ocp_supplementary_dashboard.usage_label',
   },
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/ocpUsageDashboard/ocpUsageDashboardWidgets.ts
+++ b/src/store/dashboard/ocpUsageDashboard/ocpUsageDashboardWidgets.ts
@@ -1,7 +1,7 @@
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import {
-  ChartComparison,
   ChartType,
+  ComputedReportItemType,
 } from 'components/charts/common/chartUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
@@ -28,7 +28,7 @@ export const costSummaryWidget: OcpUsageDashboardWidget = {
     limit: 3,
   },
   trend: {
-    comparison: ChartComparison.cost,
+    computedReportItem: ComputedReportItemType.cost,
     formatOptions: {},
     titleKey: 'ocp_usage_dashboard.cost_trend_title',
     type: ChartType.rolling,
@@ -60,7 +60,7 @@ export const cpuWidget: OcpUsageDashboardWidget = {
   },
 
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -91,7 +91,7 @@ export const memoryWidget: OcpUsageDashboardWidget = {
     usageKey: 'ocp_usage_dashboard.usage_label',
   },
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -122,7 +122,7 @@ export const volumeWidget: OcpUsageDashboardWidget = {
     usageKey: 'ocp_usage_dashboard.usage_label',
   },
   trend: {
-    comparison: ChartComparison.usage,
+    computedReportItem: ComputedReportItemType.usage,
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -10,12 +10,12 @@ export interface ComputedReportItem {
   cost: number;
   deltaPercent: number;
   deltaValue: number;
-  supplementaryCost: number;
   id: string | number;
   infrastructureCost: number;
   label: string | number;
   limit?: number;
   request?: number;
+  supplementaryCost: number;
   units?: string;
   usage?: number;
 }


### PR DESCRIPTION
Refactored to show supplementary cost for "OpenShift supplementary" overview

This will use the same reports/openshift/costs/ API, but instead of grabbing the costs from cost we grab from supplementary.

https://github.com/project-koku/koku-ui/issues/1339