### PR TITLE
Fixed no providers state for ocp details

### DIFF
--- a/src/components/state/noProvidersState/noProvidersState.styles.ts
+++ b/src/components/state/noProvidersState/noProvidersState.styles.ts
@@ -5,7 +5,6 @@ export const styles = {
   container: {
     display: 'flex',
     justifyContent: 'center',
-    height: '100vh',
     marginTop: '150px',
   },
   viewSources: {

--- a/src/pages/details/components/costOverview/costOverviewBase.tsx
+++ b/src/pages/details/components/costOverview/costOverviewBase.tsx
@@ -143,7 +143,7 @@ class CostOverviewBase extends React.Component<CostOverviewProps> {
     for (const groupById of widget.reportSummary.showWidgetOnGroupBy) {
       if (
         groupById === groupBy ||
-        query.group_by[orgUnitIdKey] ||
+        (query && query.group_by[orgUnitIdKey]) ||
         (groupById === tagKeyPrefix &&
           groupBy &&
           groupBy.indexOf(tagKeyPrefix) !== -1)


### PR DESCRIPTION
Fixes the "no providers" state for ocp details. The empty state component shouldn't be at the bottom of the page.