### PR TITLE
Export fails when filtering tag key values

### DIFF
--- a/src/api/queries/query.ts
+++ b/src/api/queries/query.ts
@@ -56,6 +56,9 @@ export function convertFilterByToGroupBy(query: Query) {
     filter_by: {},
   };
   for (const key of Object.keys(query.filter_by)) {
+    if (!newQuery.group_by) {
+      newQuery.group_by = {};
+    }
     newQuery.group_by[key] = query.filter_by[key];
   }
   return newQuery;


### PR DESCRIPTION
When applying a tag filter in the details page, exporting a table row fails.

https://issues.redhat.com/browse/COST-168