### PR TITLE
COST-328: Details cost heading should be right aligned

### DIFF
--- a/src/pages/details/awsDetails/detailsTable.styles.ts
+++ b/src/pages/details/awsDetails/detailsTable.styles.ts
@@ -64,7 +64,7 @@ export const tableOverride = css`
   &.pf-c-table {
     thead th + th + th {
       .pf-c-table__button {
-        justify-content: flex-end;
+        margin-left: auto
       }
       text-align: right;
     }

--- a/src/pages/details/azureDetails/detailsTable.styles.ts
+++ b/src/pages/details/azureDetails/detailsTable.styles.ts
@@ -64,7 +64,7 @@ export const tableOverride = css`
   &.pf-c-table {
     thead th + th + th {
       .pf-c-table__button {
-        justify-content: flex-end;
+        margin-left: auto
       }
       text-align: right;
     }

--- a/src/pages/details/ocpDetails/detailsTable.styles.ts
+++ b/src/pages/details/ocpDetails/detailsTable.styles.ts
@@ -64,7 +64,7 @@ export const tableOverride = css`
   &.pf-c-table {
     thead th + th + th {
       .pf-c-table__button {
-        justify-content: flex-end;
+        margin-left: auto
       }
       text-align: right;
     }


### PR DESCRIPTION
The Details cost heading is no longer right aligned, due to a change in PatternFly.

We need to replace justify-content: flex-end; with margin-left: auto;

https://issues.redhat.com/browse/COST-328