### PR TITLE
1461 ocp usage

### DIFF
--- a/src/components/reports/reportSummary/reportSummaryDetails.tsx
+++ b/src/components/reports/reportSummary/reportSummaryDetails.tsx
@@ -116,10 +116,12 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
   }
 
   const getCostLayout = () => {
-    const value =
-      computedReportItem === ComputedReportItemType.infrastructure
-        ? infrastructureCost
-        : cost;
+    let value = cost;
+    if (computedReportItem === ComputedReportItemType.infrastructure) {
+      value = infrastructureCost;
+    } else if (computedReportItem === ComputedReportItemType.supplementary) {
+      value = supplementaryCost;
+    }
 
     return (
       <div style={styles.valueContainer}>

--- a/src/components/reports/reportSummary/reportSummaryItems.tsx
+++ b/src/components/reports/reportSummary/reportSummaryItems.tsx
@@ -19,6 +19,7 @@ interface ReportSummaryItemsRenderProps {
 
 interface ReportSummaryItemsOwnProps
   extends ComputedReportItemsParams<Report, ReportValue> {
+  computedReportItemValue?: string;
   children?(props: ReportSummaryItemsRenderProps): React.ReactNode;
   status?: number;
 }
@@ -32,12 +33,18 @@ class ReportSummaryItemsBase extends React.Component<ReportSummaryItemsProps> {
   }
 
   private getItems() {
-    const { report, idKey, labelKey } = this.props;
+    const {
+      computedReportItemValue = 'total',
+      idKey,
+      labelKey,
+      report,
+    } = this.props;
 
     const computedItems = getComputedReportItems({
       report,
       idKey,
       labelKey,
+      reportItemValue: computedReportItemValue,
     });
 
     const otherIndex = computedItems.findIndex(i => {

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -345,8 +345,14 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   };
 
   private getTab = <T extends DashboardWidget<any>>(tab: T, index: number) => {
-    const { getIdKeyForTab, tabsReport, tabsReportFetchStatus } = this.props;
+    const {
+      getIdKeyForTab,
+      tabsReport,
+      tabsReportFetchStatus,
+      trend,
+    } = this.props;
     const currentTab: any = getIdKeyForTab(tab);
+    const computedReportItemValue = trend.computedReportItemValue || 'total';
 
     return (
       <Tab
@@ -356,6 +362,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
       >
         <div style={styles.tabItems}>
           <ReportSummaryItems
+            computedReportItemValue={computedReportItemValue}
             idKey={currentTab}
             key={`${currentTab}-items`}
             report={tabsReport}


### PR DESCRIPTION
The top project costs shown for the Ocp usage overview should be $0.00. We're still showing the cost prop instead of the meta's infrastructure.usage.value prop.

https://github.com/project-koku/koku-ui/issues/1461