### PR TITLE
Add reportPathsType to report ID

### DIFF
--- a/src/pages/dashboard/awsCloudDashboard/awsCloudDashboardWidget.tsx
+++ b/src/pages/dashboard/awsCloudDashboard/awsCloudDashboardWidget.tsx
@@ -51,26 +51,31 @@ const mapStateToProps = createMapStateToProps<
     tabsQuery: queries.tabs,
     currentReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.current
     ),
     currentReportFetchStatus: reportSelectors.selectReportFetchStatus(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.current
     ),
     previousReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.previous
     ),
     tabsReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.tabs
     ),
     tabsReportFetchStatus: reportSelectors.selectReportFetchStatus(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.tabs
     ),

--- a/src/pages/dashboard/awsDashboard/awsDashboardWidget.tsx
+++ b/src/pages/dashboard/awsDashboard/awsDashboardWidget.tsx
@@ -48,26 +48,31 @@ const mapStateToProps = createMapStateToProps<
     tabsQuery: queries.tabs,
     currentReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.current
     ),
     currentReportFetchStatus: reportSelectors.selectReportFetchStatus(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.current
     ),
     previousReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.previous
     ),
     tabsReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.tabs
     ),
     tabsReportFetchStatus: reportSelectors.selectReportFetchStatus(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.tabs
     ),

--- a/src/pages/dashboard/azureCloudDashboard/azureCloudDashboardWidget.tsx
+++ b/src/pages/dashboard/azureCloudDashboard/azureCloudDashboardWidget.tsx
@@ -51,26 +51,31 @@ const mapStateToProps = createMapStateToProps<
     tabsQuery: queries.tabs,
     currentReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.current
     ),
     currentReportFetchStatus: reportSelectors.selectReportFetchStatus(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.current
     ),
     previousReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.previous
     ),
     tabsReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.tabs
     ),
     tabsReportFetchStatus: reportSelectors.selectReportFetchStatus(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.tabs
     ),

--- a/src/pages/dashboard/azureDashboard/azureDashboardWidget.tsx
+++ b/src/pages/dashboard/azureDashboard/azureDashboardWidget.tsx
@@ -48,26 +48,31 @@ const mapStateToProps = createMapStateToProps<
     tabsQuery: queries.tabs,
     currentReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.current
     ),
     currentReportFetchStatus: reportSelectors.selectReportFetchStatus(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.current
     ),
     previousReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.previous
     ),
     tabsReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.tabs
     ),
     tabsReportFetchStatus: reportSelectors.selectReportFetchStatus(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.tabs
     ),

--- a/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboardWidget.tsx
@@ -49,26 +49,31 @@ const mapStateToProps = createMapStateToProps<
     tabsQuery: queries.tabs,
     currentReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.current
     ),
     currentReportFetchStatus: reportSelectors.selectReportFetchStatus(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.current
     ),
     previousReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.previous
     ),
     tabsReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.tabs
     ),
     tabsReportFetchStatus: reportSelectors.selectReportFetchStatus(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.tabs
     ),

--- a/src/pages/dashboard/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpDashboard/ocpDashboardWidget.tsx
@@ -49,26 +49,31 @@ const mapStateToProps = createMapStateToProps<
     tabsQuery: queries.tabs,
     currentReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.current
     ),
     currentReportFetchStatus: reportSelectors.selectReportFetchStatus(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.current
     ),
     previousReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.previous
     ),
     tabsReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.tabs
     ),
     tabsReportFetchStatus: reportSelectors.selectReportFetchStatus(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.tabs
     ),

--- a/src/pages/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidget.tsx
@@ -55,26 +55,31 @@ const mapStateToProps = createMapStateToProps<
     tabsQuery: queries.tabs,
     currentReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.current
     ),
     currentReportFetchStatus: reportSelectors.selectReportFetchStatus(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.current
     ),
     previousReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.previous
     ),
     tabsReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.tabs
     ),
     tabsReportFetchStatus: reportSelectors.selectReportFetchStatus(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.tabs
     ),

--- a/src/pages/dashboard/ocpUsageDashboard/ocpUsageDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpUsageDashboard/ocpUsageDashboardWidget.tsx
@@ -49,26 +49,31 @@ const mapStateToProps = createMapStateToProps<
     tabsQuery: queries.tabs,
     currentReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.current
     ),
     currentReportFetchStatus: reportSelectors.selectReportFetchStatus(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.current
     ),
     previousReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.previous
     ),
     tabsReport: reportSelectors.selectReport(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.tabs
     ),
     tabsReportFetchStatus: reportSelectors.selectReportFetchStatus(
       state,
+      widget.reportPathsType,
       widget.reportType,
       queries.tabs
     ),

--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -444,14 +444,21 @@ const mapStateToProps = createMapStateToProps<
     order_by: queryFromRoute.order_by || baseQuery.order_by,
   };
   const queryString = getQuery(query);
-  const report = reportSelectors.selectReport(state, reportType, queryString);
+  const report = reportSelectors.selectReport(
+    state,
+    reportPathsType,
+    reportType,
+    queryString
+  );
   const reportError = reportSelectors.selectReportError(
     state,
+    reportPathsType,
     reportType,
     queryString
   );
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     reportType,
     queryString
   );

--- a/src/pages/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/details/awsDetails/detailsToolbar.tsx
@@ -105,9 +105,15 @@ const mapStateToProps = createMapStateToProps<
       time_scope_value: -1,
     },
   });
-  const report = reportSelectors.selectReport(state, reportType, queryString);
+  const report = reportSelectors.selectReport(
+    state,
+    reportPathsType,
+    reportType,
+    queryString
+  );
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     reportType,
     queryString
   );

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -450,14 +450,21 @@ const mapStateToProps = createMapStateToProps<
     order_by: queryFromRoute.order_by || baseQuery.order_by,
   };
   const queryString = getQuery(query);
-  const report = reportSelectors.selectReport(state, reportType, queryString);
+  const report = reportSelectors.selectReport(
+    state,
+    reportPathsType,
+    reportType,
+    queryString
+  );
   const reportError = reportSelectors.selectReportError(
     state,
+    reportPathsType,
     reportType,
     queryString
   );
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     reportType,
     queryString
   );

--- a/src/pages/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/details/azureDetails/detailsToolbar.tsx
@@ -111,9 +111,15 @@ const mapStateToProps = createMapStateToProps<
       time_scope_value: -1,
     },
   });
-  const report = reportSelectors.selectReport(state, reportType, queryString);
+  const report = reportSelectors.selectReport(
+    state,
+    reportPathsType,
+    reportType,
+    queryString
+  );
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     reportType,
     queryString
   );

--- a/src/pages/details/components/bulletChart/bulletChart.tsx
+++ b/src/pages/details/components/bulletChart/bulletChart.tsx
@@ -59,7 +59,6 @@ type BulletChartProps = BulletChartOwnProps &
 
 const cpuReportType = ReportType.cpu;
 const memoryReportType = ReportType.memory;
-const reportPathsType = ReportPathsType.ocp;
 
 class BulletChartBase extends React.Component<BulletChartProps> {
   private containerRef = React.createRef<HTMLDivElement>();
@@ -68,7 +67,7 @@ class BulletChartBase extends React.Component<BulletChartProps> {
   };
 
   public componentDidMount() {
-    const { fetchReport, queryString } = this.props;
+    const { fetchReport, queryString, reportPathsType } = this.props;
     fetchReport(reportPathsType, cpuReportType, queryString);
     fetchReport(reportPathsType, memoryReportType, queryString);
 
@@ -77,7 +76,7 @@ class BulletChartBase extends React.Component<BulletChartProps> {
   }
 
   public componentDidUpdate(prevProps: BulletChartProps) {
-    const { fetchReport, queryString } = this.props;
+    const { fetchReport, queryString, reportPathsType } = this.props;
     if (prevProps.queryString !== this.props.queryString) {
       fetchReport(reportPathsType, cpuReportType, queryString);
       fetchReport(reportPathsType, memoryReportType, queryString);
@@ -584,7 +583,7 @@ class BulletChartBase extends React.Component<BulletChartProps> {
 const mapStateToProps = createMapStateToProps<
   BulletChartOwnProps,
   BulletChartStateProps
->((state, { groupBy, item }) => {
+>((state, { groupBy, item, reportPathsType }) => {
   const query: Query = {
     filter: {
       time_scope_units: 'month',
@@ -599,21 +598,25 @@ const mapStateToProps = createMapStateToProps<
   const queryString = getQuery(query);
   const cpuReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     cpuReportType,
     queryString
   );
   const cpuReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     cpuReportType,
     queryString
   );
   const memoryReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     memoryReportType,
     queryString
   );
   const memoryReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     memoryReportType,
     queryString
   );

--- a/src/pages/details/components/groupBy/groupBy.tsx
+++ b/src/pages/details/components/groupBy/groupBy.tsx
@@ -193,7 +193,7 @@ class GroupByBase extends React.Component<GroupByProps> {
 const mapStateToProps = createMapStateToProps<
   GroupByOwnProps,
   GroupByStateProps
->(state => {
+>((state, { reportPathsType }) => {
   const queryString = getQuery({
     filter: {
       resolution: 'monthly',
@@ -201,9 +201,15 @@ const mapStateToProps = createMapStateToProps<
       time_scope_value: -1,
     },
   });
-  const report = reportSelectors.selectReport(state, reportType, queryString);
+  const report = reportSelectors.selectReport(
+    state,
+    reportPathsType,
+    reportType,
+    queryString
+  );
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     reportType,
     queryString
   );

--- a/src/pages/details/components/historicalChart/historicalChart.tsx
+++ b/src/pages/details/components/historicalChart/historicalChart.tsx
@@ -235,35 +235,41 @@ class HistoricalChartBase extends React.Component<HistoricalChartProps> {
 const mapStateToProps = createMapStateToProps<
   HistoricalChartOwnProps,
   HistoricalChartStateProps
->((state, { currentQueryString, previousQueryString }) => {
+>((state, { currentQueryString, previousQueryString, reportPathsType }) => {
   // Current report
   const currentCostReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     costReportType,
     currentQueryString
   );
   const currentCostReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     costReportType,
     currentQueryString
   );
   const currentInstanceReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     instanceReportType,
     currentQueryString
   );
   const currentInstanceReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     instanceReportType,
     currentQueryString
   );
   const currentStorageReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     storageReportType,
     currentQueryString
   );
   const currentStorageReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     storageReportType,
     currentQueryString
   );
@@ -271,31 +277,37 @@ const mapStateToProps = createMapStateToProps<
   // Previous report
   const previousCostReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     costReportType,
     previousQueryString
   );
   const previousCostReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     costReportType,
     previousQueryString
   );
   const previousInstanceReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     instanceReportType,
     previousQueryString
   );
   const previousInstanceReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     instanceReportType,
     previousQueryString
   );
   const previousStorageReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     storageReportType,
     previousQueryString
   );
   const previousStorageReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     storageReportType,
     previousQueryString
   );

--- a/src/pages/details/components/summary/summaryModalView.tsx
+++ b/src/pages/details/components/summary/summaryModalView.tsx
@@ -99,7 +99,7 @@ class SummaryModalViewBase extends React.Component<SummaryModalViewProps> {
 const mapStateToProps = createMapStateToProps<
   SummaryModalViewOwnProps,
   SummaryModalViewStateProps
->((state, { groupBy, item, parentGroupBy }) => {
+>((state, { groupBy, item, parentGroupBy, reportPathsType }) => {
   const query: Query = {
     filter: {
       time_scope_units: 'month',
@@ -110,9 +110,15 @@ const mapStateToProps = createMapStateToProps<
     group_by: { [groupBy]: '*' },
   };
   const queryString = getQuery(query);
-  const report = reportSelectors.selectReport(state, reportType, queryString);
+  const report = reportSelectors.selectReport(
+    state,
+    reportPathsType,
+    reportType,
+    queryString
+  );
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     reportType,
     queryString
   );

--- a/src/pages/details/components/summary/summaryView.tsx
+++ b/src/pages/details/components/summary/summaryView.tsx
@@ -95,7 +95,11 @@ class SummaryViewBase extends React.Component<SummaryViewProps> {
             ? report.meta.total.cost.total.value
             : report.meta.total.usage.value
         }
-        units={reportItem.units}
+        units={
+          reportType === ReportType.cost
+            ? report.meta.total.cost.total.units
+            : report.meta.total.usage.units
+        }
         value={
           reportType === ReportType.cost ? reportItem.cost : reportItem.usage
         }
@@ -187,7 +191,7 @@ class SummaryViewBase extends React.Component<SummaryViewProps> {
 const mapStateToProps = createMapStateToProps<
   SummaryViewOwnProps,
   SummaryViewStateProps
->((state, { groupBy, item, parentGroupBy }) => {
+>((state, { groupBy, item, parentGroupBy, reportPathsType }) => {
   const query: Query = {
     filter: {
       limit: 3,
@@ -199,9 +203,15 @@ const mapStateToProps = createMapStateToProps<
     group_by: { [groupBy]: '*' },
   };
   const queryString = getQuery(query);
-  const report = reportSelectors.selectReport(state, reportType, queryString);
+  const report = reportSelectors.selectReport(
+    state,
+    reportPathsType,
+    reportType,
+    queryString
+  );
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     reportType,
     queryString
   );

--- a/src/pages/details/components/tag/tag.tsx
+++ b/src/pages/details/components/tag/tag.tsx
@@ -147,7 +147,7 @@ class TagBase extends React.Component<TagProps> {
 }
 
 const mapStateToProps = createMapStateToProps<TagOwnProps, TagStateProps>(
-  (state, { account }) => {
+  (state, { account, reportPathsType }) => {
     const queryString = getQuery({
       filter: {
         account,
@@ -156,9 +156,15 @@ const mapStateToProps = createMapStateToProps<TagOwnProps, TagStateProps>(
         time_scope_value: -1,
       },
     });
-    const report = reportSelectors.selectReport(state, reportType, queryString);
+    const report = reportSelectors.selectReport(
+      state,
+      reportPathsType,
+      reportType,
+      queryString
+    );
     const reportFetchStatus = reportSelectors.selectReportFetchStatus(
       state,
+      reportPathsType,
       reportType,
       queryString
     );

--- a/src/pages/details/components/tag/tagView.tsx
+++ b/src/pages/details/components/tag/tagView.tsx
@@ -71,7 +71,7 @@ class TagViewBase<T extends ReportPathsType> extends React.Component<
 const mapStateToProps = createMapStateToProps<
   TagViewOwnProps,
   TagViewStateProps
->((state, { account }) => {
+>((state, { account, reportPathsType }) => {
   const queryString = getQuery({
     filter: {
       account,
@@ -80,9 +80,15 @@ const mapStateToProps = createMapStateToProps<
       time_scope_value: -1,
     },
   });
-  const report = reportSelectors.selectReport(state, reportType, queryString);
+  const report = reportSelectors.selectReport(
+    state,
+    reportPathsType,
+    reportType,
+    queryString
+  );
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     reportType,
     queryString
   );

--- a/src/pages/details/ocpCloudDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsToolbar.tsx
@@ -105,9 +105,15 @@ const mapStateToProps = createMapStateToProps<
       time_scope_value: -1,
     },
   });
-  const report = reportSelectors.selectReport(state, reportType, queryString);
+  const report = reportSelectors.selectReport(
+    state,
+    reportPathsType,
+    reportType,
+    queryString
+  );
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     reportType,
     queryString
   );

--- a/src/pages/details/ocpCloudDetails/historicalChart.tsx
+++ b/src/pages/details/ocpCloudDetails/historicalChart.tsx
@@ -306,31 +306,37 @@ const mapStateToProps = createMapStateToProps<
   // Current report
   const currentCostReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     costReportType,
     currentQueryString
   );
   const currentCostReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     costReportType,
     currentQueryString
   );
   const currentCpuReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     cpuReportType,
     currentQueryString
   );
   const currentCpuReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     cpuReportType,
     currentQueryString
   );
   const currentMemoryReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     memoryReportType,
     currentQueryString
   );
   const currentMemoryReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     memoryReportType,
     currentQueryString
   );
@@ -338,31 +344,37 @@ const mapStateToProps = createMapStateToProps<
   // Previous report
   const previousCostReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     costReportType,
     previousQueryString
   );
   const previousCostReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     costReportType,
     previousQueryString
   );
   const previousCpuReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     cpuReportType,
     previousQueryString
   );
   const previousCpuReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     cpuReportType,
     previousQueryString
   );
   const previousMemoryReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     memoryReportType,
     previousQueryString
   );
   const previousMemoryReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     memoryReportType,
     previousQueryString
   );

--- a/src/pages/details/ocpCloudDetails/ocpCloudDetails.tsx
+++ b/src/pages/details/ocpCloudDetails/ocpCloudDetails.tsx
@@ -447,14 +447,21 @@ const mapStateToProps = createMapStateToProps<
     order_by: queryFromRoute.order_by || baseQuery.order_by,
   };
   const queryString = getQuery(query);
-  const report = reportSelectors.selectReport(state, reportType, queryString);
+  const report = reportSelectors.selectReport(
+    state,
+    reportPathsType,
+    reportType,
+    queryString
+  );
   const reportError = reportSelectors.selectReportError(
     state,
+    reportPathsType,
     reportType,
     queryString
   );
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     reportType,
     queryString
   );

--- a/src/pages/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpDetails/detailsToolbar.tsx
@@ -105,9 +105,15 @@ const mapStateToProps = createMapStateToProps<
       time_scope_value: -1,
     },
   });
-  const report = reportSelectors.selectReport(state, reportType, queryString);
+  const report = reportSelectors.selectReport(
+    state,
+    reportPathsType,
+    reportType,
+    queryString
+  );
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     reportType,
     queryString
   );

--- a/src/pages/details/ocpDetails/historicalChart.tsx
+++ b/src/pages/details/ocpDetails/historicalChart.tsx
@@ -320,31 +320,37 @@ const mapStateToProps = createMapStateToProps<
   // Current report
   const currentCostReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     costReportType,
     currentQueryString
   );
   const currentCostReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     costReportType,
     currentQueryString
   );
   const currentCpuReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     cpuReportType,
     currentQueryString
   );
   const currentCpuReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     cpuReportType,
     currentQueryString
   );
   const currentMemoryReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     memoryReportType,
     currentQueryString
   );
   const currentMemoryReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     memoryReportType,
     currentQueryString
   );
@@ -352,31 +358,37 @@ const mapStateToProps = createMapStateToProps<
   // Previous report
   const previousCostReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     costReportType,
     previousQueryString
   );
   const previousCostReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     costReportType,
     previousQueryString
   );
   const previousCpuReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     cpuReportType,
     previousQueryString
   );
   const previousCpuReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     cpuReportType,
     previousQueryString
   );
   const previousMemoryReport = reportSelectors.selectReport(
     state,
+    reportPathsType,
     memoryReportType,
     previousQueryString
   );
   const previousMemoryReportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     memoryReportType,
     previousQueryString
   );

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -446,14 +446,21 @@ const mapStateToProps = createMapStateToProps<
     order_by: queryFromRoute.order_by || baseQuery.order_by,
   };
   const queryString = getQuery(query);
-  const report = reportSelectors.selectReport(state, reportType, queryString);
+  const report = reportSelectors.selectReport(
+    state,
+    reportPathsType,
+    reportType,
+    queryString
+  );
   const reportError = reportSelectors.selectReportError(
     state,
+    reportPathsType,
     reportType,
     queryString
   );
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     reportType,
     queryString
   );

--- a/src/pages/details/ocpDetails/summary.tsx
+++ b/src/pages/details/ocpDetails/summary.tsx
@@ -192,9 +192,15 @@ const mapStateToProps = createMapStateToProps<
     group_by: { project: '*' },
   };
   const queryString = getQuery(query);
-  const report = reportSelectors.selectReport(state, reportType, queryString);
+  const report = reportSelectors.selectReport(
+    state,
+    reportPathsType,
+    reportType,
+    queryString
+  );
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(
     state,
+    reportPathsType,
     reportType,
     queryString
   );

--- a/src/store/dashboard/ocpUsageDashboard/ocpUsageDashboardWidgets.ts
+++ b/src/store/dashboard/ocpUsageDashboard/ocpUsageDashboardWidgets.ts
@@ -15,7 +15,7 @@ const getId = () => currrentId++;
 export const costSummaryWidget: OcpUsageDashboardWidget = {
   id: getId(),
   titleKey: 'ocp_usage_dashboard.cost_title',
-  reportPathsType: ReportPathsType.ocpCloud,
+  reportPathsType: ReportPathsType.ocpUsage,
   reportType: ReportType.cost,
   details: {
     costKey: 'ocp_usage_dashboard.cumulative_cost_label',
@@ -28,7 +28,7 @@ export const costSummaryWidget: OcpUsageDashboardWidget = {
     limit: 3,
   },
   trend: {
-    computedReportItem: ComputedReportItemType.cost,
+    computedReportItem: ComputedReportItemType.infrastructure,
     formatOptions: {},
     titleKey: 'ocp_usage_dashboard.cost_trend_title',
     type: ChartType.rolling,
@@ -44,7 +44,7 @@ export const costSummaryWidget: OcpUsageDashboardWidget = {
 export const cpuWidget: OcpUsageDashboardWidget = {
   id: getId(),
   titleKey: 'ocp_usage_dashboard.cpu_title',
-  reportPathsType: ReportPathsType.ocpCloud,
+  reportPathsType: ReportPathsType.ocpUsage,
   reportType: ReportType.cpu,
   details: {
     formatOptions: {
@@ -73,7 +73,7 @@ export const cpuWidget: OcpUsageDashboardWidget = {
 export const memoryWidget: OcpUsageDashboardWidget = {
   id: getId(),
   titleKey: 'ocp_usage_dashboard.memory_title',
-  reportPathsType: ReportPathsType.ocpCloud,
+  reportPathsType: ReportPathsType.ocpUsage,
   reportType: ReportType.memory,
   details: {
     formatOptions: {
@@ -104,7 +104,7 @@ export const memoryWidget: OcpUsageDashboardWidget = {
 export const volumeWidget: OcpUsageDashboardWidget = {
   id: getId(),
   titleKey: 'ocp_usage_dashboard.volume_title',
-  reportPathsType: ReportPathsType.ocpCloud,
+  reportPathsType: ReportPathsType.ocpUsage,
   reportType: ReportType.volume,
   details: {
     formatOptions: {

--- a/src/store/reports/report.test.ts
+++ b/src/store/reports/report.test.ts
@@ -41,19 +41,34 @@ test('fetch report success', async () => {
   store.dispatch(actions.fetchReport(reportPathsType, reportType, query));
   expect(runReportMock).toBeCalled();
   expect(
-    selectors.selectReportFetchStatus(store.getState(), reportType, query)
+    selectors.selectReportFetchStatus(
+      store.getState(),
+      reportPathsType,
+      reportType,
+      query
+    )
   ).toBe(FetchStatus.inProgress);
   await wait();
   const finishedState = store.getState();
   expect(
-    selectors.selectReport(finishedState, reportType, query)
+    selectors.selectReport(finishedState, reportPathsType, reportType, query)
   ).toMatchSnapshot();
   expect(
-    selectors.selectReportFetchStatus(finishedState, reportType, query)
+    selectors.selectReportFetchStatus(
+      finishedState,
+      reportPathsType,
+      reportType,
+      query
+    )
   ).toBe(FetchStatus.complete);
-  expect(selectors.selectReportError(finishedState, reportType, query)).toBe(
-    null
-  );
+  expect(
+    selectors.selectReportError(
+      finishedState,
+      reportPathsType,
+      reportType,
+      query
+    )
+  ).toBe(null);
 });
 
 test('fetch report failure', async () => {
@@ -63,16 +78,31 @@ test('fetch report failure', async () => {
   store.dispatch(actions.fetchReport(reportPathsType, reportType, query));
   expect(runReport).toBeCalled();
   expect(
-    selectors.selectReportFetchStatus(store.getState(), reportType, query)
+    selectors.selectReportFetchStatus(
+      store.getState(),
+      reportPathsType,
+      reportType,
+      query
+    )
   ).toBe(FetchStatus.inProgress);
   await wait();
   const finishedState = store.getState();
   expect(
-    selectors.selectReportFetchStatus(finishedState, reportType, query)
+    selectors.selectReportFetchStatus(
+      finishedState,
+      reportPathsType,
+      reportType,
+      query
+    )
   ).toBe(FetchStatus.complete);
-  expect(selectors.selectReportError(finishedState, reportType, query)).toBe(
-    error
-  );
+  expect(
+    selectors.selectReportError(
+      finishedState,
+      reportPathsType,
+      reportType,
+      query
+    )
+  ).toBe(error);
 });
 
 test('does not fetch report if the request is in progress', () => {

--- a/src/store/reports/reportActions.ts
+++ b/src/store/reports/reportActions.ts
@@ -32,12 +32,12 @@ export function fetchReport(
   query: string
 ): ThunkAction<void, RootState, void, any> {
   return (dispatch, getState) => {
-    if (!isReportExpired(getState(), reportType, query)) {
+    if (!isReportExpired(getState(), reportPathsType, reportType, query)) {
       return;
     }
 
     const meta: ReportActionMeta = {
-      reportId: getReportId(reportType, query),
+      reportId: getReportId(reportPathsType, reportType, query),
     };
 
     dispatch(fetchReportRequest(meta));
@@ -55,11 +55,17 @@ export function fetchReport(
 
 function isReportExpired(
   state: RootState,
+  reportPathsType: ReportPathsType,
   reportType: ReportType,
   query: string
 ) {
-  const report = selectReport(state, reportType, query);
-  const fetchStatus = selectReportFetchStatus(state, reportType, query);
+  const report = selectReport(state, reportPathsType, reportType, query);
+  const fetchStatus = selectReportFetchStatus(
+    state,
+    reportPathsType,
+    reportType,
+    query
+  );
   if (fetchStatus === FetchStatus.inProgress) {
     return false;
   }

--- a/src/store/reports/reportCommon.ts
+++ b/src/store/reports/reportCommon.ts
@@ -1,7 +1,11 @@
-import { ReportType } from 'api/reports/report';
+import { ReportPathsType, ReportType } from 'api/reports/report';
 
 export const reportStateKey = 'report';
 
-export function getReportId(type: ReportType, query: string) {
-  return `${type}--${query}`;
+export function getReportId(
+  reportPathsType: ReportPathsType,
+  reportType: ReportType,
+  query: string
+) {
+  return `${reportPathsType}--${reportType}--${query}`;
 }

--- a/src/store/reports/reportSelectors.ts
+++ b/src/store/reports/reportSelectors.ts
@@ -1,4 +1,4 @@
-import { ReportType } from 'api/reports/report';
+import { ReportPathsType, ReportType } from 'api/reports/report';
 import { RootState } from 'store/rootReducer';
 import { getReportId, reportStateKey } from './reportCommon';
 
@@ -6,18 +6,30 @@ export const selectReportState = (state: RootState) => state[reportStateKey];
 
 export const selectReport = (
   state: RootState,
+  reportPathsType: ReportPathsType,
   reportType: ReportType,
   query: string
-) => selectReportState(state).byId.get(getReportId(reportType, query));
+) =>
+  selectReportState(state).byId.get(
+    getReportId(reportPathsType, reportType, query)
+  );
 
 export const selectReportFetchStatus = (
   state: RootState,
+  reportPathsType: ReportPathsType,
   reportType: ReportType,
   query: string
-) => selectReportState(state).fetchStatus.get(getReportId(reportType, query));
+) =>
+  selectReportState(state).fetchStatus.get(
+    getReportId(reportPathsType, reportType, query)
+  );
 
 export const selectReportError = (
   state: RootState,
+  reportPathsType: ReportPathsType,
   reportType: ReportType,
   query: string
-) => selectReportState(state).errors.get(getReportId(reportType, query));
+) =>
+  selectReportState(state).errors.get(
+    getReportId(reportPathsType, reportType, query)
+  );


### PR DESCRIPTION
When a report is requested, the data is cached in the store via a report ID. The problem is that the next report requested may also use that same ID. This can result in some overview cards are displaying the wrong report.

Now that we are using common report code, the report ID needs to be more unique. For example, instead of this ID:

${reportType}--${query};

We can use something more like:

${reportPathsType}--${reportType}--${query};

Where the reportType is cost, storage, tag, etc. and reportPathsType is ocp, aws, azure, etc.

This ensures that when a report is requested, the correct report is retrieved from the store.