### PR TITLE
Perspective offers choices that have no data

### DIFF
--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -87,7 +87,7 @@ interface AvailableTab {
 
 interface OverviewState {
   activeTabKey: number;
-  currentInfrastructurePerspective: string;
+  currentInfrastructurePerspective?: string;
   currentOcpPerspective?: string;
   showPopover: boolean;
 }
@@ -100,8 +100,8 @@ const ocpOptions = [
   { label: 'overview.perspective.supplementary', value: 'supplementary' },
 ];
 
-// Infrastructure options
-const infrastructureOptions = [
+// Infrastructure all cloud options
+const infrastructureAllCloudOptions = [
   { label: 'overview.perspective.all_cloud', value: 'all_cloud' },
 ];
 
@@ -125,8 +125,6 @@ const infrastructureOcpOptions = [
 class OverviewBase extends React.Component<OverviewProps> {
   protected defaultState: OverviewState = {
     activeTabKey: 0,
-    currentInfrastructurePerspective: infrastructureOptions[0].value,
-    currentOcpPerspective: ocpOptions[0].value,
     showPopover: false,
   };
   public state: OverviewState = { ...this.defaultState };
@@ -197,8 +195,11 @@ class OverviewBase extends React.Component<OverviewProps> {
     // Dynamically show options if providers are available
     if (this.getCurrentTab() === OverviewTab.infrastructure) {
       currentItem = currentInfrastructurePerspective;
-      options = [...infrastructureOptions];
+      options = [];
 
+      if (isOcpAvailable) {
+        options.push(...infrastructureAllCloudOptions);
+      }
       if (isAwsAvailable) {
         options.push(...infrastructureAwsOptions);
       }
@@ -211,7 +212,7 @@ class OverviewBase extends React.Component<OverviewProps> {
     }
     return (
       <Perspective
-        currentItem={currentItem}
+        currentItem={currentItem || options[0].value}
         onItemClicked={this.handlePerspectiveClick}
         options={options}
       />


### PR DESCRIPTION
Don't show "All cloud filtered by OpenShift" when there are no Ocp providers.

https://github.com/project-koku/koku-ui/issues/1536

<img width="527" alt="Screen Shot 2020-04-24 at 2 55 30 PM" src="https://user-images.githubusercontent.com/17481322/80247460-12cff600-863c-11ea-8018-92e2a38881cb.png">

