### PR TITLE
Empty filter state is positioned incorrectly

### DIFF
--- a/src/components/state/emptyFilterState/emptyFilterState.styles.ts
+++ b/src/components/state/emptyFilterState/emptyFilterState.styles.ts
@@ -4,7 +4,6 @@ export const styles = {
   container: {
     display: 'flex',
     justifyContent: 'center',
-    height: '100vh',
   },
   containerMargin: {
     marginTop: '150px',

--- a/src/pages/details/awsDetails/detailsTable.tsx
+++ b/src/pages/details/awsDetails/detailsTable.tsx
@@ -208,9 +208,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   private getEmptyState = () => {
     const { query, t } = this.props;
 
-    for (const val of Object.values(query.group_by)) {
+    for (const val of Object.values(query.filter_by)) {
       if (val !== '*') {
-        return <EmptyFilterState showMargin={false} />;
+        return <EmptyFilterState filter={val} showMargin={false} />;
       }
     }
     return (

--- a/src/pages/details/azureDetails/detailsTable.tsx
+++ b/src/pages/details/azureDetails/detailsTable.tsx
@@ -208,9 +208,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   private getEmptyState = () => {
     const { query, t } = this.props;
 
-    for (const val of Object.values(query.group_by)) {
+    for (const val of Object.values(query.filter_by)) {
       if (val !== '*') {
-        return <EmptyFilterState showMargin={false} />;
+        return <EmptyFilterState filter={val} showMargin={false} />;
       }
     }
     return (

--- a/src/pages/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/details/ocpDetails/detailsTable.tsx
@@ -235,9 +235,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   private getEmptyState = () => {
     const { query, t } = this.props;
 
-    for (const val of Object.values(query.group_by)) {
+    for (const val of Object.values(query.filter_by)) {
       if (val !== '*') {
-        return <EmptyFilterState showMargin={false} />;
+        return <EmptyFilterState filter={val} showMargin={false} />;
       }
     }
     return (


### PR DESCRIPTION
This ensures that the empty filter state appears within the table body. 

Currently, the component appears below the table. Seems to be a regression after updating to the PatternFly "breaking changes release".

https://issues.redhat.com/browse/COST-306