### PR TITLE
fix(costmodels): reordered modal buttons correctly

### DIFF
--- a/src/pages/costModels/costModelsDetails/addSourceWizard.tsx
+++ b/src/pages/costModels/costModelsDetails/addSourceWizard.tsx
@@ -94,14 +94,6 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
         variant="large"
         actions={[
           <Button
-            key="cancel"
-            variant="link"
-            isDisabled={isUpdateInProgress}
-            onClick={onClose}
-          >
-            {t('cost_models_wizard.cancel_button')}
-          </Button>,
-          <Button
             key="save"
             isDisabled={isUpdateInProgress || this.props.isLoadingSources}
             onClick={() => {
@@ -113,6 +105,14 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
             }}
           >
             {t('cost_models_details.action_assign')}
+          </Button>,
+          <Button
+            key="cancel"
+            variant="link"
+            isDisabled={isUpdateInProgress}
+            onClick={onClose}
+          >
+            {t('cost_models_wizard.cancel_button')}
           </Button>,
         ]}
       >

--- a/src/pages/costModels/costModelsDetails/components/addRateModal.tsx
+++ b/src/pages/costModels/costModelsDetails/components/addRateModal.tsx
@@ -94,7 +94,7 @@ export class AddRateModelBase extends React.Component<Props, State> {
           {t('cost_models_details.add_rate')}
         </Button>
       );
-      return [ValidCancelButton, ValidOkButton];
+      return [ValidOkButton, ValidCancelButton];
     }
     const CancelButton = (
       <Button key="cancel" variant={ButtonVariant.secondary} onClick={onClose}>
@@ -106,7 +106,7 @@ export class AddRateModelBase extends React.Component<Props, State> {
         {t('cost_models_details.add_rate')}
       </Button>
     );
-    return [CancelButton, OkButton];
+    return [OkButton, CancelButton];
   }
 
   public renderForm() {

--- a/src/pages/costModels/costModelsDetails/components/updateMarkupDialog.tsx
+++ b/src/pages/costModels/costModelsDetails/components/updateMarkupDialog.tsx
@@ -53,14 +53,6 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
         variant="small"
         actions={[
           <Button
-            key="cancel"
-            variant="secondary"
-            onClick={() => onClose({ name: 'updateMarkup', isOpen: false })}
-            isDisabled={isLoading}
-          >
-            {t('cost_models_details.add_rate_modal.cancel')}
-          </Button>,
-          <Button
             key="proceed"
             variant="primary"
             onClick={() => {
@@ -85,6 +77,14 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
             }
           >
             {t('cost_models_details.add_rate_modal.save')}
+          </Button>,
+          <Button
+            key="cancel"
+            variant="secondary"
+            onClick={() => onClose({ name: 'updateMarkup', isOpen: false })}
+            isDisabled={isLoading}
+          >
+            {t('cost_models_details.add_rate_modal.cancel')}
           </Button>,
         ]}
       >

--- a/src/pages/costModels/costModelsDetails/components/updateRateModel.tsx
+++ b/src/pages/costModels/costModelsDetails/components/updateRateModel.tsx
@@ -82,14 +82,6 @@ class UpdateRateModelBase extends React.Component<Props, State> {
         variant="small"
         actions={[
           <Button
-            key="cancel"
-            variant="secondary"
-            onClick={onClose}
-            isDisabled={isProcessing}
-          >
-            {t('cost_models_details.add_rate_modal.cancel')}
-          </Button>,
-          <Button
             key="proceed"
             variant="primary"
             onClick={() =>
@@ -108,6 +100,14 @@ class UpdateRateModelBase extends React.Component<Props, State> {
             }
           >
             {t('cost_models_details.add_rate_modal.save')}
+          </Button>,
+          <Button
+            key="cancel"
+            variant="secondary"
+            onClick={onClose}
+            isDisabled={isProcessing}
+          >
+            {t('cost_models_details.add_rate_modal.cancel')}
           </Button>,
         ]}
       >


### PR DESCRIPTION
Fix the following modals:
 - assign sources
 - edit markup
 - edit rate
 - add rate