### PR TITLE
Adjust timeout to resize chart to 300ms

### DIFF
--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -177,7 +177,7 @@ class CostChart extends React.Component<CostChartProps, State> {
   };
 
   private handleNavToggle = () => {
-    setTimeout(this.handleResize, 250);
+    setTimeout(this.handleResize, 300);
   };
 
   private handleResize = () => {

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -142,7 +142,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   };
 
   private handleNavToggle = () => {
-    setTimeout(this.handleResize, 250);
+    setTimeout(this.handleResize, 300);
   };
 
   private handleResize = () => {

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -182,7 +182,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
   };
 
   private handleNavToggle = () => {
-    setTimeout(this.handleResize, 250);
+    setTimeout(this.handleResize, 300);
   };
 
   private handleResize = () => {


### PR DESCRIPTION
Adjusted timeout to resize chart to 300ms. Previous attempt worked better, but could be a little longer for CI beta.

https://github.com/project-koku/koku-ui/issues/1504