### PR TITLE
fix(costmodel): change buttons order in update cost model modal

### DIFF
--- a/src/pages/costModels/costModelsDetails/components/updateCostModel.tsx
+++ b/src/pages/costModels/costModelsDetails/components/updateCostModel.tsx
@@ -59,16 +59,6 @@ class UpdateCostModelBase extends React.Component<Props, State> {
         variant="small"
         actions={[
           <Button
-            key="cancel"
-            variant="secondary"
-            onClick={() =>
-              setDialogOpen({ name: 'updateCostModel', isOpen: false })
-            }
-            isDisabled={isProcessing}
-          >
-            {t('dialog.cancel')}
-          </Button>,
-          <Button
             key="proceed"
             variant="primary"
             onClick={() => {
@@ -101,6 +91,16 @@ class UpdateCostModelBase extends React.Component<Props, State> {
             }
           >
             {t('cost_models_details.save_button')}
+          </Button>,
+          <Button
+            key="cancel"
+            variant="secondary"
+            onClick={() =>
+              setDialogOpen({ name: 'updateCostModel', isOpen: false })
+            }
+            isDisabled={isProcessing}
+          >
+            {t('dialog.cancel')}
           </Button>,
         ]}
       >


### PR DESCRIPTION
Missed the edit cost model modal buttons.
This one will fix it and is part of the COST-280 ticket