### PR TITLE
Remove route redirects

### DIFF
--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -360,18 +360,20 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
   };
 
   private updateReport = () => {
-    const { query, location, fetchReport, history, queryString } = this.props;
-    if (!location.search) {
-      history.replace(
-        this.getRouteForQuery({
-          filter_by: query.filter_by,
-          group_by: query.group_by,
-          order_by: { cost: 'desc' },
-        })
-      );
-    } else {
-      fetchReport(reportPathsType, reportType, queryString);
-    }
+    // Temp disabled for https://github.com/project-koku/koku-ui/issues/1445
+    //
+    // const { query, location, fetchReport, history, queryString } = this.props;
+    // if (!location.search) {
+    //   history.replace(
+    //     this.getRouteForQuery({
+    //       filter_by: query.filter_by,
+    //       group_by: query.group_by,
+    //       order_by: { cost: 'desc' },
+    //     })
+    //   );
+    // } else {
+    //   fetchReport(reportPathsType, reportType, queryString);
+    // }
   };
 
   public render() {

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -366,18 +366,20 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
   };
 
   private updateReport = () => {
-    const { query, location, fetchReport, history, queryString } = this.props;
-    if (!location.search) {
-      history.replace(
-        this.getRouteForQuery({
-          filter_by: query.filter_by,
-          group_by: query.group_by,
-          order_by: { cost: 'desc' },
-        })
-      );
-    } else {
-      fetchReport(reportPathsType, reportType, queryString);
-    }
+    // Temp disabled for https://github.com/project-koku/koku-ui/issues/1445
+    //
+    // const { query, location, fetchReport, history, queryString } = this.props;
+    // if (!location.search) {
+    //   history.replace(
+    //     this.getRouteForQuery({
+    //       filter_by: query.filter_by,
+    //       group_by: query.group_by,
+    //       order_by: { cost: 'desc' },
+    //     })
+    //   );
+    // } else {
+    //   fetchReport(reportPathsType, reportType, queryString);
+    // }
   };
 
   public render() {

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -362,18 +362,20 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
   };
 
   private updateReport = () => {
-    const { query, location, fetchReport, history, queryString } = this.props;
-    if (!location.search) {
-      history.replace(
-        this.getRouteForQuery({
-          filter_by: query.filter_by,
-          group_by: query.group_by,
-          order_by: { cost: 'desc' },
-        })
-      );
-    } else {
-      fetchReport(reportPathsType, reportType, queryString);
-    }
+    // Temp disabled for https://github.com/project-koku/koku-ui/issues/1445
+    //
+    // const { query, location, fetchReport, history, queryString } = this.props;
+    // if (!location.search) {
+    //   history.replace(
+    //     this.getRouteForQuery({
+    //       filter_by: query.filter_by,
+    //       group_by: query.group_by,
+    //       order_by: { cost: 'desc' },
+    //     })
+    //   );
+    // } else {
+    //   fetchReport(reportPathsType, reportType, queryString);
+    // }
   };
 
   public render() {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Redirect, Route, Switch } from 'react-router-dom';
+import { Route, Switch } from 'react-router-dom';
 import { asyncComponent } from './utils/asyncComponent';
 
 const NotFound = asyncComponent(() =>
@@ -66,13 +66,15 @@ const routes = [
 ];
 
 /* Redirect workaround for https://github.com/project-koku/koku-ui/issues/1389 */
+/*
+    <Route path="/aws" exact render={() => <Redirect to="/details/aws" />} />
+    <Route path="/ocp" exact render={() => <Redirect to="/details/ocp" />} />
+ */
 const Routes = () => (
   <Switch>
     {routes.map(route => (
       <Route key={route.path as any} {...route} />
     ))}
-    <Route path="/aws" exact render={() => <Redirect to="/details/aws" />} />
-    <Route path="/ocp" exact render={() => <Redirect to="/details/ocp" />} />
     <Route component={NotFound} />
   </Switch>
 );


### PR DESCRIPTION
This was a request made by the Insights team to help debug their navigation pane.
While Insights works out the kinks, folks won't be able to navigate to the details pages.

https://github.com/project-koku/koku-ui/issues/1445