### PR TITLE
Restored redirects in favor of a cloud-services-config fix

### DIFF
--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -186,6 +186,8 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
   };
 
   private getRouteForQuery(query: AwsQuery, reset: boolean = false) {
+    const { history } = this.props;
+
     // Reset pagination
     if (reset) {
       query.filter = {
@@ -193,7 +195,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
         offset: baseQuery.filter.offset,
       };
     }
-    return `/details/aws?${getQueryRoute(query)}`;
+    return `${history.location.pathname}?${getQueryRoute(query)}`;
   }
 
   private getTable = () => {

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -186,6 +186,8 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
   };
 
   private getRouteForQuery(query: AzureQuery, reset: boolean = false) {
+    const { history } = this.props;
+
     // Reset pagination
     if (reset) {
       query.filter = {
@@ -193,7 +195,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
         offset: baseQuery.filter.offset,
       };
     }
-    return `/details/azure?${getQueryRoute(query)}`;
+    return `${history.location.pathname}?${getQueryRoute(query)}`;
   }
 
   private getTable = () => {

--- a/src/pages/details/ocpCloudDetails/ocpCloudDetails.tsx
+++ b/src/pages/details/ocpCloudDetails/ocpCloudDetails.tsx
@@ -189,6 +189,8 @@ class OcpCloudDetails extends React.Component<OcpCloudDetailsProps> {
   };
 
   private getRouteForQuery(query: OcpCloudQuery, reset: boolean = false) {
+    const { history } = this.props;
+
     // Reset pagination
     if (reset) {
       query.filter = {
@@ -196,7 +198,7 @@ class OcpCloudDetails extends React.Component<OcpCloudDetailsProps> {
         offset: baseQuery.filter.offset,
       };
     }
-    return `/details/ocp-cloud?${getQueryRoute(query)}`;
+    return `${history.location.pathname}?${getQueryRoute(query)}`;
   }
 
   private getTable = () => {

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -188,6 +188,8 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
   };
 
   private getRouteForQuery(query: OcpQuery, reset: boolean = false) {
+    const { history } = this.props;
+
     // Reset pagination
     if (reset) {
       query.filter = {
@@ -195,7 +197,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
         offset: baseQuery.filter.offset,
       };
     }
-    return `/details/ocp?${getQueryRoute(query)}`;
+    return `${history.location.pathname}?${getQueryRoute(query)}`;
   }
 
   private getTable = () => {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, Switch } from 'react-router-dom';
+import { Redirect, Route, Switch } from 'react-router-dom';
 import { asyncComponent } from './utils/asyncComponent';
 
 const NotFound = asyncComponent(() =>
@@ -34,12 +34,6 @@ const routes = [
     exact: true,
   },
   {
-    path: '/cost-models',
-    labelKey: 'navigation.cost_models',
-    component: CostModelsDetails,
-    exact: true,
-  },
-  {
     path: '/details/aws',
     labelKey: 'navigation.aws_details',
     component: AwsDetails,
@@ -63,40 +57,22 @@ const routes = [
     component: OcpCloudDetails,
     exact: true,
   },
-
-  /* Workaround for https://github.com/project-koku/koku-ui/issues/1389 */
   {
-    path: '/aws',
-    labelKey: 'navigation.aws_details',
-    component: AwsDetails,
-    exact: true,
-  },
-  {
-    path: '/azure',
-    labelKey: 'navigation.azure_details',
-    component: AzureDetails,
-    exact: true,
-  },
-  {
-    path: '/ocp',
-    labelKey: 'navigation.ocp_details',
-    component: OcpDetails,
-    exact: true,
-  },
-  {
-    path: '/ocp-cloud',
-    labelKey: 'navigation.ocp_cloud_details',
-    component: OcpCloudDetails,
+    path: '/cost-models',
+    labelKey: 'navigation.cost_models',
+    component: CostModelsDetails,
     exact: true,
   },
 ];
 
-// Redirects are written for production env
+/* Redirect workaround for https://github.com/project-koku/koku-ui/issues/1389 */
 const Routes = () => (
   <Switch>
     {routes.map(route => (
       <Route key={route.path as any} {...route} />
     ))}
+    <Route path="/aws" exact render={() => <Redirect to="/details/aws" />} />
+    <Route path="/ocp" exact render={() => <Redirect to="/details/ocp" />} />
     <Route component={NotFound} />
   </Switch>
 );


### PR DESCRIPTION
Restored redirects (cleaner solution) in favor of a cloud-services-config fix. That is, I removed "paths" from main.yml of cloud-services-config -- Insights was not looking for the correct app
