### PR TITLE
Details pages export file naming convention

### DIFF
--- a/src/api/exports/export.ts
+++ b/src/api/exports/export.ts
@@ -1,0 +1,3 @@
+export interface Export {
+  data: string;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -129,7 +129,7 @@
     "tag_column_title": "Tag names",
     "tags_label": "Related tags:",
     "tags_modal_title": "$t(group_by.values.{{groupBy}}) {{name}} related tags",
-    "title": "Azure",
+    "title": "Microsoft Azure",
     "total_cost": "Total cost"
   },
   "chart": {
@@ -477,6 +477,7 @@
     "confirm": "Generate and download",
     "daily": "Daily",
     "export": "Export",
+    "file_name": "cost-management-{{provider}}-$t(group_by.top_values.{{groupBy}})-{{date}}",
     "heading": "Aggregates of the following {{groupBy}}s will be exported to a .csv file.",
     "monthly": "Monthly",
     "selected": "Selected {{groupBy}}s",
@@ -493,7 +494,7 @@
     "type_aria_label": "Select filter type",
     "type_aws": "AWS",
     "type_empty": "Choose source type",
-    "type_ocp": "Red HatOpenShift"
+    "type_ocp": "Red Hat OpenShift"
   },
   "filter_by": {
     "account_button_aria_label": "Search button for account name",
@@ -1003,7 +1004,7 @@
   "overview": {
     "aws": "Amazon Web Services",
     "aws_desc": "Raw cost from Amazon Web Services infrastructure.",
-    "azure": "Azure",
+    "azure": "Microsoft Azure",
     "azure_desc": "Raw cost from Azure infrastructure.",
     "infrastructure": "Infrastructure",
     "ocp": "OpenShift",

--- a/src/pages/details/components/export/exportSubmit.tsx
+++ b/src/pages/details/components/export/exportSubmit.tsx
@@ -1,0 +1,197 @@
+import { Button, ButtonVariant } from '@patternfly/react-core';
+import { Export } from 'api/exports/export';
+import { getQuery, Query } from 'api/queries/query';
+import { ReportPathsType, ReportType } from 'api/reports/report';
+import { AxiosError } from 'axios';
+import formatDate from 'date-fns/format';
+import fileDownload from 'js-file-download';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { exportActions, exportSelectors } from 'store/exports';
+import { getTestProps, testIds } from 'testIds';
+import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
+
+export interface ExportSubmitOwnProps extends InjectedTranslateProps {
+  groupBy?: string;
+  isAllItems?: boolean;
+  items?: ComputedReportItem[];
+  onClose(isOpen: boolean);
+  query?: Query;
+  reportPathsType: ReportPathsType;
+  resolution: string;
+}
+
+interface ExportSubmitStateProps {
+  queryString: string;
+  report: Export;
+  reportError: AxiosError;
+  reportFetchStatus?: FetchStatus;
+}
+
+interface ExportSubmitDispatchProps {
+  exportReport?: typeof exportActions.exportReport;
+}
+
+interface ExportSubmitState {
+  fetchReportClicked: boolean;
+}
+
+type ExportSubmitProps = ExportSubmitOwnProps &
+  ExportSubmitStateProps &
+  ExportSubmitDispatchProps &
+  InjectedTranslateProps;
+
+const reportType = ReportType.cost;
+
+export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
+  protected defaultState: ExportSubmitState = {
+    fetchReportClicked: false,
+  };
+  public state: ExportSubmitState = { ...this.defaultState };
+
+  constructor(stateProps, dispatchProps) {
+    super(stateProps, dispatchProps);
+    this.handleResolutionChange = this.handleResolutionChange.bind(this);
+  }
+
+  public componentDidUpdate(prevProps: ExportSubmitProps) {
+    const { report } = this.props;
+    const { fetchReportClicked } = this.state;
+
+    if (prevProps.report !== report && fetchReportClicked) {
+      this.getExport();
+    }
+  }
+
+  private getExport = () => {
+    const { report, reportFetchStatus } = this.props;
+
+    if (report && reportFetchStatus === FetchStatus.complete) {
+      fileDownload(report.data, this.getFileName(), 'text/csv');
+      this.handleClose();
+    }
+  };
+
+  private getFileName = () => {
+    const { groupBy, reportPathsType, t } = this.props;
+
+    const fileName = t('export.file_name', {
+      provider: reportPathsType,
+      groupBy,
+      date: formatDate(new Date(), 'YYYY-MM-DD'),
+    });
+
+    return `${fileName}.csv`;
+  };
+
+  private handleClose = () => {
+    this.props.onClose(false);
+  };
+
+  private handleFetchReport = () => {
+    const { exportReport, queryString, reportPathsType } = this.props;
+
+    exportReport(reportPathsType, reportType, queryString);
+
+    this.setState(
+      {
+        fetchReportClicked: true,
+      },
+      () => {
+        this.getExport();
+      }
+    );
+  };
+
+  public handleResolutionChange = (_, event) => {
+    this.setState({ resolution: event.currentTarget.value });
+  };
+
+  public render() {
+    const { reportFetchStatus, t } = this.props;
+
+    return (
+      <Button
+        {...getTestProps(testIds.export.submit_btn)}
+        isDisabled={reportFetchStatus === FetchStatus.inProgress}
+        key="confirm"
+        onClick={this.handleFetchReport}
+        variant={ButtonVariant.primary}
+      >
+        {t('export.confirm')}
+      </Button>
+    );
+  }
+}
+
+const mapStateToProps = createMapStateToProps<
+  ExportSubmitOwnProps,
+  ExportSubmitStateProps
+>((state, props) => {
+  const {
+    groupBy,
+    isAllItems,
+    items,
+    query,
+    reportPathsType,
+    resolution,
+  } = props;
+
+  const getQueryString = () => {
+    const newQuery: Query = {
+      ...JSON.parse(JSON.stringify(query)),
+      group_by: undefined,
+      order_by: undefined,
+    };
+    newQuery.filter.resolution = resolution as any;
+    let newQueryString = getQuery(newQuery);
+
+    if (isAllItems) {
+      newQueryString += `&group_by[${groupBy}]=*`;
+    } else {
+      for (const item of items) {
+        newQueryString += `&group_by[${groupBy}]=` + item.label;
+      }
+    }
+    return newQueryString;
+  };
+
+  const queryString = getQueryString();
+  const report = exportSelectors.selectExport(
+    state,
+    reportPathsType,
+    reportType,
+    queryString
+  );
+  const reportError = exportSelectors.selectExportError(
+    state,
+    reportPathsType,
+    reportType,
+    queryString
+  );
+  const reportFetchStatus = exportSelectors.selectExportFetchStatus(
+    state,
+    reportPathsType,
+    reportType,
+    queryString
+  );
+
+  return {
+    queryString,
+    report,
+    reportError,
+    reportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: ExportSubmitDispatchProps = {
+  exportReport: exportActions.exportReport,
+};
+
+const ExportSubmit = translate()(
+  connect(mapStateToProps, mapDispatchToProps)(ExportSubmitBase)
+);
+
+export { ExportSubmit, ExportSubmitProps };

--- a/src/store/exports/__snapshots__/export.test.ts.snap
+++ b/src/store/exports/__snapshots__/export.test.ts.snap
@@ -2,10 +2,21 @@
 
 exports[`default state 1`] = `
 Object {
-  "export": null,
-  "exportError": null,
-  "exportFetchStatus": 0,
+  "byId": Map {},
+  "errors": Map {},
+  "fetchStatus": Map {},
 }
 `;
 
-exports[`fetch export success 1`] = `"data"`;
+exports[`fetch export success 1`] = `
+Object {
+  "data": Object {
+    "data": Array [],
+    "total": Object {
+      "units": "USD",
+      "value": 100,
+    },
+  },
+  "timeRequested": 12345,
+}
+`;

--- a/src/store/exports/exportCommon.ts
+++ b/src/store/exports/exportCommon.ts
@@ -1,0 +1,11 @@
+import { ReportPathsType, ReportType } from 'api/reports/report';
+
+export const exportStateKey = 'export';
+
+export function getExportId(
+  reportPathsType: ReportPathsType,
+  reportType: ReportType,
+  query: string
+) {
+  return `${reportPathsType}-${reportType}--${query}`;
+}

--- a/src/store/exports/exportSelectors.ts
+++ b/src/store/exports/exportSelectors.ts
@@ -1,13 +1,35 @@
+import { ReportPathsType, ReportType } from 'api/reports/report';
 import { RootState } from 'store/rootReducer';
-import { stateKey } from './exportReducer';
+import { exportStateKey, getExportId } from './exportCommon';
 
-export const selectExportState = (state: RootState) => state[stateKey];
+export const selectExportState = (state: RootState) => state[exportStateKey];
 
-export const selectExport = (state: RootState) =>
-  selectExportState(state).export;
+export const selectExport = (
+  state: RootState,
+  reportPathsType: ReportPathsType,
+  reportType: ReportType,
+  query: string
+) =>
+  selectExportState(state).byId.get(
+    getExportId(reportPathsType, reportType, query)
+  );
 
-export const selectExportFetchStatus = (state: RootState) =>
-  selectExportState(state).exportFetchStatus;
+export const selectExportFetchStatus = (
+  state: RootState,
+  reportPathsType: ReportPathsType,
+  reportType: ReportType,
+  query: string
+) =>
+  selectExportState(state).fetchStatus.get(
+    getExportId(reportPathsType, reportType, query)
+  );
 
-export const selectExportError = (state: RootState) =>
-  selectExportState(state).exportError;
+export const selectExportError = (
+  state: RootState,
+  reportPathsType: ReportPathsType,
+  reportType: ReportType,
+  query: string
+) =>
+  selectExportState(state).errors.get(
+    getExportId(reportPathsType, reportType, query)
+  );

--- a/src/store/exports/index.ts
+++ b/src/store/exports/index.ts
@@ -1,10 +1,6 @@
 import * as exportActions from './exportActions';
-import {
-  ExportAction,
-  exportReducer,
-  ExportState,
-  stateKey as exportStateKey,
-} from './exportReducer';
+import { exportStateKey } from './exportCommon';
+import { ExportAction, exportReducer, ExportState } from './exportReducer';
 import * as exportSelectors from './exportSelectors';
 
 export {


### PR DESCRIPTION
Refactored the details export functionality to better support the file naming convention described below.

>As a user I would like to see exports from the details pages have a better naming convention on files from exports. For example: app_name-details_name-date so cost-management-openshift-2020-04-14.csv

The resulting file names are shown below for the various details pages and group-by combinations.

<img width="376" alt="Screen Shot 2020-04-15 at 5 49 53 PM" src="https://user-images.githubusercontent.com/17481322/79394096-b1759c00-7f44-11ea-9e06-50b446c58a25.png">

FYI, the `js-file-download` code was moved from the store to the details page component, which allows us to customize the filename for each export. In addition, I added the ability to store reports by ID in order to fetch cached reports.

https://github.com/project-koku/koku-ui/issues/1497