### PR TITLE
 Microsoft Azure units label

### DIFF
--- a/src/components/reports/reportSummary/reportSummaryDetails.styles.ts
+++ b/src/components/reports/reportSummary/reportSummaryDetails.styles.ts
@@ -5,6 +5,7 @@ import {
   global_LineHeight_sm,
   global_spacer_md,
   global_spacer_sm,
+  global_spacer_xs,
 } from '@patternfly/react-tokens';
 import React from 'react';
 
@@ -15,7 +16,13 @@ export const styles = {
     alignItems: 'flex-end',
   },
   text: {
-    paddingBottom: 14,
+    paddingBottom: global_spacer_sm.value,
+    lineHeight: global_LineHeight_sm.value,
+    fontSize: global_FontSize_xs.value,
+  },
+  units: {
+    paddingLeft: global_spacer_xs.value,
+    paddingBottom: global_spacer_sm.value,
     lineHeight: global_LineHeight_sm.value,
     fontSize: global_FontSize_xs.value,
   },

--- a/src/components/reports/reportSummary/reportSummaryDetails.tsx
+++ b/src/components/reports/reportSummary/reportSummaryDetails.tsx
@@ -162,7 +162,7 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
           {Boolean(
             showUnits &&
               (units || (hasRequest && report.meta.total.request.value >= 0))
-          ) && <span style={styles.text}>{unitsLabel}</span>}
+          ) && <span style={styles.units}>{unitsLabel}</span>}
         </div>
         <div style={styles.text}>
           <div>{requestLabel}</div>
@@ -187,7 +187,7 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
           {Boolean(
             showUnits &&
               (units || (hasUsage && report.meta.total.usage.value >= 0))
-          ) && <span style={styles.text}>{unitsLabel}</span>}
+          ) && <span style={styles.units}>{unitsLabel}</span>}
         </div>
         <div style={styles.text}>
           <div>{usageLabel}</div>

--- a/src/components/reports/reportSummary/reportSummaryDetails.tsx
+++ b/src/components/reports/reportSummary/reportSummaryDetails.tsx
@@ -160,7 +160,8 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
         <div style={styles.value}>
           {request}
           {Boolean(
-            showUnits && hasRequest && report.meta.total.request.value >= 0
+            showUnits &&
+              (units || (hasRequest && report.meta.total.request.value >= 0))
           ) && <span style={styles.text}>{unitsLabel}</span>}
         </div>
         <div style={styles.text}>
@@ -184,7 +185,8 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
         <div style={styles.value}>
           {usage}
           {Boolean(
-            showUnits && hasUsage && report.meta.total.usage.value >= 0
+            showUnits &&
+              (units || (hasUsage && report.meta.total.usage.value >= 0))
           ) && <span style={styles.text}>{unitsLabel}</span>}
         </div>
         <div style={styles.text}>

--- a/src/components/reports/reportSummary/reportSummaryItems.test.tsx
+++ b/src/components/reports/reportSummary/reportSummaryItems.test.tsx
@@ -22,6 +22,7 @@ test('computes report items', () => {
     report: props.report,
     idKey: props.idKey,
     labelKey: props.labelKey,
+    reportItemValue: 'total',
   });
   expect(props.children).toBeCalledWith({ items: [] });
 });

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -282,6 +282,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         showTooltip={details.showTooltip}
         showUnits={details.showUnits}
         showUsageFirst={details.showUsageFirst}
+        units={details.units}
         usageFormatOptions={details.usageFormatOptions}
         usageLabel={this.getDetailsLabel(details.usageKey, units)}
       />


### PR DESCRIPTION
Microsoft Azure chart is missing VM-hours for the hero number and storage services usage.

The backend APIs provide no units; thus, we must hard code something.

https://github.com/project-koku/koku-ui/issues/1469

<img width="1740" alt="Screen Shot 2020-04-07 at 9 54 01 PM" src="https://user-images.githubusercontent.com/17481322/78736093-53303400-791a-11ea-923e-b6d4a1a6aaac.png">
