### PR TITLE
Details page export button is not a button consistent across platform

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -476,7 +476,6 @@
     "cancel": "Cancel",
     "confirm": "Generate and download",
     "daily": "Daily",
-    "export": "Export",
     "file_name": "cost-management-{{provider}}-$t(group_by.top_values.{{groupBy}})-{{date}}",
     "heading": "Aggregates of the following {{groupBy}}s will be exported to a .csv file.",
     "monthly": "Monthly",

--- a/src/pages/details/components/toolbar/toolbar.tsx
+++ b/src/pages/details/components/toolbar/toolbar.tsx
@@ -638,16 +638,15 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
   // Export button
 
   public getExportButton = () => {
-    const { isExportDisabled, t } = this.props;
+    const { isExportDisabled } = this.props;
 
     return (
       <DataToolbarItem>
         <Button
           isDisabled={isExportDisabled}
           onClick={this.handleExportClicked}
-          variant={ButtonVariant.link}
+          variant={ButtonVariant.plain}
         >
-          <span style={styles.export}>{t('export.export')}</span>
           <ExportIcon />
         </Button>
       </DataToolbarItem>


### PR DESCRIPTION
This removes the "Export" text associated with the toolbar icon. The button variant has also been changed from `link` to `plain`.

https://github.com/project-koku/koku-ui/issues/1496

<img width="796" alt="Screen Shot 2020-04-17 at 1 22 47 PM" src="https://user-images.githubusercontent.com/17481322/79596434-8d35ce80-80ae-11ea-9f0a-49073c6d73d0.png">
