### PR TITLE
Added redirect workaround for Insights Nav

### DIFF
--- a/src/__snapshots__/app.test.tsx.snap
+++ b/src/__snapshots__/app.test.tsx.snap
@@ -4,39 +4,7 @@ exports[`renders login if isLoggedIn is false 1`] = `
 <I18nProvider
   locale="en"
 >
-  <Component
-    childProps={
-      Object {
-        "awsProviders": null,
-        "awsProvidersFetchStatus": 0,
-        "awsProvidersQueryString": "",
-        "fetchProviders": [MockFunction] {
-          "calls": Array [
-            Array [
-              "aws",
-              "",
-            ],
-            Array [
-              "azure",
-              undefined,
-            ],
-            Array [
-              "ocp",
-              "",
-            ],
-          ],
-        },
-        "history": Object {
-          "listen": [MockFunction],
-          "push": [MockFunction],
-        },
-        "location": null,
-        "ocpProviders": null,
-        "ocpProvidersFetchStatus": 0,
-        "ocpProvidersQueryString": "",
-      }
-    }
-  />
+  <Routes />
 </I18nProvider>
 `;
 
@@ -44,38 +12,6 @@ exports[`renders page layout 1`] = `
 <I18nProvider
   locale="en"
 >
-  <Component
-    childProps={
-      Object {
-        "awsProviders": null,
-        "awsProvidersFetchStatus": 0,
-        "awsProvidersQueryString": "",
-        "fetchProviders": [MockFunction] {
-          "calls": Array [
-            Array [
-              "aws",
-              "",
-            ],
-            Array [
-              "azure",
-              undefined,
-            ],
-            Array [
-              "ocp",
-              "",
-            ],
-          ],
-        },
-        "history": Object {
-          "listen": [MockFunction],
-          "push": [MockFunction],
-        },
-        "location": null,
-        "ocpProviders": null,
-        "ocpProvidersFetchStatus": 0,
-        "ocpProvidersQueryString": "",
-      }
-    }
-  />
+  <Routes />
 </I18nProvider>
 `;

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -144,7 +144,7 @@ export class App extends React.Component<AppProps, AppState> {
   public render() {
     return (
       <I18nProvider locale={this.state.locale}>
-        <Routes childProps={this.props} />
+        <Routes />
       </I18nProvider>
     );
   }

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -490,9 +490,9 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
 
   private handleInsightsNavClick = () => {
     const { details } = this.props;
-    if (details.appNavPath) {
+    if (details.appNavId) {
       insights.chrome.appNavClick({
-        id: details.appNavPath,
+        id: details.appNavId,
         secondaryNav: true,
       });
     }

--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -186,6 +186,8 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
   };
 
   private getRouteForQuery(query: AwsQuery, reset: boolean = false) {
+    const { history } = this.props;
+
     // Reset pagination
     if (reset) {
       query.filter = {
@@ -193,7 +195,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
         offset: baseQuery.filter.offset,
       };
     }
-    return `/details/infrastructure/aws?${getQueryRoute(query)}`;
+    return `${history.location.pathname}?${getQueryRoute(query)}`;
   }
 
   private getTable = () => {

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -186,6 +186,8 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
   };
 
   private getRouteForQuery(query: AzureQuery, reset: boolean = false) {
+    const { history } = this.props;
+
     // Reset pagination
     if (reset) {
       query.filter = {
@@ -193,7 +195,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
         offset: baseQuery.filter.offset,
       };
     }
-    return `/details/infrastructure/azure?${getQueryRoute(query)}`;
+    return `${history.location.pathname}?${getQueryRoute(query)}`;
   }
 
   private getTable = () => {

--- a/src/pages/details/components/nav/tertiaryNav.tsx
+++ b/src/pages/details/components/nav/tertiaryNav.tsx
@@ -71,10 +71,18 @@ export class TertiaryNavBase extends React.Component<TertiaryNavProps> {
   // tslint:disable-next-line:no-empty
   public handleOnSelect = selectedItem => {
     const { history } = this.props;
+    const pathName = history.location.pathname.split('/');
+    pathName[pathName.length - 1] = undefined;
+
+    let prefix = pathName[0];
+    if (pathName[1]) {
+      prefix += `/${pathName[1]}`;
+    }
+
     if (selectedItem.itemId === TertiaryNavItem.aws) {
-      history.replace('/details/infrastructure/aws');
+      history.replace(`${prefix}/aws`);
     } else if (selectedItem.itemId === TertiaryNavItem.azure) {
-      history.replace('/details/infrastructure/azure');
+      history.replace(`${prefix}/azure`);
     }
   };
 

--- a/src/pages/details/ocpCloudDetails/ocpCloudDetails.tsx
+++ b/src/pages/details/ocpCloudDetails/ocpCloudDetails.tsx
@@ -189,6 +189,8 @@ class OcpCloudDetails extends React.Component<OcpCloudDetailsProps> {
   };
 
   private getRouteForQuery(query: OcpCloudQuery, reset: boolean = false) {
+    const { history } = this.props;
+
     // Reset pagination
     if (reset) {
       query.filter = {
@@ -196,7 +198,7 @@ class OcpCloudDetails extends React.Component<OcpCloudDetailsProps> {
         offset: baseQuery.filter.offset,
       };
     }
-    return `/ocp-cloud?${getQueryRoute(query)}`;
+    return `${history.location.pathname}?${getQueryRoute(query)}`;
   }
 
   private getTable = () => {

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -188,6 +188,8 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
   };
 
   private getRouteForQuery(query: OcpQuery, reset: boolean = false) {
+    const { history } = this.props;
+
     // Reset pagination
     if (reset) {
       query.filter = {
@@ -195,7 +197,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
         offset: baseQuery.filter.offset,
       };
     }
-    return `/details/ocp?${getQueryRoute(query)}`;
+    return `${history.location.pathname}?${getQueryRoute(query)}`;
   }
 
   private getTable = () => {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,112 +1,83 @@
-import some from 'lodash/some';
 import React from 'react';
 import { Redirect, Route, Switch } from 'react-router-dom';
 import { asyncComponent } from './utils/asyncComponent';
 
-/**
- * Aysnc imports of components
- *
- * https://webpack.js.org/guides/code-splitting/
- * https://reactjs.org/docs/code-splitting.html
- *
- * pros:
- *      1) code splitting
- *      2) can be used in server-side rendering
- * cons:
- *      1) nameing chunk names adds unnecessary docs to code,
- *         see the difference with DashboardMap and InventoryDeployments.
- *
- */
+const NotFound = asyncComponent(() =>
+  import(/* webpackChunkName: "notFound" */ './pages/notFound')
+);
 const AwsDetails = asyncComponent(() =>
   import(/* webpackChunkName: "aws" */ './pages/details/awsDetails')
 );
 const AzureDetails = asyncComponent(() =>
   import(/* webpackChunkName: "azure" */ './pages/details/azureDetails')
 );
-const CostModels = asyncComponent(() =>
-  import(
-    /* webpackChunkName: "costModels" */ './pages/costModels/costModelsDetails'
-  )
+const OcpDetails = asyncComponent(() =>
+  import(/* webpackChunkName: "ocp" */ './pages/details/ocpDetails')
 );
 const OcpCloudDetails = asyncComponent(() =>
   import(/* webpackChunkName: "ocpCloud" */ './pages/details/ocpCloudDetails')
 );
-const OcpDetails = asyncComponent(() =>
-  import(/* webpackChunkName: "ocp" */ './pages/details/ocpDetails')
-);
 const Overview = asyncComponent(() =>
   import(/* webpackChunkName: "overview" */ './pages/overview')
 );
+const CostModelsDetails = asyncComponent(() =>
+  import(
+    /* webpackChunkName: "costModels" */ './pages/costModels/costModelsDetails'
+  )
+);
 
-const paths = {
-  awsDetails: '/details/infrastructure/aws',
-  azureDetails: '/details/infrastructure/azure',
-  costModels: '/cost-models',
-  ocpCloudDetails: '/details/infrastructure/ocp-cloud',
-  ocpDetails: '/details/ocp',
-  overview: '/',
-};
-
-const InsightsRoute = ({ component: Component, rootClass, ...rest }) => {
-  const root = document.getElementById('root');
-  root.removeAttribute('class');
-  root.classList.add(`page__${rootClass}`, 'pf-c-page__main');
-  root.setAttribute('role', 'main');
-
-  return <Route {...rest} component={Component} exact />;
-};
-
-/**
- * the Switch component changes routes depending on the path.
- *
- * Route properties:
- *      exact - path must match exactly,
- *      path - https://prod.foo.redhat.com:1337/insights/advisor/rules
- *      component - component to be rendered when a route has been chosen.
+const routes = [
+  {
+    path: '/',
+    labelKey: 'navigation.overview',
+    component: Overview,
+    exact: true,
+  },
+  {
+    path: '/details/aws',
+    labelKey: 'navigation.aws_details',
+    component: AwsDetails,
+    exact: true,
+  },
+  {
+    path: '/details/azure',
+    labelKey: 'navigation.azure_details',
+    component: AzureDetails,
+    exact: true,
+  },
+  {
+    path: '/details/ocp',
+    labelKey: 'navigation.ocp_details',
+    component: OcpDetails,
+    exact: true,
+  },
+  {
+    path: '/details/ocp-cloud',
+    labelKey: 'navigation.ocp_cloud_details',
+    component: OcpCloudDetails,
+    exact: true,
+  },
+  {
+    path: '/cost-models',
+    labelKey: 'navigation.cost_models',
+    component: CostModelsDetails,
+    exact: true,
+  },
+];
+/*
+<Redirect from="/details/infrastructure" to="/details/aws" exact />
  */
-export const Routes = props => {
-  const path = props.childProps.location.pathname;
+const Routes = () => (
+  <Switch>
+    {routes.map(route => (
+      <Route key={route.path as any} {...route} />
+    ))}
+    <Redirect from="/aws" to="/details/aws" exact />
+    <Redirect from="/ocp" to="/details/ocp" exact />
 
-  return (
-    <Switch>
-      <Redirect from="/details/infrastructure" to={paths.awsDetails} exact />
-      <InsightsRoute
-        path={paths.awsDetails}
-        component={AwsDetails}
-        rootClass="awsdetails"
-      />
-      <InsightsRoute
-        path={paths.azureDetails}
-        component={AzureDetails}
-        rootClass="azuredetails"
-      />
-      <InsightsRoute
-        path={paths.costModels}
-        component={CostModels}
-        rootClass="costmodels"
-      />
-      <InsightsRoute
-        path={paths.ocpCloudDetails}
-        component={OcpCloudDetails}
-        rootClass="ocpclouddetails"
-      />
-      <InsightsRoute
-        path={paths.ocpDetails}
-        component={OcpDetails}
-        rootClass="ocpdetails"
-      />
-      <InsightsRoute
-        path={paths.overview}
-        component={Overview}
-        rootClass="overview"
-      />
+    <Redirect from="/infrastructure" to="/details/aws" exact />
+    <Route component={NotFound} />
+  </Switch>
+);
 
-      {/* Finally, catch all unmatched routes */}
-      <Route
-        render={() =>
-          some(paths, p => p === path) ? null : <Redirect to={paths.overview} />
-        }
-      />
-    </Switch>
-  );
-};
+export { Routes, routes };

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -59,13 +59,13 @@ export const costSummaryWidget: AwsDashboardWidget = {
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.cost,
   details: {
-    appNavPath: '/details/infrastructure/aws',
+    appNavId: 'aws',
     costKey: 'aws_dashboard.cumulative_cost_label',
     formatOptions: {
       fractionDigits: 2,
     },
     showHorizontal: true,
-    viewAllPath: '/details/infrastructure/aws',
+    viewAllPath: '/details/aws',
   },
   tabsFilter: {
     limit: 3,

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -18,13 +18,13 @@ export const costSummaryWidget: AzureDashboardWidget = {
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.cost,
   details: {
-    appNavPath: '/details/infrastructure/aws',
+    appNavId: 'aws',
     costKey: 'aws_dashboard.cumulative_cost_label',
     formatOptions: {
       fractionDigits: 2,
     },
     showHorizontal: true,
-    viewAllPath: '/details/infrastructure/azure',
+    viewAllPath: '/details/azure',
   },
   tabsFilter: {
     limit: 3,

--- a/src/store/dashboard/common/dashboardCommon.ts
+++ b/src/store/dashboard/common/dashboardCommon.ts
@@ -15,7 +15,7 @@ export interface DashboardWidget<T> {
   chartType?: DashboardChartType;
   currentTab?: T;
   details: {
-    appNavPath?: string; // Highlights Insights nav-item when view all link is clicked
+    appNavId?: string; // Highlights Insights nav-item when view all link is clicked
     costKey?: string; // i18n key
     formatOptions: ValueFormatOptions;
     labelKey?: string; // i18n key

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -15,7 +15,7 @@ export const costSummaryWidget: OcpDashboardWidget = {
   reportPathsType: ReportPathsType.ocp,
   reportType: ReportType.cost,
   details: {
-    appNavPath: '/details/ocp',
+    appNavId: 'ocp',
     costKey: 'ocp_dashboard.cumulative_cost_label',
     formatOptions: {
       fractionDigits: 2,


### PR DESCRIPTION
Implemented a workaround using redirects.

Attempted to flatten paths using `suppress_id:true` or `reload` in the main.yml of cloud-services-config. Forcing the path to be `/ocp` instead of `/details/ocp` also worked, but the Insights nav doesn't highlight when either property is used.