### PR TITLE
fix(costmodel): make it easy to track unassigned sources in table

### DIFF
--- a/src/pages/costModels/costModelsDetails/addSourceStep.tsx
+++ b/src/pages/costModels/costModelsDetails/addSourceStep.tsx
@@ -111,12 +111,7 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
         </>
       );
       return {
-        cells: [
-          checkbox,
-          cellName,
-          provCostModels ||
-            this.props.t('cost_models_wizard.source_table.default_cost_model'),
-        ],
+        cells: [checkbox, cellName, provCostModels || ''],
         selected: isSelected,
       };
     });

--- a/src/pages/costModels/createCostModelWizard/table.tsx
+++ b/src/pages/costModels/createCostModelWizard/table.tsx
@@ -138,11 +138,7 @@ const SourcesTable: React.SFC<InjectedTranslateProps> = ({ t }) => {
                             />
                           )}
                         </>,
-                        Boolean(r.costmodel)
-                          ? r.costmodel
-                          : t(
-                              'cost_models_wizard.source_table.default_cost_model'
-                            ),
+                        Boolean(r.costmodel) ? r.costmodel : '',
                       ],
                       selected: r.selected,
                     };


### PR DESCRIPTION
Remove the "Default cost model" string from all the sources that can be assigned. That way the user can easily see that the ones that are available has no cost model assigned to it and easier to see that those with a cost model attached to it cannot be selected.

![Screenshot_2020-05-11 Cost Management(1)](https://user-images.githubusercontent.com/2453279/81796049-91ba9f00-9515-11ea-95e8-ed3f1cf0c762.png)
