### PR TITLE
Loading state forces modal to be full page

### DIFF
--- a/src/components/state/loadingState/loadingState.styles.ts
+++ b/src/components/state/loadingState/loadingState.styles.ts
@@ -4,7 +4,6 @@ export const styles = {
   container: {
     display: 'flex',
     justifyContent: 'center',
-    height: '100vh',
     marginTop: '150px',
   },
 } as { [className: string]: React.CSSProperties };


### PR DESCRIPTION
Fixed style which forces loading state to be full page in wizard modal. Tested with overview and details pages -- the style isn't needed there anymore.

https://issues.redhat.com/browse/COST-139
