### PR TITLE
Progress bar margin

### DIFF
--- a/src/components/reports/reportSummary/reportSummaryItem.styles.ts
+++ b/src/components/reports/reportSummary/reportSummaryItem.styles.ts
@@ -2,7 +2,7 @@ import { global_spacer_md } from '@patternfly/react-tokens';
 import { css } from 'emotion';
 
 export const reportSummaryItem = css`
-  :not(:last-child): {
-    marginbottom: ${global_spacer_md.value};
+  :not(:last-child) {
+    margin-bottom: ${global_spacer_md.value};
   }
 `;


### PR DESCRIPTION
The spacing between the progress bars is off.

https://github.com/project-koku/koku-ui/issues/1471

<img width="665" alt="Screen Shot 2020-04-07 at 10 07 36 PM" src="https://user-images.githubusercontent.com/17481322/78736877-34cb3800-791c-11ea-905a-4ad29d60598e.png">
