### PR TITLE
Maintenance state

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -2,6 +2,7 @@ import { Providers, ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { AxiosError } from 'axios';
 import { I18nProvider } from 'components/i18nProvider';
+import { MaintenanceState } from 'components/state/maintenanceState/maintenanceState';
 import React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router';
@@ -41,6 +42,7 @@ interface AppDispatchProps {
 
 interface AppState {
   locale: string;
+  maintenanceMode: boolean;
 }
 
 type AppProps = AppOwnProps & AppStateProps & AppDispatchProps;
@@ -48,7 +50,9 @@ type AppProps = AppOwnProps & AppStateProps & AppDispatchProps;
 export class App extends React.Component<AppProps, AppState> {
   public appNav: any;
 
-  public state: AppState = { locale: 'en' };
+  // Todo: Will Insights provide a flag to enable maintenance mode?
+  // https://docs.google.com/document/d/1VLs7vFczWUzyIpH6EUsTEpJugDsjeuh4a_azs6IJbC0/edit#
+  public state: AppState = { locale: 'en', maintenanceMode: false };
 
   public componentDidMount() {
     const {
@@ -145,9 +149,10 @@ export class App extends React.Component<AppProps, AppState> {
   };
 
   public render() {
+    const { maintenanceMode } = this.state;
     return (
       <I18nProvider locale={this.state.locale}>
-        <Routes />
+        {Boolean(maintenanceMode) ? <MaintenanceState /> : <Routes />}
       </I18nProvider>
     );
   }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -52,7 +52,7 @@ export class App extends React.Component<AppProps, AppState> {
 
   // Todo: Will Insights provide a flag to enable maintenance mode?
   // https://docs.google.com/document/d/1VLs7vFczWUzyIpH6EUsTEpJugDsjeuh4a_azs6IJbC0/edit#
-  public state: AppState = { locale: 'en', maintenanceMode: false };
+  public state: AppState = { locale: 'en', maintenanceMode: true };
 
   public componentDidMount() {
     const {
@@ -149,10 +149,19 @@ export class App extends React.Component<AppProps, AppState> {
   };
 
   public render() {
+    const {
+      awsProvidersError,
+      azureProvidersError,
+      ocpProvidersError,
+    } = this.props;
     const { maintenanceMode } = this.state;
+
+    // The providers API should return a 500 error while under maintenance
+    const error = awsProvidersError || azureProvidersError || ocpProvidersError;
+
     return (
       <I18nProvider locale={this.state.locale}>
-        {Boolean(maintenanceMode) ? <MaintenanceState /> : <Routes />}
+        {Boolean(maintenanceMode && error) ? <MaintenanceState /> : <Routes />}
       </I18nProvider>
     );
   }

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -156,7 +156,7 @@ export class App extends React.Component<AppProps, AppState> {
     } = this.props;
     const { maintenanceMode } = this.state;
 
-    // The providers API should return a 500 error while under maintenance
+    // The providers API should error while under maintenance
     const error = awsProvidersError || azureProvidersError || ocpProvidersError;
 
     return (

--- a/src/components/state/maintenanceState/maintenanceState.styles.ts
+++ b/src/components/state/maintenanceState/maintenanceState.styles.ts
@@ -1,0 +1,10 @@
+import React from 'react';
+
+export const styles = {
+  container: {
+    display: 'flex',
+    justifyContent: 'center',
+    height: '100vh',
+    marginTop: '150px',
+  },
+} as { [className: string]: React.CSSProperties };

--- a/src/components/state/maintenanceState/maintenanceState.tsx
+++ b/src/components/state/maintenanceState/maintenanceState.tsx
@@ -1,0 +1,34 @@
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  Title,
+} from '@patternfly/react-core';
+import { ExclamationTriangleIcon } from '@patternfly/react-icons';
+import React from 'react';
+import { InjectedTranslateProps, translate } from 'react-i18next';
+import { connect } from 'react-redux';
+import { styles } from './maintenanceState.styles';
+
+type MaintenanceStateOwnProps = InjectedTranslateProps;
+type MaintenanceStateProps = MaintenanceStateOwnProps;
+
+class MaintenanceStateBase extends React.Component<MaintenanceStateProps> {
+  public render() {
+    const { t } = this.props;
+
+    return (
+      <div style={styles.container}>
+        <EmptyState>
+          <EmptyStateIcon icon={ExclamationTriangleIcon} />
+          <Title size="lg">{t('maintenance.empty_state_title')}</Title>
+          <EmptyStateBody>{t('maintenance.empty_state_desc')}</EmptyStateBody>
+        </EmptyState>
+      </div>
+    );
+  }
+}
+
+const MaintenanceState = translate()(connect()(MaintenanceStateBase));
+
+export { MaintenanceState };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -620,6 +620,10 @@
     "username_label": "Username"
   },
   "logout": "Log Out",
+  "maintenance": {
+    "empty_state_desc": "We are currently undergoing scheduled maintenance from 6am-9am EST. We will be back shortly, thank you for your patience",
+    "empty_state_title": "Maintenance in progress"
+  },
   "months": [
     "January",
     "February",


### PR DESCRIPTION
Added a full page for displaying maintenance state messages.

If the `maintenanceMode` flag is enabled, the providers API should error and the maintenance state is displayed; otherwise, pages will display normally. 

https://issues.redhat.com/browse/COST-47

<img width="1425" alt="Screen Shot 2020-05-05 at 10 22 04 AM" src="https://user-images.githubusercontent.com/17481322/81078631-7b309a00-8ebc-11ea-8575-9a3b3cd2e8d1.png">
