### PR TITLE
Moved :not selectors from style to className props

### DIFF
--- a/src/components/charts/common/chart.styles.ts
+++ b/src/components/charts/common/chart.styles.ts
@@ -6,6 +6,7 @@ import {
   global_success_color_100,
   global_success_color_200,
 } from '@patternfly/react-tokens';
+import { css } from 'emotion';
 import React from 'react';
 
 export const chartStyles = {
@@ -32,14 +33,8 @@ export const chartStyles = {
   },
 };
 
-export const styles = {
-  reportSummaryTrend: {
-    ':not(foo) svg': {
-      overflow: 'visible',
-    },
-    ':not(foo) text': {
-      fontSize: '12px',
-      length: '12px',
-    },
-  },
-} as { [className: string]: React.CSSProperties };
+export const chartOverride = css`
+  :not(foo) svg {
+    overflow: visible;
+  }
+`;

--- a/src/components/charts/costChart/costChart.styles.ts
+++ b/src/components/charts/costChart/costChart.styles.ts
@@ -7,7 +7,6 @@ import {
   global_disabled_color_200,
   global_FontFamily_sans_serif,
 } from '@patternfly/react-tokens';
-import React from 'react';
 
 export const chartStyles = {
   currentCostData: {
@@ -89,11 +88,3 @@ export const chartStyles = {
     },
   },
 };
-
-export const styles = {
-  chartContainer: {
-    ':not(foo) svg': {
-      overflow: 'visible',
-    },
-  },
-} as { [className: string]: React.CSSProperties };

--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -8,6 +8,7 @@ import {
   getInteractiveLegendItemStyles,
 } from '@patternfly/react-charts';
 import { default as ChartTheme } from 'components/charts/chartTheme';
+import { chartOverride } from 'components/charts/common/chart.styles';
 import {
   getCostRangeString,
   getDateRange,
@@ -20,7 +21,7 @@ import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
 import { DomainTuple, VictoryStyleInterface } from 'victory';
-import { chartStyles, styles } from './costChart.styles';
+import { chartStyles } from './costChart.styles';
 
 interface CostChartProps {
   adjustContainerHeight?: boolean;
@@ -401,8 +402,9 @@ class CostChart extends React.Component<CostChartProps, State> {
 
     return (
       <div
+        className={chartOverride}
         ref={this.containerRef}
-        style={{ ...styles.chartContainer, height: adjustedContainerHeight }}
+        style={{ height: adjustedContainerHeight }}
       >
         <div>{title}</div>
         <Chart

--- a/src/components/charts/historicalCostChart/historicalCostChart.styles.ts
+++ b/src/components/charts/historicalCostChart/historicalCostChart.styles.ts
@@ -121,11 +121,6 @@ export const styles = {
   chart: {
     marginTop: global_spacer_sm.value,
   },
-  chartContainer: {
-    ':not(foo) svg': {
-      overflow: 'visible',
-    },
-  },
   title: {
     marginLeft: '-' + global_spacer_lg.value,
   },

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -8,13 +8,14 @@ import {
   getInteractiveLegendItemStyles,
 } from '@patternfly/react-charts';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import { getDateRange } from 'components/charts/common/chartUtils';
+import { chartOverride } from 'components/charts/common/chart.styles';
 import {
   getCostRangeString,
   getMaxValue,
   getTooltipContent,
   getTooltipLabel,
 } from 'components/charts/common/chartUtils';
+import { getDateRange } from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
 import React from 'react';
@@ -381,7 +382,7 @@ class HistoricalCostChart extends React.Component<
     const midDate = Math.floor(endDate / 2);
 
     return (
-      <div style={styles.chartContainer} ref={this.containerRef}>
+      <div className={chartOverride} ref={this.containerRef}>
         <div style={styles.title}>{title}</div>
         <div style={{ ...styles.chart, height: containerHeight }}>
           <Chart

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.styles.ts
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.styles.ts
@@ -70,11 +70,6 @@ export const styles = {
   chart: {
     marginTop: global_spacer_sm.value,
   },
-  chartContainer: {
-    ':not(foo) svg': {
-      overflow: 'visible',
-    },
-  },
   title: {
     marginLeft: '-' + global_spacer_lg.value,
   },

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -8,6 +8,7 @@ import {
   getInteractiveLegendItemStyles,
 } from '@patternfly/react-charts';
 import { default as ChartTheme } from 'components/charts/chartTheme';
+import { chartOverride } from 'components/charts/common/chart.styles';
 import {
   getCostRangeString,
   getDateRange,
@@ -302,7 +303,7 @@ class HistoricalTrendChart extends React.Component<
     const midDate = Math.floor(endDate / 2);
 
     return (
-      <div style={styles.chartContainer} ref={this.containerRef}>
+      <div className={chartOverride} ref={this.containerRef}>
         <div style={styles.title}>{title}</div>
         <div style={{ ...styles.chart, height: containerHeight }}>
           <Chart

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.styles.ts
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.styles.ts
@@ -133,11 +133,6 @@ export const styles = {
   chart: {
     marginTop: global_spacer_sm.value,
   },
-  chartContainer: {
-    ':not(foo) svg': {
-      overflow: 'visible',
-    },
-  },
   title: {
     marginLeft: '-' + global_spacer_lg.value,
   },

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -8,13 +8,14 @@ import {
   getInteractiveLegendItemStyles,
 } from '@patternfly/react-charts';
 import { default as ChartTheme } from 'components/charts/chartTheme';
+import { chartOverride } from 'components/charts/common/chart.styles';
+import { getDateRange } from 'components/charts/common/chartUtils';
 import {
   getMaxValue,
   getTooltipContent,
   getTooltipLabel,
   getUsageRangeString,
 } from 'components/charts/common/chartUtils';
-import { getDateRange } from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
 import React from 'react';
@@ -452,7 +453,7 @@ class HistoricalUsageChart extends React.Component<
     const midDate = Math.floor(endDate / 2);
 
     return (
-      <div style={styles.chartContainer} ref={this.containerRef}>
+      <div className={chartOverride} ref={this.containerRef}>
         <div style={styles.title}>{title}</div>
         <div style={{ ...styles.chart, height: containerHeight }}>
           <Chart

--- a/src/components/charts/trendChart/trendChart.styles.ts
+++ b/src/components/charts/trendChart/trendChart.styles.ts
@@ -7,7 +7,6 @@ import {
   global_disabled_color_200,
   global_FontFamily_sans_serif,
 } from '@patternfly/react-tokens';
-import React from 'react';
 
 export const chartStyles = {
   legend: {
@@ -64,11 +63,3 @@ export const chartStyles = {
     },
   },
 };
-
-export const styles = {
-  chartContainer: {
-    ':not(foo) svg': {
-      overflow: 'visible',
-    },
-  },
-} as { [className: string]: React.CSSProperties };

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -8,6 +8,7 @@ import {
   getInteractiveLegendItemStyles,
 } from '@patternfly/react-charts';
 import { default as ChartTheme } from 'components/charts/chartTheme';
+import { chartOverride } from 'components/charts/common/chart.styles';
 import {
   getCostRangeString,
   getDateRange,
@@ -19,7 +20,7 @@ import getDate from 'date-fns/get_date';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
 import { DomainTuple, VictoryStyleInterface } from 'victory';
-import { chartStyles, styles } from './trendChart.styles';
+import { chartStyles } from './trendChart.styles';
 
 interface TrendChartProps {
   adjustContainerHeight?: boolean;
@@ -312,8 +313,9 @@ class TrendChart extends React.Component<TrendChartProps, State> {
 
     return (
       <div
+        className={chartOverride}
         ref={this.containerRef}
-        style={{ ...styles.chartContainer, height: adjustedContainerHeight }}
+        style={{ height: adjustedContainerHeight }}
       >
         <div>{title}</div>
         <Chart

--- a/src/components/charts/usageChart/usageChart.styles.ts
+++ b/src/components/charts/usageChart/usageChart.styles.ts
@@ -8,9 +8,11 @@ import {
   global_FontFamily_sans_serif,
   global_spacer_lg,
 } from '@patternfly/react-tokens';
-import React from 'react';
 
 export const chartStyles = {
+  chartContainer: {
+    marginTop: global_spacer_lg.value,
+  },
   currentRequestData: {
     data: {
       fill: 'none',
@@ -92,12 +94,3 @@ export const chartStyles = {
     },
   },
 };
-
-export const styles = {
-  chartContainer: {
-    ':not(foo) svg': {
-      overflow: 'visible',
-    },
-    marginTop: global_spacer_lg.value,
-  },
-} as { [className: string]: React.CSSProperties };

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -8,6 +8,7 @@ import {
   getInteractiveLegendItemStyles,
 } from '@patternfly/react-charts';
 import { default as ChartTheme } from 'components/charts/chartTheme';
+import { chartOverride } from 'components/charts/common/chart.styles';
 import {
   getDateRange,
   getMaxValue,
@@ -20,7 +21,7 @@ import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
 import { DomainTuple, VictoryStyleInterface } from 'victory';
-import { chartStyles, styles } from './usageChart.styles';
+import { chartStyles } from './usageChart.styles';
 
 interface UsageChartProps {
   adjustContainerHeight?: boolean;
@@ -407,8 +408,9 @@ class UsageChart extends React.Component<UsageChartProps, State> {
 
     return (
       <div
+        className={chartOverride}
         ref={this.containerRef}
-        style={{ ...styles.chartContainer, height: adjustedContainerHeight }}
+        style={{ height: adjustedContainerHeight }}
       >
         <div>{title}</div>
         <Chart

--- a/src/components/reports/reportSummary/reportSummaryItem.styles.ts
+++ b/src/components/reports/reportSummary/reportSummaryItem.styles.ts
@@ -1,15 +1,8 @@
 import { global_spacer_md } from '@patternfly/react-tokens';
-import React from 'react';
+import { css } from 'emotion';
 
-export const styles = {
-  reportSummaryItem: {
-    ':not(:last-child)': {
-      marginBottom: global_spacer_md.value,
-    },
-  },
-  test: {
-    ':not(foo) svg': {
-      overflow: 'visible',
-    },
-  },
-} as { [className: string]: React.CSSProperties };
+export const reportSummaryItem = css`
+  :not(:last-child): {
+    marginbottom: ${global_spacer_md.value};
+  }
+`;

--- a/src/components/reports/reportSummary/reportSummaryItem.tsx
+++ b/src/components/reports/reportSummary/reportSummaryItem.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
 import { unitLookupKey } from 'utils/formatValue';
-import { styles } from './reportSummaryItem.styles';
+import { reportSummaryItem } from './reportSummaryItem.styles';
 
 interface ReportSummaryItemProps extends InjectedTranslateProps {
   formatValue: ValueFormatter;
@@ -35,7 +35,7 @@ const ReportSummaryItemBase: React.SFC<ReportSummaryItemProps> = ({
   });
 
   return (
-    <li style={styles.reportSummaryItem}>
+    <li className={reportSummaryItem}>
       <Progress
         label={percentLabel}
         value={percentVal}


### PR DESCRIPTION
Moved `:not` selectors from style to className props. This fixes and issue where the CSS `overflow` is not being overridden, which hides the chart legends.

This was intended to be merged with https://github.com/project-koku/koku-ui/pull/1418.

https://github.com/project-koku/koku-ui/issues/1417