### PR TITLE
Ocp Usage overview not showing the correct cost

### DIFF
--- a/src/components/charts/common/chartUtils.ts
+++ b/src/components/charts/common/chartUtils.ts
@@ -30,10 +30,19 @@ export interface ChartDatum {
 
 // The computed report cost or usage item
 export const enum ComputedReportItemType {
-  cost = 'cost', // supplementary.cost.value
-  infrastructure = 'infrastructure', // infrastructure.usage.value
+  cost = 'cost', // cost.total.value
+  infrastructure = 'infrastructure', // infrastructure.total.value
   supplementary = 'supplementary', // supplementary.total.value
   usage = 'usage', // usage.value
+}
+
+// The computed report value
+export const enum ComputedReportItemValueType {
+  none = 'none', // A value type is not used in this scenario (e.g., usage.value)
+  markup = 'markup', // infrastructure.markup.value
+  raw = 'raw', // infrastructure.raw.value
+  total = 'total', // // infrastructure.total.value
+  usage = 'usage', // infrastructure.usage.value
 }
 
 export const enum ChartType {
@@ -46,14 +55,16 @@ export function transformReport(
   report: Report,
   type: ChartType = ChartType.daily,
   key: any = 'date',
-  reportItem: string = 'cost'
+  reportItem: string = 'cost',
+  reportItemValue: string = 'total'
 ): ChartDatum[] {
   if (!report) {
     return [];
   }
   const items = {
-    report,
     idKey: key,
+    report,
+    reportItemValue,
     sortKey: 'id',
     sortDirection: SortDirection.desc,
   } as any;

--- a/src/components/charts/historicalCostChart/historicalCostChart.test.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.test.tsx
@@ -24,7 +24,7 @@ const currentInfrastructureCostData = utils.transformReport(
   currentMonthReport,
   utils.ChartType.daily,
   'date',
-  'infrastructureCost'
+  'infrastructure'
 );
 const previousCostData = utils.transformReport(
   previousMonthReport,
@@ -36,7 +36,7 @@ const previousInfrastructureCostData = utils.transformReport(
   previousMonthReport,
   utils.ChartType.daily,
   'date',
-  'infrastructureCost'
+  'infrastructure'
 );
 
 jest.spyOn(utils, 'getTooltipLabel');

--- a/src/components/reports/reportSummary/reportSummaryDetails.tsx
+++ b/src/components/reports/reportSummary/reportSummaryDetails.tsx
@@ -1,5 +1,6 @@
 import { Tooltip } from '@patternfly/react-core';
 import { Report } from 'api/reports/report';
+import { ComputedReportItemType } from 'components/charts/common/chartUtils';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -13,6 +14,8 @@ import { styles } from './reportSummaryDetails.styles';
 
 interface ReportSummaryDetailsProps extends InjectedTranslateProps {
   chartType?: DashboardChartType;
+  computedReportItem?: string;
+  computedReportItemValue?: string;
   costLabel?: string;
   formatValue?: ValueFormatter;
   formatOptions?: FormatOptions;
@@ -29,6 +32,8 @@ interface ReportSummaryDetailsProps extends InjectedTranslateProps {
 
 const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
   chartType,
+  computedReportItem = 'cost',
+  computedReportItemValue = 'total',
   costLabel,
   formatValue,
   formatOptions,
@@ -61,8 +66,8 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
   const hasInfrastructureCost =
     hasTotal &&
     report.meta.total.infrastructure &&
-    report.meta.total.infrastructure.total &&
-    report.meta.total.infrastructure.total.value;
+    report.meta.total.infrastructure[computedReportItemValue] &&
+    report.meta.total.infrastructure[computedReportItemValue].value;
   const hasRequest = hasTotal && report.meta.total.request;
   const hasUsage = hasTotal && report.meta.total.usage;
 
@@ -80,9 +85,11 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
       formatOptions
     );
     infrastructureCost = formatValue(
-      hasInfrastructureCost ? report.meta.total.infrastructure.total.value : 0,
       hasInfrastructureCost
-        ? report.meta.total.infrastructure.total.units
+        ? report.meta.total.infrastructure[computedReportItemValue].value
+        : 0,
+      hasInfrastructureCost
+        ? report.meta.total.infrastructure[computedReportItemValue].units
         : 'USD',
       formatOptions
     );
@@ -108,26 +115,33 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
     }
   }
 
-  const getCostLayout = () => (
-    <div style={styles.valueContainer}>
-      {Boolean(showTooltip) ? (
-        <Tooltip
-          content={t('dashboard.total_cost_tooltip', {
-            infrastructureCost,
-            supplementaryCost,
-          })}
-          enableFlip
-        >
-          <div style={styles.value}>{cost}</div>
-        </Tooltip>
-      ) : (
-        <div style={styles.value}>{cost}</div>
-      )}
-      <div style={styles.text}>
-        <div>{costLabel}</div>
+  const getCostLayout = () => {
+    const value =
+      computedReportItem === ComputedReportItemType.infrastructure
+        ? infrastructureCost
+        : cost;
+
+    return (
+      <div style={styles.valueContainer}>
+        {Boolean(showTooltip) ? (
+          <Tooltip
+            content={t('dashboard.total_cost_tooltip', {
+              infrastructureCost,
+              supplementaryCost,
+            })}
+            enableFlip
+          >
+            <div style={styles.value}>{value}</div>
+          </Tooltip>
+        ) : (
+          <div style={styles.value}>{value}</div>
+        )}
+        <div style={styles.text}>
+          <div>{costLabel}</div>
+        </div>
       </div>
-    </div>
-  );
+    );
+  };
 
   const getRequestLayout = () => {
     if (!usageLabel) {

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -109,19 +109,22 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     const units = this.getUnits();
     const title = t(trend.titleKey, { units: t(`units.${units}`) });
     const computedReportItem = trend.computedReportItem || 'cost'; // cost, supplementaryCost, etc.
+    const computedReportItemValue = trend.computedReportItemValue || 'total';
 
     // Infrastructure data
     const currentInfrastructureData = transformReport(
       currentReport,
       trend.type,
       'date',
-      'infrastructureCost'
+      'infrastructure',
+      computedReportItemValue
     );
     const previousInfrastructureData = transformReport(
       previousReport,
       trend.type,
       'date',
-      'infrastructureCost'
+      'infrastructure',
+      computedReportItemValue
     );
 
     // Usage data
@@ -129,13 +132,15 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
       currentReport,
       trend.type,
       'date',
-      computedReportItem
+      computedReportItem,
+      computedReportItemValue
     );
     const previousUsageData = transformReport(
       previousReport,
       trend.type,
       'date',
-      computedReportItem
+      computedReportItem,
+      computedReportItemValue
     );
 
     return (
@@ -165,19 +170,22 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     const units = this.getUnits();
     const title = t(trend.titleKey, { units: t(`units.${units}`) });
     const computedReportItem = trend.computedReportItem || 'cost'; // cost, supplementaryCost, etc.
+    const computedReportItemValue = trend.computedReportItemValue || 'total';
 
     // Data
     const currentData = transformReport(
       currentReport,
       trend.type,
       'date',
-      computedReportItem
+      computedReportItem,
+      computedReportItemValue
     );
     const previousData = transformReport(
       previousReport,
       trend.type,
       'date',
-      computedReportItem
+      computedReportItem,
+      computedReportItemValue
     );
 
     return (
@@ -247,11 +255,16 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   };
 
   private getDetails = () => {
-    const { chartType, currentReport, details } = this.props;
+    const { chartType, currentReport, details, trend } = this.props;
+    const computedReportItem = trend.computedReportItem || 'cost';
+    const computedReportItemValue = trend.computedReportItemValue || 'total';
     const units = this.getUnits();
+
     return (
       <ReportSummaryDetails
         chartType={chartType}
+        computedReportItem={computedReportItem}
+        computedReportItemValue={computedReportItemValue}
         costLabel={this.getDetailsLabel(details.costKey, units)}
         formatOptions={details.formatOptions}
         formatValue={formatValue}
@@ -371,6 +384,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     const currentTab = getIdKeyForTab(tab);
     const activeTab = getIdKeyForTab(availableTabs[activeTabKey]);
     const computedReportItem = trend.computedReportItem || 'cost';
+    const computedReportItemValue = trend.computedReportItemValue || 'total';
 
     let totalValue;
     const hasTotal = tabsReport && tabsReport.meta && tabsReport.meta.total;
@@ -382,9 +396,11 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
       if (
         hasTotal &&
         tabsReport.meta.total[computedReportItem] &&
-        tabsReport.meta.total[computedReportItem].total
+        tabsReport.meta.total[computedReportItem][computedReportItemValue]
       ) {
-        totalValue = tabsReport.meta.total[computedReportItem].total.value;
+        totalValue =
+          tabsReport.meta.total[computedReportItem][computedReportItemValue]
+            .value;
       }
     }
 
@@ -439,6 +455,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   private getUnits = () => {
     const { currentReport, details, trend } = this.props;
     const computedReportItem = trend.computedReportItem || 'cost';
+    const computedReportItemValue = trend.computedReportItemValue || 'total';
 
     if (details.units) {
       return details.units;
@@ -456,10 +473,12 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
       const hasCost =
         hasTotal &&
         currentReport.meta.total[computedReportItem] &&
-        currentReport.meta.total[computedReportItem].total;
+        currentReport.meta.total[computedReportItem][computedReportItemValue];
       units = hasCost
         ? unitLookupKey(
-            currentReport.meta.total[computedReportItem].total.units
+            currentReport.meta.total[computedReportItem][
+              computedReportItemValue
+            ].units
           )
         : '';
     }

--- a/src/pages/details/ocpDetails/historicalChart.tsx
+++ b/src/pages/details/ocpDetails/historicalChart.tsx
@@ -123,7 +123,7 @@ class HistoricalChartBase extends React.Component<HistoricalChartProps> {
       currentCostReport,
       ChartType.rolling,
       'date',
-      'infrastructureCost'
+      'infrastructure'
     );
     const previousCostData = transformReport(
       previousCostReport,
@@ -135,7 +135,7 @@ class HistoricalChartBase extends React.Component<HistoricalChartProps> {
       previousCostReport,
       ChartType.rolling,
       'date',
-      'infrastructureCost'
+      'infrastructure'
     );
 
     // Cpu data

--- a/src/store/dashboard/awsCloudDashboard/awsCloudDashboardWidgets.ts
+++ b/src/store/dashboard/awsCloudDashboard/awsCloudDashboardWidgets.ts
@@ -2,6 +2,7 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import {
   ChartType,
   ComputedReportItemType,
+  ComputedReportItemValueType,
 } from 'components/charts/common/chartUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
@@ -38,6 +39,7 @@ export const computeWidget: AwsCloudDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -73,6 +75,7 @@ export const costSummaryWidget: AwsCloudDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
     titleKey: 'aws_cloud_dashboard.cost_trend_title',
     type: ChartType.rolling,
@@ -111,6 +114,7 @@ export const databaseWidget: AwsCloudDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
     titleKey: 'aws_cloud_dashboard.database_trend_title',
     type: ChartType.rolling,
@@ -147,6 +151,7 @@ export const networkWidget: AwsCloudDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
     titleKey: 'aws_cloud_dashboard.network_trend_title',
     type: ChartType.rolling,
@@ -183,6 +188,7 @@ export const storageWidget: AwsCloudDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -2,6 +2,7 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import {
   ChartType,
   ComputedReportItemType,
+  ComputedReportItemValueType,
 } from 'components/charts/common/chartUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { AwsDashboardTab, AwsDashboardWidget } from './awsDashboardCommon';
@@ -35,6 +36,7 @@ export const computeWidget: AwsDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -72,6 +74,7 @@ export const costSummaryWidget: AwsDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
     titleKey: 'aws_dashboard.cost_trend_title',
     type: ChartType.rolling,
@@ -110,6 +113,7 @@ export const databaseWidget: AwsDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
     titleKey: 'aws_dashboard.database_trend_title',
     type: ChartType.rolling,
@@ -146,6 +150,7 @@ export const networkWidget: AwsDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
     titleKey: 'aws_dashboard.network_trend_title',
     type: ChartType.rolling,
@@ -182,6 +187,7 @@ export const storageWidget: AwsDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
+++ b/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
@@ -2,6 +2,7 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import {
   ChartType,
   ComputedReportItemType,
+  ComputedReportItemValueType,
 } from 'components/charts/common/chartUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
@@ -29,6 +30,7 @@ export const costSummaryWidget: AzureCloudDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
     titleKey: 'azure_cloud_dashboard.cost_trend_title',
     type: ChartType.rolling,
@@ -65,6 +67,7 @@ export const databaseWidget: AzureCloudDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
     titleKey: 'azure_cloud_dashboard.database_trend_title',
     type: ChartType.rolling,
@@ -103,6 +106,7 @@ export const networkWidget: AzureCloudDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
     titleKey: 'azure_cloud_dashboard.network_trend_title',
     type: ChartType.rolling,
@@ -146,6 +150,7 @@ export const storageWidget: AzureCloudDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -191,6 +196,7 @@ export const virtualMachineWidget: AzureCloudDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -2,6 +2,7 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import {
   ChartType,
   ComputedReportItemType,
+  ComputedReportItemValueType,
 } from 'components/charts/common/chartUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
@@ -31,6 +32,7 @@ export const costSummaryWidget: AzureDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
     titleKey: 'azure_dashboard.cost_trend_title',
     type: ChartType.rolling,
@@ -67,6 +69,7 @@ export const databaseWidget: AzureDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
     titleKey: 'azure_dashboard.database_trend_title',
     type: ChartType.rolling,
@@ -105,6 +108,7 @@ export const networkWidget: AzureDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
     titleKey: 'azure_dashboard.network_trend_title',
     type: ChartType.rolling,
@@ -148,6 +152,7 @@ export const storageWidget: AzureDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -193,6 +198,7 @@ export const virtualMachineWidget: AzureDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/common/dashboardCommon.ts
+++ b/src/store/dashboard/common/dashboardCommon.ts
@@ -50,6 +50,7 @@ export interface DashboardWidget<T> {
   };
   trend: {
     computedReportItem: string; // The computed report item to use in charts, summary, etc.
+    computedReportItemValue: string; // The computed report value (e.g., raw, markup, total, or usage)
     titleKey: string;
     type: number;
     formatOptions: ValueFormatOptions;

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
@@ -2,6 +2,7 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import {
   ChartType,
   ComputedReportItemType,
+  ComputedReportItemValueType,
 } from 'components/charts/common/chartUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
@@ -29,6 +30,7 @@ export const costSummaryWidget: OcpCloudDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
     titleKey: 'ocp_cloud_dashboard.cost_trend_title',
     type: ChartType.rolling,
@@ -70,6 +72,7 @@ export const computeWidget: OcpCloudDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -98,6 +101,7 @@ export const databaseWidget: OcpCloudDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
     titleKey: 'ocp_cloud_dashboard.database_trend_title',
     type: ChartType.rolling,
@@ -124,6 +128,7 @@ export const networkWidget: OcpCloudDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
     titleKey: 'ocp_cloud_dashboard.network_trend_title',
     type: ChartType.rolling,
@@ -151,6 +156,7 @@ export const storageWidget: OcpCloudDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -2,6 +2,7 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import {
   ChartType,
   ComputedReportItemType,
+  ComputedReportItemValueType,
 } from 'components/charts/common/chartUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { OcpDashboardTab, OcpDashboardWidget } from './ocpDashboardCommon';
@@ -26,6 +27,7 @@ export const costSummaryWidget: OcpDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
     titleKey: 'ocp_dashboard.cost_trend_title',
     type: ChartType.rolling,
@@ -63,6 +65,7 @@ export const cpuWidget: OcpDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -99,6 +102,7 @@ export const memoryWidget: OcpDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -135,6 +139,7 @@ export const volumeWidget: OcpDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidgets.ts
+++ b/src/store/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidgets.ts
@@ -2,6 +2,7 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import {
   ChartType,
   ComputedReportItemType,
+  ComputedReportItemValueType,
 } from 'components/charts/common/chartUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
@@ -26,6 +27,7 @@ export const costSummaryWidget: OcpSupplementaryDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.supplementary,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
     titleKey: 'ocp_supplementary_dashboard.cost_trend_title',
     type: ChartType.rolling,
@@ -66,6 +68,7 @@ export const cpuWidget: OcpSupplementaryDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.none,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -105,6 +108,7 @@ export const memoryWidget: OcpSupplementaryDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -144,6 +148,7 @@ export const volumeWidget: OcpSupplementaryDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.none,
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/ocpUsageDashboard/ocpUsageDashboardWidgets.ts
+++ b/src/store/dashboard/ocpUsageDashboard/ocpUsageDashboardWidgets.ts
@@ -2,6 +2,7 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import {
   ChartType,
   ComputedReportItemType,
+  ComputedReportItemValueType,
 } from 'components/charts/common/chartUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import {
@@ -29,6 +30,7 @@ export const costSummaryWidget: OcpUsageDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.infrastructure,
+    computedReportItemValue: ComputedReportItemValueType.usage,
     formatOptions: {},
     titleKey: 'ocp_usage_dashboard.cost_trend_title',
     type: ChartType.rolling,
@@ -61,6 +63,7 @@ export const cpuWidget: OcpUsageDashboardWidget = {
 
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -92,6 +95,7 @@ export const memoryWidget: OcpUsageDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {
       fractionDigits: 2,
     },
@@ -123,6 +127,7 @@ export const volumeWidget: OcpUsageDashboardWidget = {
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
+    computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -30,6 +30,7 @@ export interface ComputedReportItemsParams<
 > {
   report: R;
   idKey: keyof T;
+  reportItemValue?: string; // Only supported for infrastructure values
   sortKey?: keyof ComputedReportItem;
   labelKey?: keyof T;
   sortDirection?: SortDirection;
@@ -39,17 +40,19 @@ export function getComputedReportItems<
   R extends Report,
   T extends ReportValue
 >({
-  report,
   idKey,
   labelKey = idKey,
+  report,
+  reportItemValue = 'total',
   sortDirection = SortDirection.asc,
   sortKey = 'cost',
 }: ComputedReportItemsParams<R, T>) {
   return sort(
     getUnsortedComputedReportItems<R, T>({
-      report,
       idKey,
       labelKey,
+      report,
+      reportItemValue,
       sortDirection,
       sortKey,
     }),
@@ -63,7 +66,12 @@ export function getComputedReportItems<
 export function getUnsortedComputedReportItems<
   R extends Report,
   T extends ReportValue
->({ report, idKey, labelKey = idKey }: ComputedReportItemsParams<R, T>) {
+>({
+  report,
+  idKey,
+  labelKey = idKey,
+  reportItemValue = 'total',
+}: ComputedReportItemsParams<R, T>) {
   if (!report) {
     return [];
   }
@@ -87,8 +95,8 @@ export function getUnsortedComputedReportItems<
             ? value.supplementary.total.value
             : 0;
         const infrastructure =
-          value.infrastructure && value.infrastructure.usage
-            ? value.infrastructure.usage.value
+          value.infrastructure && value.infrastructure[reportItemValue]
+            ? value.infrastructure[reportItemValue].value
             : 0;
         // Ensure unique IDs -- https://github.com/project-koku/koku-ui/issues/706
         const idSuffix =


### PR DESCRIPTION
The Ocp Usage overview is not showing the correct cost. This page should should zero cost, right now.

For Ocp Usage, we want to use the meta prop `infrastructure.usage.value` as the total cost. However, for the Ocp overview, we still want to use the meta prop `cost.total.value` as the total cost, while using `infrastructure.total.value` for chart data.

https://github.com/project-koku/koku-ui/issues/1457