### PR TITLE
COST-135: Export modal consistency update

### DIFF
--- a/src/pages/details/components/export/exportModal.tsx
+++ b/src/pages/details/components/export/exportModal.tsx
@@ -116,14 +116,6 @@ export class ExportModalBase extends React.Component<
         title={t('export.title')}
         variant="small"
         actions={[
-          <Button
-            {...getTestProps(testIds.export.cancel_btn)}
-            key="cancel"
-            onClick={this.handleClose}
-            variant={ButtonVariant.secondary}
-          >
-            {t('export.cancel')}
-          </Button>,
           <ExportSubmit
             groupBy={groupBy}
             isAllItems={isAllItems}
@@ -134,6 +126,14 @@ export class ExportModalBase extends React.Component<
             reportPathsType={reportPathsType}
             resolution={resolution}
           />,
+          <Button
+            {...getTestProps(testIds.export.cancel_btn)}
+            key="cancel"
+            onClick={this.handleClose}
+            variant={ButtonVariant.link}
+          >
+            {t('export.cancel')}
+          </Button>
         ]}
       >
         <Title headingLevel="h2" style={styles.title} size="xl">


### PR DESCRIPTION
Swapped button order for the export modal in the details pages. Updated cancel variant to a link button.

https://issues.redhat.com/browse/COST-135

<img width="591" alt="Screen Shot 2020-07-16 at 12 33 22 PM" src="https://user-images.githubusercontent.com/17481322/87698152-1669a980-c761-11ea-8738-9989afd64ea6.png">
