### PR TITLE
Use paginated API request for header total cost

### DIFF
--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -393,8 +393,8 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     const error = providersError || reportError;
     const isLoading = providersFetchStatus === FetchStatus.inProgress;
     const noProviders =
-      providers !== undefined &&
-      providers.meta !== undefined &&
+      providers &&
+      providers.meta &&
       providers.meta.count === 0 &&
       providersFetchStatus === FetchStatus.complete;
 
@@ -403,6 +403,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
         <DetailsHeader
           groupBy={groupById}
           onGroupByClicked={this.handleGroupByClick}
+          report={report}
         />
         {Boolean(error) ? (
           <ErrorState error={error} />

--- a/src/pages/details/awsDetails/detailsHeader.tsx
+++ b/src/pages/details/awsDetails/detailsHeader.tsx
@@ -3,7 +3,7 @@ import { Providers, ProviderType } from 'api/providers';
 import { AwsQuery, getQuery } from 'api/queries/awsQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { AwsReport } from 'api/reports/awsReports';
-import { ReportPathsType, ReportType } from 'api/reports/report';
+import { ReportPathsType } from 'api/reports/report';
 import { AxiosError } from 'axios';
 import { GroupBy } from 'pages/details/components/groupBy/groupBy';
 import {
@@ -15,7 +15,6 @@ import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { awsProvidersQuery, providersSelectors } from 'store/providers';
-import { reportActions, reportSelectors } from 'store/reports';
 import {
   ComputedAwsReportItemsParams,
   getIdKeyForGroupBy,
@@ -27,6 +26,7 @@ import { styles } from './detailsHeader.styles';
 interface DetailsHeaderOwnProps {
   groupBy?: string;
   onGroupByClicked(value: string);
+  report: AwsReport;
 }
 
 interface DetailsHeaderStateProps {
@@ -34,18 +34,10 @@ interface DetailsHeaderStateProps {
   providers: Providers;
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
-  report: AwsReport;
-  reportError?: AxiosError;
-  reportFetchStatus: FetchStatus;
-}
-
-interface DetailsHeaderDispatchProps {
-  fetchReport?: typeof reportActions.fetchReport;
 }
 
 type DetailsHeaderProps = DetailsHeaderOwnProps &
   DetailsHeaderStateProps &
-  DetailsHeaderDispatchProps &
   InjectedTranslateProps;
 
 const baseQuery: AwsQuery = {
@@ -66,22 +58,9 @@ const groupByOptions: {
   { label: 'region', value: 'region' },
 ];
 
-const reportType = ReportType.cost;
 const reportPathsType = ReportPathsType.aws;
 
 class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
-  public componentDidMount() {
-    const { fetchReport, queryString } = this.props;
-    fetchReport(reportPathsType, reportType, queryString);
-  }
-
-  public componentDidUpdate(prevProps: DetailsHeaderProps) {
-    const { fetchReport, queryString } = this.props;
-    if (prevProps.queryString !== queryString) {
-      fetchReport(reportPathsType, reportType, queryString);
-    }
-  }
-
   public render() {
     const {
       groupBy,
@@ -89,12 +68,10 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       providers,
       providersError,
       report,
-      reportError,
       t,
     } = this.props;
     const showContent =
       report &&
-      !reportError &&
       !providersError &&
       providers &&
       providers.meta &&
@@ -151,18 +128,6 @@ const mapStateToProps = createMapStateToProps<
   DetailsHeaderStateProps
 >((state, props) => {
   const queryString = getQuery(baseQuery);
-  const report = reportSelectors.selectReport(state, reportType, queryString);
-  const reportError = reportSelectors.selectReportError(
-    state,
-    reportType,
-    queryString
-  );
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
-    state,
-    reportType,
-    queryString
-  );
-
   const providersQueryString = getProvidersQuery(awsProvidersQuery);
   const providers = providersSelectors.selectProviders(
     state,
@@ -185,18 +150,11 @@ const mapStateToProps = createMapStateToProps<
     providersError,
     providersFetchStatus,
     queryString,
-    report,
-    reportError,
-    reportFetchStatus,
   };
 });
 
-const mapDispatchToProps: DetailsHeaderDispatchProps = {
-  fetchReport: reportActions.fetchReport,
-};
-
 const DetailsHeader = translate()(
-  connect(mapStateToProps, mapDispatchToProps)(DetailsHeaderBase)
+  connect(mapStateToProps, {})(DetailsHeaderBase)
 );
 
 export { DetailsHeader, DetailsHeaderProps };

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -399,8 +399,8 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     const error = providersError || reportError;
     const isLoading = providersFetchStatus === FetchStatus.inProgress;
     const noProviders =
-      providers !== undefined &&
-      providers.meta !== undefined &&
+      providers &&
+      providers.meta &&
       providers.meta.count === 0 &&
       providersFetchStatus === FetchStatus.complete;
 
@@ -409,6 +409,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
         <DetailsHeader
           groupBy={groupById}
           onGroupByClicked={this.handleGroupByClick}
+          report={report}
         />
         {Boolean(error) ? (
           <ErrorState error={error} />

--- a/src/pages/details/azureDetails/detailsHeader.tsx
+++ b/src/pages/details/azureDetails/detailsHeader.tsx
@@ -3,7 +3,7 @@ import { Providers, ProviderType } from 'api/providers';
 import { AzureQuery, getQuery } from 'api/queries/azureQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { AzureReport } from 'api/reports/azureReports';
-import { ReportPathsType, ReportType } from 'api/reports/report';
+import { ReportPathsType } from 'api/reports/report';
 import { AxiosError } from 'axios';
 import { GroupBy } from 'pages/details/components/groupBy/groupBy';
 import {
@@ -15,7 +15,6 @@ import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { azureProvidersQuery, providersSelectors } from 'store/providers';
-import { reportActions, reportSelectors } from 'store/reports';
 import {
   ComputedAzureReportItemsParams,
   getIdKeyForGroupBy,
@@ -27,6 +26,7 @@ import { styles } from './detailsHeader.styles';
 interface DetailsHeaderOwnProps {
   groupBy?: string;
   onGroupByClicked(value: string);
+  report: AzureReport;
 }
 
 interface DetailsHeaderStateProps {
@@ -34,18 +34,10 @@ interface DetailsHeaderStateProps {
   providers: Providers;
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
-  report: AzureReport;
-  reportError?: AxiosError;
-  reportFetchStatus: FetchStatus;
-}
-
-interface DetailsHeaderDispatchProps {
-  fetchReport?: typeof reportActions.fetchReport;
 }
 
 type DetailsHeaderProps = DetailsHeaderOwnProps &
   DetailsHeaderStateProps &
-  DetailsHeaderDispatchProps &
   InjectedTranslateProps;
 
 const baseQuery: AzureQuery = {
@@ -66,22 +58,9 @@ const groupByOptions: {
   { label: 'resource_location', value: 'resource_location' },
 ];
 
-const reportType = ReportType.cost;
 const reportPathsType = ReportPathsType.azure;
 
 class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
-  public componentDidMount() {
-    const { fetchReport, queryString } = this.props;
-    fetchReport(reportPathsType, reportType, queryString);
-  }
-
-  public componentDidUpdate(prevProps: DetailsHeaderProps) {
-    const { fetchReport, queryString } = this.props;
-    if (prevProps.queryString !== queryString) {
-      fetchReport(reportPathsType, reportType, queryString);
-    }
-  }
-
   public render() {
     const {
       groupBy,
@@ -89,12 +68,10 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       providers,
       providersError,
       report,
-      reportError,
       t,
     } = this.props;
     const showContent =
       report &&
-      !reportError &&
       !providersError &&
       providers &&
       providers.meta &&
@@ -151,18 +128,6 @@ const mapStateToProps = createMapStateToProps<
   DetailsHeaderStateProps
 >((state, props) => {
   const queryString = getQuery(baseQuery);
-  const report = reportSelectors.selectReport(state, reportType, queryString);
-  const reportError = reportSelectors.selectReportError(
-    state,
-    reportType,
-    queryString
-  );
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
-    state,
-    reportType,
-    queryString
-  );
-
   const providersQueryString = getProvidersQuery(azureProvidersQuery);
   const providers = providersSelectors.selectProviders(
     state,
@@ -185,18 +150,11 @@ const mapStateToProps = createMapStateToProps<
     providersError,
     providersFetchStatus,
     queryString,
-    report,
-    reportError,
-    reportFetchStatus,
   };
 });
 
-const mapDispatchToProps: DetailsHeaderDispatchProps = {
-  fetchReport: reportActions.fetchReport,
-};
-
 const DetailsHeader = translate()(
-  connect(mapStateToProps, mapDispatchToProps)(DetailsHeaderBase)
+  connect(mapStateToProps, {})(DetailsHeaderBase)
 );
 
 export { DetailsHeader, DetailsHeaderProps };

--- a/src/pages/details/ocpCloudDetails/detailsHeader.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsHeader.tsx
@@ -4,7 +4,7 @@ import { Providers, ProviderType } from 'api/providers';
 import { getQuery, OcpCloudQuery } from 'api/queries/ocpCloudQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { OcpCloudReport } from 'api/reports/ocpCloudReports';
-import { ReportPathsType, ReportType } from 'api/reports/report';
+import { ReportPathsType } from 'api/reports/report';
 import { AxiosError } from 'axios';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import { GroupBy } from 'pages/details/components/groupBy/groupBy';
@@ -13,7 +13,6 @@ import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { ocpProvidersQuery, providersSelectors } from 'store/providers';
-import { reportActions, reportSelectors } from 'store/reports';
 import {
   ComputedOcpReportItemsParams,
   getIdKeyForGroupBy,
@@ -25,6 +24,7 @@ import { styles } from './detailsHeader.styles';
 interface DetailsHeaderOwnProps {
   groupBy?: string;
   onGroupByClicked(value: string);
+  report: OcpCloudReport;
 }
 
 interface DetailsHeaderStateProps {
@@ -32,13 +32,6 @@ interface DetailsHeaderStateProps {
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
   queryString: string;
-  report: OcpCloudReport;
-  reportError?: AxiosError;
-  reportFetchStatus: FetchStatus;
-}
-
-interface DetailsHeaderDispatchProps {
-  fetchReport?: typeof reportActions.fetchReport;
 }
 
 interface DetailsHeaderState {
@@ -47,7 +40,6 @@ interface DetailsHeaderState {
 
 type DetailsHeaderProps = DetailsHeaderOwnProps &
   DetailsHeaderStateProps &
-  DetailsHeaderDispatchProps &
   InjectedTranslateProps;
 
 const baseQuery: OcpCloudQuery = {
@@ -68,7 +60,6 @@ const groupByOptions: {
   { label: 'project', value: 'project' },
 ];
 
-const reportType = ReportType.cost;
 const reportPathsType = ReportPathsType.ocpCloud;
 
 class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
@@ -76,18 +67,6 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     showPopover: false,
   };
   public state: DetailsHeaderState = { ...this.defaultState };
-
-  public componentDidMount() {
-    const { fetchReport, queryString } = this.props;
-    fetchReport(reportPathsType, reportType, queryString);
-  }
-
-  public componentDidUpdate(prevProps: DetailsHeaderProps) {
-    const { fetchReport, queryString } = this.props;
-    if (prevProps.queryString !== queryString) {
-      fetchReport(reportPathsType, reportType, queryString);
-    }
-  }
 
   private handlePopoverClick = () => {
     this.setState({
@@ -102,12 +81,10 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       providers,
       providersError,
       report,
-      reportError,
       t,
     } = this.props;
     const showContent =
       report &&
-      !reportError &&
       !providersError &&
       providers &&
       providers.meta &&
@@ -202,18 +179,6 @@ const mapStateToProps = createMapStateToProps<
   DetailsHeaderStateProps
 >((state, props) => {
   const queryString = getQuery(baseQuery);
-  const report = reportSelectors.selectReport(state, reportType, queryString);
-  const reportError = reportSelectors.selectReportError(
-    state,
-    reportType,
-    queryString
-  );
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
-    state,
-    reportType,
-    queryString
-  );
-
   const providersQueryString = getProvidersQuery(ocpProvidersQuery);
   const providers = providersSelectors.selectProviders(
     state,
@@ -236,18 +201,11 @@ const mapStateToProps = createMapStateToProps<
     providersError,
     providersFetchStatus,
     queryString,
-    report,
-    reportError,
-    reportFetchStatus,
   };
 });
 
-const mapDispatchToProps: DetailsHeaderDispatchProps = {
-  fetchReport: reportActions.fetchReport,
-};
-
 const DetailsHeader = translate()(
-  connect(mapStateToProps, mapDispatchToProps)(DetailsHeaderBase)
+  connect(mapStateToProps, {})(DetailsHeaderBase)
 );
 
 export { DetailsHeader, DetailsHeaderProps };

--- a/src/pages/details/ocpCloudDetails/ocpCloudDetails.tsx
+++ b/src/pages/details/ocpCloudDetails/ocpCloudDetails.tsx
@@ -396,8 +396,8 @@ class OcpCloudDetails extends React.Component<OcpCloudDetailsProps> {
     const error = providersError || reportError;
     const isLoading = providersFetchStatus === FetchStatus.inProgress;
     const noProviders =
-      providers !== undefined &&
-      providers.meta !== undefined &&
+      providers &&
+      providers.meta &&
       providers.meta.count === 0 &&
       providersFetchStatus === FetchStatus.complete;
 
@@ -406,6 +406,7 @@ class OcpCloudDetails extends React.Component<OcpCloudDetailsProps> {
         <DetailsHeader
           groupBy={groupById}
           onGroupByClicked={this.handleGroupByClick}
+          report={report}
         />
         {Boolean(error) ? (
           <ErrorState error={error} />

--- a/src/pages/details/ocpDetails/detailsHeader.tsx
+++ b/src/pages/details/ocpDetails/detailsHeader.tsx
@@ -4,7 +4,7 @@ import { Providers, ProviderType } from 'api/providers';
 import { getQuery, OcpQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { OcpReport } from 'api/reports/ocpReports';
-import { ReportPathsType, ReportType } from 'api/reports/report';
+import { ReportPathsType } from 'api/reports/report';
 import { AxiosError } from 'axios';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import { GroupBy } from 'pages/details/components/groupBy/groupBy';
@@ -13,7 +13,6 @@ import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { ocpProvidersQuery, providersSelectors } from 'store/providers';
-import { reportActions, reportSelectors } from 'store/reports';
 import {
   ComputedOcpReportItemsParams,
   getIdKeyForGroupBy,
@@ -25,6 +24,7 @@ import { styles } from './detailsHeader.styles';
 interface DetailsHeaderOwnProps {
   groupBy?: string;
   onGroupByClicked(value: string);
+  report: OcpReport;
 }
 
 interface DetailsHeaderStateProps {
@@ -32,13 +32,6 @@ interface DetailsHeaderStateProps {
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
   queryString: string;
-  report: OcpReport;
-  reportError?: AxiosError;
-  reportFetchStatus: FetchStatus;
-}
-
-interface DetailsHeaderDispatchProps {
-  fetchReport?: typeof reportActions.fetchReport;
 }
 
 interface DetailsHeaderState {
@@ -47,7 +40,6 @@ interface DetailsHeaderState {
 
 type DetailsHeaderProps = DetailsHeaderOwnProps &
   DetailsHeaderStateProps &
-  DetailsHeaderDispatchProps &
   InjectedTranslateProps;
 
 const baseQuery: OcpQuery = {
@@ -68,7 +60,6 @@ const groupByOptions: {
   { label: 'project', value: 'project' },
 ];
 
-const reportType = ReportType.cost;
 const reportPathsType = ReportPathsType.ocp;
 
 class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
@@ -76,18 +67,6 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     showPopover: false,
   };
   public state: DetailsHeaderState = { ...this.defaultState };
-
-  public componentDidMount() {
-    const { fetchReport, queryString } = this.props;
-    fetchReport(reportPathsType, reportType, queryString);
-  }
-
-  public componentDidUpdate(prevProps: DetailsHeaderProps) {
-    const { fetchReport, queryString } = this.props;
-    if (prevProps.queryString !== queryString) {
-      fetchReport(reportPathsType, reportType, queryString);
-    }
-  }
 
   private handlePopoverClick = () => {
     this.setState({
@@ -102,12 +81,10 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       providers,
       providersError,
       report,
-      reportError,
       t,
     } = this.props;
     const showContent =
       report &&
-      !reportError &&
       !providersError &&
       providers &&
       providers.meta &&
@@ -218,18 +195,6 @@ const mapStateToProps = createMapStateToProps<
   DetailsHeaderStateProps
 >((state, props) => {
   const queryString = getQuery(baseQuery);
-  const report = reportSelectors.selectReport(state, reportType, queryString);
-  const reportError = reportSelectors.selectReportError(
-    state,
-    reportType,
-    queryString
-  );
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
-    state,
-    reportType,
-    queryString
-  );
-
   const providersQueryString = getProvidersQuery(ocpProvidersQuery);
   const providers = providersSelectors.selectProviders(
     state,
@@ -252,18 +217,11 @@ const mapStateToProps = createMapStateToProps<
     providersError,
     providersFetchStatus,
     queryString,
-    report,
-    reportError,
-    reportFetchStatus,
   };
 });
 
-const mapDispatchToProps: DetailsHeaderDispatchProps = {
-  fetchReport: reportActions.fetchReport,
-};
-
 const DetailsHeader = translate()(
-  connect(mapStateToProps, mapDispatchToProps)(DetailsHeaderBase)
+  connect(mapStateToProps, {})(DetailsHeaderBase)
 );
 
 export { DetailsHeader, DetailsHeaderProps };

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -395,8 +395,8 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     const error = providersError || reportError;
     const isLoading = providersFetchStatus === FetchStatus.inProgress;
     const noProviders =
-      providers !== undefined &&
-      providers.meta !== undefined &&
+      providers &&
+      providers.meta &&
       providers.meta.count === 0 &&
       providersFetchStatus === FetchStatus.complete;
 
@@ -405,6 +405,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
         <DetailsHeader
           groupBy={groupById}
           onGroupByClicked={this.handleGroupByClick}
+          report={report}
         />
         {Boolean(error) ? (
           <ErrorState error={error} />


### PR DESCRIPTION
This change ensures the details header component uses a paginated API request for total cost.

https://github.com/project-koku/koku-ui/issues/1373