### PR TITLE
Error state positioned incorrectly

### DIFF
--- a/src/components/state/errorState/errorState.styles.ts
+++ b/src/components/state/errorState/errorState.styles.ts
@@ -4,7 +4,6 @@ export const styles = {
   container: {
     display: 'flex',
     justifyContent: 'center',
-    height: '100vh',
     marginTop: '150px',
   },
 } as { [className: string]: React.CSSProperties };

--- a/src/components/state/maintenanceState/maintenanceState.styles.ts
+++ b/src/components/state/maintenanceState/maintenanceState.styles.ts
@@ -4,7 +4,6 @@ export const styles = {
   container: {
     display: 'flex',
     justifyContent: 'center',
-    height: '100vh',
     marginTop: '150px',
   },
 } as { [className: string]: React.CSSProperties };


### PR DESCRIPTION
When filtering details tables, I noticed that the error state is positioned incorrectly. The component should not appear at the bottom of the page.

This regression seems to have occurred after updating to the PatternFly "breaking changes release". 

https://issues.redhat.com/browse/COST-306