### PR TITLE
Fix navigation issues by using correct pahts

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -15,7 +15,7 @@ import {
   providersActions,
   providersSelectors,
 } from 'store/providers';
-import { Routes } from './routes';
+import { Routes, routes } from './routes';
 
 export interface AppOwnProps extends RouteComponentProps<void> {}
 
@@ -64,9 +64,12 @@ export class App extends React.Component<AppProps, AppState> {
     insights.chrome.init();
     insights.chrome.identifyApp('cost-management');
 
-    this.appNav = insights.chrome.on('APP_NAVIGATION', event =>
-      history.push(`/${event.navId}`)
-    );
+    this.appNav = insights.chrome.on('APP_NAVIGATION', event => {
+      const currRoute = routes.find(({ path }) => path.includes(event.navId));
+      if (event.domEvent && currRoute) {
+        history.push(currRoute.path);
+      }
+    });
 
     if (!awsProviders && awsProvidersFetchStatus !== FetchStatus.inProgress) {
       this.fetchAwsProviders();


### PR DESCRIPTION
This PR fixes all navigation issues with going to details. There's also PR in clous-services-config so when users go to details the entire page won't redirect.

This way has limitations! If you'll add in future nav route with dynamic part `/details/ocp/:id` and in navigation there will be option to go to specific ID this won't work. But I don't expect dynamic routes in near future, just a disclaimer.

ping @kruai @ryelo @dlabrecq 