### PR TITLE
Chart tooltips missing units

### DIFF
--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -31,6 +31,7 @@ interface TrendChartProps {
   formatDatumValue: ValueFormatter;
   formatDatumOptions?: FormatOptions;
   padding?: any;
+  showSupplementaryLabel?: boolean; // Show supplementary cost labels
   showUsageLegendLabel?: boolean; // The cost legend label is shown by default
   title?: string;
   units?: string;
@@ -92,11 +93,14 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     const {
       currentData,
       previousData,
+      showSupplementaryLabel = false,
       showUsageLegendLabel = false,
     } = this.props;
 
     const key = showUsageLegendLabel
       ? 'chart.usage_legend_label'
+      : showSupplementaryLabel
+      ? 'chart.cost_supplementary_legend_label'
       : 'chart.cost_legend_label';
 
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248

--- a/src/components/reports/reportSummary/reportSummaryDetails.tsx
+++ b/src/components/reports/reportSummary/reportSummaryDetails.tsx
@@ -194,7 +194,10 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
     );
   };
 
-  if (chartType === DashboardChartType.cost) {
+  if (
+    chartType === DashboardChartType.cost ||
+    chartType === DashboardChartType.supplementary
+  ) {
     return <>{getCostLayout()}</>;
   } else if (chartType === DashboardChartType.trend) {
     if (showUsageFirst) {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -136,6 +136,9 @@
     "cost_infrastructure_legend_label": "Infrastructure cost ({{startDate}} $t(months_abbr.{{month}}))",
     "cost_infrastructure_legend_label_plural": "Infrastructure cost ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
     "cost_infrastructure_tooltip": "{{value}} infrastructure cost",
+    "cost_supplementary_legend_label": "Supplementary cost ({{startDate}} $t(months_abbr.{{month}}))",
+    "cost_supplementary_legend_label_plural": "Supplementary cost ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
+    "cost_supplementary_tooltip": "{{value}} supplementary cost",
     "cost_legend_label": "Cost ({{startDate}} $t(months_abbr.{{month}}))",
     "cost_legend_label_plural": "Cost ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
     "cost_tooltip": "{{value}} cost",
@@ -785,7 +788,7 @@
   },
   "ocp_supplementary_dashboard": {
     "cost_title": "OpenShift supplementary cost",
-    "cost_trend_title": "OpenShift non-infrastructure cumulative cost comparison ({{units}})",
+    "cost_trend_title": "OpenShift cumulative supplementary cost comparison ({{units}})",
     "cpu_title": "CPU usage and requests",
     "cpu_trend_title": "Daily usage and requests comparison ({{units}})",
     "cumulative_cost_label": "Cumulative cost",

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -89,6 +89,13 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     const { chartType } = this.props;
     if (chartType === DashboardChartType.cost) {
       return this.getCostChart(containerHeight, height, adjustContainerHeight);
+    } else if (chartType === DashboardChartType.supplementary) {
+      return this.getTrendChart(
+        containerHeight,
+        height,
+        adjustContainerHeight,
+        true
+      );
     } else if (chartType === DashboardChartType.trend) {
       return this.getTrendChart(containerHeight, height, adjustContainerHeight);
     } else if (chartType === DashboardChartType.usage) {
@@ -163,7 +170,8 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   private getTrendChart = (
     containerHeight: number,
     height: number,
-    adjustContainerHeight: boolean = false
+    adjustContainerHeight: boolean = false,
+    showSupplementaryLabel: boolean = false
   ) => {
     const { currentReport, details, previousReport, t, trend } = this.props;
 
@@ -197,6 +205,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         formatDatumOptions={trend.formatOptions}
         height={height}
         previousData={previousData}
+        showSupplementaryLabel={showSupplementaryLabel}
         showUsageLegendLabel={details.showUsageLegendLabel}
         title={title}
         units={units}

--- a/src/pages/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidget.styles.ts
+++ b/src/pages/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidget.styles.ts
@@ -1,4 +1,0 @@
-export const chartStyles = {
-  chartAltHeight: 180,
-  containerAltHeight: 275,
-};

--- a/src/pages/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidget.tsx
@@ -13,7 +13,6 @@ import {
 } from 'store/dashboard/ocpSupplementaryDashboard';
 import { reportSelectors } from 'store/reports';
 import { ComputedOcpReportItemsParams } from 'utils/computedReport/getComputedOcpReportItems';
-import { chartStyles } from './ocpSupplementaryDashboardWidget.styles';
 
 interface OcpSupplementaryDashboardWidgetDispatchProps {
   fetchReports: typeof ocpSupplementaryDashboardActions.fetchWidgetReports;
@@ -48,8 +47,6 @@ const mapStateToProps = createMapStateToProps<
   return {
     ...widget,
     getIdKeyForTab,
-    chartAltHeight: chartStyles.chartAltHeight,
-    containerAltHeight: chartStyles.containerAltHeight,
     currentQuery: queries.current,
     previousQuery: queries.previous,
     tabsQuery: queries.tabs,

--- a/src/store/dashboard/common/dashboardCommon.ts
+++ b/src/store/dashboard/common/dashboardCommon.ts
@@ -2,6 +2,7 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 
 export const enum DashboardChartType {
   cost = 'cost', // This type displays cost and infrastructure cost
+  supplementary = 'supplementary', // This type displays supplementary cost
   trend = 'trend', // This type displays cost only
   usage = 'usage', // This type displays usage and requests
 }

--- a/src/store/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidgets.ts
+++ b/src/store/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidgets.ts
@@ -42,7 +42,7 @@ export const costSummaryWidget: OcpSupplementaryDashboardWidget = {
     OcpSupplementaryDashboardTab.projects,
     OcpSupplementaryDashboardTab.clusters,
   ],
-  chartType: DashboardChartType.cost,
+  chartType: DashboardChartType.supplementary,
   currentTab: OcpSupplementaryDashboardTab.projects,
 };
 

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -17,7 +17,11 @@ export interface ComputedReportItem {
   request?: number;
   supplementary: number;
   units?: {
+    capacity?: string;
     cost: string;
+    infrastructure?: string;
+    limit?: string;
+    request?: string;
     supplementary?: string;
     usage?: string;
   };
@@ -120,10 +124,17 @@ export function getUnsortedComputedReportItems<
         const request = value.request ? value.request.value : 0;
         const usage = value.usage ? value.usage.value : 0;
         const units = {
+          ...(value.capacity && { capacity: value.capacity.units }),
           cost: value.cost && value.cost.total ? value.cost.total.units : 'USD',
+          ...(value.limit && { limit: value.limit.units }),
+          ...(value.infrastructure &&
+            value.infrastructure.total && {
+              infrastructure: value.infrastructure.total.units,
+            }),
+          ...(value.request && { request: value.request.units }),
           ...(value.supplementary &&
             value.supplementary.total && {
-              supplementaryCost: value.supplementary.total.units,
+              supplementary: value.supplementary.total.units,
             }),
           ...(value.usage && { usage: value.usage.units }),
         };


### PR DESCRIPTION
Chart tooltip doesn’t always show the $ unit (e.g., shows as “0 infrastructure cost” or “350 infrastructure cost”).

#1468

<img width="868" alt="Screen Shot 2020-04-07 at 9 55 20 PM" src="https://user-images.githubusercontent.com/17481322/78736197-92f71b80-791a-11ea-8844-585724ed8345.png">
