### PR TITLE
Overview units wrap oddly

### DIFF
--- a/src/components/reports/reportSummary/reportSummaryDetails.styles.ts
+++ b/src/components/reports/reportSummary/reportSummaryDetails.styles.ts
@@ -25,6 +25,7 @@ export const styles = {
     paddingBottom: global_spacer_sm.value,
     lineHeight: global_LineHeight_sm.value,
     fontSize: global_FontSize_xs.value,
+    whiteSpace: 'nowrap',
   },
   value: {
     color: global_Color_100.var,


### PR DESCRIPTION
Overview units wrap oddly. For example, when resizing the window very small, `core-hours` looks odd when `core-` is on a line by itself. 

Adding a simple 'nowrap' style ensures `core-hours` appears on the same line.

https://github.com/project-koku/koku-ui/issues/1502

