### PR TITLE
Update Infrastructure > OpenShift usage API

### DIFF
--- a/src/api/reports/ocpUsageReports.test.ts
+++ b/src/api/reports/ocpUsageReports.test.ts
@@ -7,7 +7,5 @@ import { runReport } from './ocpUsageReports';
 test('api run reports calls axios get', () => {
   const query = 'filter[resolution]=daily';
   runReport(ReportType.cost, query);
-  expect(axios.get).toBeCalledWith(
-    `reports/openshift/infrastructures/all/costs/?${query}`
-  );
+  expect(axios.get).toBeCalledWith(`reports/openshift/costs/?${query}`);
 });

--- a/src/api/reports/ocpUsageReports.ts
+++ b/src/api/reports/ocpUsageReports.ts
@@ -87,15 +87,10 @@ export interface OcpUsageReport extends Report {
 }
 
 export const ReportTypePaths: Partial<Record<ReportType, string>> = {
-  [ReportType.cost]: 'reports/openshift/infrastructures/all/costs/',
+  [ReportType.cost]: 'reports/openshift/costs/',
   [ReportType.cpu]: 'reports/openshift/compute/',
-  [ReportType.database]: 'reports/openshift/infrastructures/all/costs/',
-  [ReportType.instanceType]:
-    'reports/openshift/infrastructures/all/instance-types/',
   [ReportType.memory]: 'reports/openshift/memory/',
-  [ReportType.network]: 'reports/openshift/infrastructures/all/costs/',
-  [ReportType.storage]: 'reports/openshift/infrastructures/all/storage/',
-  [ReportType.tag]: 'tags/openshift/infrastructures/all/',
+  [ReportType.tag]: 'tags/openshift/',
   [ReportType.volume]: 'reports/openshift/volumes/',
 };
 

--- a/src/components/charts/common/chartUtils.ts
+++ b/src/components/charts/common/chartUtils.ts
@@ -28,10 +28,12 @@ export interface ChartDatum {
   y: number;
 }
 
+// The computed report cost or usage item
 export const enum ComputedReportItemType {
-  cost = 'cost',
-  supplementaryCost = 'supplementaryCost',
-  usage = 'usage',
+  cost = 'cost', // supplementary.cost.value
+  infrastructure = 'infrastructure', // infrastructure.usage.value
+  supplementary = 'supplementary', // supplementary.total.value
+  usage = 'usage', // usage.value
 }
 
 export const enum ChartType {
@@ -57,21 +59,26 @@ export function transformReport(
   } as any;
   const computedItems = getComputedReportItems(items);
   if (type === ChartType.daily) {
-    return computedItems.map(i => createDatum(i[reportItem], i, key));
+    return computedItems.map(i =>
+      createDatum(i[reportItem], i, key, reportItem)
+    );
   }
   if (type === ChartType.monthly) {
-    return computedItems.map(i => createDatum(i[reportItem], i, key));
+    return computedItems.map(i =>
+      createDatum(i[reportItem], i, key, reportItem)
+    );
   }
   return computedItems.reduce<ChartDatum[]>((acc, d) => {
     const prevValue = acc.length ? acc[acc.length - 1].y : 0;
-    return [...acc, createDatum(prevValue + d[reportItem], d, key)];
+    return [...acc, createDatum(prevValue + d[reportItem], d, key, reportItem)];
   }, []);
 }
 
 export function createDatum<T extends ComputedReportItem>(
   value: number,
   computedItem: T,
-  idKey = 'date'
+  idKey = 'date',
+  reportItem: string = 'cost'
 ): ChartDatum {
   const xVal = idKey === 'date' ? getDate(computedItem.id) : computedItem.label;
   const yVal = isFloat(value)
@@ -84,7 +91,7 @@ export function createDatum<T extends ComputedReportItem>(
     y: yVal,
     key: computedItem.id,
     name: computedItem.id,
-    units: computedItem.units,
+    units: computedItem.units[reportItem],
   };
 }
 

--- a/src/components/charts/historicalCostChart/__snapshots__/historicalCostChart.test.tsx.snap
+++ b/src/components/charts/historicalCostChart/__snapshots__/historicalCostChart.test.tsx.snap
@@ -5,7 +5,7 @@ Array [
   Object {
     "key": "12-15-17",
     "name": "12-15-17",
-    "units": "unit",
+    "units": "USD",
     "x": 15,
     "y": 0,
   },
@@ -17,7 +17,7 @@ Array [
   Object {
     "key": "1-15-18",
     "name": "1-15-18",
-    "units": "unit",
+    "units": "USD",
     "x": 15,
     "y": 0,
   },
@@ -29,7 +29,7 @@ Array [
   Object {
     "key": "12-15-17",
     "name": "12-15-17",
-    "units": "unit",
+    "units": undefined,
     "x": 15,
     "y": 0,
   },
@@ -41,7 +41,7 @@ Array [
   Object {
     "key": "1-15-18",
     "name": "1-15-18",
-    "units": "unit",
+    "units": undefined,
     "x": 15,
     "y": 0,
   },

--- a/src/components/charts/historicalUsageChart/__snapshots__/historicalUsageChart.test.tsx.snap
+++ b/src/components/charts/historicalUsageChart/__snapshots__/historicalUsageChart.test.tsx.snap
@@ -29,7 +29,7 @@ Array [
   Object {
     "key": "1-15-18",
     "name": "1-15-18",
-    "units": "unit",
+    "units": undefined,
     "x": 15,
     "y": 0,
   },
@@ -41,7 +41,7 @@ Array [
   Object {
     "key": "12-15-17",
     "name": "12-15-17",
-    "units": "unit",
+    "units": undefined,
     "x": 15,
     "y": 0,
   },

--- a/src/pages/details/components/summary/summaryModalView.tsx
+++ b/src/pages/details/components/summary/summaryModalView.tsx
@@ -84,7 +84,7 @@ class SummaryModalViewBase extends React.Component<SummaryModalViewProps> {
                   formatValue={formatValue}
                   label={_item.label ? _item.label.toString() : ''}
                   totalValue={report.meta.total.cost.total.value}
-                  units={_item.units}
+                  units={report.meta.total.cost.total.units}
                   value={_item.cost}
                 />
               ))

--- a/src/pages/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/details/ocpDetails/detailsTable.tsx
@@ -267,10 +267,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
     return (
       <>
-        {formatCurrency(item.supplementaryCost)}
+        {formatCurrency(item.supplementary)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
-            value: ((item.supplementaryCost / total) * 100).toFixed(2),
+            value: ((item.supplementary / total) * 100).toFixed(2),
           })}
         </div>
       </>
@@ -307,10 +307,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
     return (
       <>
-        {formatCurrency(item.infrastructureCost)}
+        {formatCurrency(item.infrastructure)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
-            value: ((item.infrastructureCost / total) * 100).toFixed(2),
+            value: ((item.infrastructure / total) * 100).toFixed(2),
           })}
         </div>
       </>

--- a/src/pages/details/ocpDetails/summary.tsx
+++ b/src/pages/details/ocpDetails/summary.tsx
@@ -97,7 +97,7 @@ class SummaryBase extends React.Component<SummaryProps> {
                   formatValue={formatValue}
                   label={reportItem.label.toString()}
                   totalValue={report.meta.total.cost.total.value}
-                  units={reportItem.units}
+                  units={report.meta.total.cost.total.units}
                   value={reportItem.cost}
                 />
               ))

--- a/src/store/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidgets.ts
+++ b/src/store/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidgets.ts
@@ -25,7 +25,7 @@ export const costSummaryWidget: OcpSupplementaryDashboardWidget = {
     showHorizontal: true,
   },
   trend: {
-    computedReportItem: ComputedReportItemType.supplementaryCost,
+    computedReportItem: ComputedReportItemType.supplementary,
     formatOptions: {},
     titleKey: 'ocp_supplementary_dashboard.cost_trend_title',
     type: ChartType.rolling,

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -11,12 +11,16 @@ export interface ComputedReportItem {
   deltaPercent: number;
   deltaValue: number;
   id: string | number;
-  infrastructureCost: number;
+  infrastructure: number;
   label: string | number;
   limit?: number;
   request?: number;
-  supplementaryCost: number;
-  units?: string;
+  supplementary: number;
+  units?: {
+    cost: string;
+    supplementary?: string;
+    usage?: string;
+  };
   usage?: number;
 }
 
@@ -78,13 +82,13 @@ export function getUnsortedComputedReportItems<
         const capacity = value.capacity ? value.capacity.value : 0;
         const cost =
           value.cost && value.cost.total ? value.cost.total.value : 0;
-        const supplementaryCost =
+        const supplementary =
           value.supplementary && value.supplementary.total
             ? value.supplementary.total.value
             : 0;
-        const infrastructureCost =
-          value.infrastructure && value.infrastructure.total
-            ? value.infrastructure.total.value
+        const infrastructure =
+          value.infrastructure && value.infrastructure.usage
+            ? value.infrastructure.usage.value
             : 0;
         // Ensure unique IDs -- https://github.com/project-koku/koku-ui/issues/706
         const idSuffix =
@@ -107,11 +111,14 @@ export function getUnsortedComputedReportItems<
         const limit = value.limit ? value.limit.value : 0;
         const request = value.request ? value.request.value : 0;
         const usage = value.usage ? value.usage.value : 0;
-        const units = value.usage
-          ? value.usage.units
-          : value.cost && value.cost.total
-          ? value.cost.total.units
-          : 'USD';
+        const units = {
+          cost: value.cost && value.cost.total ? value.cost.total.units : 'USD',
+          ...(value.supplementary &&
+            value.supplementary.total && {
+              supplementaryCost: value.supplementary.total.units,
+            }),
+          ...(value.usage && { usage: value.usage.units }),
+        };
         if (!itemMap.get(id)) {
           itemMap.set(id, {
             capacity,
@@ -120,9 +127,9 @@ export function getUnsortedComputedReportItems<
             cost,
             deltaPercent: value.delta_percent,
             deltaValue: value.delta_value,
-            supplementaryCost,
+            supplementary,
             id,
-            infrastructureCost,
+            infrastructure,
             label,
             limit,
             request,
@@ -135,10 +142,8 @@ export function getUnsortedComputedReportItems<
           ...itemMap.get(id),
           capacity: itemMap.get(id).capacity + capacity,
           cost: itemMap.get(id).cost + cost,
-          supplementaryCost:
-            itemMap.get(id).supplementaryCost + supplementaryCost,
-          infrastructureCost:
-            itemMap.get(id).infrastructureCost + infrastructureCost,
+          supplementary: itemMap.get(id).supplementary + supplementary,
+          infrastructure: itemMap.get(id).infrastructure + infrastructure,
           limit: itemMap.get(id).limit + limit,
           request: itemMap.get(id).request + request,
           usage: itemMap.get(id).usage + usage,


### PR DESCRIPTION
The "Infrastructure > OpenShift usage" overview page should use the reports/openshift/costs API. In addition, we should use the infrastructure.usage property for these costs.

https://github.com/project-koku/koku-ui/issues/1446