### PR TITLE
fix(costmodels): edit markup dialog updates

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -256,7 +256,7 @@
     },
     "description_markup": "Percentage to add to or subtract from the base cost of the source(s)",
     "edit_cost_model": "Edit cost model",
-    "edit_markup": "Edit {{cost_model}} markup",
+    "edit_markup": "Edit markup",
     "edit_markup_action": "Edit markup",
     "edit_rate": "Edit rate",
     "empty_state": {

--- a/src/pages/costModels/costModelsDetails/components/markup.tsx
+++ b/src/pages/costModels/costModelsDetails/components/markup.tsx
@@ -15,6 +15,7 @@ import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
 import { rbacSelectors } from 'store/rbac';
+import { formatValue } from 'utils/formatValue';
 import Dropdown from './dropdown';
 import { styles } from './markup.styles';
 import UpdateMarkupDialog from './updateMarkupDialog';
@@ -35,8 +36,8 @@ const MarkupCardBase: React.SFC<Props> = ({
 }) => {
   const markupValue =
     current && current.markup && current.markup.value
-      ? Number(current.markup.value).toFixed(2)
-      : 0;
+      ? formatValue(Number(current.markup.value), 'markup', {fractionDigits: 2})
+      : '0.0';
 
   return (
     <>

--- a/src/pages/costModels/costModelsDetails/components/updateMarkupDialog.tsx
+++ b/src/pages/costModels/costModelsDetails/components/updateMarkupDialog.tsx
@@ -6,7 +6,13 @@ import {
   InputGroup,
   InputGroupText,
   Modal,
+  Stack,
+  StackItem,
+  Text,
+  TextContent,
   TextInput,
+  TextVariants,
+  Title,
 } from '@patternfly/react-core';
 import { CostModel } from 'api/costModels';
 import React from 'react';
@@ -14,6 +20,7 @@ import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
+import { formatValue } from 'utils/formatValue';
 
 interface Props extends InjectedTranslateProps {
   isLoading: boolean;
@@ -31,7 +38,7 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
   constructor(props) {
     super(props);
     this.state = {
-      markup: String(this.props.current.markup.value || 0),
+      markup: formatValue(Number(this.props.current.markup.value), 'markup', {fractionDigits: 2}) as string ||  '0.00',
     };
   }
   public render() {
@@ -45,9 +52,7 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
     } = this.props;
     return (
       <Modal
-        title={t('cost_models_details.edit_markup', {
-          cost_model: current.name,
-        })}
+        title={t('cost_models_details.edit_markup')}
         isOpen
         onClose={() => onClose({ name: 'updateMarkup', isOpen: false })}
         variant="small"
@@ -88,35 +93,57 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
           </Button>,
         ]}
       >
-        <>
-          {error && <Alert variant="danger" title={`${error}`} />}
-          <Form>
-            <FormGroup
-              label={t('cost_models_wizard.markup.markup_label')}
-              fieldId="markup-input-box"
-              helperTextInvalid={t(
-                'cost_models_wizard.markup.invalid_markup_text'
-              )}
-              validated={
-                !isNaN(Number(this.state.markup)) ? 'default' : 'error'
-              }
-            >
-              <InputGroup style={{ width: '150px' }}>
-                <TextInput
-                  type="text"
-                  aria-label={t('cost_models_wizard.markup.markup_label')}
-                  id="markup-input-box"
-                  value={this.state.markup}
-                  onChange={(markup: string) => this.setState({ markup })}
-                  validated={
-                    !isNaN(Number(this.state.markup)) ? 'default' : 'error'
-                  }
-                />
-                <InputGroupText style={{ borderLeft: '0' }}>%</InputGroupText>
-              </InputGroup>
-            </FormGroup>
-          </Form>
-        </>
+        <Stack hasGutter>
+          <StackItem>
+            {error && <Alert variant="danger" title={`${error}`} />}
+          </StackItem>
+          <StackItem>
+            <Title headingLevel="h2" size="md">
+              {t('cost_models_details.table.columns.name')}
+            </Title>
+          </StackItem>
+          <StackItem>
+            <TextContent>
+              <Text component={TextVariants.h6}>{current.name}</Text>
+            </TextContent>
+          </StackItem>
+          <StackItem>
+            <Form>
+              <FormGroup
+                label={t('cost_models_wizard.markup.markup_label')}
+                fieldId="markup-input-box"
+                helperTextInvalid={t(
+                  'cost_models_wizard.markup.invalid_markup_text'
+                )}
+                validated={
+                  !isNaN(Number(this.state.markup)) ? 'default' : 'error'
+                }
+              >
+                <InputGroup style={{ width: '150px' }}>
+                  <TextInput
+                    type="text"
+                    aria-label={t('cost_models_wizard.markup.markup_label')}
+                    id="markup-input-box"
+                    value={this.state.markup}
+                    onChange={(markup: string) => {
+                      const markupDecimal = Number(markup)
+                      const dx = markup.split('').findIndex(c => c === '.')
+                      if(!isNaN(markupDecimal) && dx > -1 && markup.length - dx - 1 > 2) {
+                        this.setState({markup: formatValue(markupDecimal, 'markup', {fractionDigits: 2}) as string})
+                        return
+                      }
+                      this.setState({ markup });
+                    }}
+                    validated={
+                      !isNaN(Number(this.state.markup)) ? 'default' : 'error'
+                    }
+                  />
+                  <InputGroupText style={{ borderLeft: '0' }}>%</InputGroupText>
+                </InputGroup>
+              </FormGroup>
+            </Form>
+          </StackItem>
+        </Stack>
       </Modal>
     );
   }

--- a/src/pages/costModels/createCostModelWizard/index.tsx
+++ b/src/pages/costModels/createCostModelWizard/index.tsx
@@ -14,6 +14,7 @@ import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions } from 'store/costModels';
 import { metricsSelectors } from 'store/metrics';
+import { formatValue } from 'utils/formatValue';
 import { fetchSources as apiSources } from './api';
 import { CostModelContext } from './context';
 import { parseApiError } from './parseError';
@@ -117,7 +118,7 @@ const defaultState = {
   type: '',
   name: '',
   description: '',
-  markup: '0',
+  markup: '0.00',
   filterName: '',
   sources: [],
   error: null,
@@ -223,7 +224,15 @@ class CostModelWizardBase extends React.Component<Props, State> {
           description: this.state.description,
           onDescChange: value => this.setState({ description: value }),
           markup: this.state.markup,
-          onMarkupChange: value => this.setState({ markup: value }),
+          onMarkupChange: value => {
+            const markupDecimal = Number(value)
+            const dx = value.split('').findIndex(c => c === '.')
+            if(!isNaN(markupDecimal) && dx > -1 && value.length - dx - 1 > 2) {
+              this.setState({markup: formatValue(markupDecimal, 'markup', {fractionDigits: 2}) as string})
+              return
+            }
+            this.setState({ markup: value });
+          },
           error: this.state.error,
           apiError: this.state.apiError,
           sources: this.state.sources,


### PR DESCRIPTION
This change will make sure that the precision of the markup is not more than 2 digits after the dot.

//cc @nlcwong