### PR TITLE
Supplementary cost should be $0.00

### DIFF
--- a/src/components/reports/reportSummary/reportSummaryDetails.tsx
+++ b/src/components/reports/reportSummary/reportSummaryDetails.tsx
@@ -116,10 +116,12 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
   }
 
   const getCostLayout = () => {
-    const value =
-      computedReportItem === ComputedReportItemType.infrastructure
-        ? infrastructureCost
-        : cost;
+    let value = cost;
+    if (computedReportItem === ComputedReportItemType.infrastructure) {
+      value = infrastructureCost;
+    } else if (computedReportItem === ComputedReportItemType.supplementary) {
+      value = supplementaryCost;
+    }
 
     return (
       <div style={styles.valueContainer}>


### PR DESCRIPTION
The cost shown for the supplementary overview should be $0.00. We're still showing the cost prop instead of supplementary cost.

https://github.com/project-koku/koku-ui/issues/1459