### PR TITLE
Details pages group cost by dropdown disappears briefly while loading…

### DIFF
--- a/src/pages/details/awsDetails/detailsHeader.tsx
+++ b/src/pages/details/awsDetails/detailsHeader.tsx
@@ -93,15 +93,14 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           <div style={styles.nav}>
             <TertiaryNav activeItem={TertiaryNavItem.aws} />
           </div>
-          {Boolean(showContent) && (
-            <GroupBy
-              getIdKeyForGroupBy={getIdKeyForGroupBy}
-              groupBy={groupBy}
-              onItemClicked={onGroupByClicked}
-              options={groupByOptions}
-              reportPathsType={reportPathsType}
-            />
-          )}
+          <GroupBy
+            getIdKeyForGroupBy={getIdKeyForGroupBy}
+            groupBy={groupBy}
+            isDisabled={!showContent}
+            onItemClicked={onGroupByClicked}
+            options={groupByOptions}
+            reportPathsType={reportPathsType}
+          />
         </div>
         {Boolean(showContent) && (
           <div style={styles.cost}>

--- a/src/pages/details/azureDetails/detailsHeader.tsx
+++ b/src/pages/details/azureDetails/detailsHeader.tsx
@@ -93,15 +93,14 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           <div style={styles.nav}>
             <TertiaryNav activeItem={TertiaryNavItem.azure} />
           </div>
-          {Boolean(showContent) && (
-            <GroupBy
-              getIdKeyForGroupBy={getIdKeyForGroupBy}
-              groupBy={groupBy}
-              onItemClicked={onGroupByClicked}
-              options={groupByOptions}
-              reportPathsType={reportPathsType}
-            />
-          )}
+          <GroupBy
+            getIdKeyForGroupBy={getIdKeyForGroupBy}
+            groupBy={groupBy}
+            isDisabled={!showContent}
+            onItemClicked={onGroupByClicked}
+            options={groupByOptions}
+            reportPathsType={reportPathsType}
+          />
         </div>
         {Boolean(showContent) && (
           <div style={styles.cost}>

--- a/src/pages/details/components/groupBy/groupBy.tsx
+++ b/src/pages/details/components/groupBy/groupBy.tsx
@@ -13,6 +13,7 @@ import { styles } from './groupBy.styles';
 interface GroupByOwnProps {
   getIdKeyForGroupBy: (groupBy: Query['group_by']) => string;
   groupBy?: string;
+  isDisabled?: boolean;
   onItemClicked(value: string);
   options: {
     label: string;
@@ -176,7 +177,7 @@ class GroupByBase extends React.Component<GroupByProps> {
   };
 
   public render() {
-    const { t } = this.props;
+    const { isDisabled = false, t } = this.props;
     const { currentItem, isGroupByOpen } = this.state;
 
     const dropdownItems = [
@@ -198,7 +199,10 @@ class GroupByBase extends React.Component<GroupByProps> {
         <Dropdown
           onSelect={this.handleGroupBySelect}
           toggle={
-            <DropdownToggle onToggle={this.handleGroupByToggle}>
+            <DropdownToggle
+              isDisabled={isDisabled}
+              onToggle={this.handleGroupByToggle}
+            >
               {label}
             </DropdownToggle>
           }

--- a/src/pages/details/ocpCloudDetails/detailsHeader.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsHeader.tsx
@@ -118,15 +118,14 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           <Title style={styles.title} size={TitleSize['2xl']}>
             {t('ocp_cloud_details.title')}
           </Title>
-          {Boolean(showContent) && (
-            <GroupBy
-              getIdKeyForGroupBy={getIdKeyForGroupBy}
-              groupBy={groupBy}
-              onItemClicked={onGroupByClicked}
-              options={groupByOptions}
-              reportPathsType={reportPathsType}
-            />
-          )}
+          <GroupBy
+            getIdKeyForGroupBy={getIdKeyForGroupBy}
+            groupBy={groupBy}
+            isDisabled={!showContent}
+            onItemClicked={onGroupByClicked}
+            options={groupByOptions}
+            reportPathsType={reportPathsType}
+          />
         </div>
         {Boolean(showContent) && (
           <div style={styles.cost}>

--- a/src/pages/details/ocpDetails/detailsHeader.tsx
+++ b/src/pages/details/ocpDetails/detailsHeader.tsx
@@ -128,15 +128,14 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           <Title style={styles.title} size={TitleSize['2xl']}>
             {t('ocp_details.title')}
           </Title>
-          {Boolean(showContent) && (
-            <GroupBy
-              getIdKeyForGroupBy={getIdKeyForGroupBy}
-              groupBy={groupBy}
-              onItemClicked={onGroupByClicked}
-              options={groupByOptions}
-              reportPathsType={reportPathsType}
-            />
-          )}
+          <GroupBy
+            getIdKeyForGroupBy={getIdKeyForGroupBy}
+            groupBy={groupBy}
+            isDisabled={!showContent}
+            onItemClicked={onGroupByClicked}
+            options={groupByOptions}
+            reportPathsType={reportPathsType}
+          />
         </div>
         {Boolean(showContent) && (
           <div style={styles.cost}>


### PR DESCRIPTION
It was requested that we don't show the group-by menu or the total cost in the header unless the provider and cost APIs return data. Although, we can disable the menu instead.

https://github.com/project-koku/koku-ui/issues/1514

![chrome-capture (1)](https://user-images.githubusercontent.com/17481322/79595104-48109d00-80ac-11ea-8dcd-dcc8a85ef70b.gif)
