### PR TITLE
Resize charts upon nav toggle event

### DIFF
--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -62,6 +62,7 @@ interface State {
 
 class CostChart extends React.Component<CostChartProps, State> {
   private containerRef = React.createRef<HTMLDivElement>();
+  public navToggle: any;
   public state: State = {
     hiddenSeries: new Set(),
     width: 0,
@@ -73,6 +74,10 @@ class CostChart extends React.Component<CostChartProps, State> {
         this.setState({ width: this.containerRef.current.clientWidth });
       }
       window.addEventListener('resize', this.handleResize);
+      this.navToggle = insights.chrome.on(
+        'NAVIGATION_TOGGLE',
+        this.handleNavToggle
+      );
     });
     this.initDatum();
   }
@@ -92,6 +97,9 @@ class CostChart extends React.Component<CostChartProps, State> {
 
   public componentWillUnmount() {
     window.removeEventListener('resize', this.handleResize);
+    if (this.navToggle) {
+      this.navToggle();
+    }
   }
 
   private initDatum = () => {
@@ -166,6 +174,10 @@ class CostChart extends React.Component<CostChartProps, State> {
         },
       ],
     });
+  };
+
+  private handleNavToggle = () => {
+    setTimeout(this.handleResize, 200);
   };
 
   private handleResize = () => {

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -61,6 +61,7 @@ interface State {
 
 class TrendChart extends React.Component<TrendChartProps, State> {
   private containerRef = React.createRef<HTMLDivElement>();
+  public navToggle: any;
   public state: State = {
     hiddenSeries: new Set(),
     width: 0,
@@ -72,6 +73,10 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         this.setState({ width: this.containerRef.current.clientWidth });
       }
       window.addEventListener('resize', this.handleResize);
+      this.navToggle = insights.chrome.on(
+        'NAVIGATION_TOGGLE',
+        this.handleNavToggle
+      );
     });
     this.initDatum();
   }
@@ -87,6 +92,9 @@ class TrendChart extends React.Component<TrendChartProps, State> {
 
   public componentWillUnmount() {
     window.removeEventListener('resize', this.handleResize);
+    if (this.navToggle) {
+      this.navToggle();
+    }
   }
 
   private initDatum = () => {
@@ -131,6 +139,10 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         },
       ],
     });
+  };
+
+  private handleNavToggle = () => {
+    setTimeout(this.handleResize, 200);
   };
 
   private handleResize = () => {

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -62,6 +62,7 @@ interface State {
 
 class UsageChart extends React.Component<UsageChartProps, State> {
   private containerRef = React.createRef<HTMLDivElement>();
+  public navToggle: any;
   public state: State = {
     hiddenSeries: new Set(),
     width: 0,
@@ -73,6 +74,10 @@ class UsageChart extends React.Component<UsageChartProps, State> {
         this.setState({ width: this.containerRef.current.clientWidth });
       }
       window.addEventListener('resize', this.handleResize);
+      this.navToggle = insights.chrome.on(
+        'NAVIGATION_TOGGLE',
+        this.handleNavToggle
+      );
     });
     this.initDatum();
   }
@@ -90,6 +95,9 @@ class UsageChart extends React.Component<UsageChartProps, State> {
 
   public componentWillUnmount() {
     window.removeEventListener('resize', this.handleResize);
+    if (this.navToggle) {
+      this.navToggle();
+    }
   }
 
   private initDatum = () => {
@@ -171,6 +179,10 @@ class UsageChart extends React.Component<UsageChartProps, State> {
         },
       ],
     });
+  };
+
+  private handleNavToggle = () => {
+    setTimeout(this.handleResize, 200);
   };
 
   private handleResize = () => {


### PR DESCRIPTION
This resizes our charts (i.e., the width) upon Insight's new NAVIGATION_TOGGLE event

https://github.com/project-koku/koku-ui/issues/1504

![chrome-capture](https://user-images.githubusercontent.com/17481322/80250035-fbdfd280-8640-11ea-8f98-71cb08f7e049.gif)
