### PR TITLE
fix(styles): replace Stylesheet.create

### DIFF
--- a/archive/components/backdrop/backdrop.styles.ts
+++ b/archive/components/backdrop/backdrop.styles.ts
@@ -1,10 +1,10 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   c_backdrop_BackdropFilter,
   c_backdrop_Color,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   backdrop: {
     position: 'fixed',
     top: 0,
@@ -14,4 +14,4 @@ export const styles = StyleSheet.create({
     filter: c_backdrop_BackdropFilter.value,
     backgroundColor: c_backdrop_Color.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/box/box.styles.ts
+++ b/archive/components/box/box.styles.ts
@@ -1,10 +1,10 @@
-import { StyleSheet } from '@patternfly/react-styles';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   box: {
     display: 'flex',
     flexDirection: 'column',
     backgroundColor: '#fff',
     boxShadow: 'rgba(3, 3, 3, 0.2) 0px 1px 2px 0px',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/box/boxBody.styles.ts
+++ b/archive/components/box/boxBody.styles.ts
@@ -1,6 +1,6 @@
-import { StyleSheet } from '@patternfly/react-styles';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   boxBody: {
     flex: '1 1 auto',
     paddingTop: '1rem',
@@ -14,4 +14,4 @@ export const styles = StyleSheet.create({
       paddingBottom: '2rem',
     },
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/box/boxBody.tsx
+++ b/archive/components/box/boxBody.tsx
@@ -3,5 +3,5 @@ import React from 'react';
 import { styles } from './boxBody.styles';
 
 export const BoxBody: React.SFC = ({ children }) => (
-  <div className={css(styles.boxBody)}>{children}</div>
+  <div style={styles.boxBody}>{children}</div>
 );

--- a/archive/components/box/boxFooter.styles.ts
+++ b/archive/components/box/boxFooter.styles.ts
@@ -1,6 +1,6 @@
-import { StyleSheet } from '@patternfly/react-styles';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   boxFooter: {
     flex: '0 0 auto',
     paddingTop: '1rem',
@@ -11,4 +11,4 @@ export const styles = StyleSheet.create({
       paddingBottom: '2rem',
     },
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/box/boxFooter.tsx
+++ b/archive/components/box/boxFooter.tsx
@@ -3,5 +3,5 @@ import React from 'react';
 import { styles } from './boxFooter.styles';
 
 export const BoxFooter: React.SFC = ({ children }) => (
-  <div className={css(styles.boxFooter)}>{children}</div>
+  <div style={styles.boxFooter}>{children}</div>
 );

--- a/archive/components/box/boxHeader.styles.ts
+++ b/archive/components/box/boxHeader.styles.ts
@@ -1,6 +1,6 @@
-import { StyleSheet } from '@patternfly/react-styles';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   boxHeader: {
     flex: '0 0 auto',
     paddingTop: '2rem',
@@ -14,4 +14,4 @@ export const styles = StyleSheet.create({
       paddingBottom: '2rem',
     },
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/box/boxHeader.tsx
+++ b/archive/components/box/boxHeader.tsx
@@ -3,5 +3,5 @@ import React from 'react';
 import { styles } from './boxHeader.styles';
 
 export const BoxHeader: React.SFC = ({ children }) => (
-  <div className={css(styles.boxHeader)}>{children}</div>
+  <div style={styles.boxHeader}>{children}</div>
 );

--- a/archive/components/charts/bulletChart/bulletChart.styles.ts
+++ b/archive/components/charts/bulletChart/bulletChart.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   chart_color_black_100,
   chart_color_black_200,
@@ -14,6 +13,7 @@ import {
   global_spacer_md,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
 export const chartStyles = {
   height: 55,
@@ -41,7 +41,7 @@ export const chartStyles = {
   valueWidth: 9,
 };
 
-export const styles = StyleSheet.create({
+export const styles = {
   bulletChart: {
     ':not(foo) svg': {
       overflow: 'visible',
@@ -54,4 +54,4 @@ export const styles = StyleSheet.create({
     paddingBottom: global_spacer_md.value,
     paddingLeft: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/charts/bulletChart/bulletChart.tsx
+++ b/archive/components/charts/bulletChart/bulletChart.tsx
@@ -121,10 +121,8 @@ class BulletChart extends React.Component<BulletChartProps, State> {
     );
 
     return (
-      <div className={css(styles.bulletChart)} ref={this.containerRef}>
-        {Boolean(title) && (
-          <span className={css(styles.bulletChartTitle)}>{title}</span>
-        )}
+      <div style={styles.bulletChart} ref={this.containerRef}>
+        {Boolean(title) && <span style={styles.bulletChartTitle}>{title}</span>}
         <Chart
           containerComponent={container}
           height={chartStyles.height}
@@ -190,7 +188,7 @@ class BulletChart extends React.Component<BulletChartProps, State> {
           />
         </Chart>
         {Boolean(legendData.length) && (
-          <div className={css(styles.bulletChartLegend)}>
+          <div style={styles.bulletChartLegend}>
             <ChartLegend
               colorScale={legendColorScale}
               data={legendData}

--- a/archive/components/charts/pieChart/pieChart.styles.ts
+++ b/archive/components/charts/pieChart/pieChart.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   chart_color_blue_100,
   chart_color_blue_200,
@@ -6,6 +5,7 @@ import {
   chart_color_blue_400,
   chart_color_blue_500,
 } from '@patternfly/react-tokens';
+import React from 'react';
 import { theme } from 'styles/theme';
 
 export const chartStyles = {
@@ -19,11 +19,11 @@ export const chartStyles = {
   ],
 };
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartContainer: {
     [theme.page_breakpoint]: {
       display: 'inline-flex',
     },
     marginTop: '2rem',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/charts/pieChart/pieChart.tsx
+++ b/archive/components/charts/pieChart/pieChart.tsx
@@ -212,7 +212,7 @@ class PieChart extends React.Component<PieChartProps, State> {
 
     return (
       <div ref={this.containerRef}>
-        <div className={css(styles.chartContainer)}>
+        <div style={styles.chartContainer}>
           {Boolean(datum && datum.cost && datum.cost.chart) &&
             this.getChart(datum.cost.chart)}
           {this.getLegend(datum && datum.cost ? datum.cost.legend : {}, width)}

--- a/archive/components/formGroup/formGroup.styles.ts
+++ b/archive/components/formGroup/formGroup.styles.ts
@@ -1,11 +1,11 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_FontWeight_normal,
   global_gutter,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   formGroup: {
     marginBottom: global_gutter.value,
   },
@@ -14,4 +14,4 @@ export const styles = StyleSheet.create({
     fontWeight: global_FontWeight_normal.value as any,
     paddingBottom: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/masthead/masthead.styles.ts
+++ b/archive/components/masthead/masthead.styles.ts
@@ -1,12 +1,12 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_Color_light_100,
   global_spacer_md,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 import { theme } from 'styles/theme';
 
-export const styles = StyleSheet.create({
+export const styles = {
   masthead: {
     height: theme.page_masthead_height,
     top: 0,
@@ -40,4 +40,4 @@ export const styles = StyleSheet.create({
     textTransform: 'capitalize',
     marginRight: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/masthead/masthead.tsx
+++ b/archive/components/masthead/masthead.tsx
@@ -55,7 +55,7 @@ class MastheadBase extends React.Component<Props, State> {
             className={css(styles.masthead, hasScrolled && styles.scrolled)}
             {...getTestProps(testIds.masthead.masthead)}
           >
-            <div className={css(styles.section)}>
+            <div style={styles.section}>
               <NavToggleButtonBase
                 title={t('navigation_toggle')}
                 isSidebarOpen={isSidebarOpen}
@@ -64,9 +64,9 @@ class MastheadBase extends React.Component<Props, State> {
               {t('app_title')}
             </div>
             {user && (
-              <div className={css(styles.section)}>
+              <div style={styles.section}>
                 <div
-                  className={css(styles.name)}
+                  style={styles.name}
                   {...getTestProps(testIds.masthead.username)}
                 >
                   {user.username}

--- a/archive/components/masthead/navToggleButton.tsx
+++ b/archive/components/masthead/navToggleButton.tsx
@@ -20,7 +20,7 @@ class NavToggleButtonBase extends React.Component<Props> {
     return (
       <Button
         aria-label={this.props.title}
-        className={css(styles.navToggle)}
+        style={styles.navToggle}
         onClick={this.props.onClick}
         variant={ButtonVariant.plain}
         {...getTestProps(testIds.masthead.sidebarToggle)}

--- a/archive/components/page/page.styles.ts
+++ b/archive/components/page/page.styles.ts
@@ -1,13 +1,13 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_300,
   global_breakpoint_md,
 } from '@patternfly/react-tokens';
+import React from 'react';
 import { theme } from 'styles/theme';
 
 const breakpoint = `@media (min-width: ${global_breakpoint_md.value})`;
 
-export const styles = StyleSheet.create({
+export const styles = {
   body: {
     backgroundColor: global_BackgroundColor_300.value,
   },
@@ -25,4 +25,4 @@ export const styles = StyleSheet.create({
       marginLeft: theme.page_sidebar_width,
     },
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/page/page.tsx
+++ b/archive/components/page/page.tsx
@@ -25,7 +25,7 @@ const PageBase: React.SFC<Props> = ({
     </Helmet>
     <BackgroundImage />
     {masthead}
-    <main className={css(styles.main)}>{children}</main>
+    <main style={styles.main}>{children}</main>
     {sidebar}
   </>
 );

--- a/archive/components/reports/awsReportSummary/awsReportSummary.styles.ts
+++ b/archive/components/reports/awsReportSummary/awsReportSummary.styles.ts
@@ -1,11 +1,11 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_Color_200,
   global_FontSize_xs,
   global_spacer_md,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartSkeleton: {
     height: '125px',
     marginBottom: global_spacer_md.value,
@@ -23,4 +23,4 @@ export const styles = StyleSheet.create({
     color: global_Color_200.var,
     marginBottom: '0',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/awsReportSummary/awsReportSummary.tsx
+++ b/archive/components/reports/awsReportSummary/awsReportSummary.tsx
@@ -31,24 +31,18 @@ const AwsReportSummaryBase: React.SFC<AwsReportSummaryProps> = ({
   status,
   t,
 }) => (
-  <Card className={css(styles.reportSummary)}>
+  <Card style={styles.reportSummary}>
     <CardHeader>
       <Title size="lg">{title}</Title>
-      {Boolean(subTitle) && <p className={css(styles.subtitle)}>{subTitle}</p>}
+      {Boolean(subTitle) && <p style={styles.subtitle}>{subTitle}</p>}
     </CardHeader>
     <CardBody>
       {status === FetchStatus.inProgress ? (
         <>
           <Skeleton size={SkeletonSize.xs} />
-          <Skeleton
-            className={css(styles.chartSkeleton)}
-            size={SkeletonSize.md}
-          />
+          <Skeleton style={styles.chartSkeleton} size={SkeletonSize.md} />
           <Skeleton size={SkeletonSize.sm} />
-          <Skeleton
-            className={css(styles.legendSkeleton)}
-            size={SkeletonSize.xs}
-          />
+          <Skeleton style={styles.legendSkeleton} size={SkeletonSize.xs} />
         </>
       ) : (
         children

--- a/archive/components/reports/awsReportSummary/awsReportSummaryAlt.styles.ts
+++ b/archive/components/reports/awsReportSummary/awsReportSummaryAlt.styles.ts
@@ -1,12 +1,12 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_Color_200,
   global_FontSize_xs,
   global_spacer_lg,
   global_spacer_md,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartSkeleton: {
     height: '175px',
     marginBottom: global_spacer_md.value,
@@ -36,4 +36,4 @@ export const styles = StyleSheet.create({
     flexGrow: 1,
     marginTop: global_spacer_lg.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/awsReportSummary/awsReportSummaryAlt.tsx
+++ b/archive/components/reports/awsReportSummary/awsReportSummaryAlt.tsx
@@ -35,27 +35,22 @@ const AwsReportSummaryAltBase: React.SFC<AwsReportSummaryAltProps> = ({
   tabs,
   title,
 }) => (
-  <Card className={css(styles.reportSummary)}>
+  <Card style={styles.reportSummary}>
     <Grid gutter="md">
       <GridItem lg={5} xl={6}>
-        <div className={css(styles.cost)}>
+        <div style={styles.cost}>
           <CardHeader>
             <Title size="lg">{title}</Title>
-            {Boolean(subTitle) && (
-              <p className={css(styles.subtitle)}>{subTitle}</p>
-            )}
+            {Boolean(subTitle) && <p style={styles.subtitle}>{subTitle}</p>}
           </CardHeader>
           <CardBody>
             {status === FetchStatus.inProgress ? (
               <>
                 <Skeleton size={SkeletonSize.xs} />
-                <Skeleton
-                  className={css(styles.chartSkeleton)}
-                  size={SkeletonSize.md}
-                />
+                <Skeleton style={styles.chartSkeleton} size={SkeletonSize.md} />
                 <Skeleton size={SkeletonSize.sm} />
                 <Skeleton
-                  className={css(styles.legendSkeleton)}
+                  style={styles.legendSkeleton}
                   size={SkeletonSize.xs}
                 />
               </>
@@ -66,8 +61,8 @@ const AwsReportSummaryAltBase: React.SFC<AwsReportSummaryAltProps> = ({
         </div>
       </GridItem>
       <GridItem lg={7} xl={6}>
-        <div className={css(styles.container)}>
-          <div className={css(styles.tops)}>
+        <div style={styles.container}>
+          <div style={styles.tops}>
             {status !== FetchStatus.inProgress && (
               <>
                 {Boolean(tabs) && <CardBody>{tabs}</CardBody>}

--- a/archive/components/reports/awsReportSummary/awsReportSummaryDetails.styles.ts
+++ b/archive/components/reports/awsReportSummary/awsReportSummaryDetails.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_Color_100,
   global_FontSize_4xl,
@@ -7,8 +6,9 @@ import {
   global_spacer_md,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   reportSummaryDetails: {
     marginBottom: global_spacer_md.value,
     display: 'flex',
@@ -30,4 +30,4 @@ export const styles = StyleSheet.create({
     width: '50%',
     wordWrap: 'break-word',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/awsReportSummary/awsReportSummaryDetails.tsx
+++ b/archive/components/reports/awsReportSummary/awsReportSummaryDetails.tsx
@@ -48,9 +48,9 @@ const AwsReportSummaryDetailsBase: React.SFC<AwsReportSummaryDetailsProps> = ({
   }
 
   const getCostLayout = () => (
-    <div className={css(styles.valueContainer)}>
-      <div className={css(styles.value)}>{cost}</div>
-      <div className={css(styles.text)}>
+    <div style={styles.valueContainer}>
+      <div style={styles.value}>{cost}</div>
+      <div style={styles.text}>
         <div>{costLabel}</div>
       </div>
     </div>
@@ -68,8 +68,8 @@ const AwsReportSummaryDetailsBase: React.SFC<AwsReportSummaryDetailsProps> = ({
     const unitsLabel = t(`units.${units}`);
 
     return (
-      <div className={css(styles.valueContainer)}>
-        <div className={css(styles.value)}>
+      <div style={styles.valueContainer}>
+        <div style={styles.value}>
           {usage}
           {Boolean(
             showUnits &&
@@ -77,9 +77,9 @@ const AwsReportSummaryDetailsBase: React.SFC<AwsReportSummaryDetailsProps> = ({
               report.meta &&
               report.meta.total.usage &&
               report.meta.total.usage.value >= 0
-          ) && <span className={css(styles.text)}>{unitsLabel}</span>}
+          ) && <span style={styles.text}>{unitsLabel}</span>}
         </div>
-        <div className={css(styles.text)}>
+        <div style={styles.text}>
           <div>{usageLabel}</div>
         </div>
       </div>

--- a/archive/components/reports/awsReportSummary/awsReportSummaryItem.styles.ts
+++ b/archive/components/reports/awsReportSummary/awsReportSummaryItem.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   reportSummaryItem: {
     ':not(:last-child)': {
       marginBottom: global_spacer_md.value,
@@ -12,4 +12,4 @@ export const styles = StyleSheet.create({
       overflow: 'visible',
     },
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/awsReportSummary/awsReportSummaryItem.tsx
+++ b/archive/components/reports/awsReportSummary/awsReportSummaryItem.tsx
@@ -36,7 +36,7 @@ const AwsReportSummaryItemBase: React.SFC<AwsReportSummaryItemProps> = ({
   });
 
   return (
-    <li className={css(styles.reportSummaryItem)}>
+    <li style={styles.reportSummaryItem}>
       <Progress
         label={percentLabel}
         value={percentVal}

--- a/archive/components/reports/awsReportSummary/awsReportSummaryItems.styles.ts
+++ b/archive/components/reports/awsReportSummary/awsReportSummaryItems.styles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   skeleton: {
     marginTop: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/awsReportSummary/awsReportSummaryItems.tsx
+++ b/archive/components/reports/awsReportSummary/awsReportSummaryItems.tsx
@@ -66,9 +66,9 @@ class AwsReportSummaryItemsBase extends React.Component<
       return (
         <>
           <Skeleton size={SkeletonSize.md} />
-          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+          <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+          <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+          <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
         </>
       );
     } else {

--- a/archive/components/reports/awsReportSummary/awsReportSummaryTrend.styles.ts
+++ b/archive/components/reports/awsReportSummary/awsReportSummaryTrend.styles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_sm } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chart: {
     marginBottom: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/awsReportSummary/awsReportSummaryTrend.tsx
+++ b/archive/components/reports/awsReportSummary/awsReportSummaryTrend.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { styles } from './awsReportSummaryTrend.styles';
 
 const AwsReportSummaryTrend: React.SFC<TrendChartProps> = props => (
-  <div className={css(styles.chart)}>
+  <div style={styles.chart}>
     <TrendChart {...props} />
   </div>
 );

--- a/archive/components/reports/azureReportSummary/azureReportSummary.styles.ts
+++ b/archive/components/reports/azureReportSummary/azureReportSummary.styles.ts
@@ -1,11 +1,11 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_Color_200,
   global_FontSize_xs,
   global_spacer_md,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartSkeleton: {
     height: '125px',
     marginBottom: global_spacer_md.value,
@@ -23,4 +23,4 @@ export const styles = StyleSheet.create({
     color: global_Color_200.var,
     marginBottom: '0',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/azureReportSummary/azureReportSummary.tsx
+++ b/archive/components/reports/azureReportSummary/azureReportSummary.tsx
@@ -31,24 +31,18 @@ const AzureReportSummaryBase: React.SFC<AzureReportSummaryProps> = ({
   status,
   t,
 }) => (
-  <Card className={css(styles.reportSummary)}>
+  <Card style={styles.reportSummary}>
     <CardHeader>
       <Title size="lg">{title}</Title>
-      {Boolean(subTitle) && <p className={css(styles.subtitle)}>{subTitle}</p>}
+      {Boolean(subTitle) && <p style={styles.subtitle}>{subTitle}</p>}
     </CardHeader>
     <CardBody>
       {status === FetchStatus.inProgress ? (
         <>
           <Skeleton size={SkeletonSize.xs} />
-          <Skeleton
-            className={css(styles.chartSkeleton)}
-            size={SkeletonSize.md}
-          />
+          <Skeleton style={styles.chartSkeleton} size={SkeletonSize.md} />
           <Skeleton size={SkeletonSize.sm} />
-          <Skeleton
-            className={css(styles.legendSkeleton)}
-            size={SkeletonSize.xs}
-          />
+          <Skeleton style={styles.legendSkeleton} size={SkeletonSize.xs} />
         </>
       ) : (
         children

--- a/archive/components/reports/azureReportSummary/azureReportSummaryAlt.styles.ts
+++ b/archive/components/reports/azureReportSummary/azureReportSummaryAlt.styles.ts
@@ -1,12 +1,12 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_Color_200,
   global_FontSize_xs,
   global_spacer_lg,
   global_spacer_md,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartSkeleton: {
     height: '175px',
     marginBottom: global_spacer_md.value,
@@ -36,4 +36,4 @@ export const styles = StyleSheet.create({
     flexGrow: 1,
     marginTop: global_spacer_lg.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/azureReportSummary/azureReportSummaryAlt.tsx
+++ b/archive/components/reports/azureReportSummary/azureReportSummaryAlt.tsx
@@ -35,27 +35,22 @@ const AzureReportSummaryAltBase: React.SFC<AzureReportSummaryAltProps> = ({
   tabs,
   title,
 }) => (
-  <Card className={css(styles.reportSummary)}>
+  <Card style={styles.reportSummary}>
     <Grid gutter="md">
       <GridItem lg={5} xl={6}>
-        <div className={css(styles.cost)}>
+        <div style={styles.cost}>
           <CardHeader>
             <Title size="lg">{title}</Title>
-            {Boolean(subTitle) && (
-              <p className={css(styles.subtitle)}>{subTitle}</p>
-            )}
+            {Boolean(subTitle) && <p style={styles.subtitle}>{subTitle}</p>}
           </CardHeader>
           <CardBody>
             {status === FetchStatus.inProgress ? (
               <>
                 <Skeleton size={SkeletonSize.xs} />
-                <Skeleton
-                  className={css(styles.chartSkeleton)}
-                  size={SkeletonSize.md}
-                />
+                <Skeleton style={styles.chartSkeleton} size={SkeletonSize.md} />
                 <Skeleton size={SkeletonSize.sm} />
                 <Skeleton
-                  className={css(styles.legendSkeleton)}
+                  style={styles.legendSkeleton}
                   size={SkeletonSize.xs}
                 />
               </>
@@ -66,8 +61,8 @@ const AzureReportSummaryAltBase: React.SFC<AzureReportSummaryAltProps> = ({
         </div>
       </GridItem>
       <GridItem lg={7} xl={6}>
-        <div className={css(styles.container)}>
-          <div className={css(styles.tops)}>
+        <div style={styles.container}>
+          <div style={styles.tops}>
             {status !== FetchStatus.inProgress && (
               <>
                 {Boolean(tabs) && <CardBody>{tabs}</CardBody>}

--- a/archive/components/reports/azureReportSummary/azureReportSummaryDetails.styles.ts
+++ b/archive/components/reports/azureReportSummary/azureReportSummaryDetails.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_Color_100,
   global_FontSize_4xl,
@@ -7,8 +6,9 @@ import {
   global_spacer_md,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   reportSummaryDetails: {
     marginBottom: global_spacer_md.value,
     display: 'flex',
@@ -30,4 +30,4 @@ export const styles = StyleSheet.create({
     width: '50%',
     wordWrap: 'break-word',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/azureReportSummary/azureReportSummaryDetails.tsx
+++ b/archive/components/reports/azureReportSummary/azureReportSummaryDetails.tsx
@@ -59,9 +59,9 @@ const AzureReportSummaryDetailsBase: React.SFC<AzureReportSummaryDetailsProps> =
   }
 
   const getCostLayout = () => (
-    <div className={css(styles.valueContainer)}>
-      <div className={css(styles.value)}>{cost}</div>
-      <div className={css(styles.text)}>
+    <div style={styles.valueContainer}>
+      <div style={styles.value}>{cost}</div>
+      <div style={styles.text}>
         <div>{costLabel}</div>
       </div>
     </div>
@@ -80,8 +80,8 @@ const AzureReportSummaryDetailsBase: React.SFC<AzureReportSummaryDetailsProps> =
     const unitsLabel = t(`units.${_units}`);
 
     return (
-      <div className={css(styles.valueContainer)}>
-        <div className={css(styles.value)}>
+      <div style={styles.valueContainer}>
+        <div style={styles.value}>
           {usage}
           {Boolean(
             showUnits &&
@@ -90,9 +90,9 @@ const AzureReportSummaryDetailsBase: React.SFC<AzureReportSummaryDetailsProps> =
                   report.meta &&
                   report.meta.total.usage &&
                   report.meta.total.usage.value >= 0))
-          ) && <span className={css(styles.text)}>{unitsLabel}</span>}
+          ) && <span style={styles.text}>{unitsLabel}</span>}
         </div>
-        <div className={css(styles.text)}>
+        <div style={styles.text}>
           <div>{usageLabel}</div>
         </div>
       </div>

--- a/archive/components/reports/azureReportSummary/azureReportSummaryItem.styles.ts
+++ b/archive/components/reports/azureReportSummary/azureReportSummaryItem.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   reportSummaryItem: {
     ':not(:last-child)': {
       marginBottom: global_spacer_md.value,
@@ -12,4 +12,4 @@ export const styles = StyleSheet.create({
       overflow: 'visible',
     },
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/azureReportSummary/azureReportSummaryItem.tsx
+++ b/archive/components/reports/azureReportSummary/azureReportSummaryItem.tsx
@@ -36,7 +36,7 @@ const AzureReportSummaryItemBase: React.SFC<AzureReportSummaryItemProps> = ({
   });
 
   return (
-    <li className={css(styles.reportSummaryItem)}>
+    <li style={styles.reportSummaryItem}>
       <Progress
         label={percentLabel}
         value={percentVal}

--- a/archive/components/reports/azureReportSummary/azureReportSummaryItems.styles.ts
+++ b/archive/components/reports/azureReportSummary/azureReportSummaryItems.styles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   skeleton: {
     marginTop: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/azureReportSummary/azureReportSummaryItems.tsx
+++ b/archive/components/reports/azureReportSummary/azureReportSummaryItems.tsx
@@ -67,9 +67,9 @@ class AzureReportSummaryItemsBase extends React.Component<
       return (
         <>
           <Skeleton size={SkeletonSize.md} />
-          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+          <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+          <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+          <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
         </>
       );
     } else {

--- a/archive/components/reports/azureReportSummary/azureReportSummaryTrend.styles.ts
+++ b/archive/components/reports/azureReportSummary/azureReportSummaryTrend.styles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_sm } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chart: {
     marginBottom: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/azureReportSummary/azureReportSummaryTrend.tsx
+++ b/archive/components/reports/azureReportSummary/azureReportSummaryTrend.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { styles } from './azureReportSummaryTrend.styles';
 
 const AzureReportSummaryTrend: React.SFC<TrendChartProps> = props => (
-  <div className={css(styles.chart)}>
+  <div style={styles.chart}>
     <TrendChart {...props} />
   </div>
 );

--- a/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummary.styles.ts
+++ b/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummary.styles.ts
@@ -1,11 +1,11 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_Color_200,
   global_FontSize_xs,
   global_spacer_md,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartSkeleton: {
     height: '125px',
     marginBottom: global_spacer_md.value,
@@ -23,4 +23,4 @@ export const styles = StyleSheet.create({
     color: global_Color_200.var,
     marginBottom: '0',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummary.tsx
+++ b/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummary.tsx
@@ -31,24 +31,18 @@ const OcpCloudReportSummaryBase: React.SFC<OcpCloudReportSummaryProps> = ({
   status,
   t,
 }) => (
-  <Card className={css(styles.reportSummary)}>
+  <Card style={styles.reportSummary}>
     <CardHeader>
       <Title size="lg">{title}</Title>
-      {Boolean(subTitle) && <p className={css(styles.subtitle)}>{subTitle}</p>}
+      {Boolean(subTitle) && <p style={styles.subtitle}>{subTitle}</p>}
     </CardHeader>
     <CardBody>
       {status === FetchStatus.inProgress ? (
         <>
           <Skeleton size={SkeletonSize.xs} />
-          <Skeleton
-            className={css(styles.chartSkeleton)}
-            size={SkeletonSize.md}
-          />
+          <Skeleton style={styles.chartSkeleton} size={SkeletonSize.md} />
           <Skeleton size={SkeletonSize.sm} />
-          <Skeleton
-            className={css(styles.legendSkeleton)}
-            size={SkeletonSize.xs}
-          />
+          <Skeleton style={styles.legendSkeleton} size={SkeletonSize.xs} />
         </>
       ) : (
         children

--- a/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryAlt.styles.ts
+++ b/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryAlt.styles.ts
@@ -1,12 +1,12 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_Color_200,
   global_FontSize_xs,
   global_spacer_lg,
   global_spacer_md,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartSkeleton: {
     height: '175px',
     marginBottom: global_spacer_md.value,
@@ -36,4 +36,4 @@ export const styles = StyleSheet.create({
     flexGrow: 1,
     marginTop: global_spacer_lg.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryAlt.tsx
+++ b/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryAlt.tsx
@@ -35,27 +35,22 @@ const OcpCloudReportSummaryAltBase: React.SFC<OcpCloudReportSummaryAltProps> = (
   tabs,
   title,
 }) => (
-  <Card className={css(styles.reportSummary)}>
+  <Card style={styles.reportSummary}>
     <Grid gutter="md">
       <GridItem lg={5} xl={6}>
-        <div className={css(styles.cost)}>
+        <div style={styles.cost}>
           <CardHeader>
             <Title size="lg">{title}</Title>
-            {Boolean(subTitle) && (
-              <p className={css(styles.subtitle)}>{subTitle}</p>
-            )}
+            {Boolean(subTitle) && <p style={styles.subtitle}>{subTitle}</p>}
           </CardHeader>
           <CardBody>
             {status === FetchStatus.inProgress ? (
               <>
                 <Skeleton size={SkeletonSize.xs} />
-                <Skeleton
-                  className={css(styles.chartSkeleton)}
-                  size={SkeletonSize.md}
-                />
+                <Skeleton style={styles.chartSkeleton} size={SkeletonSize.md} />
                 <Skeleton size={SkeletonSize.sm} />
                 <Skeleton
-                  className={css(styles.legendSkeleton)}
+                  style={styles.legendSkeleton}
                   size={SkeletonSize.xs}
                 />
               </>
@@ -66,8 +61,8 @@ const OcpCloudReportSummaryAltBase: React.SFC<OcpCloudReportSummaryAltProps> = (
         </div>
       </GridItem>
       <GridItem lg={7} xl={6}>
-        <div className={css(styles.container)}>
-          <div className={css(styles.tops)}>
+        <div style={styles.container}>
+          <div style={styles.tops}>
             {status !== FetchStatus.inProgress && (
               <>
                 {Boolean(tabs) && <CardBody>{tabs}</CardBody>}

--- a/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryDetails.styles.ts
+++ b/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryDetails.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_Color_100,
   global_FontSize_4xl,
@@ -7,8 +6,9 @@ import {
   global_spacer_md,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   reportSummaryDetails: {
     marginBottom: global_spacer_md.value,
     display: 'flex',
@@ -30,4 +30,4 @@ export const styles = StyleSheet.create({
     width: '50%',
     wordWrap: 'break-word',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryDetails.tsx
+++ b/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryDetails.tsx
@@ -86,16 +86,16 @@ const OcpCloudReportSummaryDetailsBase: React.SFC<OcpCloudReportSummaryDetailsPr
   }
 
   const getCostLayout = () => (
-    <div className={css(styles.valueContainer)}>
+    <div style={styles.valueContainer}>
       <Tooltip
         content={t('ocp_cloud_dashboard.total_cost_tooltip', {
           infrastructureCost,
         })}
         enableFlip
       >
-        <div className={css(styles.value)}>{cost}</div>
+        <div style={styles.value}>{cost}</div>
       </Tooltip>
-      <div className={css(styles.text)}>
+      <div style={styles.text}>
         <div>{costLabel}</div>
       </div>
     </div>
@@ -113,8 +113,8 @@ const OcpCloudReportSummaryDetailsBase: React.SFC<OcpCloudReportSummaryDetailsPr
     const unitsLabel = t(`units.${_units}`);
 
     return (
-      <div className={css(styles.valueContainer)}>
-        <div className={css(styles.value)}>
+      <div style={styles.valueContainer}>
+        <div style={styles.value}>
           {request}
           {Boolean(
             showUnits &&
@@ -122,9 +122,9 @@ const OcpCloudReportSummaryDetailsBase: React.SFC<OcpCloudReportSummaryDetailsPr
               report.meta &&
               report.meta.total.request &&
               report.meta.total.request.value >= 0
-          ) && <span className={css(styles.text)}>{unitsLabel}</span>}
+          ) && <span style={styles.text}>{unitsLabel}</span>}
         </div>
-        <div className={css(styles.text)}>
+        <div style={styles.text}>
           <div>{requestLabel}</div>
         </div>
       </div>
@@ -143,8 +143,8 @@ const OcpCloudReportSummaryDetailsBase: React.SFC<OcpCloudReportSummaryDetailsPr
     const unitsLabel = t(`units.${_units}`);
 
     return (
-      <div className={css(styles.valueContainer)}>
-        <div className={css(styles.value)}>
+      <div style={styles.valueContainer}>
+        <div style={styles.value}>
           {usage}
           {Boolean(
             showUnits &&
@@ -152,9 +152,9 @@ const OcpCloudReportSummaryDetailsBase: React.SFC<OcpCloudReportSummaryDetailsPr
               report.meta &&
               report.meta.total.usage &&
               report.meta.total.usage.value >= 0
-          ) && <span className={css(styles.text)}>{unitsLabel}</span>}
+          ) && <span style={styles.text}>{unitsLabel}</span>}
         </div>
-        <div className={css(styles.text)}>
+        <div style={styles.text}>
           <div>{usageLabel}</div>
         </div>
       </div>

--- a/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryItem.styles.ts
+++ b/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryItem.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   reportSummaryItem: {
     ':not(:last-child)': {
       marginBottom: global_spacer_md.value,
@@ -12,4 +12,4 @@ export const styles = StyleSheet.create({
       overflow: 'visible',
     },
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryItem.tsx
+++ b/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryItem.tsx
@@ -36,7 +36,7 @@ const OcpCloudReportSummaryItemBase: React.SFC<OcpCloudReportSummaryItemProps> =
   });
 
   return (
-    <li className={css(styles.reportSummaryItem)}>
+    <li style={styles.reportSummaryItem}>
       <Progress
         label={percentLabel}
         value={percentVal}

--- a/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryItems.styles.ts
+++ b/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryItems.styles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   skeleton: {
     marginTop: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryItems.tsx
+++ b/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryItems.tsx
@@ -67,9 +67,9 @@ class OcpCloudReportSummaryItemsBase extends React.Component<
       return (
         <>
           <Skeleton size={SkeletonSize.md} />
-          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+          <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+          <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+          <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
         </>
       );
     } else {

--- a/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryTrend.styles.ts
+++ b/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryTrend.styles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_sm } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chart: {
     marginBottom: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryTrend.tsx
+++ b/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryTrend.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { styles } from './ocpCloudReportSummaryTrend.styles';
 
 const OcpCloudReportSummaryTrend: React.SFC<TrendChartProps> = props => (
-  <div className={css(styles.chart)}>
+  <div style={styles.chart}>
     <TrendChart {...props} />
   </div>
 );

--- a/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryUsage.styles.ts
+++ b/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryUsage.styles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_sm } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chart: {
     marginBottom: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryUsage.tsx
+++ b/archive/components/reports/ocpCloudReportSummary/ocpCloudReportSummaryUsage.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { styles } from './ocpCloudReportSummaryTrend.styles';
 
 const OcpCloudReportSummaryUsage: React.SFC<UsageChartProps> = props => (
-  <div className={css(styles.chart)}>
+  <div style={styles.chart}>
     <UsageChart {...props} />
   </div>
 );

--- a/archive/components/reports/ocpReportSummary/ocpReportSummary.styles.ts
+++ b/archive/components/reports/ocpReportSummary/ocpReportSummary.styles.ts
@@ -1,11 +1,11 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_Color_200,
   global_FontSize_xs,
   global_spacer_md,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartSkeleton: {
     height: '125px',
     marginBottom: global_spacer_md.value,
@@ -23,4 +23,4 @@ export const styles = StyleSheet.create({
     color: global_Color_200.var,
     marginBottom: '0',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/ocpReportSummary/ocpReportSummary.tsx
+++ b/archive/components/reports/ocpReportSummary/ocpReportSummary.tsx
@@ -31,24 +31,18 @@ const OcpReportSummaryBase: React.SFC<OcpReportSummaryProps> = ({
   status,
   t,
 }) => (
-  <Card className={css(styles.reportSummary)}>
+  <Card style={styles.reportSummary}>
     <CardHeader>
       <Title size="lg">{title}</Title>
-      {Boolean(subTitle) && <p className={css(styles.subtitle)}>{subTitle}</p>}
+      {Boolean(subTitle) && <p style={styles.subtitle}>{subTitle}</p>}
     </CardHeader>
     <CardBody>
       {status === FetchStatus.inProgress ? (
         <>
           <Skeleton size={SkeletonSize.xs} />
-          <Skeleton
-            className={css(styles.chartSkeleton)}
-            size={SkeletonSize.md}
-          />
+          <Skeleton style={styles.chartSkeleton} size={SkeletonSize.md} />
           <Skeleton size={SkeletonSize.sm} />
-          <Skeleton
-            className={css(styles.legendSkeleton)}
-            size={SkeletonSize.xs}
-          />
+          <Skeleton style={styles.legendSkeleton} size={SkeletonSize.xs} />
         </>
       ) : (
         children

--- a/archive/components/reports/ocpReportSummary/ocpReportSummaryAlt.styles.ts
+++ b/archive/components/reports/ocpReportSummary/ocpReportSummaryAlt.styles.ts
@@ -1,12 +1,12 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_Color_200,
   global_FontSize_xs,
   global_spacer_lg,
   global_spacer_md,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartSkeleton: {
     height: '175px',
     marginBottom: global_spacer_md.value,
@@ -36,4 +36,4 @@ export const styles = StyleSheet.create({
     flexGrow: 1,
     marginTop: global_spacer_lg.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/ocpReportSummary/ocpReportSummaryAlt.tsx
+++ b/archive/components/reports/ocpReportSummary/ocpReportSummaryAlt.tsx
@@ -35,28 +35,23 @@ const OcpReportSummaryAltBase: React.SFC<OcpReportSummaryAltProps> = ({
   tabs,
   title,
 }) => (
-  <Card className={css(styles.reportSummary)}>
+  <Card style={styles.reportSummary}>
     <Grid gutter="md">
       <GridItem lg={5} xl={6}>
-        <div className={css(styles.cost)}>
+        <div style={styles.cost}>
           <CardHeader>
             <Title size="lg">{title}</Title>
-            {Boolean(subTitle) && (
-              <p className={css(styles.subtitle)}>{subTitle}</p>
-            )}
+            {Boolean(subTitle) && <p style={styles.subtitle}>{subTitle}</p>}
           </CardHeader>
           <CardBody>
             {status === FetchStatus.inProgress ? (
               <>
                 <Skeleton size={SkeletonSize.xs} />
-                <Skeleton
-                  size={SkeletonSize.md}
-                  className={css(styles.chartSkeleton)}
-                />
+                <Skeleton size={SkeletonSize.md} style={styles.chartSkeleton} />
                 <Skeleton size={SkeletonSize.sm} />
                 <Skeleton
                   size={SkeletonSize.xs}
-                  className={css(styles.legendSkeleton)}
+                  style={styles.legendSkeleton}
                 />
               </>
             ) : (
@@ -66,8 +61,8 @@ const OcpReportSummaryAltBase: React.SFC<OcpReportSummaryAltProps> = ({
         </div>
       </GridItem>
       <GridItem lg={7} xl={6}>
-        <div className={css(styles.container)}>
-          <div className={css(styles.tops)}>
+        <div style={styles.container}>
+          <div style={styles.tops}>
             {status !== FetchStatus.inProgress && (
               <>
                 {Boolean(tabs) && <CardBody>{tabs}</CardBody>}

--- a/archive/components/reports/ocpReportSummary/ocpReportSummaryDetails.styles.ts
+++ b/archive/components/reports/ocpReportSummary/ocpReportSummaryDetails.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_Color_100,
   global_FontSize_4xl,
@@ -7,8 +6,9 @@ import {
   global_spacer_md,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   reportSummaryDetails: {
     marginBottom: global_spacer_md.value,
     display: 'flex',
@@ -30,4 +30,4 @@ export const styles = StyleSheet.create({
     width: '50%',
     wordWrap: 'break-word',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/ocpReportSummary/ocpReportSummaryDetails.tsx
+++ b/archive/components/reports/ocpReportSummary/ocpReportSummaryDetails.tsx
@@ -85,7 +85,7 @@ const OcpReportSummaryDetailsBase: React.SFC<OcpReportSummaryDetailsProps> = ({
   }
 
   const getCostLayout = () => (
-    <div className={css(styles.valueContainer)}>
+    <div style={styles.valueContainer}>
       <Tooltip
         content={t('ocp_dashboard.total_cost_tooltip', {
           supplementaryCost,
@@ -93,9 +93,9 @@ const OcpReportSummaryDetailsBase: React.SFC<OcpReportSummaryDetailsProps> = ({
         })}
         enableFlip
       >
-        <div className={css(styles.value)}>{cost}</div>
+        <div style={styles.value}>{cost}</div>
       </Tooltip>
-      <div className={css(styles.text)}>
+      <div style={styles.text}>
         <div>{costLabel}</div>
       </div>
     </div>
@@ -113,8 +113,8 @@ const OcpReportSummaryDetailsBase: React.SFC<OcpReportSummaryDetailsProps> = ({
     const unitsLabel = t(`units.${_units}`);
 
     return (
-      <div className={css(styles.valueContainer)}>
-        <div className={css(styles.value)}>
+      <div style={styles.valueContainer}>
+        <div style={styles.value}>
           {request}
           {Boolean(
             showUnits &&
@@ -122,9 +122,9 @@ const OcpReportSummaryDetailsBase: React.SFC<OcpReportSummaryDetailsProps> = ({
               report.meta &&
               report.meta.total.request &&
               report.meta.total.request.value >= 0
-          ) && <span className={css(styles.text)}>{unitsLabel}</span>}
+          ) && <span style={styles.text}>{unitsLabel}</span>}
         </div>
-        <div className={css(styles.text)}>
+        <div style={styles.text}>
           <div>{requestLabel}</div>
         </div>
       </div>
@@ -143,8 +143,8 @@ const OcpReportSummaryDetailsBase: React.SFC<OcpReportSummaryDetailsProps> = ({
     const unitsLabel = t(`units.${_units}`);
 
     return (
-      <div className={css(styles.valueContainer)}>
-        <div className={css(styles.value)}>
+      <div style={styles.valueContainer}>
+        <div style={styles.value}>
           {usage}
           {Boolean(
             showUnits &&
@@ -152,9 +152,9 @@ const OcpReportSummaryDetailsBase: React.SFC<OcpReportSummaryDetailsProps> = ({
               report.meta &&
               report.meta.total.usage &&
               report.meta.total.usage.value >= 0
-          ) && <span className={css(styles.text)}>{unitsLabel}</span>}
+          ) && <span style={styles.text}>{unitsLabel}</span>}
         </div>
-        <div className={css(styles.text)}>
+        <div style={styles.text}>
           <div>{usageLabel}</div>
         </div>
       </div>

--- a/archive/components/reports/ocpReportSummary/ocpReportSummaryItem.styles.ts
+++ b/archive/components/reports/ocpReportSummary/ocpReportSummaryItem.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   reportSummaryItem: {
     ':not(:last-child)': {
       marginBottom: global_spacer_md.value,
@@ -12,4 +12,4 @@ export const styles = StyleSheet.create({
       overflow: 'visible',
     },
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/ocpReportSummary/ocpReportSummaryItem.tsx
+++ b/archive/components/reports/ocpReportSummary/ocpReportSummaryItem.tsx
@@ -36,7 +36,7 @@ const OcpReportSummaryItemBase: React.SFC<OcpReportSummaryItemProps> = ({
   });
 
   return (
-    <li className={css(styles.reportSummaryItem)}>
+    <li style={styles.reportSummaryItem}>
       <Progress
         label={percentLabel}
         value={percentVal}

--- a/archive/components/reports/ocpReportSummary/ocpReportSummaryItems.styles.ts
+++ b/archive/components/reports/ocpReportSummary/ocpReportSummaryItems.styles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   skeleton: {
     marginTop: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/ocpReportSummary/ocpReportSummaryItems.tsx
+++ b/archive/components/reports/ocpReportSummary/ocpReportSummaryItems.tsx
@@ -66,9 +66,9 @@ class OcpReportSummaryItemsBase extends React.Component<
       return (
         <>
           <Skeleton size={SkeletonSize.md} />
-          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+          <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+          <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+          <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
         </>
       );
     } else {

--- a/archive/components/reports/ocpReportSummary/ocpReportSummaryTrend.styles.ts
+++ b/archive/components/reports/ocpReportSummary/ocpReportSummaryTrend.styles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_sm } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chart: {
     marginBottom: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/ocpReportSummary/ocpReportSummaryTrend.tsx
+++ b/archive/components/reports/ocpReportSummary/ocpReportSummaryTrend.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { styles } from './ocpReportSummaryTrend.styles';
 
 const OcpReportSummaryTrend: React.SFC<CostChartProps> = props => (
-  <div className={css(styles.chart)}>
+  <div style={styles.chart}>
     <CostChart {...props} />
   </div>
 );

--- a/archive/components/reports/ocpReportSummary/ocpReportSummaryUsage.styles.ts
+++ b/archive/components/reports/ocpReportSummary/ocpReportSummaryUsage.styles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_sm } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chart: {
     marginBottom: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/reports/ocpReportSummary/ocpReportSummaryUsage.tsx
+++ b/archive/components/reports/ocpReportSummary/ocpReportSummaryUsage.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { styles } from './ocpReportSummaryTrend.styles';
 
 const OcpReportSummaryUsage: React.SFC<UsageChartProps> = props => (
-  <div className={css(styles.chart)}>
+  <div style={styles.chart}>
     <UsageChart {...props} />
   </div>
 );

--- a/archive/components/sidebar/sidebar.styles.ts
+++ b/archive/components/sidebar/sidebar.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
+import React from 'react';
 import { theme } from 'styles/theme';
 
-export const styles = StyleSheet.create({
+export const styles = {
   sidebar: {
     position: 'fixed',
     top: theme.page_masthead_height,
@@ -24,4 +24,4 @@ export const styles = StyleSheet.create({
       display: 'none',
     },
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/sidebar/sidebar.tsx
+++ b/archive/components/sidebar/sidebar.tsx
@@ -24,7 +24,7 @@ const SidebarBase: React.SFC<Props> = ({ isSidebarOpen, toggleSidebar }) => (
         {isSidebarOpen && (
           <Backdrop
             onClick={toggleSidebar}
-            className={css(styles.mask)}
+            style={styles.mask}
             {...getTestProps(testIds.sidebar.backdrop)}
           />
         )}

--- a/archive/components/tabs/tabItem.styles.ts
+++ b/archive/components/tabs/tabItem.styles.ts
@@ -1,12 +1,12 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_FontSize_md,
   global_primary_color_100,
   global_spacer_md,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   tabItem: {
     position: 'relative',
     flexGrow: 1,
@@ -23,8 +23,6 @@ export const styles = StyleSheet.create({
     marginRight: '20px',
   },
   selected: {
-    backgroundImage: `linear-gradient(to top, ${
-      global_primary_color_100.value
-    } 2px, transparent 2px)`,
+    backgroundImage: `linear-gradient(to top, ${global_primary_color_100.value} 2px, transparent 2px)`,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/tabs/tabNavigation.styles.ts
+++ b/archive/components/tabs/tabNavigation.styles.ts
@@ -1,10 +1,10 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   tabNavigation: {
     display: 'flex',
     alignItems: 'flex-end',
     marginBottom: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/tabs/tabNavigation.tsx
+++ b/archive/components/tabs/tabNavigation.tsx
@@ -32,7 +32,7 @@ class TabNavigation extends React.Component<TabNavigationProps> {
     return (
       <div
         role="tablist"
-        className={css(styles.tabNavigation)}
+        style={styles.tabNavigation}
         onKeyDown={this.handleKeyDown}
       >
         {tabs.map(tab => (

--- a/archive/components/textInput/textInput.styles.ts
+++ b/archive/components/textInput/textInput.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BorderColor_100,
   global_BorderColor_dark_100,
@@ -11,8 +10,9 @@ import {
   global_spacer_xl,
   global_spacer_xs,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   textInput: {
     width: '100%',
     fontSize: global_FontSize_md.value,
@@ -22,9 +22,7 @@ export const styles = StyleSheet.create({
     paddingLeft: global_spacer_sm.value,
     lineHeight: '24px',
     outline: 0,
-    border: `${global_BorderWidth_sm.value} solid ${
-      global_BorderColor_100.value
-    }`,
+    border: `${global_BorderWidth_sm.value} solid ${global_BorderColor_100.value}`,
     ':focus': {
       borderColor: global_BorderColor_dark_100.value,
     },
@@ -50,4 +48,4 @@ export const styles = StyleSheet.create({
       borderColor: global_danger_color_200.value,
     },
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/verticalNav/verticalNav.styles.ts
+++ b/archive/components/verticalNav/verticalNav.styles.ts
@@ -1,6 +1,6 @@
-import { StyleSheet } from '@patternfly/react-styles';
+import React from 'react';
 import { theme } from 'styles/theme';
 
-export const styles = StyleSheet.create({
+export const styles = {
   verticalNav: { color: theme.verticalNav_color },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/verticalNav/verticalNav.tsx
+++ b/archive/components/verticalNav/verticalNav.tsx
@@ -10,7 +10,7 @@ interface Props {
 
 export const VerticalNav: React.SFC<Props> = ({ children, label }) => (
   <nav
-    className={css(styles.verticalNav)}
+    style={styles.verticalNav}
     role="navigation"
     aria-label={label}
     {...getTestProps(testIds.sidebar.nav)}

--- a/archive/components/verticalNav/verticalNavItem.styles.ts
+++ b/archive/components/verticalNav/verticalNavItem.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_active_color_100,
   global_Color_dark_100,
@@ -7,6 +6,7 @@ import {
   global_spacer_xl,
 } from '@patternfly/react-tokens';
 import { StyleDeclaration } from 'aphrodite';
+import React from 'react';
 
 const activeIdicator: StyleDeclaration = {
   position: 'absolute',
@@ -18,7 +18,7 @@ const activeIdicator: StyleDeclaration = {
   backgroundColor: global_active_color_100.value,
 };
 
-export const styles = StyleSheet.create({
+export const styles = {
   verticalNavLink: {
     display: 'flex',
     alignItems: 'center',
@@ -51,4 +51,4 @@ export const styles = StyleSheet.create({
   textActive: {
     ':after': activeIdicator,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/components/verticalNav/verticalNavItem.tsx
+++ b/archive/components/verticalNav/verticalNavItem.tsx
@@ -45,7 +45,7 @@ export const VerticalNavItem: React.SFC<Props> = ({
                 aria-disabled={isDisabled ? true : null}
                 {...getTestProps(testIds.sidebar.link)}
               >
-                <Icon className={css(styles.icon)} size="sm" />
+                <Icon style={styles.icon} size="sm" />
                 <span
                   className={css(styles.text, isActive && styles.textActive)}
                 >

--- a/archive/pages/details/awsDetails/detailsTag.styles.ts
+++ b/archive/pages/details/awsDetails/detailsTag.styles.ts
@@ -1,9 +1,9 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_3xl, global_spacer_sm } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   tagsContainer: {
     marginRight: global_spacer_3xl.value,
     marginTop: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/pages/details/awsDetails/detailsTag.tsx
+++ b/archive/pages/details/awsDetails/detailsTag.tsx
@@ -112,7 +112,7 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
     }
 
     return (
-      <div className={css(styles.tagsContainer)} id={id}>
+      <div style={styles.tagsContainer} id={id}>
         {Boolean(someTags) &&
           someTags.map((tag, tagIndex) => <span key={tagIndex}>{tag}</span>)}
         {Boolean(someTags.length < allTags.length) && (

--- a/archive/pages/details/awsDetails/detailsTagModal.styles.ts
+++ b/archive/pages/details/awsDetails/detailsTagModal.styles.ts
@@ -1,13 +1,13 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_2xl, global_spacer_lg } from '@patternfly/react-tokens';
 import { css } from 'emotion';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   subTitle: {
     marginTop: global_spacer_2xl.value,
     textAlign: 'right',
   },
-});
+} as { [className: string]: React.CSSProperties };
 
 export const modalOverride = css`
   /* Workaround for isLarge not working properly */

--- a/archive/pages/details/awsDetails/detailsWidget.styles.ts
+++ b/archive/pages/details/awsDetails/detailsWidget.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md, global_spacer_xl } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   skeleton: {
     marginTop: global_spacer_md.value,
   },
@@ -12,4 +12,4 @@ export const styles = StyleSheet.create({
     marginLeft: '-18px',
     paddingTop: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/pages/details/awsDetails/detailsWidgetModal.styles.ts
+++ b/archive/pages/details/awsDetails/detailsWidgetModal.styles.ts
@@ -1,15 +1,15 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_lg, global_spacer_xl } from '@patternfly/react-tokens';
 import { css } from 'emotion';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   mainContent: {
     marginTop: global_spacer_xl.value,
   },
   subTitle: {
     textAlign: 'right',
   },
-});
+} as { [className: string]: React.CSSProperties };
 
 export const modalOverride = css`
   /* Workaround for isLarge not working properly */

--- a/archive/pages/details/awsDetails/detailsWidgetView.tsx
+++ b/archive/pages/details/awsDetails/detailsWidgetView.tsx
@@ -119,7 +119,7 @@ class DetailsWidgetViewBase extends React.Component<DetailsWidgetViewProps> {
 
     if (otherIndex !== -1) {
       return (
-        <div className={css(styles.viewAllContainer)}>
+        <div style={styles.viewAllContainer}>
           <Button
             {...getTestProps(testIds.details.view_all_btn)}
             onClick={this.handleWidgetModalOpen}
@@ -159,13 +159,13 @@ class DetailsWidgetViewBase extends React.Component<DetailsWidgetViewProps> {
         {Boolean(reportFetchStatus === FetchStatus.inProgress) ? (
           <>
             <Skeleton size={SkeletonSize.md} />
-            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+            <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+            <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+            <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
           </>
         ) : (
           <>
-            <div className={css(styles.tabs)}>
+            <div style={styles.tabs}>
               <ReportSummaryItems
                 idKey={groupBy as any}
                 key={`${groupBy}-items`}

--- a/archive/pages/details/awsDetails/exportModal.styles.ts
+++ b/archive/pages/details/awsDetails/exportModal.styles.ts
@@ -1,11 +1,11 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_spacer_sm,
   global_spacer_xl,
   global_spacer_xs,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   form: {
     marginLeft: global_spacer_sm.var,
   },
@@ -23,4 +23,4 @@ export const styles = StyleSheet.create({
   title: {
     paddingBottom: global_spacer_xl.var,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/pages/details/awsDetails/exportModal.tsx
+++ b/archive/pages/details/awsDetails/exportModal.tsx
@@ -142,7 +142,7 @@ export class ExportModalBase extends React.Component<
 
     return (
       <Modal
-        className={css(styles.modal)}
+        style={styles.modal}
         isLarge
         isOpen={this.props.isOpen}
         onClose={this.handleClose}
@@ -167,10 +167,10 @@ export class ExportModalBase extends React.Component<
           </Button>,
         ]}
       >
-        <Title className={css(styles.title)} size="xl">
+        <Title style={styles.title} size="xl">
           {t('export.heading', { groupBy })}
         </Title>
-        <Form className={css(styles.form)}>
+        <Form style={styles.form}>
           <FormGroup
             label={t('export.aggregate_type')}
             fieldId="aggregate-type"

--- a/archive/pages/details/awsDetails/groupBy.styles.ts
+++ b/archive/pages/details/awsDetails/groupBy.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   groupBySelector: {
     display: 'flex',
     alignItems: 'center',
@@ -10,4 +10,4 @@ export const styles = StyleSheet.create({
     marginBottom: 0,
     marginRight: global_spacer_md.var,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/pages/details/awsDetails/groupBy.tsx
+++ b/archive/pages/details/awsDetails/groupBy.tsx
@@ -182,10 +182,8 @@ class GroupByBase extends React.Component<GroupByProps> {
         : t(`group_by.values.${currentItem}`);
 
     return (
-      <div className={css(styles.groupBySelector)}>
-        <label className={css(styles.groupBySelectorLabel)}>
-          {t('group_by.cost')}:
-        </label>
+      <div style={styles.groupBySelector}>
+        <label style={styles.groupBySelectorLabel}>{t('group_by.cost')}:</label>
         <Dropdown
           onSelect={this.handleGroupBySelect}
           toggle={

--- a/archive/pages/details/awsDetails/historicalChart.styles.ts
+++ b/archive/pages/details/awsDetails/historicalChart.styles.ts
@@ -1,17 +1,17 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_spacer_3xl,
   global_spacer_lg,
   global_spacer_md,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
 export const chartStyles = {
   chartHeight: 90,
   chartContainerHeight: 215,
 };
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartContainer: {
     marginLeft: global_spacer_lg.value,
   },
@@ -32,4 +32,4 @@ export const styles = StyleSheet.create({
   storageChart: {
     marginTop: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/pages/details/awsDetails/historicalChart.tsx
+++ b/archive/pages/details/awsDetails/historicalChart.tsx
@@ -85,14 +85,8 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
   private getSkeleton = () => {
     return (
       <>
-        <Skeleton
-          className={css(styles.chartSkeleton)}
-          size={SkeletonSize.md}
-        />
-        <Skeleton
-          className={css(styles.legendSkeleton)}
-          size={SkeletonSize.xs}
-        />
+        <Skeleton style={styles.chartSkeleton} size={SkeletonSize.md} />
+        <Skeleton style={styles.legendSkeleton} size={SkeletonSize.xs} />
       </>
     );
   };
@@ -165,8 +159,8 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
         : 'USD';
 
     return (
-      <div className={css(styles.chartContainer)}>
-        <div className={css(styles.costChart)}>
+      <div style={styles.chartContainer}>
+        <div style={styles.costChart}>
           {currentCostReportFetchStatus === FetchStatus.inProgress &&
           previousCostReportFetchStatus === FetchStatus.inProgress ? (
             this.getSkeleton()
@@ -186,7 +180,7 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
             />
           )}
         </div>
-        <div className={css(styles.instanceChart)}>
+        <div style={styles.instanceChart}>
           {currentInstanceReportFetchStatus === FetchStatus.inProgress &&
           previousInstanceReportFetchStatus === FetchStatus.inProgress ? (
             this.getSkeleton()
@@ -205,7 +199,7 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
             />
           )}
         </div>
-        <div className={css(styles.storageChart)}>
+        <div style={styles.storageChart}>
           {currentStorageReportFetchStatus === FetchStatus.inProgress &&
           previousStorageReportFetchStatus === FetchStatus.inProgress ? (
             this.getSkeleton()

--- a/archive/pages/login/login.styles.ts
+++ b/archive/pages/login/login.styles.ts
@@ -1,11 +1,11 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_dark_100,
   global_spacer_2xl,
   global_spacer_md,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   alert: {
     marginBottom: global_spacer_md.value,
   },
@@ -20,4 +20,4 @@ export const styles = StyleSheet.create({
   loginBox: {
     padding: global_spacer_2xl.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/pages/login/login.tsx
+++ b/archive/pages/login/login.tsx
@@ -82,12 +82,12 @@ export class Login extends React.Component<Props, State> {
     return (
       <>
         <Helmet>
-          <body className={css(styles.body)} />
+          <body style={styles.body} />
         </Helmet>
         <BackgroundImage />
-        <div className={css(styles.loginPage)}>
+        <div style={styles.loginPage}>
           <Bullseye>
-            <Card className={css(styles.loginBox)}>
+            <Card style={styles.loginBox}>
               <CardHeader>
                 <Title size={TitleSize['2xl']}>{t('login.title')}</Title>
               </CardHeader>
@@ -97,7 +97,7 @@ export class Login extends React.Component<Props, State> {
                   onSubmit={this.handleSubmit}
                 >
                   {Boolean(error) && (
-                    <div className={css(styles.alert)}>
+                    <div style={styles.alert}>
                       <Alert
                         {...getTestProps(testIds.login.alert)}
                         variant={AlertVariant.danger}

--- a/archive/pages/onboardingModal/sourceKind/checkList.styles.ts
+++ b/archive/pages/onboardingModal/sourceKind/checkList.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   listWrapper: {
     paddingLeft: global_spacer_md.value,
     marginBottom: global_spacer_md.value,
@@ -10,4 +10,4 @@ export const styles = StyleSheet.create({
   listTitle: {
     marginBottom: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/pages/onboardingModal/sourceKind/checkList.tsx
+++ b/archive/pages/onboardingModal/sourceKind/checkList.tsx
@@ -21,7 +21,7 @@ const SourceKindCheckListBase: React.SFC<Props> = ({
 }) => {
   return (
     <React.Fragment>
-      <div className={css(styles.listTitle)}>
+      <div style={styles.listTitle}>
         {t('onboarding.source_kind.checklist_title')}
       </div>
       <CheckItem
@@ -32,7 +32,7 @@ const SourceKindCheckListBase: React.SFC<Props> = ({
         id={'install_openshift'}
         ariaLabel={t('onboarding.source_kind.checkbox_1_aria_label')}
       >
-        <div className={css(styles.listWrapper)}>
+        <div style={styles.listWrapper}>
           <List>
             <ListItem>
               <a
@@ -61,7 +61,7 @@ const SourceKindCheckListBase: React.SFC<Props> = ({
         id={'install_others'}
         ariaLabel={t('onboarding.source_kind.checkbox_2_aria_label')}
       >
-        <div className={css(styles.listWrapper)}>
+        <div style={styles.listWrapper}>
           <List>
             <ListItem>
               <a

--- a/archive/pages/providersModal/providersModal.styles.ts
+++ b/archive/pages/providersModal/providersModal.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   alert: {
     marginBottom: global_spacer_md.value,
   },
@@ -12,4 +12,4 @@ export const styles = StyleSheet.create({
     // Workaround for isLarge not working properly
     width: '700px',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/pages/providersModal/providersModal.tsx
+++ b/archive/pages/providersModal/providersModal.tsx
@@ -193,7 +193,7 @@ export class ProvidersModal extends React.Component<Props, State> {
 
     return (
       <Modal
-        className={css(styles.modal)}
+        style={styles.modal}
         isLarge
         isOpen={this.props.isProviderModalOpen}
         onClose={this.handleCancel}
@@ -223,7 +223,7 @@ export class ProvidersModal extends React.Component<Props, State> {
         ]}
       >
         {Boolean(error || invalidField) && (
-          <div className={css(styles.alert)}>
+          <div style={styles.alert}>
             <Alert
               {...getTestProps(testIds.login.alert)}
               variant={AlertVariant.danger}
@@ -231,7 +231,7 @@ export class ProvidersModal extends React.Component<Props, State> {
             />
           </div>
         )}
-        <p className={css(styles.docs)}>
+        <p style={styles.docs}>
           View the{' '}
           <a
             href="https://koku.readthedocs.io/en/latest/providers.html#adding-an-aws-account"

--- a/archive/pages/sourceSettings/header.tsx
+++ b/archive/pages/sourceSettings/header.tsx
@@ -5,12 +5,12 @@ import { InjectedTranslateProps } from 'react-i18next';
 import { styles } from './sourceSettings.styles';
 
 const Header: React.SFC<InjectedTranslateProps> = ({ t }) => (
-  <header className={css(styles.header)}>
-    <Breadcrumb className={css(styles.breadcrumb)}>
+  <header style={styles.header}>
+    <Breadcrumb style={styles.breadcrumb}>
       <BreadcrumbItem>{t('settings')}</BreadcrumbItem>
       <BreadcrumbItem isActive>{t('cost_management')}</BreadcrumbItem>
     </Breadcrumb>
-    <Title className={css(styles.title)} size="2xl">
+    <Title style={styles.title} size="2xl">
       {t('source_details.title')}
     </Title>
   </header>

--- a/archive/pages/sourceSettings/noSourcesState.styles.ts
+++ b/archive/pages/sourceSettings/noSourcesState.styles.ts
@@ -1,10 +1,10 @@
-import { StyleSheet } from '@patternfly/react-styles';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   container: {
     display: 'flex',
     justifyContent: 'center',
     height: '100vh',
     marginTop: '150px',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/pages/sourceSettings/noSourcesState.tsx
+++ b/archive/pages/sourceSettings/noSourcesState.tsx
@@ -22,7 +22,7 @@ class NoSourcesStateBase extends React.Component<Props> {
     const { t, openModal } = this.props;
 
     return (
-      <div className={css(styles.container)}>
+      <div style={styles.container}>
         <EmptyState>
           <EmptyStateIcon icon={WrenchIcon} />
           <Title size="lg">{t('source_details.no_sources.title')}</Title>

--- a/archive/pages/sourceSettings/sourceSettings.styles.ts
+++ b/archive/pages/sourceSettings/sourceSettings.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_100,
   global_BackgroundColor_300,
@@ -6,8 +5,9 @@ import {
   global_spacer_sm,
   global_spacer_xl,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   sourceSettings: {
     backgroundColor: global_BackgroundColor_300.var,
   },
@@ -48,4 +48,4 @@ export const styles = StyleSheet.create({
   title: {
     paddingBottom: global_spacer_sm.var,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/archive/pages/sourceSettings/sourceSettings.tsx
+++ b/archive/pages/sourceSettings/sourceSettings.tsx
@@ -224,13 +224,13 @@ class SourceSettings extends React.Component<Props, State> {
       .find(k => this.props.query[k]);
 
     return (
-      <div className={css(styles.sourceSettings)}>
+      <div style={styles.sourceSettings}>
         <Header t={t} />
-        <div className={css(styles.content)}>
+        <div style={styles.content}>
           {status !== FetchStatus.none &&
             error === null &&
             (rows.length > 0 || filterValue) && (
-              <div className={css(styles.toolbarContainer)}>
+              <div style={styles.toolbarContainer}>
                 <Toolbar>
                   <ToolbarSection
                     aria-label={t('source_details.filter.section_below')}
@@ -295,7 +295,7 @@ class SourceSettings extends React.Component<Props, State> {
                   columns={columns}
                   rows={rows}
                 />
-                <div className={css(styles.paginationContainer)}>
+                <div style={styles.paginationContainer}>
                   <SourcePagination
                     status={status}
                     fetchSources={this.onPaginationChange}

--- a/archive/pages/sourceSettings/sourceTable.tsx
+++ b/archive/pages/sourceSettings/sourceTable.tsx
@@ -5,7 +5,7 @@ import { styles } from './sourceSettings.styles';
 import { tableOverride } from './sourceTable.styles';
 
 const SourceTable = ({ onCollapse, columns, rows }) => (
-  <div className={css(styles.tableContainer)}>
+  <div style={styles.tableContainer}>
     <Table
       aria-label="source-table"
       // TODO: Uncomment once bulk delete is available

--- a/src/components/charts/common/chart.styles.ts
+++ b/src/components/charts/common/chart.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_Color_dark_100,
   global_Color_light_100,
@@ -7,6 +6,7 @@ import {
   global_success_color_100,
   global_success_color_200,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
 export const chartStyles = {
   padding: 8,
@@ -32,7 +32,7 @@ export const chartStyles = {
   },
 };
 
-export const styles = StyleSheet.create({
+export const styles = {
   reportSummaryTrend: {
     ':not(foo) svg': {
       overflow: 'visible',
@@ -42,4 +42,4 @@ export const styles = StyleSheet.create({
       length: '12px',
     },
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/charts/common/chartLegend.tsx
+++ b/src/components/charts/common/chartLegend.tsx
@@ -1,13 +1,12 @@
 import { css } from '@patternfly/react-styles';
-import { StyleSheet } from '@patternfly/react-styles';
 import React from 'react';
 
-const styles = StyleSheet.create({
+const styles = {
   legend: {
     display: 'flex',
     alignItems: 'center',
   },
-});
+} as { [className: string]: React.CSSProperties };
 
 interface ChartLegendProps {
   children: React.ReactNode;

--- a/src/components/charts/common/chartLegendItem.styles.ts
+++ b/src/components/charts/common/chartLegendItem.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BorderWidth_sm,
   global_Color_200,
@@ -6,9 +5,10 @@ import {
   global_spacer_md,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 import { chartStyles } from './chart.styles';
 
-export const styles = StyleSheet.create({
+export const styles = {
   legendItem: {
     display: 'flex',
     alignItems: 'center',
@@ -31,4 +31,4 @@ export const styles = StyleSheet.create({
     backgroundColor: chartStyles.previousMonth.data.fill,
     borderColor: chartStyles.previousMonth.data.stroke,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/charts/common/chartLegendItem.tsx
+++ b/src/components/charts/common/chartLegendItem.tsx
@@ -1,4 +1,3 @@
-import { css } from '@patternfly/react-styles';
 import React from 'react';
 import { styles } from './chartLegendItem.styles';
 import { ChartDatum, getDateRangeString } from './chartUtils';
@@ -28,24 +27,24 @@ const ChartLegendItem: React.SFC<ChartLegendItemProps> = ({
   if (idKey === 'date') {
     const label = getDateRangeString(data);
     return (
-      <div className={css(styling)}>
+      <div style={styling}>
         <div
-          className={css(
-            styles.color,
-            isCurrent ? styles.currentColor : styles.previousColor
-          )}
+          style={{
+            ...styles.color,
+            ...(isCurrent ? styles.currentColor : styles.previousColor),
+          }}
         />
         {label}
       </div>
     );
   } else {
     return (
-      <div key={data[index].key} className={css(styling)}>
+      <div key={data[index].key} style={styling}>
         <div
-          className={css(
-            styles.color,
-            isCurrent ? styles.currentColor : styles.previousColor
-          )}
+          style={{
+            ...styles.color,
+            ...(isCurrent ? styles.currentColor : styles.previousColor),
+          }}
         />
         {data[index].key}
       </div>

--- a/src/components/charts/common/chartTitle.tsx
+++ b/src/components/charts/common/chartTitle.tsx
@@ -1,4 +1,3 @@
-import { css } from '@patternfly/react-styles';
 import { global_FontSize_xs, global_spacer_sm } from '@patternfly/react-tokens';
 import React from 'react';
 
@@ -14,7 +13,7 @@ interface ChartTitleProps {
 }
 
 const ChartTitle: React.SFC<ChartTitleProps> = ({ children }) => (
-  <div className={css(styles.chartTitle)}>{children}</div>
+  <div style={styles.chartTitle}>{children}</div>
 );
 
 export { ChartTitle, ChartTitleProps };

--- a/src/components/charts/common/chartTitle.tsx
+++ b/src/components/charts/common/chartTitle.tsx
@@ -1,14 +1,13 @@
 import { css } from '@patternfly/react-styles';
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_FontSize_xs, global_spacer_sm } from '@patternfly/react-tokens';
 import React from 'react';
 
-const styles = StyleSheet.create({
+const styles = {
   chartTitle: {
     fontSize: global_FontSize_xs.value,
     marginBottom: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };
 
 interface ChartTitleProps {
   children: React.ReactNode;

--- a/src/components/charts/costChart/costChart.styles.ts
+++ b/src/components/charts/costChart/costChart.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   chart_color_green_100,
   chart_color_green_200,
@@ -8,6 +7,7 @@ import {
   global_disabled_color_200,
   global_FontFamily_sans_serif,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
 export const chartStyles = {
   currentCostData: {
@@ -90,10 +90,10 @@ export const chartStyles = {
   },
 };
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartContainer: {
     ':not(foo) svg': {
       overflow: 'visible',
     },
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -7,7 +7,6 @@ import {
   getInteractiveLegendEvents,
   getInteractiveLegendItemStyles,
 } from '@patternfly/react-charts';
-import { css } from '@patternfly/react-styles';
 import { default as ChartTheme } from 'components/charts/chartTheme';
 import {
   getCostRangeString,
@@ -402,9 +401,8 @@ class CostChart extends React.Component<CostChartProps, State> {
 
     return (
       <div
-        className={css(styles.chartContainer)}
         ref={this.containerRef}
-        style={{ height: adjustedContainerHeight }}
+        style={{ ...styles.chartContainer, height: adjustedContainerHeight }}
       >
         <div>{title}</div>
         <Chart

--- a/src/components/charts/historicalCostChart/historicalCostChart.styles.ts
+++ b/src/components/charts/historicalCostChart/historicalCostChart.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   chart_color_blue_100,
   chart_color_blue_200,
@@ -14,6 +13,7 @@ import {
   global_spacer_lg,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
 export const chartStyles = {
   currentCapacityData: {
@@ -117,7 +117,7 @@ export const chartStyles = {
   },
 };
 
-export const styles = StyleSheet.create({
+export const styles = {
   chart: {
     marginTop: global_spacer_sm.value,
   },
@@ -129,4 +129,4 @@ export const styles = StyleSheet.create({
   title: {
     marginLeft: '-' + global_spacer_lg.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -7,7 +7,6 @@ import {
   getInteractiveLegendEvents,
   getInteractiveLegendItemStyles,
 } from '@patternfly/react-charts';
-import { css } from '@patternfly/react-styles';
 import { default as ChartTheme } from 'components/charts/chartTheme';
 import { getDateRange } from 'components/charts/common/chartUtils';
 import {
@@ -382,9 +381,9 @@ class HistoricalCostChart extends React.Component<
     const midDate = Math.floor(endDate / 2);
 
     return (
-      <div className={css(styles.chartContainer)} ref={this.containerRef}>
-        <div className={css(styles.title)}>{title}</div>
-        <div className={css(styles.chart)} style={{ height: containerHeight }}>
+      <div style={styles.chartContainer} ref={this.containerRef}>
+        <div style={styles.title}>{title}</div>
+        <div style={{ ...styles.chart, height: containerHeight }}>
           <Chart
             containerComponent={container}
             domain={domain}

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.styles.ts
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   chart_color_green_100,
   chart_color_green_200,
@@ -10,6 +9,7 @@ import {
   global_spacer_lg,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
 export const chartStyles = {
   currentMonth: {
@@ -66,7 +66,7 @@ export const chartStyles = {
   },
 };
 
-export const styles = StyleSheet.create({
+export const styles = {
   chart: {
     marginTop: global_spacer_sm.value,
   },
@@ -78,4 +78,4 @@ export const styles = StyleSheet.create({
   title: {
     marginLeft: '-' + global_spacer_lg.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -7,7 +7,6 @@ import {
   getInteractiveLegendEvents,
   getInteractiveLegendItemStyles,
 } from '@patternfly/react-charts';
-import { css } from '@patternfly/react-styles';
 import { default as ChartTheme } from 'components/charts/chartTheme';
 import {
   getCostRangeString,
@@ -303,9 +302,9 @@ class HistoricalTrendChart extends React.Component<
     const midDate = Math.floor(endDate / 2);
 
     return (
-      <div className={css(styles.chartContainer)} ref={this.containerRef}>
-        <div className={css(styles.title)}>{title}</div>
-        <div className={css(styles.chart)} style={{ height: containerHeight }}>
+      <div style={styles.chartContainer} ref={this.containerRef}>
+        <div style={styles.title}>{title}</div>
+        <div style={{ ...styles.chart, height: containerHeight }}>
           <Chart
             containerComponent={container}
             domain={domain}

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.styles.ts
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   chart_color_blue_100,
   chart_color_blue_200,
@@ -14,6 +13,7 @@ import {
   global_spacer_lg,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
 export const chartStyles = {
   currentCapacityData: {
@@ -129,7 +129,7 @@ export const chartStyles = {
   },
 };
 
-export const styles = StyleSheet.create({
+export const styles = {
   chart: {
     marginTop: global_spacer_sm.value,
   },
@@ -141,4 +141,4 @@ export const styles = StyleSheet.create({
   title: {
     marginLeft: '-' + global_spacer_lg.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -7,7 +7,6 @@ import {
   getInteractiveLegendEvents,
   getInteractiveLegendItemStyles,
 } from '@patternfly/react-charts';
-import { css } from '@patternfly/react-styles';
 import { default as ChartTheme } from 'components/charts/chartTheme';
 import {
   getMaxValue,
@@ -453,9 +452,9 @@ class HistoricalUsageChart extends React.Component<
     const midDate = Math.floor(endDate / 2);
 
     return (
-      <div className={css(styles.chartContainer)} ref={this.containerRef}>
-        <div className={css(styles.title)}>{title}</div>
-        <div className={css(styles.chart)} style={{ height: containerHeight }}>
+      <div style={styles.chartContainer} ref={this.containerRef}>
+        <div style={styles.title}>{title}</div>
+        <div style={{ ...styles.chart, height: containerHeight }}>
           <Chart
             containerComponent={container}
             domain={domain}

--- a/src/components/charts/trendChart/trendChart.styles.ts
+++ b/src/components/charts/trendChart/trendChart.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   chart_color_green_100,
   chart_color_green_200,
@@ -8,6 +7,7 @@ import {
   global_disabled_color_200,
   global_FontFamily_sans_serif,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
 export const chartStyles = {
   legend: {
@@ -65,10 +65,10 @@ export const chartStyles = {
   },
 };
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartContainer: {
     ':not(foo) svg': {
       overflow: 'visible',
     },
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -7,7 +7,6 @@ import {
   getInteractiveLegendEvents,
   getInteractiveLegendItemStyles,
 } from '@patternfly/react-charts';
-import { css } from '@patternfly/react-styles';
 import { default as ChartTheme } from 'components/charts/chartTheme';
 import {
   getCostRangeString,
@@ -313,9 +312,8 @@ class TrendChart extends React.Component<TrendChartProps, State> {
 
     return (
       <div
-        className={css(styles.chartContainer)}
         ref={this.containerRef}
-        style={{ height: adjustedContainerHeight }}
+        style={{ ...styles.chartContainer, height: adjustedContainerHeight }}
       >
         <div>{title}</div>
         <Chart

--- a/src/components/charts/usageChart/usageChart.styles.ts
+++ b/src/components/charts/usageChart/usageChart.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   chart_color_green_100,
   chart_color_green_200,
@@ -9,6 +8,7 @@ import {
   global_FontFamily_sans_serif,
   global_spacer_lg,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
 export const chartStyles = {
   currentRequestData: {
@@ -93,11 +93,11 @@ export const chartStyles = {
   },
 };
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartContainer: {
     ':not(foo) svg': {
       overflow: 'visible',
     },
     marginTop: global_spacer_lg.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -7,7 +7,6 @@ import {
   getInteractiveLegendEvents,
   getInteractiveLegendItemStyles,
 } from '@patternfly/react-charts';
-import { css } from '@patternfly/react-styles';
 import { default as ChartTheme } from 'components/charts/chartTheme';
 import {
   getDateRange,
@@ -408,9 +407,8 @@ class UsageChart extends React.Component<UsageChartProps, State> {
 
     return (
       <div
-        className={css(styles.chartContainer)}
         ref={this.containerRef}
-        style={{ height: adjustedContainerHeight }}
+        style={{ ...styles.chartContainer, height: adjustedContainerHeight }}
       >
         <div>{title}</div>
         <Chart

--- a/src/components/progressBar/progressBar.styles.ts
+++ b/src/components/progressBar/progressBar.styles.ts
@@ -1,11 +1,11 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_primary_color_200,
   global_spacer_lg,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   progressBar: {
     height: 10,
     backgroundColor: 'rgba(0, 123, 186, 0.2)',
@@ -16,4 +16,4 @@ export const styles = StyleSheet.create({
     height: '100%',
     backgroundColor: global_primary_color_200.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/progressBar/progressBar.tsx
+++ b/src/components/progressBar/progressBar.tsx
@@ -1,4 +1,3 @@
-import { css } from '@patternfly/react-styles';
 import React from 'react';
 import { styles } from './progressBar.styles';
 
@@ -9,8 +8,8 @@ interface ProgressBarProps {
 const ProgressBar: React.SFC<ProgressBarProps> = ({ progress }) => {
   const width = Math.min(Math.max(0, progress), 100); // force between 0 - 100;
   return (
-    <div className={css(styles.progressBar)}>
-      <div className={css(styles.bar)} style={{ width: `${width}%` }} />
+    <div style={styles.progressBar}>
+      <div style={{ ...styles.bar, width: `${width}%` }} />
     </div>
   );
 };

--- a/src/components/reports/reportSummary/__snapshots__/reportSummaryItem.test.tsx.snap
+++ b/src/components/reports/reportSummary/__snapshots__/reportSummaryItem.test.tsx.snap
@@ -2,44 +2,8 @@
 
 exports[`gets percentage from value and total value: Progress Bar Value 1`] = `10`;
 
-exports[`gets percentage from value and total value: Rendered Label 1`] = `
-<li
-  className="css-1e999ct"
->
-  <Progress
-    className=""
-    id=""
-    label="percent_of_total"
-    max={100}
-    measureLocation="top"
-    min={0}
-    size="sm"
-    title="Label"
-    value={10}
-    valueText={null}
-    variant="info"
-  />
-</li>
-`;
+exports[`gets percentage from value and total value: Rendered Label 1`] = `null`;
 
 exports[`sets percent to 0 if totalValue is 0: Progress Bar Value 1`] = `0`;
 
-exports[`sets percent to 0 if totalValue is 0: Rendered label 1`] = `
-<li
-  className="css-1e999ct"
->
-  <Progress
-    className=""
-    id=""
-    label="percent_of_total"
-    max={100}
-    measureLocation="top"
-    min={0}
-    size="sm"
-    title="Label"
-    value={0}
-    valueText={null}
-    variant="info"
-  />
-</li>
-`;
+exports[`sets percent to 0 if totalValue is 0: Rendered label 1`] = `null`;

--- a/src/components/reports/reportSummary/reportSummary.styles.ts
+++ b/src/components/reports/reportSummary/reportSummary.styles.ts
@@ -1,11 +1,11 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_Color_200,
   global_FontSize_xs,
   global_spacer_md,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartSkeleton: {
     height: '125px',
     marginBottom: global_spacer_md.value,
@@ -23,4 +23,4 @@ export const styles = StyleSheet.create({
     color: global_Color_200.var,
     marginBottom: '0',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/reports/reportSummary/reportSummary.tsx
+++ b/src/components/reports/reportSummary/reportSummary.tsx
@@ -5,7 +5,6 @@ import {
   CardHeader,
   Title,
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import {
   Skeleton,
   SkeletonSize,
@@ -31,24 +30,18 @@ const ReportSummaryBase: React.SFC<ReportSummaryProps> = ({
   status,
   t,
 }) => (
-  <Card className={css(styles.reportSummary)}>
+  <Card style={styles.reportSummary}>
     <CardHeader>
       <Title size="lg">{title}</Title>
-      {Boolean(subTitle) && <p className={css(styles.subtitle)}>{subTitle}</p>}
+      {Boolean(subTitle) && <p style={styles.subtitle}>{subTitle}</p>}
     </CardHeader>
     <CardBody>
       {status === FetchStatus.inProgress ? (
         <>
           <Skeleton size={SkeletonSize.xs} />
-          <Skeleton
-            className={css(styles.chartSkeleton)}
-            size={SkeletonSize.md}
-          />
+          <Skeleton style={styles.chartSkeleton} size={SkeletonSize.md} />
           <Skeleton size={SkeletonSize.sm} />
-          <Skeleton
-            className={css(styles.legendSkeleton)}
-            size={SkeletonSize.xs}
-          />
+          <Skeleton style={styles.legendSkeleton} size={SkeletonSize.xs} />
         </>
       ) : (
         children

--- a/src/components/reports/reportSummary/reportSummaryAlt.styles.ts
+++ b/src/components/reports/reportSummary/reportSummaryAlt.styles.ts
@@ -1,12 +1,12 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_Color_200,
   global_FontSize_xs,
   global_spacer_lg,
   global_spacer_md,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartSkeleton: {
     height: '175px',
     marginBottom: global_spacer_md.value,
@@ -36,4 +36,4 @@ export const styles = StyleSheet.create({
     flexGrow: 1,
     marginTop: global_spacer_lg.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/reports/reportSummary/reportSummaryAlt.tsx
+++ b/src/components/reports/reportSummary/reportSummaryAlt.tsx
@@ -7,7 +7,6 @@ import {
   GridItem,
   Title,
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import {
   Skeleton,
   SkeletonSize,
@@ -35,27 +34,22 @@ const OcpCloudReportSummaryAltBase: React.SFC<OcpCloudReportSummaryAltProps> = (
   tabs,
   title,
 }) => (
-  <Card className={css(styles.reportSummary)}>
+  <Card style={styles.reportSummary}>
     <Grid gutter="md">
       <GridItem lg={5} xl={6}>
-        <div className={css(styles.cost)}>
+        <div style={styles.cost}>
           <CardHeader>
             <Title size="lg">{title}</Title>
-            {Boolean(subTitle) && (
-              <p className={css(styles.subtitle)}>{subTitle}</p>
-            )}
+            {Boolean(subTitle) && <p style={styles.subtitle}>{subTitle}</p>}
           </CardHeader>
           <CardBody>
             {status === FetchStatus.inProgress ? (
               <>
                 <Skeleton size={SkeletonSize.xs} />
-                <Skeleton
-                  className={css(styles.chartSkeleton)}
-                  size={SkeletonSize.md}
-                />
+                <Skeleton style={styles.chartSkeleton} size={SkeletonSize.md} />
                 <Skeleton size={SkeletonSize.sm} />
                 <Skeleton
-                  className={css(styles.legendSkeleton)}
+                  style={styles.legendSkeleton}
                   size={SkeletonSize.xs}
                 />
               </>
@@ -66,8 +60,8 @@ const OcpCloudReportSummaryAltBase: React.SFC<OcpCloudReportSummaryAltProps> = (
         </div>
       </GridItem>
       <GridItem lg={7} xl={6}>
-        <div className={css(styles.container)}>
-          <div className={css(styles.tops)}>
+        <div style={styles.container}>
+          <div style={styles.tops}>
             {status !== FetchStatus.inProgress && (
               <>
                 {Boolean(tabs) && <CardBody>{tabs}</CardBody>}

--- a/src/components/reports/reportSummary/reportSummaryCost.styles.ts
+++ b/src/components/reports/reportSummary/reportSummaryCost.styles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_sm } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chart: {
     marginBottom: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/reports/reportSummary/reportSummaryCost.tsx
+++ b/src/components/reports/reportSummary/reportSummaryCost.tsx
@@ -1,10 +1,9 @@
-import { css } from '@patternfly/react-styles';
 import { CostChart, CostChartProps } from 'components/charts/costChart';
 import React from 'react';
 import { styles } from './reportSummaryTrend.styles';
 
 const ReportSummaryCost: React.SFC<CostChartProps> = props => (
-  <div className={css(styles.chart)}>
+  <div style={styles.chart}>
     <CostChart {...props} />
   </div>
 );

--- a/src/components/reports/reportSummary/reportSummaryDetails.styles.ts
+++ b/src/components/reports/reportSummary/reportSummaryDetails.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_Color_100,
   global_FontSize_4xl,
@@ -7,8 +6,9 @@ import {
   global_spacer_md,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   reportSummaryDetails: {
     marginBottom: global_spacer_md.value,
     display: 'flex',
@@ -30,4 +30,4 @@ export const styles = StyleSheet.create({
     width: '50%',
     wordWrap: 'break-word',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/reports/reportSummary/reportSummaryDetails.tsx
+++ b/src/components/reports/reportSummary/reportSummaryDetails.tsx
@@ -1,5 +1,4 @@
 import { Tooltip } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { Report } from 'api/reports/report';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
@@ -110,7 +109,7 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
   }
 
   const getCostLayout = () => (
-    <div className={css(styles.valueContainer)}>
+    <div style={styles.valueContainer}>
       {Boolean(showTooltip) ? (
         <Tooltip
           content={t('dashboard.total_cost_tooltip', {
@@ -119,12 +118,12 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
           })}
           enableFlip
         >
-          <div className={css(styles.value)}>{cost}</div>
+          <div style={styles.value}>{cost}</div>
         </Tooltip>
       ) : (
-        <div className={css(styles.value)}>{cost}</div>
+        <div style={styles.value}>{cost}</div>
       )}
-      <div className={css(styles.text)}>
+      <div style={styles.text}>
         <div>{costLabel}</div>
       </div>
     </div>
@@ -141,14 +140,14 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
     const unitsLabel = t(`units.${_units}`);
 
     return (
-      <div className={css(styles.valueContainer)}>
-        <div className={css(styles.value)}>
+      <div style={styles.valueContainer}>
+        <div style={styles.value}>
           {request}
           {Boolean(
             showUnits && hasRequest && report.meta.total.request.value >= 0
-          ) && <span className={css(styles.text)}>{unitsLabel}</span>}
+          ) && <span style={styles.text}>{unitsLabel}</span>}
         </div>
-        <div className={css(styles.text)}>
+        <div style={styles.text}>
           <div>{requestLabel}</div>
         </div>
       </div>
@@ -165,14 +164,14 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
     const unitsLabel = t(`units.${_units}`);
 
     return (
-      <div className={css(styles.valueContainer)}>
-        <div className={css(styles.value)}>
+      <div style={styles.valueContainer}>
+        <div style={styles.value}>
           {usage}
           {Boolean(
             showUnits && hasUsage && report.meta.total.usage.value >= 0
-          ) && <span className={css(styles.text)}>{unitsLabel}</span>}
+          ) && <span style={styles.text}>{unitsLabel}</span>}
         </div>
-        <div className={css(styles.text)}>
+        <div style={styles.text}>
           <div>{usageLabel}</div>
         </div>
       </div>

--- a/src/components/reports/reportSummary/reportSummaryItem.styles.ts
+++ b/src/components/reports/reportSummary/reportSummaryItem.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   reportSummaryItem: {
     ':not(:last-child)': {
       marginBottom: global_spacer_md.value,
@@ -12,4 +12,4 @@ export const styles = StyleSheet.create({
       overflow: 'visible',
     },
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/reports/reportSummary/reportSummaryItem.test.tsx
+++ b/src/components/reports/reportSummary/reportSummaryItem.test.tsx
@@ -1,5 +1,4 @@
 import { Progress } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { shallow } from 'enzyme';
 import React from 'react';
 import { ReportSummaryItem, ReportSummaryItemProps } from './reportSummaryItem';
@@ -30,7 +29,7 @@ test('gets percentage from value and total value', () => {
   expect(view.find(Progress).props().value).toMatchSnapshot(
     'Progress Bar Value'
   );
-  expect(view.find(`.${css(styles.reportSummaryItem)}`)).toMatchSnapshot(
+  expect(view.find('.pf-c-progress__measure')).toMatchSnapshot(
     'Rendered Label'
   );
 });
@@ -40,7 +39,7 @@ test('sets percent to 0 if totalValue is 0', () => {
   expect(view.find(Progress).props().value).toMatchSnapshot(
     'Progress Bar Value'
   );
-  expect(view.find(`.${css(styles.reportSummaryItem)}`)).toMatchSnapshot(
+  expect(view.find('.pf-c-progress__measure')).toMatchSnapshot(
     'Rendered label'
   );
 });

--- a/src/components/reports/reportSummary/reportSummaryItem.tsx
+++ b/src/components/reports/reportSummary/reportSummaryItem.tsx
@@ -1,5 +1,4 @@
 import { Progress, ProgressSize } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
@@ -36,7 +35,7 @@ const ReportSummaryItemBase: React.SFC<ReportSummaryItemProps> = ({
   });
 
   return (
-    <li className={css(styles.reportSummaryItem)}>
+    <li style={styles.reportSummaryItem}>
       <Progress
         label={percentLabel}
         value={percentVal}

--- a/src/components/reports/reportSummary/reportSummaryItems.styles.ts
+++ b/src/components/reports/reportSummary/reportSummaryItems.styles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   skeleton: {
     marginTop: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/reports/reportSummary/reportSummaryItems.tsx
+++ b/src/components/reports/reportSummary/reportSummaryItems.tsx
@@ -1,4 +1,3 @@
-import { css } from '@patternfly/react-styles';
 import {
   Skeleton,
   SkeletonSize,
@@ -66,9 +65,9 @@ class ReportSummaryItemsBase extends React.Component<ReportSummaryItemsProps> {
       return (
         <>
           <Skeleton size={SkeletonSize.md} />
-          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-          <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+          <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+          <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+          <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
         </>
       );
     } else {

--- a/src/components/reports/reportSummary/reportSummaryTrend.styles.ts
+++ b/src/components/reports/reportSummary/reportSummaryTrend.styles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_sm } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chart: {
     marginBottom: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/reports/reportSummary/reportSummaryTrend.tsx
+++ b/src/components/reports/reportSummary/reportSummaryTrend.tsx
@@ -1,10 +1,9 @@
-import { css } from '@patternfly/react-styles';
 import { TrendChart, TrendChartProps } from 'components/charts/trendChart';
 import React from 'react';
 import { styles } from './reportSummaryTrend.styles';
 
 const ReportSummaryTrend: React.SFC<TrendChartProps> = props => (
-  <div className={css(styles.chart)}>
+  <div style={styles.chart}>
     <TrendChart {...props} />
   </div>
 );

--- a/src/components/reports/reportSummary/reportSummaryUsage.styles.ts
+++ b/src/components/reports/reportSummary/reportSummaryUsage.styles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_sm } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chart: {
     marginBottom: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/reports/reportSummary/reportSummaryUsage.tsx
+++ b/src/components/reports/reportSummary/reportSummaryUsage.tsx
@@ -1,10 +1,9 @@
-import { css } from '@patternfly/react-styles';
 import { UsageChart, UsageChartProps } from 'components/charts/usageChart';
 import React from 'react';
 import { styles } from './reportSummaryTrend.styles';
 
 const ReportSummaryUsage: React.SFC<UsageChartProps> = props => (
-  <div className={css(styles.chart)}>
+  <div style={styles.chart}>
     <UsageChart {...props} />
   </div>
 );

--- a/src/components/state/emptyFilterState/emptyFilterState.styles.ts
+++ b/src/components/state/emptyFilterState/emptyFilterState.styles.ts
@@ -1,6 +1,6 @@
-import { StyleSheet } from '@patternfly/react-styles';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   container: {
     display: 'flex',
     justifyContent: 'center',
@@ -21,4 +21,4 @@ export const styles = StyleSheet.create({
     marginBottom: '20px',
     width: '100px',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/state/emptyFilterState/emptyFilterState.tsx
+++ b/src/components/state/emptyFilterState/emptyFilterState.tsx
@@ -5,7 +5,6 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import { OcpCloudQuery, parseQuery } from 'api/queries/ocpCloudQuery';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -76,7 +75,7 @@ const EmptyFilterStateBase: React.SFC<EmptyFilterStateProps> = ({
       }
     }
     if (showAltIcon1 || showAltIcon2) {
-      return <img className={showAltIcon1 ? styles.icon1 : styles.icon2} />;
+      return <img style={showAltIcon1 ? styles.icon1 : styles.icon2} />;
     } else {
       return <EmptyStateIcon icon={icon} />;
     }
@@ -84,10 +83,10 @@ const EmptyFilterStateBase: React.SFC<EmptyFilterStateProps> = ({
 
   return (
     <div
-      className={css(
-        styles.container,
-        showMargin ? styles.containerMargin : ''
-      )}
+      style={{
+        ...styles.container,
+        ...(showMargin ? styles.containerMargin : {}),
+      }}
     >
       <EmptyState>
         {getIcon()}

--- a/src/components/state/emptyValueState/emptyValueState.styles.ts
+++ b/src/components/state/emptyValueState/emptyValueState.styles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_FontSize_sm } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   container: {
     fontSize: global_FontSize_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/state/emptyValueState/emptyValueState.tsx
+++ b/src/components/state/emptyValueState/emptyValueState.tsx
@@ -1,11 +1,10 @@
 import { MinusIcon } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import React from 'react';
 import { styles } from './emptyValueState.styles';
 
 export const EmptyValueState: React.SFC = () => {
   return (
-    <span className={css(styles.container)}>
+    <span style={styles.container}>
       <MinusIcon />
     </span>
   );

--- a/src/components/state/errorState/errorState.styles.ts
+++ b/src/components/state/errorState/errorState.styles.ts
@@ -1,10 +1,10 @@
-import { StyleSheet } from '@patternfly/react-styles';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   container: {
     display: 'flex',
     justifyContent: 'center',
     height: '100vh',
     marginTop: '150px',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/state/errorState/errorState.tsx
+++ b/src/components/state/errorState/errorState.tsx
@@ -5,7 +5,6 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { ErrorCircleOIcon, LockIcon } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import { AxiosError } from 'axios';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -35,7 +34,7 @@ const ErrorStateBase: React.SFC<ErrorStateProps> = ({
   }
 
   return (
-    <div className={css(styles.container)}>
+    <div style={styles.container}>
       <PfEmptyState>
         <EmptyStateIcon icon={icon} />
         <Title size="lg">{title}</Title>

--- a/src/components/state/loadingState/loadingState.styles.ts
+++ b/src/components/state/loadingState/loadingState.styles.ts
@@ -1,10 +1,10 @@
-import { StyleSheet } from '@patternfly/react-styles';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   container: {
     display: 'flex',
     justifyContent: 'center',
     height: '100vh',
     marginTop: '150px',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/state/loadingState/loadingState.tsx
+++ b/src/components/state/loadingState/loadingState.tsx
@@ -5,7 +5,6 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { BinocularsIcon } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { styles } from './loadingState.styles';
@@ -22,7 +21,7 @@ const LoadingStateBase: React.SFC<LoadingStateProps> = ({
   const subTitle = t('loading_state.sources_desc');
 
   return (
-    <div className={css(styles.container)}>
+    <div style={styles.container}>
       <EmptyState>
         <Spinner size="lg" />
         <Title size="lg">{title}</Title>

--- a/src/components/state/noProvidersState/noProvidersState.styles.ts
+++ b/src/components/state/noProvidersState/noProvidersState.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_lg } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   container: {
     display: 'flex',
     justifyContent: 'center',
@@ -11,4 +11,4 @@ export const styles = StyleSheet.create({
   viewSources: {
     marginTop: global_spacer_lg.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/components/state/noProvidersState/noProvidersState.tsx
+++ b/src/components/state/noProvidersState/noProvidersState.tsx
@@ -5,7 +5,6 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { DollarSignIcon } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -41,12 +40,12 @@ class NoProvidersStateBase extends React.Component<NoProvidersStateProps> {
     const { t } = this.props;
 
     return (
-      <div className={css(styles.container)}>
+      <div style={styles.container}>
         <EmptyState>
           <EmptyStateIcon icon={DollarSignIcon} />
           <Title size="lg">{t('providers.empty_state_title')}</Title>
           <EmptyStateBody>{t('providers.empty_state_desc')}</EmptyStateBody>
-          <div className={css(styles.viewSources)}>{this.getViewSources()}</div>
+          <div style={styles.viewSources}>{this.getViewSources()}</div>
         </EmptyState>
       </div>
     );

--- a/src/pages/costModels/components/addPriceList.styles.ts
+++ b/src/pages/costModels/components/addPriceList.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   form: {
     width: '350px',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/costModels/components/addPriceList.tsx
+++ b/src/pages/costModels/components/addPriceList.tsx
@@ -10,7 +10,6 @@ import {
   Title,
   TitleSize,
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { Metric, MetricHash } from 'api/metrics';
 import { Form } from 'components/forms/form';
 import React from 'react';
@@ -457,7 +456,7 @@ export class AddPriceListBase extends React.Component<
           </TextContent>
         </StackItem>
         <StackItem>
-          <Form className={css(styles.form)}>
+          <Form style={styles.form}>
             {this.renderForm()}
             {this.renderActions()}
           </Form>

--- a/src/pages/costModels/costModelsDetails/components/addRateModal.styles.ts
+++ b/src/pages/costModels/costModelsDetails/components/addRateModal.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   form: {
     width: '350px',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/costModels/costModelsDetails/components/addRateModal.tsx
+++ b/src/pages/costModels/costModelsDetails/components/addRateModal.tsx
@@ -11,7 +11,6 @@ import {
   Title,
   TitleSize,
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { CostModel } from 'api/costModels';
 import { MetricHash } from 'api/metrics';
 import { Form } from 'components/forms/form';
@@ -178,14 +177,14 @@ export class AddRateModelBase extends React.Component<Props, State> {
                 send({ type: 'CHANGE_METRIC', value })
               }
               metric={metric}
-              measurementOptions={Object.keys(
-                availableRates[metric] || {}
-              ).map(m => ({
-                label: t(`cost_models.${m}`, {
-                  units: metricsHash[metric][m].label_measurement_unit,
-                }),
-                value: m,
-              }))}
+              measurementOptions={Object.keys(availableRates[metric] || {}).map(
+                m => ({
+                  label: t(`cost_models.${m}`, {
+                    units: metricsHash[metric][m].label_measurement_unit,
+                  }),
+                  value: m,
+                })
+              )}
               measurement={measurement}
               measurementChange={(value: string) =>
                 send({ type: 'CHANGE_MEASUREMENT', value })
@@ -212,14 +211,14 @@ export class AddRateModelBase extends React.Component<Props, State> {
                 send({ type: 'CHANGE_METRIC', value })
               }
               metric={metric}
-              measurementOptions={Object.keys(
-                availableRates[metric] || {}
-              ).map(m => ({
-                label: t(`cost_models.${m}`, {
-                  units: metricsHash[metric][m].label_measurement_unit,
-                }),
-                value: m,
-              }))}
+              measurementOptions={Object.keys(availableRates[metric] || {}).map(
+                m => ({
+                  label: t(`cost_models.${m}`, {
+                    units: metricsHash[metric][m].label_measurement_unit,
+                  }),
+                  value: m,
+                })
+              )}
               measurement={measurement}
               measurementChange={(value: string) =>
                 send({ type: 'CHANGE_MEASUREMENT', value })
@@ -246,14 +245,14 @@ export class AddRateModelBase extends React.Component<Props, State> {
                 send({ type: 'CHANGE_METRIC', value })
               }
               metric={metric}
-              measurementOptions={Object.keys(
-                availableRates[metric]
-              ).map(m => ({
-                label: t(`cost_models.${m}`, {
-                  units: metricsHash[metric][m].label_measurement_unit,
-                }),
-                value: m,
-              }))}
+              measurementOptions={Object.keys(availableRates[metric]).map(
+                m => ({
+                  label: t(`cost_models.${m}`, {
+                    units: metricsHash[metric][m].label_measurement_unit,
+                  }),
+                  value: m,
+                })
+              )}
               measurement={measurement}
               measurementChange={(value: string) =>
                 send({ type: 'CHANGE_MEASUREMENT', value })
@@ -299,7 +298,7 @@ export class AddRateModelBase extends React.Component<Props, State> {
               </TextContent>
             </StackItem>
             <StackItem>
-              <Form className={css(styles.form)}>{this.renderForm()}</Form>
+              <Form style={styles.form}>{this.renderForm()}</Form>
             </StackItem>
           </Stack>
         </>

--- a/src/pages/costModels/costModelsDetails/components/markup.styles.ts
+++ b/src/pages/costModels/costModelsDetails/components/markup.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_FontSize_xl, global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   card: {
     minHeight: '130px',
     maxWidth: '400px',
@@ -11,4 +11,4 @@ export const styles = StyleSheet.create({
     fontSize: global_FontSize_xl.value,
     textAlign: 'center',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/costModels/costModelsDetails/components/markup.tsx
+++ b/src/pages/costModels/costModelsDetails/components/markup.tsx
@@ -6,7 +6,6 @@ import {
   CardHeader,
   DropdownItem,
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { CostModel } from 'api/costModels';
 import { ReadOnlyTooltip } from 'pages/costModels/costModelsDetails/components/readOnlyTooltip';
 import React from 'react';
@@ -42,7 +41,7 @@ const MarkupCardBase: React.SFC<Props> = ({
   return (
     <>
       {isUpdateDialogOpen && <UpdateMarkupDialog />}
-      <Card className={css(styles.card)}>
+      <Card style={styles.card}>
         <CardHead>
           <CardActions>
             <Dropdown
@@ -65,7 +64,7 @@ const MarkupCardBase: React.SFC<Props> = ({
           <CardHeader>{t('cost_models_details.description_markup')}</CardHeader>
         </CardHead>
         <CardBody isFilled />
-        <CardBody className={css(styles.cardBody)}>{markupValue}%</CardBody>
+        <CardBody style={styles.cardBody}>{markupValue}%</CardBody>
         <CardBody isFilled />
       </Card>
     </>

--- a/src/pages/costModels/costModelsDetails/components/table.styles.ts
+++ b/src/pages/costModels/costModelsDetails/components/table.styles.ts
@@ -1,9 +1,9 @@
-import { StyleSheet } from '@patternfly/react-styles';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   emptyState: {
     display: 'flex',
     flexDirection: 'row',
     justifyContent: 'center',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/costModels/costModelsDetails/components/table.tsx
+++ b/src/pages/costModels/costModelsDetails/components/table.tsx
@@ -10,7 +10,6 @@ import {
   ToolbarSection,
 } from '@patternfly/react-core';
 import { DollarSignIcon } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import { Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import {
@@ -155,7 +154,7 @@ class TableBase extends React.Component<Props, State> {
           </Table>
         )}
         {rows.length === 0 && (
-          <div className={css(styles.emptyState)}>
+          <div style={styles.emptyState}>
             <EmptyState>
               <EmptyStateIcon icon={DollarSignIcon} />
               <Title size="lg">

--- a/src/pages/costModels/costModelsDetails/costModelInfo/costModelInfo.styles.ts
+++ b/src/pages/costModels/costModelsDetails/costModelInfo/costModelInfo.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_100,
   global_BackgroundColor_300,
@@ -7,8 +6,9 @@ import {
   global_spacer_sm,
   global_spacer_xl,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   headerDescription: {
     width: '97%',
     wordWrap: 'break-word',
@@ -38,4 +38,4 @@ export const styles = StyleSheet.create({
   title: {
     paddingBottom: global_spacer_sm.var,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/costModels/costModelsDetails/costModelInfo/header.tsx
+++ b/src/pages/costModels/costModelsDetails/costModelInfo/header.tsx
@@ -11,7 +11,6 @@ import {
   Tabs,
   Title,
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { CostModel } from 'api/costModels';
 import Dialog from 'pages/costModels/costModelsDetails/components/dialog';
 import Dropdown from 'pages/costModels/costModelsDetails/components/dropdown';
@@ -106,7 +105,7 @@ class Header extends React.Component<Props> {
             current.sources.length === 0 ? t('dialog.deleteCostModel') : ''
           }
         />
-        <header ref={this.cmpRef} className={css(styles.headerCostModel)}>
+        <header ref={this.cmpRef} style={styles.headerCostModel}>
           <Breadcrumb>
             <BreadcrumbItem>
               <Button
@@ -120,19 +119,19 @@ class Header extends React.Component<Props> {
             <BreadcrumbItem isActive>{current.name}</BreadcrumbItem>
           </Breadcrumb>
           <Split>
-            <SplitItem className={css(styles.headerDescription)}>
-              <Title className={css(styles.title)} size="2xl">
+            <SplitItem style={styles.headerDescription}>
+              <Title style={styles.title} size="2xl">
                 {current.name}
               </Title>
               {current.description && (
                 <>
-                  <Title className={css(styles.title)} size="md">
+                  <Title style={styles.title} size="md">
                     {current.description}
                   </Title>
                   <br />
                 </>
               )}
-              <Title className={css(styles.title)} size="md">
+              <Title style={styles.title} size="md">
                 {t('cost_models_details.cost_model.source_type')}:{' '}
                 {current.source_type}
               </Title>

--- a/src/pages/costModels/costModelsDetails/costModelInfo/index.tsx
+++ b/src/pages/costModels/costModelsDetails/costModelInfo/index.tsx
@@ -1,5 +1,4 @@
 import { TabContent } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { CostModel, CostModelProvider } from 'api/costModels';
 import MarkupCard from 'pages/costModels/costModelsDetails/components/markup';
 import PriceListTable from 'pages/costModels/costModelsDetails/components/priceListTable';
@@ -33,14 +32,14 @@ class CostModelInformation extends React.Component<Props, State> {
   public render() {
     const { sources, rates, goBack, current } = this.props;
     return (
-      <div className={css(styles.sourceSettings)}>
+      <div style={styles.sourceSettings}>
         <Header
           goBack={goBack}
           tabRefs={this.tabRefs}
           tabIndex={this.state.tabIndex}
           onSelectTab={tabIndex => this.setState({ tabIndex })}
         />
-        <div className={css(styles.content)}>
+        <div style={styles.content}>
           {current.source_type === 'OpenShift Container Platform' ? (
             <>
               <TabContent
@@ -49,7 +48,7 @@ class CostModelInformation extends React.Component<Props, State> {
                 ref={this.tabRefs[0]}
                 hidden={this.state.tabIndex !== 0}
               >
-                <div className={css(styles.costmodelsContainer)}>
+                <div style={styles.costmodelsContainer}>
                   <PriceListTable
                     costModel={current.name}
                     assignees={sources.map(p => p.name)}
@@ -72,7 +71,7 @@ class CostModelInformation extends React.Component<Props, State> {
                 ref={this.tabRefs[2]}
                 hidden={this.state.tabIndex !== 2}
               >
-                <div className={css(styles.costmodelsContainer)}>
+                <div style={styles.costmodelsContainer}>
                   <SourceTable costModel={current} sources={sources} />
                 </div>
               </TabContent>
@@ -93,7 +92,7 @@ class CostModelInformation extends React.Component<Props, State> {
                 ref={this.tabRefs[1]}
                 hidden={this.state.tabIndex !== 1}
               >
-                <div className={css(styles.costmodelsContainer)}>
+                <div style={styles.costmodelsContainer}>
                   <SourceTable costModel={current} sources={sources} />
                 </div>
               </TabContent>

--- a/src/pages/costModels/costModelsDetails/costModelsDetails.styles.ts
+++ b/src/pages/costModels/costModelsDetails/costModelsDetails.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_100,
   global_BackgroundColor_300,
@@ -7,8 +6,9 @@ import {
   global_spacer_sm,
   global_spacer_xl,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   headerDescription: {
     width: '97%',
     wordWrap: 'break-word',
@@ -68,4 +68,4 @@ export const styles = StyleSheet.create({
   title: {
     paddingBottom: global_spacer_sm.var,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/costModels/costModelsDetails/costModelsDetails.tsx
+++ b/src/pages/costModels/costModelsDetails/costModelsDetails.tsx
@@ -1,4 +1,3 @@
-import { css } from '@patternfly/react-styles';
 import { CostModel } from 'api/costModels';
 import { AxiosError } from 'axios';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
@@ -168,13 +167,13 @@ class CostModelsDetails extends React.Component<Props, State> {
           closeWizard={() => this.setState({ isWizardOpen: false })}
           openWizard={() => this.setState({ isWizardOpen: true })}
         />
-        <div className={css(styles.sourceSettings)}>
+        <div style={styles.sourceSettings}>
           <Header t={t} />
-          <div className={css(styles.content)}>
+          <div style={styles.content}>
             {status !== FetchStatus.none &&
               error === null &&
               (costModels.length > 0 || filterValue) && (
-                <div className={css(styles.toolbarContainer)}>
+                <div style={styles.toolbarContainer}>
                   <CostModelDetailsToolbar
                     buttonProps={{
                       isDisabled: !isWritePermission,
@@ -240,7 +239,7 @@ class CostModelsDetails extends React.Component<Props, State> {
                       setDialogOpen({ isOpen: true, name: 'deleteCostModel' });
                     }}
                   />
-                  <div className={css(styles.paginationContainer)}>
+                  <div style={styles.paginationContainer}>
                     <CostModelsPagination
                       status={status}
                       fetch={this.onPaginationChange}

--- a/src/pages/costModels/costModelsDetails/costModelsTable.tsx
+++ b/src/pages/costModels/costModelsDetails/costModelsTable.tsx
@@ -1,5 +1,4 @@
 import { Button, List, ListItem } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import {
   sortable,
   SortByDirection,
@@ -119,7 +118,7 @@ class CostModelsTable extends React.Component<TableProps, TableState> {
               : ''
           }
         />
-        <div className={css(styles.tableContainer)}>
+        <div style={styles.tableContainer}>
           <Table
             sortBy={getSortByData(sortBy, costModelsTableMap)}
             onSort={(_evt, index, direction) => {

--- a/src/pages/costModels/costModelsDetails/emptyState.styles.ts
+++ b/src/pages/costModels/costModelsDetails/emptyState.styles.ts
@@ -1,10 +1,10 @@
-import { StyleSheet } from '@patternfly/react-styles';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   container: {
     display: 'flex',
     justifyContent: 'center',
     height: '100vh',
     marginTop: '150px',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/costModels/costModelsDetails/emptyState.tsx
+++ b/src/pages/costModels/costModelsDetails/emptyState.tsx
@@ -6,7 +6,6 @@ import {
   Title,
 } from '@patternfly/react-core';
 import { FileInvoiceDollarIcon } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { styles } from './emptyState.styles';
@@ -20,7 +19,7 @@ class NoSourcesStateBase extends React.Component<Props> {
     const { t, openModal } = this.props;
 
     return (
-      <div className={css(styles.container)}>
+      <div style={styles.container}>
         <EmptyState>
           <EmptyStateIcon icon={FileInvoiceDollarIcon} />
           <Title size="lg">{t('cost_models_details.empty_state.title')}</Title>

--- a/src/pages/costModels/costModelsDetails/header.tsx
+++ b/src/pages/costModels/costModelsDetails/header.tsx
@@ -1,13 +1,12 @@
 import { Button, ButtonVariant, Popover, Title } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import React from 'react';
 import { InjectedTranslateProps } from 'react-i18next';
 import { styles } from './costModelsDetails.styles';
 
 const Header: React.SFC<InjectedTranslateProps> = ({ t }) => (
-  <header className={css(styles.header)}>
-    <Title className={css(styles.title)} size="2xl">
+  <header style={styles.header}>
+    <Title style={styles.title} size="2xl">
       {t('cost_models_details.header.title')}
       <Popover
         aria-label={t('cost_models_details.header.sub')}

--- a/src/pages/costModels/createCostModelWizard/generalInformation.tsx
+++ b/src/pages/costModels/createCostModelWizard/generalInformation.tsx
@@ -8,7 +8,6 @@ import {
   TextInput,
   Title,
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { Form } from 'components/forms/form';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -40,7 +39,7 @@ const GeneralInformation: React.SFC<InjectedTranslateProps> = ({ t }) => {
             </a>
           </StackItem>
           <StackItem>
-            <Form className={css(styles.form)}>
+            <Form style={styles.form}>
               <FormGroup
                 label={t('cost_models_wizard.general_info.name_label')}
                 isRequired
@@ -60,7 +59,7 @@ const GeneralInformation: React.SFC<InjectedTranslateProps> = ({ t }) => {
                 fieldId="description"
               >
                 <TextArea
-                  className={css(styles.textArea)}
+                  style={styles.textArea}
                   type="text"
                   id="description"
                   name="description"

--- a/src/pages/costModels/createCostModelWizard/wizard.styles.ts
+++ b/src/pages/costModels/createCostModelWizard/wizard.styles.ts
@@ -1,6 +1,4 @@
-import { StyleSheet } from '@patternfly/react-styles';
-
-export const styles = StyleSheet.create({
+export const styles = {
   form: {
     width: '350px',
   },
@@ -10,4 +8,4 @@ export const styles = StyleSheet.create({
     minHeight: '75px',
     maxHeight: '150px',
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/dashboard/awsCloudDashboard/awsCloudDashboardWidget.styles.ts
+++ b/src/pages/dashboard/awsCloudDashboard/awsCloudDashboardWidget.styles.ts
@@ -1,5 +1,5 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_2xl, global_spacer_xl } from '@patternfly/react-tokens';
+import React from 'react';
 
 export const chartStyles = {
   chartAltHeight: 180,
@@ -8,11 +8,11 @@ export const chartStyles = {
   containerTrendHeight: 150,
 };
 
-export const styles = StyleSheet.create({
+export const styles = {
   tabs: {
     marginTop: global_spacer_2xl.value,
   },
   tabItems: {
     marginTop: global_spacer_xl.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/dashboard/components/dashboardWidget.styles.ts
+++ b/src/pages/dashboard/components/dashboardWidget.styles.ts
@@ -1,5 +1,5 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_2xl, global_spacer_xl } from '@patternfly/react-tokens';
+import React from 'react';
 
 export const chartStyles = {
   chartAltHeight: 180,
@@ -9,11 +9,11 @@ export const chartStyles = {
   containerUsageHeight: 180,
 };
 
-export const styles = StyleSheet.create({
+export const styles = {
   tabs: {
     marginTop: global_spacer_2xl.value,
   },
   tabItems: {
     marginTop: global_spacer_xl.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -1,5 +1,4 @@
 import { Tab, Tabs } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { getQuery } from 'api/queries/awsQuery';
 import { Report } from 'api/reports/report';
 import {
@@ -342,7 +341,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         key={`${getIdKeyForTab(tab)}-tab`}
         title={this.getTabTitle(tab)}
       >
-        <div className={css(styles.tabItems)}>
+        <div style={styles.tabItems}>
           <ReportSummaryItems
             idKey={currentTab}
             key={`${currentTab}-items`}
@@ -483,7 +482,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
           chartStyles.chartHeight
         )}
         {Boolean(availableTabs) && (
-          <div className={css(styles.tabs)}>{this.getTabs()}</div>
+          <div style={styles.tabs}>{this.getTabs()}</div>
         )}
       </ReportSummary>
     );

--- a/src/pages/details/awsDetails/awsDetails.styles.ts
+++ b/src/pages/details/awsDetails/awsDetails.styles.ts
@@ -1,12 +1,12 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_300,
   global_BackgroundColor_light_100,
   global_spacer_md,
   global_spacer_xl,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   awsDetails: {
     backgroundColor: global_BackgroundColor_300.value,
     minHeight: '100%',
@@ -29,4 +29,4 @@ export const styles = StyleSheet.create({
     marginLeft: global_spacer_xl.value,
     marginRight: global_spacer_xl.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -1,5 +1,4 @@
 import { Pagination, PaginationVariant } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { Providers, ProviderType } from 'api/providers';
 import {
   AwsQuery,
@@ -400,7 +399,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
       providersFetchStatus === FetchStatus.complete;
 
     return (
-      <div className={css(styles.awsDetails)}>
+      <div style={styles.awsDetails}>
         <DetailsHeader
           groupBy={groupById}
           onGroupByClicked={this.handleGroupByClick}
@@ -412,14 +411,12 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
         ) : Boolean(isLoading) ? (
           <LoadingState />
         ) : (
-          <div className={css(styles.content)}>
+          <div style={styles.content}>
             {this.getToolbar()}
             {this.getExportModal(computedItems)}
-            <div className={css(styles.tableContainer)}>{this.getTable()}</div>
-            <div className={css(styles.paginationContainer)}>
-              <div className={css(styles.pagination)}>
-                {this.getPagination(true)}
-              </div>
+            <div style={styles.tableContainer}>{this.getTable()}</div>
+            <div style={styles.paginationContainer}>
+              <div style={styles.pagination}>{this.getPagination(true)}</div>
             </div>
           </div>
         )}

--- a/src/pages/details/awsDetails/detailsHeader.styles.ts
+++ b/src/pages/details/awsDetails/detailsHeader.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_100,
   global_Color_100,
@@ -8,8 +7,9 @@ import {
   global_spacer_sm,
   global_spacer_xl,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   cost: {
     display: 'flex',
     alignItems: 'center',
@@ -40,4 +40,4 @@ export const styles = StyleSheet.create({
   title: {
     paddingBottom: global_spacer_sm.var,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/awsDetails/detailsHeader.tsx
+++ b/src/pages/details/awsDetails/detailsHeader.tsx
@@ -1,5 +1,4 @@
 import { Title, TitleSize } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { Providers, ProviderType } from 'api/providers';
 import { AwsQuery, getQuery } from 'api/queries/awsQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
@@ -106,12 +105,12 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       report.meta.total.cost.total;
 
     return (
-      <header className={css(styles.header)}>
+      <header style={styles.header}>
         <div>
-          <Title className={css(styles.title)} size={TitleSize['2xl']}>
+          <Title style={styles.title} size={TitleSize['2xl']}>
             {t('navigation.cloud_details')}
           </Title>
-          <div className={css(styles.nav)}>
+          <div style={styles.nav}>
             <TertiaryNav activeItem={TertiaryNavItem.aws} />
           </div>
           {Boolean(showContent) && (
@@ -124,15 +123,15 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           )}
         </div>
         {Boolean(showContent) && (
-          <div className={css(styles.cost)}>
-            <Title className={css(styles.costValue)} size="4xl">
+          <div style={styles.cost}>
+            <Title style={styles.costValue} size="4xl">
               {formatCurrency(hasCost ? report.meta.total.cost.total.value : 0)}
             </Title>
-            <div className={css(styles.costLabel)}>
-              <div className={css(styles.costLabelUnit)}>
+            <div style={styles.costLabel}>
+              <div style={styles.costLabelUnit}>
                 {t('aws_details.total_cost')}
               </div>
-              <div className={css(styles.costLabelDate)}>
+              <div style={styles.costLabelDate}>
                 {getSinceDateRangeString()}
               </div>
             </div>

--- a/src/pages/details/awsDetails/detailsTable.styles.ts
+++ b/src/pages/details/awsDetails/detailsTable.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_light_100,
   global_danger_color_100,
@@ -9,8 +8,9 @@ import {
   global_success_color_100,
 } from '@patternfly/react-tokens';
 import { css } from 'emotion';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   emptyState: {
     backgroundColor: global_BackgroundColor_light_100.value,
     display: 'flex',
@@ -29,7 +29,7 @@ export const styles = StyleSheet.create({
     color: global_disabled_color_100.value,
     fontSize: global_FontSize_xs.value,
   },
-});
+} as { [className: string]: React.CSSProperties };
 
 export const monthOverMonthOverride = css`
   div {

--- a/src/pages/details/awsDetails/detailsTable.tsx
+++ b/src/pages/details/awsDetails/detailsTable.tsx
@@ -4,7 +4,6 @@ import {
   EmptyStateIcon,
 } from '@patternfly/react-core';
 import { CalculatorIcon } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import {
   sortable,
   SortByDirection,
@@ -266,7 +265,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
                 item.deltaValue > 0
             ) && (
               <span
-                className={css('fa fa-sort-up', styles.infoArrow)}
+                className="fa fa-sort-up"
+                style={styles.infoArrow}
                 key={`month-over-month-icon-${index}`}
               />
             )}
@@ -276,17 +276,17 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
                 item.deltaValue < 0
             ) && (
               <span
-                className={css(
-                  'fa fa-sort-down',
-                  styles.infoArrow,
-                  styles.infoArrowDesc
-                )}
+                className="fa fa-sort-down"
+                style={{
+                  ...styles.infoArrow,
+                  ...styles.infoArrowDesc,
+                }}
                 key={`month-over-month-icon-${index}`}
               />
             )}
           </div>
           <div
-            className={css(styles.infoDescription)}
+            style={styles.infoDescription}
             key={`month-over-month-info-${index}`}
           >
             {getForDateRangeString(value)}
@@ -350,10 +350,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <>
         {formatCurrency(item.cost)}
-        <div
-          className={css(styles.infoDescription)}
-          key={`total-cost-${index}`}
-        >
+        <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
             value: ((item.cost / cost) * 100).toFixed(2),
           })}
@@ -442,7 +439,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           <TableBody />
         </Table>
         {Boolean(rows.length === 0) && (
-          <div className={css(styles.emptyState)}>{this.getEmptyState()}</div>
+          <div style={styles.emptyState}>{this.getEmptyState()}</div>
         )}
       </>
     );

--- a/src/pages/details/awsDetails/detailsTableItem.styles.ts
+++ b/src/pages/details/awsDetails/detailsTableItem.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_3xl, global_spacer_xl } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   clusterContainer: {
     marginBottom: global_spacer_xl.value,
   },
@@ -22,4 +22,4 @@ export const styles = StyleSheet.create({
   tagsContainer: {
     marginBottom: global_spacer_xl.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/awsDetails/detailsTableItem.tsx
+++ b/src/pages/details/awsDetails/detailsTableItem.tsx
@@ -7,7 +7,6 @@ import {
   Grid,
   GridItem,
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { ReportPathsType } from 'api/reports/report';
 import { HistoricalModal } from 'pages/details/components/historicalChart/historicalModal';
 import { Tag } from 'pages/details/components/tag/tag';
@@ -62,7 +61,7 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
       <>
         <Grid>
           <GridItem sm={12}>
-            <div className={css(styles.historicalContainer)}>
+            <div style={styles.historicalContainer}>
               <Button
                 {...getTestProps(testIds.details.historical_data_btn)}
                 onClick={this.handleHistoricalModalOpen}
@@ -74,7 +73,7 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
             </div>
           </GridItem>
           <GridItem lg={12} xl={6}>
-            <div className={css(styles.leftPane)}>
+            <div style={styles.leftPane}>
               <DetailsSummary
                 groupBy={groupBy}
                 item={item}
@@ -83,9 +82,9 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
             </div>
           </GridItem>
           <GridItem lg={12} xl={6}>
-            <div className={css(styles.rightPane)}>
+            <div style={styles.rightPane}>
               {Boolean(groupBy === 'account') && (
-                <div className={css(styles.tagsContainer)}>
+                <div style={styles.tagsContainer}>
                   <Form>
                     <FormGroup
                       label={t('aws_details.tags_label')}

--- a/src/pages/details/azureDetails/azureDetails.styles.ts
+++ b/src/pages/details/azureDetails/azureDetails.styles.ts
@@ -1,12 +1,12 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_300,
   global_BackgroundColor_light_100,
   global_spacer_md,
   global_spacer_xl,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   azureDetails: {
     backgroundColor: global_BackgroundColor_300.value,
     minHeight: '100%',
@@ -29,4 +29,4 @@ export const styles = StyleSheet.create({
     marginLeft: global_spacer_xl.value,
     marginRight: global_spacer_xl.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -1,5 +1,4 @@
 import { Pagination, PaginationVariant } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { Providers, ProviderType } from 'api/providers';
 import {
   AzureQuery,
@@ -407,7 +406,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
       providersFetchStatus === FetchStatus.complete;
 
     return (
-      <div className={css(styles.azureDetails)}>
+      <div style={styles.azureDetails}>
         <DetailsHeader
           groupBy={groupById}
           onGroupByClicked={this.handleGroupByClick}
@@ -419,14 +418,12 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
         ) : Boolean(isLoading) ? (
           <LoadingState />
         ) : (
-          <div className={css(styles.content)}>
+          <div style={styles.content}>
             {this.getToolbar()}
             {this.getExportModal(computedItems)}
-            <div className={css(styles.tableContainer)}>{this.getTable()}</div>
-            <div className={css(styles.paginationContainer)}>
-              <div className={css(styles.pagination)}>
-                {this.getPagination(true)}
-              </div>
+            <div style={styles.tableContainer}>{this.getTable()}</div>
+            <div style={styles.paginationContainer}>
+              <div style={styles.pagination}>{this.getPagination(true)}</div>
             </div>
           </div>
         )}

--- a/src/pages/details/azureDetails/detailsHeader.styles.ts
+++ b/src/pages/details/azureDetails/detailsHeader.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_100,
   global_Color_100,
@@ -8,8 +7,9 @@ import {
   global_spacer_sm,
   global_spacer_xl,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   cost: {
     display: 'flex',
     alignItems: 'center',
@@ -40,4 +40,4 @@ export const styles = StyleSheet.create({
   title: {
     paddingBottom: global_spacer_sm.var,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/azureDetails/detailsHeader.tsx
+++ b/src/pages/details/azureDetails/detailsHeader.tsx
@@ -1,5 +1,4 @@
 import { Title, TitleSize } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { Providers, ProviderType } from 'api/providers';
 import { AzureQuery, getQuery } from 'api/queries/azureQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
@@ -98,12 +97,12 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       report.meta.total.cost.total;
 
     return (
-      <header className={css(styles.header)}>
+      <header style={styles.header}>
         <div>
-          <Title className={css(styles.title)} size={TitleSize['2xl']}>
+          <Title style={styles.title} size={TitleSize['2xl']}>
             {t('navigation.cloud_details')}
           </Title>
-          <div className={css(styles.nav)}>
+          <div style={styles.nav}>
             <TertiaryNav activeItem={TertiaryNavItem.azure} />
           </div>
           {Boolean(showContent) && (
@@ -111,15 +110,15 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           )}
         </div>
         {Boolean(showContent) && (
-          <div className={css(styles.cost)}>
-            <Title className={css(styles.costValue)} size="4xl">
+          <div style={styles.cost}>
+            <Title style={styles.costValue} size="4xl">
               {formatCurrency(hasCost ? report.meta.total.cost.total.value : 0)}
             </Title>
-            <div className={css(styles.costLabel)}>
-              <div className={css(styles.costLabelUnit)}>
+            <div style={styles.costLabel}>
+              <div style={styles.costLabelUnit}>
                 {t('azure_details.total_cost')}
               </div>
-              <div className={css(styles.costLabelDate)}>
+              <div style={styles.costLabelDate}>
                 {getSinceDateRangeString()}
               </div>
             </div>

--- a/src/pages/details/azureDetails/detailsTable.styles.ts
+++ b/src/pages/details/azureDetails/detailsTable.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_light_100,
   global_danger_color_100,
@@ -9,8 +8,9 @@ import {
   global_success_color_100,
 } from '@patternfly/react-tokens';
 import { css } from 'emotion';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   emptyState: {
     backgroundColor: global_BackgroundColor_light_100.value,
     display: 'flex',
@@ -29,7 +29,7 @@ export const styles = StyleSheet.create({
     color: global_disabled_color_100.value,
     fontSize: global_FontSize_xs.value,
   },
-});
+} as { [className: string]: React.CSSProperties };
 
 export const monthOverMonthOverride = css`
   div {

--- a/src/pages/details/azureDetails/detailsTable.tsx
+++ b/src/pages/details/azureDetails/detailsTable.tsx
@@ -4,7 +4,6 @@ import {
   EmptyStateIcon,
 } from '@patternfly/react-core';
 import { CalculatorIcon } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import {
   sortable,
   SortByDirection,
@@ -266,7 +265,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
                 item.deltaValue > 0
             ) && (
               <span
-                className={css('fa fa-sort-up', styles.infoArrow)}
+                className="fa fa-sort-up"
+                style={styles.infoArrow}
                 key={`month-over-month-icon-${index}`}
               />
             )}
@@ -276,17 +276,17 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
                 item.deltaValue < 0
             ) && (
               <span
-                className={css(
-                  'fa fa-sort-down',
-                  styles.infoArrow,
-                  styles.infoArrowDesc
-                )}
+                className="fa fa-sort-down"
+                style={{
+                  ...styles.infoArrow,
+                  ...styles.infoArrowDesc,
+                }}
                 key={`month-over-month-icon-${index}`}
               />
             )}
           </div>
           <div
-            className={css(styles.infoDescription)}
+            style={styles.infoDescription}
             key={`month-over-month-info-${index}`}
           >
             {getForDateRangeString(value)}
@@ -350,10 +350,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <>
         {formatCurrency(item.cost)}
-        <div
-          className={css(styles.infoDescription)}
-          key={`total-cost-${index}`}
-        >
+        <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
             value: ((item.cost / cost) * 100).toFixed(2),
           })}
@@ -442,7 +439,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           <TableBody />
         </Table>
         {Boolean(rows.length === 0) && (
-          <div className={css(styles.emptyState)}>{this.getEmptyState()}</div>
+          <div style={styles.emptyState}>{this.getEmptyState()}</div>
         )}
       </>
     );

--- a/src/pages/details/azureDetails/detailsTableItem.styles.ts
+++ b/src/pages/details/azureDetails/detailsTableItem.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_3xl, global_spacer_xl } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   clusterContainer: {
     marginBottom: global_spacer_xl.value,
   },
@@ -22,4 +22,4 @@ export const styles = StyleSheet.create({
   tagsContainer: {
     marginBottom: global_spacer_xl.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/azureDetails/detailsTableItem.tsx
+++ b/src/pages/details/azureDetails/detailsTableItem.tsx
@@ -7,7 +7,6 @@ import {
   Grid,
   GridItem,
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -59,7 +58,7 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
       <>
         <Grid>
           <GridItem sm={12}>
-            <div className={css(styles.historicalContainer)}>
+            <div style={styles.historicalContainer}>
               <Button
                 {...getTestProps(testIds.details.historical_data_btn)}
                 onClick={this.handleHistoricalModalOpen}
@@ -71,14 +70,14 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
             </div>
           </GridItem>
           <GridItem lg={12} xl={6}>
-            <div className={css(styles.leftPane)}>
+            <div style={styles.leftPane}>
               <DetailsWidget groupBy={groupBy} item={item} />
             </div>
           </GridItem>
           <GridItem lg={12} xl={6}>
-            <div className={css(styles.rightPane)}>
+            <div style={styles.rightPane}>
               {Boolean(groupBy === 'subscription_guid') && (
-                <div className={css(styles.tagsContainer)}>
+                <div style={styles.tagsContainer}>
                   <Form>
                     <FormGroup
                       label={t('azure_details.tags_label')}

--- a/src/pages/details/azureDetails/detailsTag.styles.ts
+++ b/src/pages/details/azureDetails/detailsTag.styles.ts
@@ -1,9 +1,9 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_3xl, global_spacer_sm } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   tagsContainer: {
     marginRight: global_spacer_3xl.value,
     marginTop: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/azureDetails/detailsTag.tsx
+++ b/src/pages/details/azureDetails/detailsTag.tsx
@@ -1,4 +1,3 @@
-import { css } from '@patternfly/react-styles';
 import { getQuery } from 'api/queries/azureQuery';
 import { AzureReport } from 'api/reports/azureReports';
 import { ReportType } from 'api/reports/report';
@@ -122,7 +121,7 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
     }
 
     return (
-      <div className={css(styles.tagsContainer)} id={id}>
+      <div style={styles.tagsContainer} id={id}>
         {Boolean(someTags) &&
           someTags.map((tag, tagIndex) => <span key={tagIndex}>{tag}</span>)}
         {Boolean(someTags.length < allTags.length) && (

--- a/src/pages/details/azureDetails/detailsTagModal.styles.ts
+++ b/src/pages/details/azureDetails/detailsTagModal.styles.ts
@@ -1,13 +1,13 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_2xl, global_spacer_lg } from '@patternfly/react-tokens';
 import { css } from 'emotion';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   subTitle: {
     marginTop: global_spacer_2xl.value,
     textAlign: 'right',
   },
-});
+} as { [className: string]: React.CSSProperties };
 
 export const modalOverride = css`
   /* Workaround for isLarge not working properly */

--- a/src/pages/details/azureDetails/detailsWidget.styles.ts
+++ b/src/pages/details/azureDetails/detailsWidget.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md, global_spacer_xl } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   skeleton: {
     marginTop: global_spacer_md.value,
   },
@@ -12,4 +12,4 @@ export const styles = StyleSheet.create({
     marginLeft: '-18px',
     paddingTop: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/azureDetails/detailsWidgetModal.styles.ts
+++ b/src/pages/details/azureDetails/detailsWidgetModal.styles.ts
@@ -1,15 +1,15 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_lg, global_spacer_xl } from '@patternfly/react-tokens';
 import { css } from 'emotion';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   mainContent: {
     marginTop: global_spacer_xl.value,
   },
   subTitle: {
     textAlign: 'right',
   },
-});
+} as { [className: string]: React.CSSProperties };
 
 export const modalOverride = css`
   /* Workaround for isLarge not working properly */

--- a/src/pages/details/azureDetails/detailsWidgetModalView.tsx
+++ b/src/pages/details/azureDetails/detailsWidgetModalView.tsx
@@ -72,12 +72,12 @@ class DetailsWidgetModalViewBase extends React.Component<
 
     return (
       <>
-        <div className={styles.subTitle}>
+        <div style={styles.subTitle}>
           <Title size="lg">
             {t('azure_details.cost_value', { value: cost })}
           </Title>
         </div>
-        <div className={styles.mainContent}>
+        <div style={styles.mainContent}>
           <ReportSummaryItems
             idKey={groupBy as any}
             report={report}

--- a/src/pages/details/azureDetails/detailsWidgetView.tsx
+++ b/src/pages/details/azureDetails/detailsWidgetView.tsx
@@ -1,5 +1,4 @@
 import { Button, ButtonType, ButtonVariant } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import {
   Skeleton,
   SkeletonSize,
@@ -121,7 +120,7 @@ class DetailsWidgetViewBase extends React.Component<DetailsWidgetViewProps> {
 
     if (otherIndex !== -1) {
       return (
-        <div className={css(styles.viewAllContainer)}>
+        <div style={styles.viewAllContainer}>
           <Button
             {...getTestProps(testIds.details.view_all_btn)}
             onClick={this.handleWidgetModalOpen}
@@ -163,13 +162,13 @@ class DetailsWidgetViewBase extends React.Component<DetailsWidgetViewProps> {
         {Boolean(reportFetchStatus === FetchStatus.inProgress) ? (
           <>
             <Skeleton size={SkeletonSize.md} />
-            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+            <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+            <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+            <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
           </>
         ) : (
           <>
-            <div className={css(styles.tabs)}>
+            <div style={styles.tabs}>
               <ReportSummaryItems
                 idKey={groupBy as any}
                 key={`${groupBy}-items`}

--- a/src/pages/details/azureDetails/exportModal.styles.ts
+++ b/src/pages/details/azureDetails/exportModal.styles.ts
@@ -1,11 +1,11 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_spacer_sm,
   global_spacer_xl,
   global_spacer_xs,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   form: {
     marginLeft: global_spacer_sm.var,
   },
@@ -23,4 +23,4 @@ export const styles = StyleSheet.create({
   title: {
     paddingBottom: global_spacer_xl.var,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/azureDetails/exportModal.tsx
+++ b/src/pages/details/azureDetails/exportModal.tsx
@@ -7,7 +7,6 @@ import {
   Radio,
   Title,
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { AzureQuery, getQuery } from 'api/queries/azureQuery';
 import { tagKeyPrefix } from 'api/queries/query';
 import { ReportType } from 'api/reports/report';
@@ -143,7 +142,7 @@ export class ExportModalBase extends React.Component<
 
     return (
       <Modal
-        className={css(styles.modal)}
+        style={styles.modal}
         isLarge
         isOpen={this.props.isOpen}
         onClose={this.handleClose}
@@ -168,10 +167,10 @@ export class ExportModalBase extends React.Component<
           </Button>,
         ]}
       >
-        <Title className={css(styles.title)} size="xl">
+        <Title style={styles.title} size="xl">
           {t('export.heading', { groupBy })}
         </Title>
-        <Form className={css(styles.form)}>
+        <Form style={styles.form}>
           <FormGroup
             label={t('export.aggregate_type')}
             fieldId="aggregate-type"

--- a/src/pages/details/azureDetails/groupBy.styles.ts
+++ b/src/pages/details/azureDetails/groupBy.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   groupBySelector: {
     display: 'flex',
     alignItems: 'center',
@@ -10,4 +10,4 @@ export const styles = StyleSheet.create({
     marginBottom: 0,
     marginRight: global_spacer_md.var,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/azureDetails/groupBy.tsx
+++ b/src/pages/details/azureDetails/groupBy.tsx
@@ -1,5 +1,4 @@
 import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { AzureQuery, getQuery } from 'api/queries/azureQuery';
 import { parseQuery } from 'api/queries/azureQuery';
 import { tagKeyPrefix } from 'api/queries/query';
@@ -182,10 +181,8 @@ class GroupByBase extends React.Component<GroupByProps> {
         : t(`group_by.values.${currentItem}`);
 
     return (
-      <div className={css(styles.groupBySelector)}>
-        <label className={css(styles.groupBySelectorLabel)}>
-          {t('group_by.cost')}:
-        </label>
+      <div style={styles.groupBySelector}>
+        <label style={styles.groupBySelectorLabel}>{t('group_by.cost')}:</label>
         <Dropdown
           onSelect={this.handleGroupBySelect}
           toggle={

--- a/src/pages/details/azureDetails/historicalChart.styles.ts
+++ b/src/pages/details/azureDetails/historicalChart.styles.ts
@@ -1,17 +1,17 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_spacer_3xl,
   global_spacer_lg,
   global_spacer_md,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
 export const chartStyles = {
   chartHeight: 90,
   chartContainerHeight: 215,
 };
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartContainer: {
     marginLeft: global_spacer_lg.value,
   },
@@ -32,4 +32,4 @@ export const styles = StyleSheet.create({
   storageChart: {
     marginTop: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/azureDetails/historicalChart.tsx
+++ b/src/pages/details/azureDetails/historicalChart.tsx
@@ -1,4 +1,3 @@
-import { css } from '@patternfly/react-styles';
 import {
   Skeleton,
   SkeletonSize,
@@ -81,14 +80,8 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
   private getSkeleton = () => {
     return (
       <>
-        <Skeleton
-          className={css(styles.chartSkeleton)}
-          size={SkeletonSize.md}
-        />
-        <Skeleton
-          className={css(styles.legendSkeleton)}
-          size={SkeletonSize.xs}
-        />
+        <Skeleton style={styles.chartSkeleton} size={SkeletonSize.md} />
+        <Skeleton style={styles.legendSkeleton} size={SkeletonSize.xs} />
       </>
     );
   };
@@ -161,8 +154,8 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
         : 'USD';
 
     return (
-      <div className={css(styles.chartContainer)}>
-        <div className={css(styles.costChart)}>
+      <div style={styles.chartContainer}>
+        <div style={styles.costChart}>
           {currentCostReportFetchStatus === FetchStatus.inProgress &&
           previousCostReportFetchStatus === FetchStatus.inProgress ? (
             this.getSkeleton()
@@ -182,7 +175,7 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
             />
           )}
         </div>
-        <div className={css(styles.instanceChart)}>
+        <div style={styles.instanceChart}>
           {currentInstanceReportFetchStatus === FetchStatus.inProgress &&
           previousInstanceReportFetchStatus === FetchStatus.inProgress ? (
             this.getSkeleton()
@@ -201,7 +194,7 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
             />
           )}
         </div>
-        <div className={css(styles.storageChart)}>
+        <div style={styles.storageChart}>
           {currentStorageReportFetchStatus === FetchStatus.inProgress &&
           previousStorageReportFetchStatus === FetchStatus.inProgress ? (
             this.getSkeleton()

--- a/src/pages/details/components/cluster/cluster.styles.ts
+++ b/src/pages/details/components/cluster/cluster.styles.ts
@@ -1,9 +1,9 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_3xl, global_spacer_sm } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   clustersContainer: {
     marginRight: global_spacer_3xl.value,
     marginTop: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/components/cluster/cluster.tsx
+++ b/src/pages/details/components/cluster/cluster.tsx
@@ -1,4 +1,3 @@
-import { css } from '@patternfly/react-styles';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -75,7 +74,7 @@ class ClusterBase extends React.Component<ClusterProps> {
     }
 
     return (
-      <div className={css(styles.clustersContainer)}>
+      <div style={styles.clustersContainer}>
         {Boolean(someClusters) &&
           someClusters.map((cluster, index) => (
             <span key={index}>{cluster}</span>

--- a/src/pages/details/components/cluster/clusterModal.styles.ts
+++ b/src/pages/details/components/cluster/clusterModal.styles.ts
@@ -1,8 +1,8 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_2xl, global_spacer_lg } from '@patternfly/react-tokens';
 import { css } from 'emotion';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   modal: {
     // Workaround for isLarge not working properly
     height: '700px',
@@ -12,7 +12,7 @@ export const styles = StyleSheet.create({
     marginTop: global_spacer_2xl.value,
     textAlign: 'right',
   },
-});
+} as { [className: string]: React.CSSProperties };
 
 export const modalOverride = css`
   & .pf-c-modal-box__body {

--- a/src/pages/details/components/cluster/clusterModal.tsx
+++ b/src/pages/details/components/cluster/clusterModal.tsx
@@ -1,5 +1,4 @@
 import { Modal } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
@@ -35,7 +34,8 @@ class ClusterModalBase extends React.Component<ClusterModalProps> {
 
     return (
       <Modal
-        className={`${modalOverride} ${css(styles.modal)}`}
+        className={modalOverride}
+        style={styles.modal}
         isOpen={isOpen}
         onClose={this.handleClose}
         title={t('details.clusters_modal_title', {

--- a/src/pages/details/components/export/exportModal.styles.ts
+++ b/src/pages/details/components/export/exportModal.styles.ts
@@ -1,11 +1,11 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_spacer_sm,
   global_spacer_xl,
   global_spacer_xs,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   form: {
     marginLeft: global_spacer_sm.var,
   },
@@ -23,4 +23,4 @@ export const styles = StyleSheet.create({
   title: {
     paddingBottom: global_spacer_xl.var,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/components/export/exportModal.tsx
+++ b/src/pages/details/components/export/exportModal.tsx
@@ -7,7 +7,6 @@ import {
   Radio,
   Title,
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { getQuery, Query } from 'api/queries/query';
 import { tagKeyPrefix } from 'api/queries/query';
 import { ReportPathsType, ReportType } from 'api/reports/report';
@@ -141,7 +140,7 @@ export class ExportModalBase extends React.Component<
 
     return (
       <Modal
-        className={css(styles.modal)}
+        style={styles.modal}
         isLarge
         isOpen={this.props.isOpen}
         onClose={this.handleClose}
@@ -166,10 +165,10 @@ export class ExportModalBase extends React.Component<
           </Button>,
         ]}
       >
-        <Title className={css(styles.title)} size="xl">
+        <Title style={styles.title} size="xl">
           {t('export.heading', { groupBy })}
         </Title>
-        <Form className={css(styles.form)}>
+        <Form style={styles.form}>
           <FormGroup
             label={t('export.aggregate_type')}
             fieldId="aggregate-type"

--- a/src/pages/details/components/groupBy/groupBy.styles.ts
+++ b/src/pages/details/components/groupBy/groupBy.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   groupBySelector: {
     display: 'flex',
     alignItems: 'center',
@@ -10,4 +10,4 @@ export const styles = StyleSheet.create({
     marginBottom: 0,
     marginRight: global_spacer_md.var,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/components/groupBy/groupBy.tsx
+++ b/src/pages/details/components/groupBy/groupBy.tsx
@@ -1,5 +1,4 @@
 import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { getQuery, parseQuery, Query, tagKeyPrefix } from 'api/queries/query';
 import { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
@@ -172,10 +171,8 @@ class GroupByBase extends React.Component<GroupByProps> {
         : t(`group_by.values.${currentItem}`);
 
     return (
-      <div className={css(styles.groupBySelector)}>
-        <label className={css(styles.groupBySelectorLabel)}>
-          {t('group_by.cost')}:
-        </label>
+      <div style={styles.groupBySelector}>
+        <label style={styles.groupBySelectorLabel}>{t('group_by.cost')}:</label>
         <Dropdown
           onSelect={this.handleGroupBySelect}
           toggle={

--- a/src/pages/details/components/historicalChart/historicalChart.styles.ts
+++ b/src/pages/details/components/historicalChart/historicalChart.styles.ts
@@ -1,17 +1,17 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_spacer_3xl,
   global_spacer_lg,
   global_spacer_md,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
 export const chartStyles = {
   chartHeight: 90,
   chartContainerHeight: 215,
 };
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartContainer: {
     marginLeft: global_spacer_lg.value,
   },
@@ -32,4 +32,4 @@ export const styles = StyleSheet.create({
   storageChart: {
     marginTop: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/components/historicalChart/historicalChart.tsx
+++ b/src/pages/details/components/historicalChart/historicalChart.tsx
@@ -1,4 +1,3 @@
-import { css } from '@patternfly/react-styles';
 import {
   Skeleton,
   SkeletonSize,
@@ -95,14 +94,8 @@ class HistoricaModalBase extends React.Component<HistoricaModalProps> {
   private getSkeleton = () => {
     return (
       <>
-        <Skeleton
-          className={css(styles.chartSkeleton)}
-          size={SkeletonSize.md}
-        />
-        <Skeleton
-          className={css(styles.legendSkeleton)}
-          size={SkeletonSize.xs}
-        />
+        <Skeleton style={styles.chartSkeleton} size={SkeletonSize.md} />
+        <Skeleton style={styles.legendSkeleton} size={SkeletonSize.xs} />
       </>
     );
   };
@@ -175,8 +168,8 @@ class HistoricaModalBase extends React.Component<HistoricaModalProps> {
         : 'USD';
 
     return (
-      <div className={css(styles.chartContainer)}>
-        <div className={css(styles.costChart)}>
+      <div style={styles.chartContainer}>
+        <div style={styles.costChart}>
           {currentCostReportFetchStatus === FetchStatus.inProgress &&
           previousCostReportFetchStatus === FetchStatus.inProgress ? (
             this.getSkeleton()
@@ -196,7 +189,7 @@ class HistoricaModalBase extends React.Component<HistoricaModalProps> {
             />
           )}
         </div>
-        <div className={css(styles.instanceChart)}>
+        <div style={styles.instanceChart}>
           {currentInstanceReportFetchStatus === FetchStatus.inProgress &&
           previousInstanceReportFetchStatus === FetchStatus.inProgress ? (
             this.getSkeleton()
@@ -215,7 +208,7 @@ class HistoricaModalBase extends React.Component<HistoricaModalProps> {
             />
           )}
         </div>
-        <div className={css(styles.storageChart)}>
+        <div style={styles.storageChart}>
           {currentStorageReportFetchStatus === FetchStatus.inProgress &&
           previousStorageReportFetchStatus === FetchStatus.inProgress ? (
             this.getSkeleton()

--- a/src/pages/details/components/summary/summary.styles.ts
+++ b/src/pages/details/components/summary/summary.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md, global_spacer_xl } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   skeleton: {
     marginTop: global_spacer_md.value,
   },
@@ -12,4 +12,4 @@ export const styles = StyleSheet.create({
     marginLeft: '-18px',
     paddingTop: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/components/summary/summaryModal.styles.ts
+++ b/src/pages/details/components/summary/summaryModal.styles.ts
@@ -1,15 +1,15 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_lg, global_spacer_xl } from '@patternfly/react-tokens';
 import { css } from 'emotion';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   mainContent: {
     marginTop: global_spacer_xl.value,
   },
   subTitle: {
     textAlign: 'right',
   },
-});
+} as { [className: string]: React.CSSProperties };
 
 export const modalOverride = css`
   /* Workaround for isLarge not working properly */

--- a/src/pages/details/components/summary/summaryModalView.tsx
+++ b/src/pages/details/components/summary/summaryModalView.tsx
@@ -67,10 +67,10 @@ class SummaryModalViewBase extends React.Component<SummaryModalViewProps> {
 
     return (
       <>
-        <div className={styles.subTitle}>
+        <div style={styles.subTitle}>
           <Title size="lg">{t('details.cost_value', { value: cost })}</Title>
         </div>
-        <div className={styles.mainContent}>
+        <div style={styles.mainContent}>
           <ReportSummaryItems
             idKey={groupBy as any}
             report={report}

--- a/src/pages/details/components/summary/summaryView.tsx
+++ b/src/pages/details/components/summary/summaryView.tsx
@@ -1,5 +1,4 @@
 import { Button, ButtonType, ButtonVariant } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import {
   Skeleton,
   SkeletonSize,
@@ -118,7 +117,7 @@ class SummaryViewBase extends React.Component<SummaryViewProps> {
 
     if (otherIndex !== -1) {
       return (
-        <div className={css(styles.viewAllContainer)}>
+        <div style={styles.viewAllContainer}>
           <Button
             {...getTestProps(testIds.details.view_all_btn)}
             onClick={this.handleWidgetModalOpen}
@@ -159,13 +158,13 @@ class SummaryViewBase extends React.Component<SummaryViewProps> {
         {Boolean(reportFetchStatus === FetchStatus.inProgress) ? (
           <>
             <Skeleton size={SkeletonSize.md} />
-            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+            <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+            <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+            <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
           </>
         ) : (
           <>
-            <div className={css(styles.tabs)}>
+            <div style={styles.tabs}>
               <ReportSummaryItems
                 idKey={groupBy as any}
                 key={`${groupBy}-items`}

--- a/src/pages/details/components/tag/tag.styles.ts
+++ b/src/pages/details/components/tag/tag.styles.ts
@@ -1,9 +1,9 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_3xl, global_spacer_sm } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   tagsContainer: {
     marginRight: global_spacer_3xl.value,
     marginTop: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/components/tag/tag.tsx
+++ b/src/pages/details/components/tag/tag.tsx
@@ -1,4 +1,3 @@
-import { css } from '@patternfly/react-styles';
 import { getQuery } from 'api/queries/query';
 import { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
@@ -120,7 +119,7 @@ class TagBase extends React.Component<TagProps> {
     }
 
     return (
-      <div className={css(styles.tagsContainer)} id={id}>
+      <div style={styles.tagsContainer} id={id}>
         {Boolean(someTags) &&
           someTags.map((tag, tagIndex) => <span key={tagIndex}>{tag}</span>)}
         {Boolean(someTags.length < allTags.length) && (

--- a/src/pages/details/components/tag/tagModal.styles.ts
+++ b/src/pages/details/components/tag/tagModal.styles.ts
@@ -1,13 +1,13 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_2xl, global_spacer_lg } from '@patternfly/react-tokens';
 import { css } from 'emotion';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   subTitle: {
     marginTop: global_spacer_2xl.value,
     textAlign: 'right',
   },
-});
+} as { [className: string]: React.CSSProperties };
 
 export const modalOverride = css`
   /* Workaround for isLarge not working properly */

--- a/src/pages/details/components/toolbar/toolbar.styles.ts
+++ b/src/pages/details/components/toolbar/toolbar.styles.ts
@@ -1,11 +1,11 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_100,
   global_spacer_md,
   global_spacer_xl,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   export: {
     marginRight: global_spacer_md.value,
   },
@@ -18,4 +18,4 @@ export const styles = StyleSheet.create({
     marginLeft: global_spacer_xl.value,
     marginRight: global_spacer_xl.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/components/toolbar/toolbar.tsx
+++ b/src/pages/details/components/toolbar/toolbar.tsx
@@ -24,7 +24,6 @@ import {
   FilterIcon,
   SearchIcon,
 } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import { Query, tagKeyPrefix } from 'api/queries/query';
 import { cloneDeep } from 'lodash';
 import { uniqBy } from 'lodash';
@@ -568,7 +567,7 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
           onClick={this.handleExportClicked}
           variant={ButtonVariant.link}
         >
-          <span className={css(styles.export)}>{t('export.export')}</span>
+          <span style={styles.export}>{t('export.export')}</span>
           <ExternalLinkSquareAltIcon />
         </Button>
       </DataToolbarItem>
@@ -586,7 +585,7 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
       : this.getDefaultCategoryOptions();
 
     return (
-      <div className={css(styles.toolbarContainer)}>
+      <div style={styles.toolbarContainer}>
         <DataToolbar
           id="details-toolbar"
           clearAllFilters={this.onDelete}

--- a/src/pages/details/ocpCloudDetails/detailsChart.styles.ts
+++ b/src/pages/details/ocpCloudDetails/detailsChart.styles.ts
@@ -1,11 +1,11 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_spacer_lg,
   global_spacer_md,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartSkeleton: {
     marginBottom: global_spacer_md.value,
   },
@@ -16,4 +16,4 @@ export const styles = StyleSheet.create({
   legendSkeleton: {
     marginTop: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpCloudDetails/detailsChart.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsChart.tsx
@@ -6,7 +6,6 @@ import {
   TextListItemVariants,
   TextListVariants,
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import {
   Skeleton,
   SkeletonSize,
@@ -407,7 +406,7 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
     const unusedUsageCapacityPercentage = (usage / capacity) * 100;
 
     return (
-      <TextContent className={css(styles.freeSpace)}>
+      <TextContent style={styles.freeSpace}>
         <TextList component={TextListVariants.dl}>
           <TextListItem component={TextListItemVariants.dt}>
             {t(`ocp_cloud_details.bullet.${labelKey}_usage_unused_label`)}
@@ -541,14 +540,8 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
   private getSkeleton = () => {
     return (
       <>
-        <Skeleton
-          className={css(styles.chartSkeleton)}
-          size={SkeletonSize.md}
-        />
-        <Skeleton
-          className={css(styles.legendSkeleton)}
-          size={SkeletonSize.xs}
-        />
+        <Skeleton style={styles.chartSkeleton} size={SkeletonSize.md} />
+        <Skeleton style={styles.legendSkeleton} size={SkeletonSize.xs} />
       </>
     );
   };

--- a/src/pages/details/ocpCloudDetails/detailsHeader.styles.ts
+++ b/src/pages/details/ocpCloudDetails/detailsHeader.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_100,
   global_Color_100,
@@ -9,8 +8,9 @@ import {
   global_spacer_sm,
   global_spacer_xl,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   cost: {
     display: 'flex',
     alignItems: 'center',
@@ -48,4 +48,4 @@ export const styles = StyleSheet.create({
   title: {
     paddingBottom: global_spacer_sm.var,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpCloudDetails/detailsHeader.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsHeader.tsx
@@ -1,6 +1,5 @@
 import { Popover, Title, TitleSize, Tooltip } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import { Providers, ProviderType } from 'api/providers';
 import { getQuery, OcpCloudQuery } from 'api/queries/ocpCloudQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
@@ -126,9 +125,9 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     }
 
     return (
-      <header className={css(styles.header)}>
+      <header style={styles.header}>
         <div>
-          <Title className={css(styles.title)} size={TitleSize['2xl']}>
+          <Title style={styles.title} size={TitleSize['2xl']}>
             {t('ocp_cloud_details.title')}
           </Title>
           {Boolean(showContent) && (
@@ -136,8 +135,8 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           )}
         </div>
         {Boolean(showContent) && (
-          <div className={css(styles.cost)}>
-            <Title className={css(styles.costValue)} size="4xl">
+          <div style={styles.cost}>
+            <Title style={styles.costValue} size="4xl">
               <Tooltip
                 content={t('ocp_cloud_details.total_cost_tooltip', {
                   infrastructureCost,
@@ -147,16 +146,16 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
                 <span>{cost}</span>
               </Tooltip>
             </Title>
-            <div className={css(styles.costLabel)}>
-              <div className={css(styles.costLabelUnit)}>
+            <div style={styles.costLabel}>
+              <div style={styles.costLabelUnit}>
                 {t('ocp_cloud_details.total_cost')}
-                <span className={css(styles.infoIcon)}>
+                <span style={styles.infoIcon}>
                   <Popover
                     aria-label="t('ocp_cloud_details.markup_aria_label')"
                     enableFlip
                     bodyContent={
                       <>
-                        <p className={css(styles.infoTitle)}>
+                        <p style={styles.infoTitle}>
                           {t('ocp_cloud_details.infrastructure_cost_title')}
                         </p>
                         <p>{t('ocp_cloud_details.infrastructure_cost_desc')}</p>
@@ -164,13 +163,13 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
                     }
                   >
                     <InfoCircleIcon
-                      className={css(styles.info)}
+                      style={styles.info}
                       onClick={this.handlePopoverClick}
                     />
                   </Popover>
                 </span>
               </div>
-              <div className={css(styles.costLabelDate)}>
+              <div style={styles.costLabelDate}>
                 {getSinceDateRangeString()}
               </div>
             </div>

--- a/src/pages/details/ocpCloudDetails/detailsTable.styles.ts
+++ b/src/pages/details/ocpCloudDetails/detailsTable.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_light_100,
   global_danger_color_100,
@@ -9,8 +8,9 @@ import {
   global_success_color_100,
 } from '@patternfly/react-tokens';
 import { css } from 'emotion';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   emptyState: {
     backgroundColor: global_BackgroundColor_light_100.value,
     display: 'flex',
@@ -29,7 +29,7 @@ export const styles = StyleSheet.create({
     color: global_disabled_color_100.value,
     fontSize: global_FontSize_xs.value,
   },
-});
+} as { [className: string]: React.CSSProperties };
 
 export const monthOverMonthOverride = css`
   div {

--- a/src/pages/details/ocpCloudDetails/detailsTable.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsTable.tsx
@@ -4,7 +4,6 @@ import {
   EmptyStateIcon,
 } from '@patternfly/react-core';
 import { CalculatorIcon } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import {
   sortable,
   SortByDirection,
@@ -268,7 +267,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
                 item.deltaValue > 0
             ) && (
               <span
-                className={css('fa fa-sort-up', styles.infoArrow)}
+                className="fa fa-sort-up"
+                style={styles.infoArrow}
                 key={`month-over-month-icon-${index}`}
               />
             )}
@@ -278,17 +278,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
                 item.deltaValue < 0
             ) && (
               <span
-                className={css(
-                  'fa fa-sort-down',
-                  styles.infoArrow,
-                  styles.infoArrowDesc
-                )}
+                className="fa fa-sort-down"
+                style={{ ...styles.infoArrow, ...styles.infoArrowDesc }}
                 key={`month-over-month-icon-${index}`}
               />
             )}
           </div>
           <div
-            className={css(styles.infoDescription)}
+            style={styles.infoDescription}
             key={`month-over-month-info-${index}`}
           >
             {getForDateRangeString(value)}
@@ -352,10 +349,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <>
         {formatCurrency(item.cost)}
-        <div
-          className={css(styles.infoDescription)}
-          key={`total-cost-${index}`}
-        >
+        <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
             value: ((item.cost / cost) * 100).toFixed(2),
           })}
@@ -444,7 +438,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           <TableBody />
         </Table>
         {Boolean(rows.length === 0) && (
-          <div className={css(styles.emptyState)}>{this.getEmptyState()}</div>
+          <div style={styles.emptyState}>{this.getEmptyState()}</div>
         )}
       </>
     );

--- a/src/pages/details/ocpCloudDetails/detailsTableItem.styles.ts
+++ b/src/pages/details/ocpCloudDetails/detailsTableItem.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_3xl, global_spacer_xl } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   clusterContainer: {
     marginBottom: global_spacer_xl.value,
   },
@@ -22,4 +22,4 @@ export const styles = StyleSheet.create({
   tagsContainer: {
     marginBottom: global_spacer_xl.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpCloudDetails/detailsTableItem.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsTableItem.tsx
@@ -7,7 +7,6 @@ import {
   Grid,
   GridItem,
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { Cluster } from 'pages/details/components/cluster/cluster';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -61,7 +60,7 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
       <>
         <Grid>
           <GridItem sm={12}>
-            <div className={css(styles.historicalContainer)}>
+            <div style={styles.historicalContainer}>
               <Button
                 {...getTestProps(testIds.details.historical_data_btn)}
                 onClick={this.handleHistoricalModalOpen}
@@ -73,9 +72,9 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
             </div>
           </GridItem>
           <GridItem lg={12} xl={6}>
-            <div className={css(styles.leftPane)}>
+            <div style={styles.leftPane}>
               {Boolean(groupBy !== 'cluster') && (
-                <div className={css(styles.clusterContainer)}>
+                <div style={styles.clusterContainer}>
                   <Form>
                     <FormGroup
                       label={t('ocp_cloud_details.cluster_label')}
@@ -90,9 +89,9 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
             </div>
           </GridItem>
           <GridItem lg={12} xl={6}>
-            <div className={css(styles.rightPane)}>
+            <div style={styles.rightPane}>
               {Boolean(groupBy === 'project') && (
-                <div className={css(styles.tagsContainer)}>
+                <div style={styles.tagsContainer}>
                   <Form>
                     <FormGroup
                       label={t('ocp_cloud_details.tags_label')}

--- a/src/pages/details/ocpCloudDetails/detailsTag.styles.ts
+++ b/src/pages/details/ocpCloudDetails/detailsTag.styles.ts
@@ -1,9 +1,9 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_3xl, global_spacer_sm } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   tagsContainer: {
     marginRight: global_spacer_3xl.value,
     marginTop: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpCloudDetails/detailsTag.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsTag.tsx
@@ -1,4 +1,3 @@
-import { css } from '@patternfly/react-styles';
 import { getQuery } from 'api/queries/ocpCloudQuery';
 import { OcpCloudReport } from 'api/reports/ocpCloudReports';
 import { ReportType } from 'api/reports/report';
@@ -114,7 +113,7 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
     }
 
     return (
-      <div className={css(styles.tagsContainer)} id={id}>
+      <div style={styles.tagsContainer} id={id}>
         {Boolean(someTags) &&
           someTags.map((tag, tagIndex) => <span key={tagIndex}>{tag}</span>)}
         {Boolean(someTags.length < allTags.length) && (

--- a/src/pages/details/ocpCloudDetails/detailsTagModal.styles.ts
+++ b/src/pages/details/ocpCloudDetails/detailsTagModal.styles.ts
@@ -1,13 +1,13 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_2xl, global_spacer_lg } from '@patternfly/react-tokens';
 import { css } from 'emotion';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   subTitle: {
     marginTop: global_spacer_2xl.value,
     textAlign: 'right',
   },
-});
+} as { [className: string]: React.CSSProperties };
 
 export const modalOverride = css`
   /* Workaround for isLarge not working properly */

--- a/src/pages/details/ocpCloudDetails/detailsWidget.styles.ts
+++ b/src/pages/details/ocpCloudDetails/detailsWidget.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md, global_spacer_xl } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   skeleton: {
     marginTop: global_spacer_md.value,
   },
@@ -12,4 +12,4 @@ export const styles = StyleSheet.create({
     marginLeft: '-18px',
     paddingTop: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpCloudDetails/detailsWidgetModal.styles.ts
+++ b/src/pages/details/ocpCloudDetails/detailsWidgetModal.styles.ts
@@ -1,15 +1,15 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_lg, global_spacer_xl } from '@patternfly/react-tokens';
 import { css } from 'emotion';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   mainContent: {
     marginTop: global_spacer_xl.value,
   },
   subTitle: {
     textAlign: 'right',
   },
-});
+} as { [className: string]: React.CSSProperties };
 
 export const modalOverride = css`
   /* Workaround for isLarge not working properly */

--- a/src/pages/details/ocpCloudDetails/detailsWidgetModalView.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsWidgetModalView.tsx
@@ -72,12 +72,12 @@ class DetailsWidgetModalViewBase extends React.Component<
 
     return (
       <>
-        <div className={styles.subTitle}>
+        <div style={styles.subTitle}>
           <Title size="lg">
             {t('ocp_cloud_details.cost_value', { value: cost })}
           </Title>
         </div>
-        <div className={styles.mainContent}>
+        <div style={styles.mainContent}>
           <ReportSummaryItems
             idKey={groupBy as any}
             report={report}

--- a/src/pages/details/ocpCloudDetails/detailsWidgetView.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsWidgetView.tsx
@@ -1,5 +1,4 @@
 import { Button, ButtonType, ButtonVariant } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import {
   Skeleton,
   SkeletonSize,
@@ -115,7 +114,7 @@ class DetailsWidgetViewBase extends React.Component<DetailsWidgetViewProps> {
 
     if (otherIndex !== -1) {
       return (
-        <div className={css(styles.viewAllContainer)}>
+        <div style={styles.viewAllContainer}>
           <Button
             {...getTestProps(testIds.details.view_all_btn)}
             onClick={this.handleWidgetModalOpen}
@@ -155,13 +154,13 @@ class DetailsWidgetViewBase extends React.Component<DetailsWidgetViewProps> {
         {Boolean(reportFetchStatus === FetchStatus.inProgress) ? (
           <>
             <Skeleton size={SkeletonSize.md} />
-            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+            <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+            <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+            <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
           </>
         ) : (
           <>
-            <div className={css(styles.tabs)}>
+            <div style={styles.tabs}>
               <ReportSummaryItems
                 idKey={groupBy as any}
                 key={`${groupBy}-items`}

--- a/src/pages/details/ocpCloudDetails/exportModal.styles.ts
+++ b/src/pages/details/ocpCloudDetails/exportModal.styles.ts
@@ -1,11 +1,11 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_spacer_sm,
   global_spacer_xl,
   global_spacer_xs,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   form: {
     marginLeft: global_spacer_sm.var,
   },
@@ -23,4 +23,4 @@ export const styles = StyleSheet.create({
   title: {
     paddingBottom: global_spacer_xl.var,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpCloudDetails/exportModal.tsx
+++ b/src/pages/details/ocpCloudDetails/exportModal.tsx
@@ -7,7 +7,6 @@ import {
   Radio,
   Title,
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { getQuery, OcpCloudQuery } from 'api/queries/ocpCloudQuery';
 import { tagKeyPrefix } from 'api/queries/query';
 import { ReportType } from 'api/reports/report';
@@ -143,7 +142,7 @@ export class ExportModalBase extends React.Component<
 
     return (
       <Modal
-        className={css(styles.modal)}
+        style={styles.modal}
         isLarge
         isOpen={this.props.isOpen}
         onClose={this.handleClose}
@@ -168,10 +167,10 @@ export class ExportModalBase extends React.Component<
           </Button>,
         ]}
       >
-        <Title className={css(styles.title)} size="xl">
+        <Title style={styles.title} size="xl">
           {t('export.heading', { groupBy })}
         </Title>
-        <Form className={css(styles.form)}>
+        <Form style={styles.form}>
           <FormGroup
             label={t('export.aggregate_type')}
             fieldId="aggregate-type"

--- a/src/pages/details/ocpCloudDetails/groupBy.styles.ts
+++ b/src/pages/details/ocpCloudDetails/groupBy.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   groupBySelector: {
     display: 'flex',
     alignItems: 'center',
@@ -10,4 +10,4 @@ export const styles = StyleSheet.create({
     marginBottom: 0,
     marginRight: global_spacer_md.var,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpCloudDetails/groupBy.tsx
+++ b/src/pages/details/ocpCloudDetails/groupBy.tsx
@@ -1,5 +1,4 @@
 import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { getQuery, OcpCloudQuery } from 'api/queries/ocpCloudQuery';
 import { parseQuery } from 'api/queries/ocpCloudQuery';
 import { tagKeyPrefix } from 'api/queries/query';
@@ -184,10 +183,8 @@ class GroupByBase extends React.Component<GroupByProps> {
         : t(`group_by.values.${currentItem}`);
 
     return (
-      <div className={css(styles.groupBySelector)}>
-        <label className={css(styles.groupBySelectorLabel)}>
-          {t('group_by.cost')}:
-        </label>
+      <div style={styles.groupBySelector}>
+        <label style={styles.groupBySelectorLabel}>{t('group_by.cost')}:</label>
         <Dropdown
           onSelect={this.handleGroupBySelect}
           toggle={

--- a/src/pages/details/ocpCloudDetails/historicalChart.styles.ts
+++ b/src/pages/details/ocpCloudDetails/historicalChart.styles.ts
@@ -1,17 +1,17 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_spacer_3xl,
   global_spacer_lg,
   global_spacer_md,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
 export const chartStyles = {
   chartHeight: 90,
   chartContainerHeight: 215,
 };
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartContainer: {
     marginLeft: global_spacer_lg.value,
   },
@@ -32,4 +32,4 @@ export const styles = StyleSheet.create({
   memoryChart: {
     marginTop: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpCloudDetails/historicalChart.tsx
+++ b/src/pages/details/ocpCloudDetails/historicalChart.tsx
@@ -1,4 +1,3 @@
-import { css } from '@patternfly/react-styles';
 import {
   Skeleton,
   SkeletonSize,
@@ -87,14 +86,8 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
   private getSkeleton = () => {
     return (
       <>
-        <Skeleton
-          className={css(styles.chartSkeleton)}
-          size={SkeletonSize.md}
-        />
-        <Skeleton
-          className={css(styles.legendSkeleton)}
-          size={SkeletonSize.xs}
-        />
+        <Skeleton style={styles.chartSkeleton} size={SkeletonSize.md} />
+        <Skeleton style={styles.legendSkeleton} size={SkeletonSize.xs} />
       </>
     );
   };
@@ -229,8 +222,8 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
         : '';
 
     return (
-      <div className={css(styles.chartContainer)}>
-        <div className={css(styles.costChart)}>
+      <div style={styles.chartContainer}>
+        <div style={styles.costChart}>
           {currentCostReportFetchStatus === FetchStatus.inProgress &&
           previousCostReportFetchStatus === FetchStatus.inProgress ? (
             this.getSkeleton()
@@ -250,7 +243,7 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
             />
           )}
         </div>
-        <div className={css(styles.cpuChart)}>
+        <div style={styles.cpuChart}>
           {currentCpuReportFetchStatus === FetchStatus.inProgress &&
           previousCpuReportFetchStatus === FetchStatus.inProgress ? (
             this.getSkeleton()
@@ -274,7 +267,7 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
             />
           )}
         </div>
-        <div className={css(styles.memoryChart)}>
+        <div style={styles.memoryChart}>
           {currentMemoryReportFetchStatus === FetchStatus.inProgress &&
           previousMemoryReportFetchStatus === FetchStatus.inProgress ? (
             this.getSkeleton()

--- a/src/pages/details/ocpCloudDetails/ocpCloudDetails.styles.ts
+++ b/src/pages/details/ocpCloudDetails/ocpCloudDetails.styles.ts
@@ -1,12 +1,12 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_300,
   global_BackgroundColor_light_100,
   global_spacer_md,
   global_spacer_xl,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   content: {
     backgroundColor: global_BackgroundColor_300.value,
     paddingBottom: global_spacer_xl.value,
@@ -29,4 +29,4 @@ export const styles = StyleSheet.create({
     marginLeft: global_spacer_xl.value,
     marginRight: global_spacer_xl.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpCloudDetails/ocpCloudDetails.tsx
+++ b/src/pages/details/ocpCloudDetails/ocpCloudDetails.tsx
@@ -1,5 +1,4 @@
 import { Pagination, PaginationVariant } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { Providers, ProviderType } from 'api/providers';
 import {
   getQuery,
@@ -404,7 +403,7 @@ class OcpCloudDetails extends React.Component<OcpCloudDetailsProps> {
       providersFetchStatus === FetchStatus.complete;
 
     return (
-      <div className={css(styles.ocpCloudDetails)}>
+      <div style={styles.ocpCloudDetails}>
         <DetailsHeader
           groupBy={groupById}
           onGroupByClicked={this.handleGroupByClick}
@@ -416,14 +415,12 @@ class OcpCloudDetails extends React.Component<OcpCloudDetailsProps> {
         ) : Boolean(isLoading) ? (
           <LoadingState />
         ) : (
-          <div className={css(styles.content)}>
+          <div style={styles.content}>
             {this.getToolbar()}
             {this.getExportModal(computedItems)}
-            <div className={css(styles.tableContainer)}>{this.getTable()}</div>
-            <div className={css(styles.paginationContainer)}>
-              <div className={css(styles.pagination)}>
-                {this.getPagination(true)}
-              </div>
+            <div style={styles.tableContainer}>{this.getTable()}</div>
+            <div style={styles.paginationContainer}>
+              <div style={styles.pagination}>{this.getPagination(true)}</div>
             </div>
           </div>
         )}

--- a/src/pages/details/ocpDetails/detailsChart.styles.ts
+++ b/src/pages/details/ocpDetails/detailsChart.styles.ts
@@ -1,11 +1,11 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_spacer_lg,
   global_spacer_md,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartSkeleton: {
     marginBottom: global_spacer_md.value,
   },
@@ -16,4 +16,4 @@ export const styles = StyleSheet.create({
   legendSkeleton: {
     marginTop: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpDetails/detailsChart.tsx
+++ b/src/pages/details/ocpDetails/detailsChart.tsx
@@ -6,7 +6,6 @@ import {
   TextListItemVariants,
   TextListVariants,
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import {
   Skeleton,
   SkeletonSize,
@@ -414,7 +413,7 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
     }
 
     return (
-      <TextContent className={css(styles.freeSpace)}>
+      <TextContent style={styles.freeSpace}>
         <TextList component={TextListVariants.dl}>
           <TextListItem component={TextListItemVariants.dt}>
             {t(`ocp_details.bullet.${labelKey}_usage_unused_label`)}
@@ -548,14 +547,8 @@ class DetailsChartBase extends React.Component<DetailsChartProps> {
   private getSkeleton = () => {
     return (
       <>
-        <Skeleton
-          className={css(styles.chartSkeleton)}
-          size={SkeletonSize.md}
-        />
-        <Skeleton
-          className={css(styles.legendSkeleton)}
-          size={SkeletonSize.xs}
-        />
+        <Skeleton style={styles.chartSkeleton} size={SkeletonSize.md} />
+        <Skeleton style={styles.legendSkeleton} size={SkeletonSize.xs} />
       </>
     );
   };

--- a/src/pages/details/ocpDetails/detailsHeader.styles.ts
+++ b/src/pages/details/ocpDetails/detailsHeader.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_100,
   global_Color_100,
@@ -9,8 +8,9 @@ import {
   global_spacer_sm,
   global_spacer_xl,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   cost: {
     display: 'flex',
     alignItems: 'center',
@@ -48,4 +48,4 @@ export const styles = StyleSheet.create({
   title: {
     paddingBottom: global_spacer_sm.var,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpDetails/detailsHeader.tsx
+++ b/src/pages/details/ocpDetails/detailsHeader.tsx
@@ -1,6 +1,5 @@
 import { Popover, Title, TitleSize, Tooltip } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import { Providers, ProviderType } from 'api/providers';
 import { getQuery, OcpQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
@@ -136,9 +135,9 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     }
 
     return (
-      <header className={css(styles.header)}>
+      <header style={styles.header}>
         <div>
-          <Title className={css(styles.title)} size={TitleSize['2xl']}>
+          <Title style={styles.title} size={TitleSize['2xl']}>
             {t('ocp_details.title')}
           </Title>
           {Boolean(showContent) && (
@@ -146,8 +145,8 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           )}
         </div>
         {Boolean(showContent) && (
-          <div className={css(styles.cost)}>
-            <Title className={css(styles.costValue)} size="4xl">
+          <div style={styles.cost}>
+            <Title style={styles.costValue} size="4xl">
               <Tooltip
                 content={t('ocp_details.total_cost_tooltip', {
                   supplementaryCost,
@@ -158,21 +157,21 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
                 <span>{cost}</span>
               </Tooltip>
             </Title>
-            <div className={css(styles.costLabel)}>
-              <div className={css(styles.costLabelUnit)}>
+            <div style={styles.costLabel}>
+              <div style={styles.costLabelUnit}>
                 {t('ocp_details.total_cost')}
-                <span className={css(styles.infoIcon)}>
+                <span style={styles.infoIcon}>
                   <Popover
                     aria-label="t('ocp_details.supplementary_aria_label')"
                     enableFlip
                     bodyContent={
                       <>
-                        <p className={css(styles.infoTitle)}>
+                        <p style={styles.infoTitle}>
                           {t('ocp_details.supplementary_cost_title')}
                         </p>
                         <p>{t('ocp_details.supplementary_cost_desc')}</p>
                         <br />
-                        <p className={css(styles.infoTitle)}>
+                        <p style={styles.infoTitle}>
                           {t('ocp_details.infrastructure_cost_title')}
                         </p>
                         <p>{t('ocp_details.infrastructure_cost_desc')}</p>
@@ -180,13 +179,13 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
                     }
                   >
                     <InfoCircleIcon
-                      className={css(styles.info)}
+                      style={styles.info}
                       onClick={this.handlePopoverClick}
                     />
                   </Popover>
                 </span>
               </div>
-              <div className={css(styles.costLabelDate)}>
+              <div style={styles.costLabelDate}>
                 {getSinceDateRangeString()}
               </div>
             </div>

--- a/src/pages/details/ocpDetails/detailsTable.styles.ts
+++ b/src/pages/details/ocpDetails/detailsTable.styles.ts
@@ -1,4 +1,3 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_light_100,
   global_danger_color_100,
@@ -9,8 +8,9 @@ import {
   global_success_color_100,
 } from '@patternfly/react-tokens';
 import { css } from 'emotion';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   emptyState: {
     backgroundColor: global_BackgroundColor_light_100.value,
     display: 'flex',
@@ -29,7 +29,7 @@ export const styles = StyleSheet.create({
     color: global_disabled_color_100.value,
     fontSize: global_FontSize_xs.value,
   },
-});
+} as { [className: string]: React.CSSProperties };
 
 export const monthOverMonthOverride = css`
   div {

--- a/src/pages/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/details/ocpDetails/detailsTable.tsx
@@ -4,7 +4,6 @@ import {
   EmptyStateIcon,
 } from '@patternfly/react-core';
 import { CalculatorIcon } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import {
   sortable,
   SortByDirection,
@@ -252,10 +251,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <>
         {formatCurrency(item.supplementaryCost)}
-        <div
-          className={css(styles.infoDescription)}
-          key={`total-cost-${index}`}
-        >
+        <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
             value: ((item.supplementaryCost / total) * 100).toFixed(2),
           })}
@@ -295,10 +291,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <>
         {formatCurrency(item.infrastructureCost)}
-        <div
-          className={css(styles.infoDescription)}
-          key={`total-cost-${index}`}
-        >
+        <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
             value: ((item.infrastructureCost / total) * 100).toFixed(2),
           })}
@@ -344,7 +337,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
                 item.deltaValue > 0
             ) && (
               <span
-                className={css('fa fa-sort-up', styles.infoArrow)}
+                className="fa fa-sort-up"
+                style={styles.infoArrow}
                 key={`month-over-month-icon-${index}`}
               />
             )}
@@ -354,17 +348,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
                 item.deltaValue < 0
             ) && (
               <span
-                className={css(
-                  'fa fa-sort-down',
-                  styles.infoArrow,
-                  styles.infoArrowDesc
-                )}
+                className="fa fa-sort-down"
+                style={{ ...styles.ininfoArrow, ...styles.infoArrowDesc }}
                 key={`month-over-month-icon-${index}`}
               />
             )}
           </div>
           <div
-            className={css(styles.infoDescription)}
+            style={styles.infoDescription}
             key={`month-over-month-info-${index}`}
           >
             {getForDateRangeString(value)}
@@ -428,10 +419,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <>
         {formatCurrency(item.cost)}
-        <div
-          className={css(styles.infoDescription)}
-          key={`total-cost-${index}`}
-        >
+        <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
             value: ((item.cost / cost) * 100).toFixed(2),
           })}
@@ -520,7 +508,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           <TableBody />
         </Table>
         {Boolean(rows.length === 0) && (
-          <div className={css(styles.emptyState)}>{this.getEmptyState()}</div>
+          <div style={styles.emptyState}>{this.getEmptyState()}</div>
         )}
       </>
     );

--- a/src/pages/details/ocpDetails/detailsTableItem.styles.ts
+++ b/src/pages/details/ocpDetails/detailsTableItem.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_3xl, global_spacer_xl } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   clusterContainer: {
     marginBottom: global_spacer_xl.value,
   },
@@ -22,4 +22,4 @@ export const styles = StyleSheet.create({
   tagsContainer: {
     marginBottom: global_spacer_xl.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpDetails/detailsTableItem.tsx
+++ b/src/pages/details/ocpDetails/detailsTableItem.tsx
@@ -7,7 +7,6 @@ import {
   Grid,
   GridItem,
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { Cluster } from 'pages/details/components/cluster/cluster';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -60,7 +59,7 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
       <>
         <Grid>
           <GridItem sm={12}>
-            <div className={css(styles.historicalContainer)}>
+            <div style={styles.historicalContainer}>
               <Button
                 {...getTestProps(testIds.details.historical_data_btn)}
                 onClick={this.handleHistoricalModalOpen}
@@ -72,9 +71,9 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
             </div>
           </GridItem>
           <GridItem lg={12} xl={6}>
-            <div className={css(styles.leftPane)}>
+            <div style={styles.leftPane}>
               {Boolean(groupBy !== 'cluster') && (
-                <div className={css(styles.clusterContainer)}>
+                <div style={styles.clusterContainer}>
                   <Form>
                     <FormGroup
                       label={t('ocp_details.cluster_label')}
@@ -91,9 +90,9 @@ class DetailsTableItemBase extends React.Component<DetailsTableItemProps> {
             </div>
           </GridItem>
           <GridItem lg={12} xl={6}>
-            <div className={css(styles.rightPane)}>
+            <div style={styles.rightPane}>
               {Boolean(groupBy === 'project') && (
-                <div className={css(styles.tagsContainer)}>
+                <div style={styles.tagsContainer}>
                   <Form>
                     <FormGroup
                       label={t('ocp_details.tags_label')}

--- a/src/pages/details/ocpDetails/detailsTag.styles.ts
+++ b/src/pages/details/ocpDetails/detailsTag.styles.ts
@@ -1,9 +1,9 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_3xl, global_spacer_sm } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   tagsContainer: {
     marginRight: global_spacer_3xl.value,
     marginTop: global_spacer_sm.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpDetails/detailsTag.tsx
+++ b/src/pages/details/ocpDetails/detailsTag.tsx
@@ -1,4 +1,3 @@
-import { css } from '@patternfly/react-styles';
 import { getQuery } from 'api/queries/ocpQuery';
 import { OcpReport } from 'api/reports/ocpReports';
 import { ReportType } from 'api/reports/report';
@@ -114,7 +113,7 @@ class DetailsTagBase extends React.Component<DetailsTagProps> {
     }
 
     return (
-      <div className={css(styles.tagsContainer)} id={id}>
+      <div style={styles.tagsContainer} id={id}>
         {Boolean(someTags) &&
           someTags.map((tag, tagIndex) => <span key={tagIndex}>{tag}</span>)}
         {Boolean(someTags.length < allTags.length) && (

--- a/src/pages/details/ocpDetails/detailsTagModal.styles.ts
+++ b/src/pages/details/ocpDetails/detailsTagModal.styles.ts
@@ -1,13 +1,13 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_2xl, global_spacer_lg } from '@patternfly/react-tokens';
 import { css } from 'emotion';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   subTitle: {
     marginTop: global_spacer_2xl.value,
     textAlign: 'right',
   },
-});
+} as { [className: string]: React.CSSProperties };
 
 export const modalOverride = css`
   /* Workaround for isLarge not working properly */

--- a/src/pages/details/ocpDetails/detailsWidget.styles.ts
+++ b/src/pages/details/ocpDetails/detailsWidget.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   skeleton: {
     marginTop: global_spacer_md.value,
   },
@@ -12,4 +12,4 @@ export const styles = StyleSheet.create({
     marginLeft: '-18px',
     paddingTop: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpDetails/detailsWidget.tsx
+++ b/src/pages/details/ocpDetails/detailsWidget.tsx
@@ -1,5 +1,4 @@
 import { Button, ButtonType, ButtonVariant } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import {
   Skeleton,
   SkeletonSize,
@@ -86,7 +85,7 @@ class DetailsWidgetBase extends React.Component<DetailsWidgetProps> {
     return (
       <>
         {t('group_by.details', { groupBy: 'project' })}
-        <div className={css(styles.summary)}>
+        <div style={styles.summary}>
           <ReportSummaryItems
             idKey={'project' as any}
             report={report}
@@ -127,7 +126,7 @@ class DetailsWidgetBase extends React.Component<DetailsWidgetProps> {
 
     if (otherIndex !== -1) {
       return (
-        <div className={css(styles.viewAllContainer)}>
+        <div style={styles.viewAllContainer}>
           <Button
             {...getTestProps(testIds.details.view_all_btn)}
             onClick={this.handleDetailsChartModalOpen}
@@ -167,9 +166,9 @@ class DetailsWidgetBase extends React.Component<DetailsWidgetProps> {
         {Boolean(reportFetchStatus === FetchStatus.inProgress) ? (
           <>
             <Skeleton size={SkeletonSize.md} />
-            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
-            <Skeleton size={SkeletonSize.md} className={css(styles.skeleton)} />
+            <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+            <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
+            <Skeleton size={SkeletonSize.md} style={styles.skeleton} />
           </>
         ) : (
           this.getSummary()

--- a/src/pages/details/ocpDetails/detailsWidgetModal.styles.ts
+++ b/src/pages/details/ocpDetails/detailsWidgetModal.styles.ts
@@ -1,15 +1,15 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_lg, global_spacer_xl } from '@patternfly/react-tokens';
 import { css } from 'emotion';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   mainContent: {
     marginTop: global_spacer_xl.value,
   },
   subTitle: {
     textAlign: 'right',
   },
-});
+} as { [className: string]: React.CSSProperties };
 
 export const modalOverride = css`
   /* Workaround for isLarge not working properly */

--- a/src/pages/details/ocpDetails/detailsWidgetView.tsx
+++ b/src/pages/details/ocpDetails/detailsWidgetView.tsx
@@ -69,12 +69,12 @@ class DetailsWidgetViewBase extends React.Component<DetailsWidgetViewProps> {
 
     return (
       <>
-        <div className={styles.subTitle}>
+        <div style={styles.subTitle}>
           <Title size="lg">
             {t('ocp_details.cost_value', { value: cost })}
           </Title>
         </div>
-        <div className={styles.mainContent}>
+        <div style={styles.mainContent}>
           <ReportSummaryItems
             idKey={'project' as any}
             report={report}

--- a/src/pages/details/ocpDetails/exportModal.styles.ts
+++ b/src/pages/details/ocpDetails/exportModal.styles.ts
@@ -1,11 +1,11 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_spacer_sm,
   global_spacer_xl,
   global_spacer_xs,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   form: {
     marginLeft: global_spacer_sm.var,
   },
@@ -23,4 +23,4 @@ export const styles = StyleSheet.create({
   title: {
     paddingBottom: global_spacer_xl.var,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpDetails/exportModal.tsx
+++ b/src/pages/details/ocpDetails/exportModal.tsx
@@ -7,7 +7,6 @@ import {
   Radio,
   Title,
 } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { getQuery, OcpQuery } from 'api/queries/ocpQuery';
 import { tagKeyPrefix } from 'api/queries/query';
 import { ReportType } from 'api/reports/report';
@@ -140,7 +139,7 @@ export class ExportModalBase extends React.Component<
 
     return (
       <Modal
-        className={css(styles.modal)}
+        style={styles.modal}
         isLarge
         isOpen={this.props.isOpen}
         onClose={this.handleClose}
@@ -165,10 +164,10 @@ export class ExportModalBase extends React.Component<
           </Button>,
         ]}
       >
-        <Title className={css(styles.title)} size="xl">
+        <Title style={styles.title} size="xl">
           {t('export.heading', { groupBy })}
         </Title>
-        <Form className={css(styles.form)}>
+        <Form style={styles.form}>
           <FormGroup
             label={t('export.aggregate_type')}
             fieldId="aggregate-type"

--- a/src/pages/details/ocpDetails/groupBy.styles.ts
+++ b/src/pages/details/ocpDetails/groupBy.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   groupBySelector: {
     display: 'flex',
     alignItems: 'center',
@@ -10,4 +10,4 @@ export const styles = StyleSheet.create({
     marginBottom: 0,
     marginRight: global_spacer_md.var,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpDetails/groupBy.tsx
+++ b/src/pages/details/ocpDetails/groupBy.tsx
@@ -1,5 +1,4 @@
 import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { getQuery, OcpQuery } from 'api/queries/ocpQuery';
 import { parseQuery } from 'api/queries/ocpQuery';
 import { tagKeyPrefix } from 'api/queries/query';
@@ -184,10 +183,8 @@ class GroupByBase extends React.Component<GroupByProps> {
         : t(`group_by.values.${currentItem}`);
 
     return (
-      <div className={css(styles.groupBySelector)}>
-        <label className={css(styles.groupBySelectorLabel)}>
-          {t('group_by.cost')}:
-        </label>
+      <div style={styles.groupBySelector}>
+        <label style={styles.groupBySelectorLabel}>{t('group_by.cost')}:</label>
         <Dropdown
           onSelect={this.handleGroupBySelect}
           toggle={

--- a/src/pages/details/ocpDetails/historicalChart.styles.ts
+++ b/src/pages/details/ocpDetails/historicalChart.styles.ts
@@ -1,17 +1,17 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_spacer_3xl,
   global_spacer_lg,
   global_spacer_md,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
 export const chartStyles = {
   chartHeight: 90,
   chartContainerHeight: 215,
 };
 
-export const styles = StyleSheet.create({
+export const styles = {
   chartContainer: {
     marginLeft: global_spacer_lg.value,
   },
@@ -32,4 +32,4 @@ export const styles = StyleSheet.create({
   memoryChart: {
     marginTop: global_spacer_md.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpDetails/historicalChart.tsx
+++ b/src/pages/details/ocpDetails/historicalChart.tsx
@@ -1,4 +1,3 @@
-import { css } from '@patternfly/react-styles';
 import {
   Skeleton,
   SkeletonSize,
@@ -87,14 +86,8 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
   private getSkeleton = () => {
     return (
       <>
-        <Skeleton
-          className={css(styles.chartSkeleton)}
-          size={SkeletonSize.md}
-        />
-        <Skeleton
-          className={css(styles.legendSkeleton)}
-          size={SkeletonSize.xs}
-        />
+        <Skeleton style={styles.chartSkeleton} size={SkeletonSize.md} />
+        <Skeleton style={styles.legendSkeleton} size={SkeletonSize.xs} />
       </>
     );
   };
@@ -241,8 +234,8 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
         : '';
 
     return (
-      <div className={css(styles.chartContainer)}>
-        <div className={css(styles.costChart)}>
+      <div style={styles.chartContainer}>
+        <div style={styles.costChart}>
           {currentCostReportFetchStatus === FetchStatus.inProgress &&
           previousCostReportFetchStatus === FetchStatus.inProgress ? (
             this.getSkeleton()
@@ -264,7 +257,7 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
             />
           )}
         </div>
-        <div className={css(styles.cpuChart)}>
+        <div style={styles.cpuChart}>
           {currentCpuReportFetchStatus === FetchStatus.inProgress &&
           previousCpuReportFetchStatus === FetchStatus.inProgress ? (
             this.getSkeleton()
@@ -288,7 +281,7 @@ class HistoricalModalBase extends React.Component<HistoricalModalProps> {
             />
           )}
         </div>
-        <div className={css(styles.memoryChart)}>
+        <div style={styles.memoryChart}>
           {currentMemoryReportFetchStatus === FetchStatus.inProgress &&
           previousMemoryReportFetchStatus === FetchStatus.inProgress ? (
             this.getSkeleton()

--- a/src/pages/details/ocpDetails/noRatesState.styles.ts
+++ b/src/pages/details/ocpDetails/noRatesState.styles.ts
@@ -1,11 +1,11 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_xl } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   container: {
     display: 'flex',
     justifyContent: 'center',
     height: '50vh',
     marginTop: global_spacer_xl.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpDetails/noRatesState.tsx
+++ b/src/pages/details/ocpDetails/noRatesState.tsx
@@ -6,7 +6,6 @@ import {
   TitleSize,
 } from '@patternfly/react-core';
 import { MoneyCheckAltIcon } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { styles } from './noRatesState.styles';
@@ -17,7 +16,7 @@ interface Props extends InjectedTranslateProps {
 
 const NoRatesStateBase: React.SFC<Props> = ({ t, cluster }) => {
   return (
-    <div className={css(styles.container)}>
+    <div style={styles.container}>
       <PfEmptyState>
         <EmptyStateIcon icon={MoneyCheckAltIcon} />
         <Title size={TitleSize.lg}>{t('no_rates_state.title')}</Title>

--- a/src/pages/details/ocpDetails/ocpDetails.styles.ts
+++ b/src/pages/details/ocpDetails/ocpDetails.styles.ts
@@ -1,12 +1,12 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_BackgroundColor_300,
   global_BackgroundColor_light_100,
   global_spacer_md,
   global_spacer_xl,
 } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   content: {
     backgroundColor: global_BackgroundColor_300.value,
     paddingBottom: global_spacer_xl.value,
@@ -29,4 +29,4 @@ export const styles = StyleSheet.create({
     marginLeft: global_spacer_xl.value,
     marginRight: global_spacer_xl.value,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -1,5 +1,4 @@
 import { Pagination, PaginationVariant } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import { Providers, ProviderType } from 'api/providers';
 import {
   getQuery,
@@ -403,7 +402,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
       providersFetchStatus === FetchStatus.complete;
 
     return (
-      <div className={css(styles.ocpDetails)}>
+      <div style={styles.ocpDetails}>
         <DetailsHeader
           groupBy={groupById}
           onGroupByClicked={this.handleGroupByClick}
@@ -415,14 +414,12 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
         ) : Boolean(isLoading) ? (
           <LoadingState />
         ) : (
-          <div className={css(styles.content)}>
+          <div style={styles.content}>
             {this.getToolbar()}
             {this.getExportModal(computedItems)}
-            <div className={css(styles.tableContainer)}>{this.getTable()}</div>
-            <div className={css(styles.paginationContainer)}>
-              <div className={css(styles.pagination)}>
-                {this.getPagination(true)}
-              </div>
+            <div style={styles.tableContainer}>{this.getTable()}</div>
+            <div style={styles.paginationContainer}>
+              <div style={styles.pagination}>{this.getPagination(true)}</div>
             </div>
           </div>
         )}

--- a/src/pages/details/ocpDetails/priceListModal.tsx
+++ b/src/pages/details/ocpDetails/priceListModal.tsx
@@ -1,5 +1,4 @@
 import { Modal } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import {
   Skeleton,
   SkeletonSize,
@@ -56,10 +55,7 @@ class PriceListModalBase extends React.Component<Props> {
 
     if (priceListStatus !== FetchStatus.complete) {
       return (
-        <Skeleton
-          className={css(chartStyles.chartSkeleton)}
-          size={SkeletonSize.md}
-        />
+        <Skeleton style={chartStyles.chartSkeleton} size={SkeletonSize.md} />
       );
     }
     if (priceListError !== null) {

--- a/src/pages/overview/overview.styles.ts
+++ b/src/pages/overview/overview.styles.ts
@@ -1,12 +1,12 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import {
   global_FontSize_md,
   global_spacer_lg,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
 import { css } from 'emotion';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   info: {
     marginLeft: global_spacer_sm.value,
     verticalAlign: 'middle',
@@ -24,7 +24,7 @@ export const styles = StyleSheet.create({
   tabs: {
     marginTop: global_spacer_lg.value,
   },
-});
+} as { [className: string]: React.CSSProperties };
 
 export const headerOverride = css`
   &.pf-c-page__main-section {

--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -7,7 +7,6 @@ import {
   TitleSize,
 } from '@patternfly/react-core';
 import { InfoCircleIcon } from '@patternfly/react-icons';
-import { css } from '@patternfly/react-styles';
 import { Providers, ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { AxiosError } from 'axios';
@@ -379,36 +378,30 @@ class OverviewBase extends React.Component<OverviewProps> {
             <Title size={TitleSize['2xl']}>
               {t('overview.title')}
               {Boolean(showTabs) && (
-                <span className={css(styles.infoIcon)}>
+                <span style={styles.infoIcon}>
                   <Popover
                     aria-label="t('ocp_details.supplementary_aria_label')"
                     enableFlip
                     bodyContent={
                       <>
-                        <p className={css(styles.infoTitle)}>
+                        <p style={styles.infoTitle}>
                           {t('overview.ocp_cloud')}
                         </p>
                         <p>{t('overview.ocp_cloud_desc')}</p>
                         <br />
-                        <p className={css(styles.infoTitle)}>
-                          {t('overview.ocp')}
-                        </p>
+                        <p style={styles.infoTitle}>{t('overview.ocp')}</p>
                         <p>{t('overview.ocp_desc')}</p>
                         <br />
-                        <p className={css(styles.infoTitle)}>
-                          {t('overview.aws')}
-                        </p>
+                        <p style={styles.infoTitle}>{t('overview.aws')}</p>
                         <p>{t('overview.aws_desc')}</p>
                         <br />
-                        <p className={css(styles.infoTitle)}>
-                          {t('overview.azure')}
-                        </p>
+                        <p style={styles.infoTitle}>{t('overview.azure')}</p>
                         <p>{t('overview.azure_desc')}</p>
                       </>
                     }
                   >
                     <InfoCircleIcon
-                      className={css(styles.info)}
+                      style={styles.info}
                       onClick={this.handlePopoverClick}
                     />
                   </Popover>
@@ -418,12 +411,8 @@ class OverviewBase extends React.Component<OverviewProps> {
           </header>
           {Boolean(showTabs) && (
             <>
-              <div className={css(styles.tabs)}>
-                {this.getTabs(availableTabs)}
-              </div>
-              <div className={css(styles.perspective)}>
-                {this.getPerspective()}
-              </div>
+              <div style={styles.tabs}>{this.getTabs(availableTabs)}</div>
+              <div style={styles.perspective}>{this.getPerspective()}</div>
             </>
           )}
         </section>

--- a/src/pages/overview/perspective.styles.ts
+++ b/src/pages/overview/perspective.styles.ts
@@ -1,7 +1,7 @@
-import { StyleSheet } from '@patternfly/react-styles';
 import { global_spacer_md } from '@patternfly/react-tokens';
+import React from 'react';
 
-export const styles = StyleSheet.create({
+export const styles = {
   perspectiveSelector: {
     display: 'flex',
     alignItems: 'center',
@@ -10,4 +10,4 @@ export const styles = StyleSheet.create({
     marginBottom: 0,
     marginRight: global_spacer_md.var,
   },
-});
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/overview/perspective.tsx
+++ b/src/pages/overview/perspective.tsx
@@ -1,5 +1,4 @@
 import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
-import { css } from '@patternfly/react-styles';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { styles } from './perspective.styles';
@@ -77,8 +76,8 @@ class PerspectiveBase extends React.Component<PerspectiveProps> {
     const dropdownItems = this.getDropDownItems();
 
     return (
-      <div className={css(styles.perspectiveSelector)}>
-        <label className={css(styles.perspectiveLabel)}>
+      <div style={styles.perspectiveSelector}>
+        <label style={styles.perspectiveLabel}>
           {t('overview.perspective.label')}
         </label>
         <Dropdown


### PR DESCRIPTION
Transforms to *.styles.ts files:
1. `import { StyleSheet } from '@patternfly/react-styles';` -> `import React from 'react';`
2. `StyleSheet.create({` -> `{`
3. `});` -> `} as { [className: string]: React.CSSProperties };`

Transforms to *.tsx files:
1. `className=\{css\((styles\.[^,)]*)\)\}` -> `style={$1}`
2. Fix `unused import { css } from '@patternfly/react-styles';` by removing import
3. Fix `className={css(class, styles.style1)}` -> `className="class" style={style1}`
4. Fix `JSX elements cannot have multiple attributes with the same name.` by changing `<div style={style1} style={style2}` to `style={{ ...style1, ...style2}}`

**I NEVER STARTED A DEV SERVER TO TEST THIS. PLEASE TEST MY CHANGES**

#1417