### PR TITLE
Bump websocket-extensions 0.1.4

### DIFF
--- a/koku-ui-manifest
+++ b/koku-ui-manifest
@@ -1738,7 +1738,7 @@ mgmt_services/cost-mgmt:koku-ui/webpack-sources:1.4.3.yarnlock
 mgmt_services/cost-mgmt:koku-ui/webpack:4.43.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/websocket-driver:0.6.5.yarnlock
 mgmt_services/cost-mgmt:koku-ui/websocket-driver:0.7.3.yarnlock
-mgmt_services/cost-mgmt:koku-ui/websocket-extensions:0.1.3.yarnlock
+mgmt_services/cost-mgmt:koku-ui/websocket-extensions:0.1.4.yarnlock
 mgmt_services/cost-mgmt:koku-ui/whatwg-encoding:1.0.5.yarnlock
 mgmt_services/cost-mgmt:koku-ui/whatwg-encoding:1.0.5.yarnlock
 mgmt_services/cost-mgmt:koku-ui/whatwg-mimetype:2.3.0.yarnlock

--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
     "lint-staged": "7.2.0",
     "pf-codemods": "^1.0.21",
     "ts-jest": "22.4.6",
-    "webpack-dev-server": "3.11.0"
+    "webpack-dev-server": "^3.11.0"
   },
   "insights": {
     "appname": "cost-management"

--- a/yarn.lock
+++ b/yarn.lock
@@ -9057,7 +9057,7 @@ webpack-dev-middleware@^3.7.2:
     range-parser "^1.2.1"
     webpack-log "^2.0.0"
 
-webpack-dev-server@3.11.0:
+webpack-dev-server@^3.11.0:
   version "3.11.0"
   resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-3.11.0.tgz#8f154a3bce1bcfd1cc618ef4e703278855e7ff8c"
   integrity sha512-PUxZ+oSTxogFQgkTtFndEtJIPNmml7ExwufBZ9L2/Xyyd5PnOL5UreWe5ZT7IU25DSdykL9p1MLQzmLh2ljSeg==
@@ -9165,8 +9165,9 @@ websocket-driver@>=0.5.1:
     websocket-extensions ">=0.1.1"
 
 websocket-extensions@>=0.1.1:
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.3.tgz#5d2ff22977003ec687a4b87073dfbbac146ccf29"
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/websocket-extensions/-/websocket-extensions-0.1.4.tgz#7f8473bc839dfd87608adb95d7eb075211578a42"
+  integrity sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==
 
 whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.3:
   version "1.0.5"


### PR DESCRIPTION
Dependabot is reporting websocket-extensions as a moderate severity vulnerability. We need to bump websocket-extensions to 0.1.4

Based on https://github.com/project-koku/koku-ui/pull/1604

https://issues.redhat.com/browse/COST-320