### PR TITLE
Adjust details table styles

### DIFF
--- a/src/pages/details/awsDetails/detailsTable.styles.ts
+++ b/src/pages/details/awsDetails/detailsTable.styles.ts
@@ -62,17 +62,15 @@ export const monthOverMonthOverride = css`
 
 export const tableOverride = css`
   &.pf-c-table {
-    thead th + th {
-      .pf-c-button {
+    thead th + th + th {
+      .pf-c-table__button {
+        display: block;
         text-align: right;
       }
       text-align: right;
     }
     tbody td + td + td + td {
       text-align: right;
-    }
-    td {
-      vertical-align: top;
     }
   }
 `;

--- a/src/pages/details/awsDetails/detailsTable.styles.ts
+++ b/src/pages/details/awsDetails/detailsTable.styles.ts
@@ -64,8 +64,7 @@ export const tableOverride = css`
   &.pf-c-table {
     thead th + th + th {
       .pf-c-table__button {
-        display: block;
-        text-align: right;
+        justify-content: flex-end;
       }
       text-align: right;
     }

--- a/src/pages/details/azureDetails/detailsTable.styles.ts
+++ b/src/pages/details/azureDetails/detailsTable.styles.ts
@@ -62,17 +62,15 @@ export const monthOverMonthOverride = css`
 
 export const tableOverride = css`
   &.pf-c-table {
-    thead th + th {
-      .pf-c-button {
+    thead th + th + th {
+      .pf-c-table__button {
+        display: block;
         text-align: right;
       }
       text-align: right;
     }
     tbody td + td + td + td {
       text-align: right;
-    }
-    td {
-      vertical-align: top;
     }
   }
 `;

--- a/src/pages/details/azureDetails/detailsTable.styles.ts
+++ b/src/pages/details/azureDetails/detailsTable.styles.ts
@@ -64,8 +64,7 @@ export const tableOverride = css`
   &.pf-c-table {
     thead th + th + th {
       .pf-c-table__button {
-        display: block;
-        text-align: right;
+        justify-content: flex-end;
       }
       text-align: right;
     }

--- a/src/pages/details/ocpDetails/detailsTable.styles.ts
+++ b/src/pages/details/ocpDetails/detailsTable.styles.ts
@@ -62,22 +62,15 @@ export const monthOverMonthOverride = css`
 
 export const tableOverride = css`
   &.pf-c-table {
-    &.tag {
-      tbody td + td + td {
-        text-align: right;
-      }
-    }
-    thead th + th {
-      .pf-c-button {
+    thead th + th + th {
+      .pf-c-table__button {
+        display: block;
         text-align: right;
       }
       text-align: right;
     }
     tbody td + td + td + td {
       text-align: right;
-    }
-    td {
-      vertical-align: top;
     }
   }
 `;

--- a/src/pages/details/ocpDetails/detailsTable.styles.ts
+++ b/src/pages/details/ocpDetails/detailsTable.styles.ts
@@ -64,8 +64,7 @@ export const tableOverride = css`
   &.pf-c-table {
     thead th + th + th {
       .pf-c-table__button {
-        display: block;
-        text-align: right;
+        justify-content: flex-end;
       }
       text-align: right;
     }


### PR DESCRIPTION
Adjust details table styles so the last 3 columns are right aligned per the pre-PatternFly v4 breaking change update.

https://issues.redhat.com/browse/COST-43

<img width="1332" alt="Screen Shot 2020-06-16 at 4 43 53 PM" src="https://user-images.githubusercontent.com/17481322/84826873-9e895180-aff1-11ea-9d1e-df15c332085e.png">
