### PR TITLE
Refactored the details price list option to match uuid instead of name

### DIFF
--- a/src/pages/details/awsDetails/detailsTable.tsx
+++ b/src/pages/details/awsDetails/detailsTable.tsx
@@ -12,6 +12,7 @@ import {
   TableHeader,
 } from '@patternfly/react-table';
 import { AwsQuery, getQuery } from 'api/queries/awsQuery';
+import { getQueryRoute } from 'api/queries/azureQuery';
 import { tagKeyPrefix } from 'api/queries/query';
 import { AwsReport } from 'api/reports/awsReports';
 import { ReportPathsType } from 'api/reports/report';
@@ -32,7 +33,6 @@ import {
   getNoDataForDateRangeString,
 } from 'utils/dateRange';
 import { formatCurrency } from 'utils/formatValue';
-import { getQueryRoute } from '../../../api/queries/azureQuery';
 import {
   monthOverMonthOverride,
   styles,

--- a/src/pages/details/components/actions/actions.tsx
+++ b/src/pages/details/components/actions/actions.tsx
@@ -1,4 +1,5 @@
 import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
+import { ProviderType } from 'api/providers';
 import { Query } from 'api/queries/query';
 import { tagKeyPrefix } from 'api/queries/query';
 import { ReportPathsType } from 'api/reports/report';
@@ -11,6 +12,7 @@ import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems'
 interface DetailsActionsOwnProps {
   groupBy: string;
   item: ComputedReportItem;
+  providerType?: ProviderType;
   query: Query;
   reportPathsType: ReportPathsType;
   showPriceListOption?: boolean;
@@ -59,14 +61,13 @@ class DetailsActionsBase extends React.Component<DetailsActionsProps> {
   };
 
   private getPriceListModal = () => {
-    const {
-      item: { label },
-    } = this.props;
+    const { item, providerType } = this.props;
     return (
       <PriceListModal
-        name={label}
-        isOpen={this.state.isPriceListModalOpen}
         close={this.handlePriceListModalClose}
+        isOpen={this.state.isPriceListModalOpen}
+        item={item}
+        providerType={providerType}
       />
     );
   };

--- a/src/pages/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/details/ocpDetails/detailsTable.tsx
@@ -11,6 +11,7 @@ import {
   TableBody,
   TableHeader,
 } from '@patternfly/react-table';
+import { ProviderType } from 'api/providers';
 import { getQuery, getQueryRoute, OcpQuery } from 'api/queries/ocpQuery';
 import { tagKeyPrefix } from 'api/queries/query';
 import { OcpReport } from 'api/reports/ocpReports';
@@ -219,13 +220,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   private getActions = (item: ComputedReportItem, index: number) => {
     const { groupBy, query } = this.props;
 
-    // Omit showPriceListOption See https://github.com/project-koku/koku-ui/issues/1512
     return (
       <Actions
         groupBy={groupBy}
         item={item}
+        providerType={ProviderType.ocp}
         query={query}
         reportPathsType={reportPathsType}
+        showPriceListOption={groupBy === 'cluster'}
       />
     );
   };

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -15,6 +15,7 @@ export interface ComputedReportItem {
   label?: string | number;
   limit?: number;
   request?: number;
+  source_uuid?: string[];
   supplementary?: number;
   units?: {
     capacity?: string;
@@ -94,6 +95,7 @@ export function getUnsortedComputedReportItems<
         const capacity = value.capacity ? value.capacity.value : 0;
         const cost =
           value.cost && value.cost.total ? value.cost.total.value : 0;
+        const source_uuid = value.source_uuid ? value.source_uuid : [];
         const supplementary =
           value.supplementary && value.supplementary.total
             ? value.supplementary.total.value
@@ -146,6 +148,7 @@ export function getUnsortedComputedReportItems<
             cost,
             deltaPercent: value.delta_percent,
             deltaValue: value.delta_value,
+            source_uuid,
             supplementary,
             id,
             infrastructure,


### PR DESCRIPTION
Refactored the details price list option to match UUID instead of cluster name. 

Note that this is only available for group_by cluster. And we've omitted AWS and Azure, since they don't have price lists yet.

See https://issues.redhat.com/browse/COST-266

**Ocp details**
<img width="1341" alt="Screen Shot 2020-06-17 at 4 59 51 PM" src="https://user-images.githubusercontent.com/17481322/84949910-fee4c580-b0bb-11ea-9ccc-4c41d139d276.png">

**Existing price list modal**
<img width="1231" alt="Screen Shot 2020-06-17 at 4 46 39 PM" src="https://user-images.githubusercontent.com/17481322/84949973-191ea380-b0bc-11ea-8d65-7618579f44a3.png">

