### PR TITLE
Remove tag modal islarge workaround

### DIFF
--- a/src/pages/details/components/tag/tagModal.styles.ts
+++ b/src/pages/details/components/tag/tagModal.styles.ts
@@ -10,11 +10,6 @@ export const styles = {
 } as { [className: string]: React.CSSProperties };
 
 export const modalOverride = css`
-  /* Workaround for isLarge not working properly */
-  &.pf-c-modal-box {
-    height: 700px;
-    width: 600px;
-  }
   & .pf-c-modal-box__body {
     margin-top: ${global_spacer_lg.value};
   }


### PR DESCRIPTION
When there are only a few tags, the modal appears too large. Ideally, the modal would shrink to the height of its contents.

We had some style workarounds for PatternFly's isLarge / isSmall properties not working properly. We can remove those styles now.

https://github.com/project-koku/koku-ui/issues/1531