### PR TITLE
Adjust timeout to resize chart to 500ms

### DIFF
--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -177,7 +177,7 @@ class CostChart extends React.Component<CostChartProps, State> {
   };
 
   private handleNavToggle = () => {
-    setTimeout(this.handleResize, 300);
+    setTimeout(this.handleResize, 500);
   };
 
   private handleResize = () => {

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -142,7 +142,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   };
 
   private handleNavToggle = () => {
-    setTimeout(this.handleResize, 300);
+    setTimeout(this.handleResize, 500);
   };
 
   private handleResize = () => {

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -182,7 +182,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
   };
 
   private handleNavToggle = () => {
-    setTimeout(this.handleResize, 300);
+    setTimeout(this.handleResize, 500);
   };
 
   private handleResize = () => {


### PR DESCRIPTION
Adjusted timeout to resize chart to 500ms. Previous attempt worked better, but could be a little longer for CI beta.

#1504