### PR TITLE
Override cost breakdown pie chart legend layout

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -139,7 +139,6 @@
     "cost_chart": {
       "aria_desc": "Breakdown of markup, raw, and usage costs",
       "aria_title": "Cost breakdown",
-      "legend": "{{name}}: {{value}}",
       "markup_label": "Markup",
       "raw_label": "Raw",
       "tooltip": "{{name}}: {{value}}",

--- a/src/pages/details/components/costChart/costChart.styles.ts
+++ b/src/pages/details/components/costChart/costChart.styles.ts
@@ -1,8 +1,15 @@
-import { global_spacer_3xl, global_spacer_md } from '@patternfly/react-tokens';
+import {
+  global_FontWeight_bold,
+  global_spacer_3xl,
+  global_spacer_md,
+} from '@patternfly/react-tokens';
 import React from 'react';
 
 export const chartStyles = {
   chartHeight: 150,
+  subTitle: {
+    fontWeight: global_FontWeight_bold.value as any,
+  },
 };
 
 export const styles = {

--- a/src/pages/details/components/costChart/costChart.tsx
+++ b/src/pages/details/components/costChart/costChart.tsx
@@ -1,4 +1,9 @@
-import { ChartPie, ChartThemeColor } from '@patternfly/react-charts';
+import {
+  ChartLabel,
+  ChartLegend,
+  ChartPie,
+  ChartThemeColor,
+} from '@patternfly/react-charts';
 import {
   Skeleton,
   SkeletonSize,
@@ -52,6 +57,17 @@ class CostChartBase extends React.Component<CostChartProps> {
     window.removeEventListener('resize', this.handleResize);
   }
 
+  // Override legend layout
+  private getLegendLabel = () => {
+    return ({ values, ...props }) => (
+      <ChartLabel
+        {...props}
+        style={[{ fontWeight: chartStyles.subTitle.fontWeight }, {}]}
+        text={[values[props.index], props.text]}
+      />
+    );
+  };
+
   private getSkeleton = () => {
     return (
       <>
@@ -101,6 +117,19 @@ class CostChartBase extends React.Component<CostChartProps> {
     const rawLabel = t('breakdown.cost_chart.raw_label');
     const usageLabel = t('breakdown.cost_chart.usage_label');
 
+    // Override legend label layout
+    const LegendLabel = this.getLegendLabel();
+    const Legend = (
+      <ChartLegend
+        gutter={25}
+        itemsPerRow={2}
+        labelComponent={
+          <LegendLabel dy={10} lineHeight={1.5} values={[markup, raw, usage]} />
+        }
+        rowGutter={20}
+      />
+    );
+
     return (
       <div ref={this.containerRef} style={{ height: chartStyles.chartHeight }}>
         {reportFetchStatus === FetchStatus.inProgress ? (
@@ -122,24 +151,16 @@ class CostChartBase extends React.Component<CostChartProps> {
                 value: formatValue(datum.y, datum.units),
               })
             }
+            legendComponent={Legend}
             legendData={[
               {
-                name: t('breakdown.cost_chart.legend', {
-                  name: markupLabel,
-                  value: markup,
-                }),
+                name: markupLabel,
               },
               {
-                name: t('breakdown.cost_chart.legend', {
-                  name: rawLabel,
-                  value: raw,
-                }),
+                name: rawLabel,
               },
               {
-                name: t('breakdown.cost_chart.legend', {
-                  name: usageLabel,
-                  value: usage,
-                }),
+                name: usageLabel,
               },
             ]}
             legendOrientation="vertical"


### PR DESCRIPTION
Created custom label component to override the cost breakdown pie chart's legend layout, per mocks.

Mock https://marvelapp.com/616a7ba/screen/67774561

<img width="1112" alt="Screen Shot 2020-05-19 at 2 38 27 PM" src="https://user-images.githubusercontent.com/17481322/82365706-00e53700-99df-11ea-8ed2-c25c3a951a47.png">
