### PR TITLE
Ocp details shows i18n keys

### DIFF
--- a/src/pages/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/details/awsDetails/detailsToolbar.tsx
@@ -2,7 +2,6 @@ import { DataToolbarChipGroup } from '@patternfly/react-core';
 import { AwsQuery, getQuery } from 'api/queries/awsQuery';
 import { AwsReport } from 'api/reports/awsReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
-import i18next from 'i18next';
 import { Toolbar } from 'pages/details/components/toolbar/toolbar';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -41,25 +40,19 @@ type DetailsToolbarProps = DetailsToolbarOwnProps &
   DetailsToolbarDispatchProps &
   InjectedTranslateProps;
 
-const defaultOptions = [
-  { name: i18next.t('filter_by.values.account'), key: 'account' },
-  { name: i18next.t('filter_by.values.service'), key: 'service' },
-  { name: i18next.t('filter_by.values.region'), key: 'region' },
-  { name: i18next.t('filter_by.values.tag'), key: 'tag' },
-];
-
 const reportType = ReportType.tag;
 const reportPathsType = ReportPathsType.aws;
 
 export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
-  protected defaultState: DetailsToolbarState = {
-    categoryOptions: defaultOptions,
-  };
+  protected defaultState: DetailsToolbarState = {};
   public state: DetailsToolbarState = { ...this.defaultState };
 
   public componentDidMount() {
     const { fetchReport, queryString } = this.props;
     fetchReport(reportPathsType, reportType, queryString);
+    this.setState({
+      categoryOptions: this.getCategoryOptions(),
+    });
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps, prevState) {
@@ -75,11 +68,18 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   private getCategoryOptions = (): DataToolbarChipGroup[] => {
-    const { report } = this.props;
+    const { report, t } = this.props;
+
+    const options = [
+      { name: t('filter_by.values.account'), key: 'account' },
+      { name: t('filter_by.values.service'), key: 'service' },
+      { name: t('filter_by.values.region'), key: 'region' },
+      { name: t('filter_by.values.tag'), key: 'tag' },
+    ];
 
     return report && report.data && report.data.length
-      ? defaultOptions
-      : defaultOptions.filter(option => option.key !== 'tag');
+      ? options
+      : options.filter(option => option.key !== 'tag');
   };
 
   public render() {

--- a/src/pages/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/details/azureDetails/detailsToolbar.tsx
@@ -2,7 +2,6 @@ import { DataToolbarChipGroup } from '@patternfly/react-core';
 import { AzureQuery, getQuery } from 'api/queries/azureQuery';
 import { AzureReport } from 'api/reports/azureReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
-import i18next from 'i18next';
 import { Toolbar } from 'pages/details/components/toolbar/toolbar';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -41,31 +40,19 @@ type DetailsToolbarProps = DetailsToolbarOwnProps &
   DetailsToolbarDispatchProps &
   InjectedTranslateProps;
 
-const defaultOptions = [
-  {
-    name: i18next.t('filter_by.values.subscription_guid'),
-    key: 'subscription_guid',
-  },
-  { name: i18next.t('filter_by.values.service_name'), key: 'service_name' },
-  {
-    name: i18next.t('filter_by.values.resource_location'),
-    key: 'resource_location',
-  },
-  { name: i18next.t('filter_by.values.tag'), key: 'tag' },
-];
-
 const reportType = ReportType.tag;
 const reportPathsType = ReportPathsType.azure;
 
 export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
-  protected defaultState: DetailsToolbarState = {
-    categoryOptions: defaultOptions,
-  };
+  protected defaultState: DetailsToolbarState = {};
   public state: DetailsToolbarState = { ...this.defaultState };
 
   public componentDidMount() {
     const { fetchReport, queryString } = this.props;
     fetchReport(reportPathsType, reportType, queryString);
+    this.setState({
+      categoryOptions: this.getCategoryOptions(),
+    });
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps, prevState) {
@@ -81,11 +68,24 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   private getCategoryOptions = (): DataToolbarChipGroup[] => {
-    const { report } = this.props;
+    const { report, t } = this.props;
+
+    const options = [
+      {
+        name: t('filter_by.values.subscription_guid'),
+        key: 'subscription_guid',
+      },
+      { name: t('filter_by.values.service_name'), key: 'service_name' },
+      {
+        name: t('filter_by.values.resource_location'),
+        key: 'resource_location',
+      },
+      { name: t('filter_by.values.tag'), key: 'tag' },
+    ];
 
     return report && report.data && report.data.length
-      ? defaultOptions
-      : defaultOptions.filter(option => option.key !== 'tag');
+      ? options
+      : options.filter(option => option.key !== 'tag');
   };
 
   public render() {

--- a/src/pages/details/components/toolbar/toolbar.tsx
+++ b/src/pages/details/components/toolbar/toolbar.tsx
@@ -88,16 +88,18 @@ export class ToolbarBase extends React.Component<ToolbarProps> {
   }
 
   public componentDidUpdate(prevProps: ToolbarProps, prevState) {
-    const { groupBy, query, report } = this.props;
+    const { categoryOptions, groupBy, query, report } = this.props;
 
     if (
+      categoryOptions !== prevProps.categoryOptions ||
       groupBy !== prevProps.groupBy ||
       (query && !isEqual(query, prevProps.query)) ||
       (report && !isEqual(report, prevProps.report))
     ) {
       this.setState(() => {
         const filters = this.getActiveFilters(query);
-        return prevProps.groupBy !== groupBy
+        return categoryOptions !== prevProps.categoryOptions ||
+          prevProps.groupBy !== groupBy
           ? {
               currentCategory: this.getDefaultCategory(),
               filters,

--- a/src/pages/details/ocpCloudDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpCloudDetails/detailsToolbar.tsx
@@ -2,7 +2,6 @@ import { DataToolbarChipGroup } from '@patternfly/react-core';
 import { getQuery, OcpCloudQuery } from 'api/queries/ocpCloudQuery';
 import { OcpCloudReport } from 'api/reports/ocpCloudReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
-import i18next from 'i18next';
 import { Toolbar } from 'pages/details/components/toolbar/toolbar';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -41,25 +40,19 @@ type DetailsToolbarProps = DetailsToolbarOwnProps &
   DetailsToolbarDispatchProps &
   InjectedTranslateProps;
 
-const defaultOptions = [
-  { name: i18next.t('filter_by.values.cluster'), key: 'cluster' },
-  { name: i18next.t('filter_by.values.node'), key: 'node' },
-  { name: i18next.t('filter_by.values.project'), key: 'project' },
-  { name: i18next.t('filter_by.values.tag'), key: 'tag' },
-];
-
 const reportType = ReportType.tag;
 const reportPathsType = ReportPathsType.ocpCloud;
 
 export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
-  protected defaultState: DetailsToolbarState = {
-    categoryOptions: defaultOptions,
-  };
+  protected defaultState: DetailsToolbarState = {};
   public state: DetailsToolbarState = { ...this.defaultState };
 
   public componentDidMount() {
     const { fetchReport, queryString } = this.props;
     fetchReport(reportPathsType, reportType, queryString);
+    this.setState({
+      categoryOptions: this.getCategoryOptions(),
+    });
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps, prevState) {
@@ -75,11 +68,18 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   private getCategoryOptions = (): DataToolbarChipGroup[] => {
-    const { report } = this.props;
+    const { report, t } = this.props;
+
+    const options = [
+      { name: t('filter_by.values.cluster'), key: 'cluster' },
+      { name: t('filter_by.values.node'), key: 'node' },
+      { name: t('filter_by.values.project'), key: 'project' },
+      { name: t('filter_by.values.tag'), key: 'tag' },
+    ];
 
     return report && report.data && report.data.length
-      ? defaultOptions
-      : defaultOptions.filter(option => option.key !== 'tag');
+      ? options
+      : options.filter(option => option.key !== 'tag');
   };
 
   public render() {

--- a/src/pages/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpDetails/detailsToolbar.tsx
@@ -2,7 +2,6 @@ import { DataToolbarChipGroup } from '@patternfly/react-core';
 import { getQuery, OcpQuery } from 'api/queries/ocpQuery';
 import { OcpReport } from 'api/reports/ocpReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
-import i18next from 'i18next';
 import { Toolbar } from 'pages/details/components/toolbar/toolbar';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -41,25 +40,19 @@ type DetailsToolbarProps = DetailsToolbarOwnProps &
   DetailsToolbarDispatchProps &
   InjectedTranslateProps;
 
-const defaultOptions = [
-  { name: i18next.t('filter_by.values.cluster'), key: 'cluster' },
-  { name: i18next.t('filter_by.values.node'), key: 'node' },
-  { name: i18next.t('filter_by.values.project'), key: 'project' },
-  { name: i18next.t('filter_by.values.tag'), key: 'tag' },
-];
-
 const reportType = ReportType.tag;
 const reportPathsType = ReportPathsType.ocp;
 
 export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
-  protected defaultState: DetailsToolbarState = {
-    categoryOptions: defaultOptions,
-  };
+  protected defaultState: DetailsToolbarState = {};
   public state: DetailsToolbarState = { ...this.defaultState };
 
   public componentDidMount() {
     const { fetchReport, queryString } = this.props;
     fetchReport(reportPathsType, reportType, queryString);
+    this.setState({
+      categoryOptions: this.getCategoryOptions(),
+    });
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps, prevState) {
@@ -75,11 +68,18 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   private getCategoryOptions = (): DataToolbarChipGroup[] => {
-    const { report } = this.props;
+    const { report, t } = this.props;
+
+    const options = [
+      { name: t('filter_by.values.cluster'), key: 'cluster' },
+      { name: t('filter_by.values.node'), key: 'node' },
+      { name: t('filter_by.values.project'), key: 'project' },
+      { name: t('filter_by.values.tag'), key: 'tag' },
+    ];
 
     return report && report.data && report.data.length
-      ? defaultOptions
-      : defaultOptions.filter(option => option.key !== 'tag');
+      ? options
+      : options.filter(option => option.key !== 'tag');
   };
 
   public render() {


### PR DESCRIPTION
Seems i18next doesn't always translate when code is located outside of a component. For example, when refreshing the page or quickly navigating from one page to another.

https://github.com/project-koku/koku-ui/issues/1529