### PR TITLE
Restore temp disabled code

### DIFF
--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -360,20 +360,18 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
   };
 
   private updateReport = () => {
-    // Temp disabled for https://github.com/project-koku/koku-ui/issues/1445
-    //
-    // const { query, location, fetchReport, history, queryString } = this.props;
-    // if (!location.search) {
-    //   history.replace(
-    //     this.getRouteForQuery({
-    //       filter_by: query.filter_by,
-    //       group_by: query.group_by,
-    //       order_by: { cost: 'desc' },
-    //     })
-    //   );
-    // } else {
-    //   fetchReport(reportPathsType, reportType, queryString);
-    // }
+    const { query, location, fetchReport, history, queryString } = this.props;
+    if (!location.search) {
+      history.replace(
+        this.getRouteForQuery({
+          filter_by: query.filter_by,
+          group_by: query.group_by,
+          order_by: { cost: 'desc' },
+        })
+      );
+    } else {
+      fetchReport(reportPathsType, reportType, queryString);
+    }
   };
 
   public render() {

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -366,20 +366,18 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
   };
 
   private updateReport = () => {
-    // Temp disabled for https://github.com/project-koku/koku-ui/issues/1445
-    //
-    // const { query, location, fetchReport, history, queryString } = this.props;
-    // if (!location.search) {
-    //   history.replace(
-    //     this.getRouteForQuery({
-    //       filter_by: query.filter_by,
-    //       group_by: query.group_by,
-    //       order_by: { cost: 'desc' },
-    //     })
-    //   );
-    // } else {
-    //   fetchReport(reportPathsType, reportType, queryString);
-    // }
+    const { query, location, fetchReport, history, queryString } = this.props;
+    if (!location.search) {
+      history.replace(
+        this.getRouteForQuery({
+          filter_by: query.filter_by,
+          group_by: query.group_by,
+          order_by: { cost: 'desc' },
+        })
+      );
+    } else {
+      fetchReport(reportPathsType, reportType, queryString);
+    }
   };
 
   public render() {

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -362,20 +362,18 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
   };
 
   private updateReport = () => {
-    // Temp disabled for https://github.com/project-koku/koku-ui/issues/1445
-    //
-    // const { query, location, fetchReport, history, queryString } = this.props;
-    // if (!location.search) {
-    //   history.replace(
-    //     this.getRouteForQuery({
-    //       filter_by: query.filter_by,
-    //       group_by: query.group_by,
-    //       order_by: { cost: 'desc' },
-    //     })
-    //   );
-    // } else {
-    //   fetchReport(reportPathsType, reportType, queryString);
-    // }
+    const { query, location, fetchReport, history, queryString } = this.props;
+    if (!location.search) {
+      history.replace(
+        this.getRouteForQuery({
+          filter_by: query.filter_by,
+          group_by: query.group_by,
+          order_by: { cost: 'desc' },
+        })
+      );
+    } else {
+      fetchReport(reportPathsType, reportType, queryString);
+    }
   };
 
   public render() {

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -65,11 +65,6 @@ const routes = [
   },
 ];
 
-/* Redirect workaround for https://github.com/project-koku/koku-ui/issues/1389 */
-/*
-    <Route path="/aws" exact render={() => <Redirect to="/details/aws" />} />
-    <Route path="/ocp" exact render={() => <Redirect to="/details/ocp" />} />
- */
 const Routes = () => (
   <Switch>
     {routes.map(route => (


### PR DESCRIPTION
Now that Insights has fixed the nav links, we can restore code temp disabled in order to help their investigation. 

https://github.com/project-koku/koku-ui/issues/1445