### PR TITLE
Remove chart modal isLarge workaround

### DIFF
--- a/src/pages/details/components/historicalChart/historicalModal.styles.ts
+++ b/src/pages/details/components/historicalChart/historicalModal.styles.ts
@@ -1,11 +1,6 @@
 import { css } from 'emotion';
 
 export const modalOverride = css`
-  /* Workaround for isLarge not working properly */
-  &.pf-c-modal-box {
-    height: '900px;
-    width: ' 1200px;
-  }
   & .pf-c-modal-box__footer {
     display: none;
   }


### PR DESCRIPTION
We had some style workarounds for PatternFly's isLarge / isSmall properties not working properly. It appears that we can remove those styles now.

https://github.com/project-koku/koku-ui/issues/1533