### PR TITLE
fix(costmodels): update confirmation dialog's cancel and warning icon

### DIFF
--- a/src/pages/costModels/costModelsDetails/components/dialog.test.tsx
+++ b/src/pages/costModels/costModelsDetails/components/dialog.test.tsx
@@ -1,5 +1,4 @@
 import { Alert } from '@patternfly/react-core';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import { shallow } from 'enzyme';
 import React from 'react';
 import Dialog from './dialog';
@@ -12,12 +11,14 @@ const defaultProps = {
   t: (text: string) => text,
 };
 
-test('dialog has exclamation triangle icon ', () => {
+test('dialog has exclamation triangle icon in the title', () => {
   const view = shallow(<Dialog {...defaultProps} />);
-  expect(view.find(ExclamationTriangleIcon).props()).toEqual({
+  const icon = view.prop('header').props.children[0];
+  expect(icon.type.displayName).toBe('ExclamationTriangleIcon');
+  expect(icon.props).toEqual({
     color: 'orange',
     noVerticalAlign: false,
-    size: 'xl',
+    size: 'sm',
   });
 });
 
@@ -35,4 +36,9 @@ test('dialog with error', () => {
   const view = shallow(<Dialog {...defaultProps} error="Opps!" />);
   expect(view.find(Alert).props().title).toBe('Opps!');
   expect(view.find(Alert).props().variant).toBe('danger');
+});
+
+test('dialog is small', () => {
+  const view = shallow(<Dialog {...defaultProps} isSmall />);
+  expect(view.props().variant).toBe('small');
 });

--- a/src/pages/costModels/costModelsDetails/components/dialog.tsx
+++ b/src/pages/costModels/costModelsDetails/components/dialog.tsx
@@ -1,4 +1,10 @@
-import { Alert, Button, Modal, Split, SplitItem } from '@patternfly/react-core';
+import {
+  Alert,
+  Button,
+  Modal,
+  Title,
+  TitleSizes,
+} from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -9,7 +15,7 @@ interface Props extends InjectedTranslateProps {
   onProceed: () => void;
   title: string;
   body: React.ReactElement;
-  actionText: string;
+  actionText?: string;
   isOpen?: boolean;
   isProcessing?: boolean;
   error?: string;
@@ -30,7 +36,7 @@ const DialogBase: React.SFC<Props> = ({
   const CancelButtonSecondary = (
     <Button
       key="cancel"
-      variant="secondary"
+      variant="link"
       onClick={onClose}
       isDisabled={isProcessing}
     >
@@ -63,19 +69,18 @@ const DialogBase: React.SFC<Props> = ({
       : [CloseButtonPrimary];
   return (
     <Modal
-      title={title}
+      header={
+        <Title headingLevel="h1" size={TitleSizes['2xl']}>
+          <ExclamationTriangleIcon color="orange" /> {title}
+        </Title>
+      }
       isOpen={isOpen}
       onClose={onClose}
       actions={actions}
-      variant="small"
+      variant={isSmall ? 'small' : 'default'}
     >
       {error && <Alert variant="danger" title={`${error}`} />}
-      <Split hasGutter>
-        <SplitItem>
-          <ExclamationTriangleIcon size="xl" color="orange" />
-        </SplitItem>
-        <SplitItem isFilled>{body}</SplitItem>
-      </Split>
+      {body}
     </Modal>
   );
 };

--- a/src/pages/costModels/createCostModelWizard/index.tsx
+++ b/src/pages/costModels/createCostModelWizard/index.tsx
@@ -1,5 +1,10 @@
-import { Wizard, WizardStepFunctionType } from '@patternfly/react-core';
-import { Button, Modal, Split, SplitItem } from '@patternfly/react-core';
+import {
+  Title,
+  TitleSizes,
+  Wizard,
+  WizardStepFunctionType,
+} from '@patternfly/react-core';
+import { Button, Modal } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
 import { addCostModel } from 'api/costModels';
 import { MetricHash } from 'api/metrics';
@@ -343,19 +348,17 @@ class CostModelWizardBase extends React.Component<Props, State> {
         />
         <Modal
           isOpen={this.state.isDialogOpen}
-          title={t('cost_models_wizard.confirm.title')}
+          header={
+            <Title headingLevel="h1" size={TitleSizes['2xl']}>
+              <ExclamationTriangleIcon color="orange" />{' '}
+              {t('cost_models_wizard.confirm.title')}
+            </Title>
+          }
           onClose={closeConfirmDialog}
           actions={[OkButton, CancelButton]}
           variant="small"
         >
-          <Split hasGutter>
-            <SplitItem>
-              <ExclamationTriangleIcon size="xl" color="orange" />
-            </SplitItem>
-            <SplitItem isFilled>
-              <div>{t('cost_models_wizard.confirm.message')}</div>
-            </SplitItem>
-          </Split>
+          {t('cost_models_wizard.confirm.message')}
         </Modal>
       </CostModelContext.Provider>
     );


### PR DESCRIPTION
1) move the warning icon to the title
2) change the cancel button variation to "link"
 
![image](https://user-images.githubusercontent.com/2453279/86369239-d1387880-bc86-11ea-9e4f-0cd455b4555c.png)
![image](https://user-images.githubusercontent.com/2453279/86369284-e0b7c180-bc86-11ea-9713-ce75f6fdd78f.png)
![image](https://user-images.githubusercontent.com/2453279/86369330-f2996480-bc86-11ea-901d-e341a1311742.png)
![image](https://user-images.githubusercontent.com/2453279/86369366-0218ad80-bc87-11ea-98ff-a578c5cf7835.png)
