### PR TITLE
Update toolbar to use PF DataToolbarChipGroup interface

### DIFF
--- a/src/pages/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/details/awsDetails/detailsToolbar.tsx
@@ -55,14 +55,14 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     const { report, t } = this.props;
 
     const options = [
-      { label: t('filter_by.values.account'), value: 'account' },
-      { label: t('filter_by.values.service'), value: 'service' },
-      { label: t('filter_by.values.region'), value: 'region' },
-      { label: t('filter_by.values.tag'), value: 'tag' },
+      { name: t('filter_by.values.account'), key: 'account' },
+      { name: t('filter_by.values.service'), key: 'service' },
+      { name: t('filter_by.values.region'), key: 'region' },
+      { name: t('filter_by.values.tag'), key: 'tag' },
     ];
     return report && report.data && report.data.length
       ? options
-      : options.filter(option => option.value !== 'tag');
+      : options.filter(option => option.key !== 'tag');
   };
 
   public render() {

--- a/src/pages/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/details/awsDetails/detailsToolbar.tsx
@@ -2,6 +2,7 @@ import { DataToolbarChipGroup } from '@patternfly/react-core';
 import { AwsQuery, getQuery } from 'api/queries/awsQuery';
 import { AwsReport } from 'api/reports/awsReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
+import i18next from 'i18next';
 import { Toolbar } from 'pages/details/components/toolbar/toolbar';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -31,39 +32,54 @@ interface DetailsToolbarDispatchProps {
   fetchReport?: typeof reportActions.fetchReport;
 }
 
+interface DetailsToolbarState {
+  categoryOptions?: DataToolbarChipGroup[];
+}
+
 type DetailsToolbarProps = DetailsToolbarOwnProps &
   DetailsToolbarStateProps &
   DetailsToolbarDispatchProps &
   InjectedTranslateProps;
 
+const defaultOptions = [
+  { name: i18next.t('filter_by.values.account'), key: 'account' },
+  { name: i18next.t('filter_by.values.service'), key: 'service' },
+  { name: i18next.t('filter_by.values.region'), key: 'region' },
+  { name: i18next.t('filter_by.values.tag'), key: 'tag' },
+];
+
 const reportType = ReportType.tag;
 const reportPathsType = ReportPathsType.aws;
 
 export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
+  protected defaultState: DetailsToolbarState = {
+    categoryOptions: defaultOptions,
+  };
+  public state: DetailsToolbarState = { ...this.defaultState };
+
   public componentDidMount() {
     const { fetchReport, queryString } = this.props;
     fetchReport(reportPathsType, reportType, queryString);
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps, prevState) {
-    const { fetchReport, query, queryString } = this.props;
+    const { fetchReport, query, queryString, report } = this.props;
     if (query && !isEqual(query, prevProps.query)) {
       fetchReport(reportPathsType, reportType, queryString);
+    }
+    if (!isEqual(report, prevProps.report)) {
+      this.setState({
+        categoryOptions: this.getCategoryOptions(),
+      });
     }
   }
 
   private getCategoryOptions = (): DataToolbarChipGroup[] => {
-    const { report, t } = this.props;
+    const { report } = this.props;
 
-    const options = [
-      { name: t('filter_by.values.account'), key: 'account' },
-      { name: t('filter_by.values.service'), key: 'service' },
-      { name: t('filter_by.values.region'), key: 'region' },
-      { name: t('filter_by.values.tag'), key: 'tag' },
-    ];
     return report && report.data && report.data.length
-      ? options
-      : options.filter(option => option.key !== 'tag');
+      ? defaultOptions
+      : defaultOptions.filter(option => option.key !== 'tag');
   };
 
   public render() {
@@ -77,10 +93,11 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       query,
       report,
     } = this.props;
+    const { categoryOptions } = this.state;
 
     return (
       <Toolbar
-        categoryOptions={this.getCategoryOptions()}
+        categoryOptions={categoryOptions}
         groupBy={groupBy}
         isExportDisabled={isExportDisabled}
         onExportClicked={onExportClicked}

--- a/src/pages/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/details/awsDetails/detailsToolbar.tsx
@@ -1,3 +1,4 @@
+import { DataToolbarChipGroup } from '@patternfly/react-core';
 import { AwsQuery, getQuery } from 'api/queries/awsQuery';
 import { AwsReport } from 'api/reports/awsReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
@@ -51,7 +52,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     }
   }
 
-  private getCategoryOptions = () => {
+  private getCategoryOptions = (): DataToolbarChipGroup[] => {
     const { report, t } = this.props;
 
     const options = [

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -287,22 +287,20 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     const { history, query } = this.props;
     const newQuery = { ...JSON.parse(JSON.stringify(query)) };
 
-    const groupByTagKey = this.getGroupByTagKey();
-    const newFilterType =
-      filterType === 'tag' ? `${tagKeyPrefix}${groupByTagKey}` : filterType;
-
-    if (filterValue === '') {
+    if (filterType === null) {
       newQuery.filter_by = undefined; // Clear all
-    } else if (!Array.isArray(newQuery.filter_by[newFilterType])) {
-      newQuery.filter_by[newFilterType] = undefined;
-    } else {
-      const index = newQuery.filter_by[newFilterType].indexOf(filterValue);
+    } else if (filterValue === null) {
+      newQuery.filter_by[filterType] = undefined; // Clear all values
+    } else if (Array.isArray(newQuery.filter_by[filterType])) {
+      const index = newQuery.filter_by[filterType].indexOf(filterValue);
       if (index > -1) {
-        newQuery.filter_by[newFilterType] = [
-          ...query.filter_by[newFilterType].slice(0, index),
-          ...query.filter_by[newFilterType].slice(index + 1),
+        newQuery.filter_by[filterType] = [
+          ...query.filter_by[filterType].slice(0, index),
+          ...query.filter_by[filterType].slice(index + 1),
         ];
       }
+    } else {
+      newQuery.filter_by[filterType] = undefined;
     }
     const filteredQuery = this.getRouteForQuery(newQuery, true);
     history.replace(filteredQuery);

--- a/src/pages/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/details/azureDetails/detailsToolbar.tsx
@@ -56,19 +56,19 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 
     const options = [
       {
-        label: t('filter_by.values.subscription_guid'),
-        value: 'subscription_guid',
+        name: t('filter_by.values.subscription_guid'),
+        key: 'subscription_guid',
       },
-      { label: t('filter_by.values.service_name'), value: 'service_name' },
+      { name: t('filter_by.values.service_name'), key: 'service_name' },
       {
-        label: t('filter_by.values.resource_location'),
-        value: 'resource_location',
+        name: t('filter_by.values.resource_location'),
+        key: 'resource_location',
       },
-      { label: t('filter_by.values.tag'), value: 'tag' },
+      { name: t('filter_by.values.tag'), key: 'tag' },
     ];
     return report && report.data && report.data.length
       ? options
-      : options.filter(option => option.value !== 'tag');
+      : options.filter(option => option.key !== 'tag');
   };
 
   public render() {

--- a/src/pages/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/details/azureDetails/detailsToolbar.tsx
@@ -1,3 +1,4 @@
+import { DataToolbarChipGroup } from '@patternfly/react-core';
 import { AzureQuery, getQuery } from 'api/queries/azureQuery';
 import { AzureReport } from 'api/reports/azureReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
@@ -51,7 +52,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     }
   }
 
-  private getCategoryOptions = () => {
+  private getCategoryOptions = (): DataToolbarChipGroup[] => {
     const { report, t } = this.props;
 
     const options = [

--- a/src/pages/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/details/azureDetails/detailsToolbar.tsx
@@ -2,6 +2,7 @@ import { DataToolbarChipGroup } from '@patternfly/react-core';
 import { AzureQuery, getQuery } from 'api/queries/azureQuery';
 import { AzureReport } from 'api/reports/azureReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
+import i18next from 'i18next';
 import { Toolbar } from 'pages/details/components/toolbar/toolbar';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -31,45 +32,60 @@ interface DetailsToolbarDispatchProps {
   fetchReport?: typeof reportActions.fetchReport;
 }
 
+interface DetailsToolbarState {
+  categoryOptions?: DataToolbarChipGroup[];
+}
+
 type DetailsToolbarProps = DetailsToolbarOwnProps &
   DetailsToolbarStateProps &
   DetailsToolbarDispatchProps &
   InjectedTranslateProps;
 
+const defaultOptions = [
+  {
+    name: i18next.t('filter_by.values.subscription_guid'),
+    key: 'subscription_guid',
+  },
+  { name: i18next.t('filter_by.values.service_name'), key: 'service_name' },
+  {
+    name: i18next.t('filter_by.values.resource_location'),
+    key: 'resource_location',
+  },
+  { name: i18next.t('filter_by.values.tag'), key: 'tag' },
+];
+
 const reportType = ReportType.tag;
 const reportPathsType = ReportPathsType.azure;
 
 export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
+  protected defaultState: DetailsToolbarState = {
+    categoryOptions: defaultOptions,
+  };
+  public state: DetailsToolbarState = { ...this.defaultState };
+
   public componentDidMount() {
     const { fetchReport, queryString } = this.props;
     fetchReport(reportPathsType, reportType, queryString);
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps, prevState) {
-    const { fetchReport, query, queryString } = this.props;
+    const { fetchReport, query, queryString, report } = this.props;
     if (query && !isEqual(query, prevProps.query)) {
       fetchReport(reportPathsType, reportType, queryString);
+    }
+    if (!isEqual(report, prevProps.report)) {
+      this.setState({
+        categoryOptions: this.getCategoryOptions(),
+      });
     }
   }
 
   private getCategoryOptions = (): DataToolbarChipGroup[] => {
-    const { report, t } = this.props;
+    const { report } = this.props;
 
-    const options = [
-      {
-        name: t('filter_by.values.subscription_guid'),
-        key: 'subscription_guid',
-      },
-      { name: t('filter_by.values.service_name'), key: 'service_name' },
-      {
-        name: t('filter_by.values.resource_location'),
-        key: 'resource_location',
-      },
-      { name: t('filter_by.values.tag'), key: 'tag' },
-    ];
     return report && report.data && report.data.length
-      ? options
-      : options.filter(option => option.key !== 'tag');
+      ? defaultOptions
+      : defaultOptions.filter(option => option.key !== 'tag');
   };
 
   public render() {
@@ -83,10 +99,11 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       query,
       report,
     } = this.props;
+    const { categoryOptions } = this.state;
 
     return (
       <Toolbar
-        categoryOptions={this.getCategoryOptions()}
+        categoryOptions={categoryOptions}
         groupBy={groupBy}
         isExportDisabled={isExportDisabled}
         onExportClicked={onExportClicked}

--- a/src/pages/details/components/toolbar/toolbar.tsx
+++ b/src/pages/details/components/toolbar/toolbar.tsx
@@ -13,6 +13,7 @@ import {
 } from '@patternfly/react-core';
 import {
   DataToolbar,
+  DataToolbarChipGroup,
   DataToolbarContent,
   DataToolbarFilter,
   DataToolbarGroup,
@@ -34,7 +35,7 @@ interface Filters {
 }
 
 interface ToolbarOwnProps {
-  categoryOptions?: { name: string; key: string }[]; // Options for category menu
+  categoryOptions?: DataToolbarChipGroup[]; // Options for category menu
   groupBy?: string; // Sync category selection with groupBy value
   isExportDisabled?: boolean; // Show export icon as disabled
   onExportClicked();
@@ -150,22 +151,24 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
   };
 
   private onDelete = (type, id) => {
-    if (type) {
+    if (type && type.key) {
+      const filterType = type.key;
+
       // Workaround for https://github.com/patternfly/patternfly-react/issues/3552
       // This prevents us from using an ID
-      let filterType = type.toLowerCase();
-
-      // Workaround for Azure IDs
-      if (filterType === 'account' && this.state.filters.subscription_guid) {
-        filterType = 'subscription_guid';
-      } else if (
-        filterType === 'region' &&
-        this.state.filters.resource_location
-      ) {
-        filterType = 'resource_location';
-      } else if (filterType === 'service' && this.state.filters.service_name) {
-        filterType = 'service_name';
-      }
+      // let filterType = type.toLowerCase();
+      //
+      // // Workaround for Azure IDs
+      // if (filterType === 'account' && this.state.filters.subscription_guid) {
+      //   filterType = 'subscription_guid';
+      // } else if (
+      //   filterType === 'region' &&
+      //   this.state.filters.resource_location
+      // ) {
+      //   filterType = 'resource_location';
+      // } else if (filterType === 'service' && this.state.filters.service_name) {
+      //   filterType = 'service_name';
+      // }
 
       this.setState(
         (prevState: any) => {
@@ -243,7 +246,7 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
     );
   }
 
-  private getCurrentCategoryOption = () => {
+  private getCurrentCategoryOption = (): DataToolbarChipGroup => {
     const { categoryOptions } = this.props;
     const { currentCategory } = this.state;
 
@@ -286,7 +289,7 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
 
     return (
       <DataToolbarFilter
-        categoryName={categoryOption.name}
+        categoryName={categoryOption}
         chips={filters[categoryOption.key]}
         deleteChip={this.onDelete}
         key={categoryOption.key}
@@ -315,7 +318,7 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
     );
   };
 
-  private getDefaultCategoryOptions = () => {
+  private getDefaultCategoryOptions = (): DataToolbarChipGroup[] => {
     const { t } = this.props;
 
     return [{ name: t('filter_by.values.name'), key: 'name' }];

--- a/src/pages/details/components/toolbar/toolbar.tsx
+++ b/src/pages/details/components/toolbar/toolbar.tsx
@@ -34,7 +34,7 @@ interface Filters {
 }
 
 interface ToolbarOwnProps {
-  categoryOptions?: { label: string; value: string }[]; // Options for category menu
+  categoryOptions?: { name: string; key: string }[]; // Options for category menu
   groupBy?: string; // Sync category selection with groupBy value
   isExportDisabled?: boolean; // Show export icon as disabled
   onExportClicked();
@@ -119,15 +119,15 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
 
     for (const option of categoryOptions) {
       if (
-        groupBy === option.value ||
+        groupBy === option.key ||
         (groupBy &&
           groupBy.indexOf(tagKeyPrefix) !== -1 &&
-          option.value === 'tag')
+          option.key === 'tag')
       ) {
-        return option.value;
+        return option.key;
       }
     }
-    return categoryOptions[0].value;
+    return categoryOptions[0].key;
   };
 
   private getActiveFilters = query => {
@@ -222,7 +222,7 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
               onToggle={this.onCategoryToggle}
               style={{ width: '100%' }}
             >
-              <FilterIcon /> {this.getCurrentCategoryOption().label}
+              <FilterIcon /> {this.getCurrentCategoryOption().name}
             </DropdownToggle>
           }
           isOpen={isCategoryDropdownOpen}
@@ -230,10 +230,10 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
             categoryOptions &&
             categoryOptions.map(option => (
               <DropdownItem
-                key={option.value}
-                onClick={() => this.onCategoryClick(option.value)}
+                key={option.key}
+                onClick={() => this.onCategoryClick(option.key)}
               >
-                {option.label}
+                {option.name}
               </DropdownItem>
             ))
           }
@@ -251,7 +251,7 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
       return undefined;
     }
     for (const option of categoryOptions) {
-      if (currentCategory === option.value) {
+      if (currentCategory === option.key) {
         return option;
       }
     }
@@ -286,29 +286,27 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
 
     return (
       <DataToolbarFilter
-        categoryName={categoryOption.label}
-        chips={filters[categoryOption.value]}
+        categoryName={categoryOption.name}
+        chips={filters[categoryOption.key]}
         deleteChip={this.onDelete}
-        key={categoryOption.value}
-        showToolbarItem={currentCategory === categoryOption.value}
+        key={categoryOption.key}
+        showToolbarItem={currentCategory === categoryOption.key}
       >
         <InputGroup>
           <TextInput
-            name={`${categoryOption.value}-input`}
-            id={`${categoryOption.value}-input`}
+            name={`${categoryOption.key}-input`}
+            id={`${categoryOption.key}-input`}
             type="search"
-            aria-label={t(`filter_by.${categoryOption.value}_input_aria_label`)}
+            aria-label={t(`filter_by.${categoryOption.key}_input_aria_label`)}
             onChange={this.onCategoryInputChange}
             value={categoryInput}
-            placeholder={t(`filter_by.${categoryOption.value}_placeholder`)}
-            onKeyDown={evt => this.onCategoryInput(evt, categoryOption.value)}
+            placeholder={t(`filter_by.${categoryOption.key}_placeholder`)}
+            onKeyDown={evt => this.onCategoryInput(evt, categoryOption.key)}
           />
           <Button
             variant={ButtonVariant.control}
-            aria-label={t(
-              `filter_by.${categoryOption.value}_button_aria_label`
-            )}
-            onClick={evt => this.onCategoryInput(evt, categoryOption.value)}
+            aria-label={t(`filter_by.${categoryOption.key}_button_aria_label`)}
+            onClick={evt => this.onCategoryInput(evt, categoryOption.key)}
           >
             <SearchIcon />
           </Button>
@@ -320,7 +318,7 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
   private getDefaultCategoryOptions = () => {
     const { t } = this.props;
 
-    return [{ label: t('filter_by.values.name'), value: 'name' }];
+    return [{ name: t('filter_by.values.name'), key: 'name' }];
   };
 
   private onCategoryInputChange = value => {
@@ -680,7 +678,7 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
                 )}
                 {options &&
                   options
-                    .filter(option => option.value !== 'tag')
+                    .filter(option => option.key !== 'tag')
                     .map(option => this.getCategoryInput(option))}
               </DataToolbarGroup>
               {Boolean(showExport) && (

--- a/src/pages/details/components/toolbar/toolbar.tsx
+++ b/src/pages/details/components/toolbar/toolbar.tsx
@@ -151,25 +151,11 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
   };
 
   private onDelete = (type, id) => {
-    if (type && type.key) {
-      const filterType = type.key;
+    // Todo: workaround for https://github.com/patternfly/patternfly-react/issues/3552
+    // This prevents us from using a localized string, if necessary
+    const filterType = type && type.key ? type.key : type;
 
-      // Workaround for https://github.com/patternfly/patternfly-react/issues/3552
-      // This prevents us from using an ID
-      // let filterType = type.toLowerCase();
-      //
-      // // Workaround for Azure IDs
-      // if (filterType === 'account' && this.state.filters.subscription_guid) {
-      //   filterType = 'subscription_guid';
-      // } else if (
-      //   filterType === 'region' &&
-      //   this.state.filters.resource_location
-      // ) {
-      //   filterType = 'resource_location';
-      // } else if (filterType === 'service' && this.state.filters.service_name) {
-      //   filterType = 'service_name';
-      // }
-
+    if (filterType) {
       this.setState(
         (prevState: any) => {
           if (prevState.filters.tag[filterType]) {
@@ -371,9 +357,7 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
     }
 
     const selectOptions = this.getTagKeyOptions().map(selectOption => {
-      return (
-        <SelectOption key={selectOption.value} value={selectOption.value} />
-      );
+      return <SelectOption key={selectOption.key} value={selectOption.key} />;
     });
 
     return (
@@ -394,7 +378,7 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
     );
   };
 
-  private getTagKeyOptions() {
+  private getTagKeyOptions(): DataToolbarChipGroup[] {
     const { report } = this.props;
 
     let data = [];
@@ -423,8 +407,10 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
 
     if (data.length > 0) {
       options = data.map(tag => {
+        const key = hasTagKeys ? tag.key : tag;
         return {
-          value: hasTagKeys ? tag.key : tag,
+          key,
+          name: key, // tag keys not localized
         };
       });
     }
@@ -464,32 +450,17 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
     } = this.state;
 
     const selectOptions = this.getTagValueOptions().map(selectOption => {
-      return (
-        <SelectOption key={selectOption.value} value={selectOption.value} />
-      );
+      return <SelectOption key={selectOption.key} value={selectOption.key} />;
     });
-
-    // Workaround for https://github.com/patternfly/patternfly-react/issues/3770
-    if (
-      !(
-        (filters.tag[tagKeyPrefixOption.value] &&
-          filters.tag[tagKeyPrefixOption.value].length) ||
-        (currentCategory === 'tag' &&
-          currentTagKey === tagKeyPrefixOption.value)
-      )
-    ) {
-      return null;
-    }
 
     return (
       <DataToolbarFilter
-        categoryName={tagKeyPrefixOption.value}
-        chips={filters.tag[tagKeyPrefixOption.value]}
+        categoryName={tagKeyPrefixOption}
+        chips={filters.tag[tagKeyPrefixOption.key]}
         deleteChip={this.onDelete}
-        key={tagKeyPrefixOption.value}
+        key={tagKeyPrefixOption.key}
         showToolbarItem={
-          currentCategory === 'tag' &&
-          currentTagKey === tagKeyPrefixOption.value
+          currentCategory === 'tag' && currentTagKey === tagKeyPrefixOption.key
         }
       >
         {Boolean(selectOptions.length < tagKeyValueLimit) ? (
@@ -499,8 +470,8 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
             onToggle={this.onTagValueToggle}
             onSelect={this.onTagValueSelect}
             selections={
-              filters.tag[tagKeyPrefixOption.value]
-                ? filters.tag[tagKeyPrefixOption.value]
+              filters.tag[tagKeyPrefixOption.key]
+                ? filters.tag[tagKeyPrefixOption.key]
                 : []
             }
             isExpanded={isTagValueSelectExpanded}
@@ -533,7 +504,7 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
     );
   };
 
-  private getTagValueOptions() {
+  private getTagValueOptions(): DataToolbarChipGroup[] {
     const { report } = this.props;
     const { currentTagKey } = this.state;
 
@@ -548,7 +519,8 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
         if (currentTagKey === tag.key && tag.values) {
           options = tag.values.map(val => {
             return {
-              value: val,
+              key: val,
+              name: val, // tag key values not localized
             };
           });
           break;

--- a/src/pages/details/ocpCloudDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsToolbar.tsx
@@ -1,3 +1,4 @@
+import { DataToolbarChipGroup } from '@patternfly/react-core';
 import { getQuery, OcpCloudQuery } from 'api/queries/ocpCloudQuery';
 import { OcpCloudReport } from 'api/reports/ocpCloudReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
@@ -51,7 +52,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     }
   }
 
-  private getCategoryOptions = () => {
+  private getCategoryOptions = (): DataToolbarChipGroup[] => {
     const { report, t } = this.props;
 
     const options = [

--- a/src/pages/details/ocpCloudDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsToolbar.tsx
@@ -55,14 +55,14 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     const { report, t } = this.props;
 
     const options = [
-      { label: t('filter_by.values.cluster'), value: 'cluster' },
-      { label: t('filter_by.values.node'), value: 'node' },
-      { label: t('filter_by.values.project'), value: 'project' },
-      { label: t('filter_by.values.tag'), value: 'tag' },
+      { name: t('filter_by.values.cluster'), key: 'cluster' },
+      { name: t('filter_by.values.node'), key: 'node' },
+      { name: t('filter_by.values.project'), key: 'project' },
+      { name: t('filter_by.values.tag'), key: 'tag' },
     ];
     return report && report.data && report.data.length
       ? options
-      : options.filter(option => option.value !== 'tag');
+      : options.filter(option => option.key !== 'tag');
   };
 
   public render() {

--- a/src/pages/details/ocpCloudDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsToolbar.tsx
@@ -2,6 +2,7 @@ import { DataToolbarChipGroup } from '@patternfly/react-core';
 import { getQuery, OcpCloudQuery } from 'api/queries/ocpCloudQuery';
 import { OcpCloudReport } from 'api/reports/ocpCloudReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
+import i18next from 'i18next';
 import { Toolbar } from 'pages/details/components/toolbar/toolbar';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -31,39 +32,54 @@ interface DetailsToolbarDispatchProps {
   fetchReport?: typeof reportActions.fetchReport;
 }
 
+interface DetailsToolbarState {
+  categoryOptions?: DataToolbarChipGroup[];
+}
+
 type DetailsToolbarProps = DetailsToolbarOwnProps &
   DetailsToolbarStateProps &
   DetailsToolbarDispatchProps &
   InjectedTranslateProps;
 
+const defaultOptions = [
+  { name: i18next.t('filter_by.values.cluster'), key: 'cluster' },
+  { name: i18next.t('filter_by.values.node'), key: 'node' },
+  { name: i18next.t('filter_by.values.project'), key: 'project' },
+  { name: i18next.t('filter_by.values.tag'), key: 'tag' },
+];
+
 const reportType = ReportType.tag;
 const reportPathsType = ReportPathsType.ocpCloud;
 
 export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
+  protected defaultState: DetailsToolbarState = {
+    categoryOptions: defaultOptions,
+  };
+  public state: DetailsToolbarState = { ...this.defaultState };
+
   public componentDidMount() {
     const { fetchReport, queryString } = this.props;
     fetchReport(reportPathsType, reportType, queryString);
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps, prevState) {
-    const { fetchReport, query, queryString } = this.props;
+    const { fetchReport, query, queryString, report } = this.props;
     if (query && !isEqual(query, prevProps.query)) {
       fetchReport(reportPathsType, reportType, queryString);
+    }
+    if (!isEqual(report, prevProps.report)) {
+      this.setState({
+        categoryOptions: this.getCategoryOptions(),
+      });
     }
   }
 
   private getCategoryOptions = (): DataToolbarChipGroup[] => {
-    const { report, t } = this.props;
+    const { report } = this.props;
 
-    const options = [
-      { name: t('filter_by.values.cluster'), key: 'cluster' },
-      { name: t('filter_by.values.node'), key: 'node' },
-      { name: t('filter_by.values.project'), key: 'project' },
-      { name: t('filter_by.values.tag'), key: 'tag' },
-    ];
     return report && report.data && report.data.length
-      ? options
-      : options.filter(option => option.key !== 'tag');
+      ? defaultOptions
+      : defaultOptions.filter(option => option.key !== 'tag');
   };
 
   public render() {
@@ -77,10 +93,11 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       query,
       report,
     } = this.props;
+    const { categoryOptions } = this.state;
 
     return (
       <Toolbar
-        categoryOptions={this.getCategoryOptions()}
+        categoryOptions={categoryOptions}
         groupBy={groupBy}
         isExportDisabled={isExportDisabled}
         onExportClicked={onExportClicked}

--- a/src/pages/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpDetails/detailsToolbar.tsx
@@ -55,14 +55,14 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     const { report, t } = this.props;
 
     const options = [
-      { label: t('filter_by.values.cluster'), value: 'cluster' },
-      { label: t('filter_by.values.node'), value: 'node' },
-      { label: t('filter_by.values.project'), value: 'project' },
-      { label: t('filter_by.values.tag'), value: 'tag' },
+      { name: t('filter_by.values.cluster'), key: 'cluster' },
+      { name: t('filter_by.values.node'), key: 'node' },
+      { name: t('filter_by.values.project'), key: 'project' },
+      { name: t('filter_by.values.tag'), key: 'tag' },
     ];
     return report && report.data && report.data.length
       ? options
-      : options.filter(option => option.value !== 'tag');
+      : options.filter(option => option.key !== 'tag');
   };
 
   public render() {

--- a/src/pages/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpDetails/detailsToolbar.tsx
@@ -2,6 +2,7 @@ import { DataToolbarChipGroup } from '@patternfly/react-core';
 import { getQuery, OcpQuery } from 'api/queries/ocpQuery';
 import { OcpReport } from 'api/reports/ocpReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
+import i18next from 'i18next';
 import { Toolbar } from 'pages/details/components/toolbar/toolbar';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -31,39 +32,54 @@ interface DetailsToolbarDispatchProps {
   fetchReport?: typeof reportActions.fetchReport;
 }
 
+interface DetailsToolbarState {
+  categoryOptions?: DataToolbarChipGroup[];
+}
+
 type DetailsToolbarProps = DetailsToolbarOwnProps &
   DetailsToolbarStateProps &
   DetailsToolbarDispatchProps &
   InjectedTranslateProps;
 
+const defaultOptions = [
+  { name: i18next.t('filter_by.values.cluster'), key: 'cluster' },
+  { name: i18next.t('filter_by.values.node'), key: 'node' },
+  { name: i18next.t('filter_by.values.project'), key: 'project' },
+  { name: i18next.t('filter_by.values.tag'), key: 'tag' },
+];
+
 const reportType = ReportType.tag;
 const reportPathsType = ReportPathsType.ocp;
 
 export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
+  protected defaultState: DetailsToolbarState = {
+    categoryOptions: defaultOptions,
+  };
+  public state: DetailsToolbarState = { ...this.defaultState };
+
   public componentDidMount() {
     const { fetchReport, queryString } = this.props;
     fetchReport(reportPathsType, reportType, queryString);
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps, prevState) {
-    const { fetchReport, query, queryString } = this.props;
+    const { fetchReport, query, queryString, report } = this.props;
     if (query && !isEqual(query, prevProps.query)) {
       fetchReport(reportPathsType, reportType, queryString);
+    }
+    if (!isEqual(report, prevProps.report)) {
+      this.setState({
+        categoryOptions: this.getCategoryOptions(),
+      });
     }
   }
 
   private getCategoryOptions = (): DataToolbarChipGroup[] => {
-    const { report, t } = this.props;
+    const { report } = this.props;
 
-    const options = [
-      { name: t('filter_by.values.cluster'), key: 'cluster' },
-      { name: t('filter_by.values.node'), key: 'node' },
-      { name: t('filter_by.values.project'), key: 'project' },
-      { name: t('filter_by.values.tag'), key: 'tag' },
-    ];
     return report && report.data && report.data.length
-      ? options
-      : options.filter(option => option.key !== 'tag');
+      ? defaultOptions
+      : defaultOptions.filter(option => option.key !== 'tag');
   };
 
   public render() {
@@ -77,10 +93,11 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       query,
       report,
     } = this.props;
+    const { categoryOptions } = this.state;
 
     return (
       <Toolbar
-        categoryOptions={this.getCategoryOptions()}
+        categoryOptions={categoryOptions}
         groupBy={groupBy}
         isExportDisabled={isExportDisabled}
         onExportClicked={onExportClicked}

--- a/src/pages/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpDetails/detailsToolbar.tsx
@@ -1,3 +1,4 @@
+import { DataToolbarChipGroup } from '@patternfly/react-core';
 import { getQuery, OcpQuery } from 'api/queries/ocpQuery';
 import { OcpReport } from 'api/reports/ocpReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
@@ -51,7 +52,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     }
   }
 
-  private getCategoryOptions = () => {
+  private getCategoryOptions = (): DataToolbarChipGroup[] => {
     const { report, t } = this.props;
 
     const options = [


### PR DESCRIPTION
Replace workarounds for PatternFly's DataToolbarFilter with the new DataToolbarChipGroup interface.

https://github.com/project-koku/koku-ui/issues/1523

<img width="716" alt="Screen Shot 2020-04-20 at 5 44 29 PM" src="https://user-images.githubusercontent.com/17481322/79802789-9df47780-832e-11ea-900b-fb4dbbbe1bfa.png">
