### PR TITLE
Charts scale beyond cards when toggling Insights nav

### DIFF
--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -406,29 +406,31 @@ class CostChart extends React.Component<CostChartProps, State> {
         ref={this.containerRef}
         style={{ height: adjustedContainerHeight }}
       >
-        <div>{title}</div>
-        <Chart
-          containerComponent={container}
-          domain={domain}
-          events={this.getEvents()}
-          height={height}
-          legendComponent={this.getLegend()}
-          legendData={this.getLegendData()}
-          legendPosition="bottom-left"
-          padding={padding}
-          theme={ChartTheme}
-          width={width}
-        >
-          {series &&
-            series.map((s, index) => {
-              return this.getChart(s, index);
-            })}
-          <ChartAxis
-            style={chartStyles.xAxis}
-            tickValues={[1, midDate, endDate]}
-          />
-          <ChartAxis dependentAxis style={chartStyles.yAxis} />
-        </Chart>
+        {title}
+        <div style={{ height, width }}>
+          <Chart
+            containerComponent={container}
+            domain={domain}
+            events={this.getEvents()}
+            height={height}
+            legendComponent={this.getLegend()}
+            legendData={this.getLegendData()}
+            legendPosition="bottom-left"
+            padding={padding}
+            theme={ChartTheme}
+            width={width}
+          >
+            {series &&
+              series.map((s, index) => {
+                return this.getChart(s, index);
+              })}
+            <ChartAxis
+              style={chartStyles.xAxis}
+              tickValues={[1, midDate, endDate]}
+            />
+            <ChartAxis dependentAxis style={chartStyles.yAxis} />
+          </Chart>
+        </div>
       </div>
     );
   }

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -385,33 +385,35 @@ class HistoricalCostChart extends React.Component<
       <div className={chartOverride} ref={this.containerRef}>
         <div style={styles.title}>{title}</div>
         <div style={{ ...styles.chart, height: containerHeight }}>
-          <Chart
-            containerComponent={container}
-            domain={domain}
-            events={this.getEvents()}
-            height={height}
-            legendComponent={this.getLegend()}
-            legendData={this.getLegendData()}
-            legendPosition="bottom"
-            padding={padding}
-            theme={ChartTheme}
-            width={width}
-          >
-            {series &&
-              series.map((s, index) => {
-                return this.getChart(s, index);
-              })}
-            <ChartAxis
-              label={xAxisLabel}
-              style={chartStyles.xAxis}
-              tickValues={[1, midDate, endDate]}
-            />
-            <ChartAxis
-              dependentAxis
-              label={yAxisLabel}
-              style={chartStyles.yAxis}
-            />
-          </Chart>
+          <div style={{ height, width }}>
+            <Chart
+              containerComponent={container}
+              domain={domain}
+              events={this.getEvents()}
+              height={height}
+              legendComponent={this.getLegend()}
+              legendData={this.getLegendData()}
+              legendPosition="bottom"
+              padding={padding}
+              theme={ChartTheme}
+              width={width}
+            >
+              {series &&
+                series.map((s, index) => {
+                  return this.getChart(s, index);
+                })}
+              <ChartAxis
+                label={xAxisLabel}
+                style={chartStyles.xAxis}
+                tickValues={[1, midDate, endDate]}
+              />
+              <ChartAxis
+                dependentAxis
+                label={yAxisLabel}
+                style={chartStyles.yAxis}
+              />
+            </Chart>
+          </div>
         </div>
       </div>
     );

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -306,33 +306,35 @@ class HistoricalTrendChart extends React.Component<
       <div className={chartOverride} ref={this.containerRef}>
         <div style={styles.title}>{title}</div>
         <div style={{ ...styles.chart, height: containerHeight }}>
-          <Chart
-            containerComponent={container}
-            domain={domain}
-            events={this.getEvents()}
-            height={height}
-            legendComponent={this.getLegend()}
-            legendData={this.getLegendData()}
-            legendPosition="bottom"
-            padding={padding}
-            theme={ChartTheme}
-            width={width}
-          >
-            {series &&
-              series.map((s, index) => {
-                return this.getChart(s, index);
-              })}
-            <ChartAxis
-              label={xAxisLabel}
-              style={chartStyles.xAxis}
-              tickValues={[1, midDate, endDate]}
-            />
-            <ChartAxis
-              dependentAxis
-              label={yAxisLabel}
-              style={chartStyles.yAxis}
-            />
-          </Chart>
+          <div style={{ height, width }}>
+            <Chart
+              containerComponent={container}
+              domain={domain}
+              events={this.getEvents()}
+              height={height}
+              legendComponent={this.getLegend()}
+              legendData={this.getLegendData()}
+              legendPosition="bottom"
+              padding={padding}
+              theme={ChartTheme}
+              width={width}
+            >
+              {series &&
+                series.map((s, index) => {
+                  return this.getChart(s, index);
+                })}
+              <ChartAxis
+                label={xAxisLabel}
+                style={chartStyles.xAxis}
+                tickValues={[1, midDate, endDate]}
+              />
+              <ChartAxis
+                dependentAxis
+                label={yAxisLabel}
+                style={chartStyles.yAxis}
+              />
+            </Chart>
+          </div>
         </div>
       </div>
     );

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -456,33 +456,35 @@ class HistoricalUsageChart extends React.Component<
       <div className={chartOverride} ref={this.containerRef}>
         <div style={styles.title}>{title}</div>
         <div style={{ ...styles.chart, height: containerHeight }}>
-          <Chart
-            containerComponent={container}
-            domain={domain}
-            events={this.getEvents()}
-            height={height}
-            legendComponent={this.getLegend()}
-            legendData={this.getLegendData()}
-            legendPosition="bottom"
-            padding={padding}
-            theme={ChartTheme}
-            width={width}
-          >
-            {series &&
-              series.map((s, index) => {
-                return this.getChart(s, index);
-              })}
-            <ChartAxis
-              label={xAxisLabel}
-              style={chartStyles.xAxis}
-              tickValues={[1, midDate, endDate]}
-            />
-            <ChartAxis
-              dependentAxis
-              label={yAxisLabel}
-              style={chartStyles.yAxis}
-            />
-          </Chart>
+          <div style={{ height, width }}>
+            <Chart
+              containerComponent={container}
+              domain={domain}
+              events={this.getEvents()}
+              height={height}
+              legendComponent={this.getLegend()}
+              legendData={this.getLegendData()}
+              legendPosition="bottom"
+              padding={padding}
+              theme={ChartTheme}
+              width={width}
+            >
+              {series &&
+                series.map((s, index) => {
+                  return this.getChart(s, index);
+                })}
+              <ChartAxis
+                label={xAxisLabel}
+                style={chartStyles.xAxis}
+                tickValues={[1, midDate, endDate]}
+              />
+              <ChartAxis
+                dependentAxis
+                label={yAxisLabel}
+                style={chartStyles.yAxis}
+              />
+            </Chart>
+          </div>
         </div>
       </div>
     );

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -321,29 +321,31 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         ref={this.containerRef}
         style={{ height: adjustedContainerHeight }}
       >
-        <div>{title}</div>
-        <Chart
-          containerComponent={container}
-          domain={domain}
-          events={this.getEvents()}
-          height={height}
-          legendComponent={this.getLegend()}
-          legendData={this.getLegendData()}
-          legendPosition="bottom-left"
-          padding={padding}
-          theme={ChartTheme}
-          width={width}
-        >
-          {series &&
-            series.map((s, index) => {
-              return this.getChart(s, index);
-            })}
-          <ChartAxis
-            style={chartStyles.xAxis}
-            tickValues={[1, midDate, endDate]}
-          />
-          <ChartAxis dependentAxis style={chartStyles.yAxis} />
-        </Chart>
+        {title}
+        <div style={{ height, width }}>
+          <Chart
+            containerComponent={container}
+            domain={domain}
+            events={this.getEvents()}
+            height={height}
+            legendComponent={this.getLegend()}
+            legendData={this.getLegendData()}
+            legendPosition="bottom-left"
+            padding={padding}
+            theme={ChartTheme}
+            width={width}
+          >
+            {series &&
+              series.map((s, index) => {
+                return this.getChart(s, index);
+              })}
+            <ChartAxis
+              style={chartStyles.xAxis}
+              tickValues={[1, midDate, endDate]}
+            />
+            <ChartAxis dependentAxis style={chartStyles.yAxis} />
+          </Chart>
+        </div>
       </div>
     );
   }

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -412,29 +412,31 @@ class UsageChart extends React.Component<UsageChartProps, State> {
         ref={this.containerRef}
         style={{ height: adjustedContainerHeight }}
       >
-        <div>{title}</div>
-        <Chart
-          containerComponent={container}
-          domain={domain}
-          events={this.getEvents()}
-          height={height}
-          legendComponent={this.getLegend()}
-          legendData={this.getLegendData()}
-          legendPosition="bottom-left"
-          padding={padding}
-          theme={ChartTheme}
-          width={width}
-        >
-          {series &&
-            series.map((s, index) => {
-              return this.getChart(s, index);
-            })}
-          <ChartAxis
-            style={chartStyles.xAxis}
-            tickValues={[1, midDate, endDate]}
-          />
-          <ChartAxis dependentAxis style={chartStyles.yAxis} />
-        </Chart>
+        {title}
+        <div style={{ height, width }}>
+          <Chart
+            containerComponent={container}
+            domain={domain}
+            events={this.getEvents()}
+            height={height}
+            legendComponent={this.getLegend()}
+            legendData={this.getLegendData()}
+            legendPosition="bottom-left"
+            padding={padding}
+            theme={ChartTheme}
+            width={width}
+          >
+            {series &&
+              series.map((s, index) => {
+                return this.getChart(s, index);
+              })}
+            <ChartAxis
+              style={chartStyles.xAxis}
+              tickValues={[1, midDate, endDate]}
+            />
+            <ChartAxis dependentAxis style={chartStyles.yAxis} />
+          </Chart>
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
Charts scale beyond card boundary when toggling Insights nav (i.e., the hamburger icon, top-left in page header). Added height and width to a div container wrapping the charts.

https://github.com/project-koku/koku-ui/issues/1493

![chrome-capture (3)](https://user-images.githubusercontent.com/17481322/79289710-0a3b2b00-7e98-11ea-8af3-d903da01071e.gif)