### PR TITLE
COST-134: Tag list modal consistency update

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1097,6 +1097,11 @@
       "OCP": "Red Hat OpenShift"
     }
   },
+  "tag": {
+    "heading_key": "Key",
+    "heading_value": "Value",
+    "title": "Tags ({{value}})"
+  },
   "toolbar": {
     "filterby": "Filter by {{ name }}",
     "pricelist": {

--- a/src/pages/details/components/tag/tag.styles.ts
+++ b/src/pages/details/components/tag/tag.styles.ts
@@ -1,7 +1,13 @@
-import { global_spacer_3xl, global_spacer_sm } from '@patternfly/react-tokens';
+import { global_FontWeight_bold, global_spacer_3xl, global_spacer_lg, global_spacer_sm } from '@patternfly/react-tokens';
 import React from 'react';
 
 export const styles = {
+  dataListHeading: {
+    fontWeight: global_FontWeight_bold.value as any
+  },
+  groupByHeading: {
+    marginBottom: global_spacer_lg.value
+  },
   tagLink: {
     marginLeft: global_spacer_sm.value,
   },

--- a/src/pages/details/components/tag/tagLink.tsx
+++ b/src/pages/details/components/tag/tagLink.tsx
@@ -77,19 +77,19 @@ class TagLinkBase extends React.Component<TagLinkProps> {
     const { filterBy, groupBy, id, report, reportPathsType } = this.props;
     const { isOpen } = this.state;
 
-    const tagKeyValues = [];
+    let tagKeyValuesCount = 0;
 
     if (report) {
       for (const tag of report.data) {
-        for (const val of tag.values) {
-          tagKeyValues.push(`${(tag as any).key}: ${val}`);
+        for (const {} of tag.values) {
+          tagKeyValuesCount++;
         }
       }
     }
 
     return (
       <div style={styles.tagsContainer} id={id}>
-        {Boolean(tagKeyValues.length) && (
+        {Boolean(tagKeyValuesCount > 0) && (
           <>
             <TagIcon />
             <a
@@ -98,7 +98,7 @@ class TagLinkBase extends React.Component<TagLinkProps> {
               onClick={this.handleOpen}
               style={styles.tagLink}
             >
-              {tagKeyValues.length}
+              {tagKeyValuesCount}
             </a>
           </>
         )}

--- a/src/pages/details/components/tag/tagLink.tsx
+++ b/src/pages/details/components/tag/tagLink.tsx
@@ -77,19 +77,19 @@ class TagLinkBase extends React.Component<TagLinkProps> {
     const { filterBy, groupBy, id, report, reportPathsType } = this.props;
     const { isOpen } = this.state;
 
-    let tagKeyValuesCount = 0;
+    let count = 0;
 
     if (report) {
       for (const tag of report.data) {
-        for (const {} of tag.values) {
-          tagKeyValuesCount++;
+        if (tag.values) {
+          count += tag.values.length;
         }
       }
     }
 
     return (
       <div style={styles.tagsContainer} id={id}>
-        {Boolean(tagKeyValuesCount > 0) && (
+        {Boolean(count > 0) && (
           <>
             <TagIcon />
             <a
@@ -98,7 +98,7 @@ class TagLinkBase extends React.Component<TagLinkProps> {
               onClick={this.handleOpen}
               style={styles.tagLink}
             >
-              {tagKeyValuesCount}
+              {count}
             </a>
           </>
         )}

--- a/src/pages/details/components/tag/tagModal.styles.ts
+++ b/src/pages/details/components/tag/tagModal.styles.ts
@@ -1,5 +1,4 @@
-import { global_spacer_2xl, global_spacer_lg } from '@patternfly/react-tokens';
-import { css } from 'emotion';
+import { global_spacer_2xl } from '@patternfly/react-tokens';
 import React from 'react';
 
 export const styles = {
@@ -8,12 +7,3 @@ export const styles = {
     textAlign: 'right',
   },
 } as { [className: string]: React.CSSProperties };
-
-export const modalOverride = css`
-  & .pf-c-modal-box__body {
-    margin-top: ${global_spacer_lg.value};
-  }
-  & .pf-c-modal-box__footer {
-    display: none;
-  }
-`;

--- a/src/pages/details/components/tag/tagModal.tsx
+++ b/src/pages/details/components/tag/tagModal.tsx
@@ -1,8 +1,11 @@
 import { Modal } from '@patternfly/react-core';
-import { ReportPathsType } from 'api/reports/report';
+import { getQuery, parseQuery, Query } from 'api/queries/query';
+import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
-import { modalOverride } from './tagModal.styles';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { reportActions, reportSelectors } from 'store/reports';
 import { TagView } from './tagView';
 
 interface TagModalOwnProps {
@@ -13,7 +16,22 @@ interface TagModalOwnProps {
   reportPathsType: ReportPathsType;
 }
 
-type TagModalProps = TagModalOwnProps & InjectedTranslateProps;
+interface TagModalStateProps {
+  queryString?: string;
+  report?: Report;
+  reportFetchStatus?: FetchStatus;
+}
+
+interface TagModalDispatchProps {
+  fetchReport?: typeof reportActions.fetchReport;
+}
+
+type TagModalProps = TagModalOwnProps &
+  TagModalStateProps &
+  TagModalDispatchProps &
+  InjectedTranslateProps;
+
+const reportType = ReportType.tag;
 
 class TagModalBase extends React.Component<TagModalProps> {
   constructor(props: TagModalProps) {
@@ -21,39 +39,102 @@ class TagModalBase extends React.Component<TagModalProps> {
     this.handleClose = this.handleClose.bind(this);
   }
 
+  public componentDidMount() {
+    const { fetchReport, queryString, reportPathsType } = this.props;
+    fetchReport(reportPathsType, reportType, queryString);
+  }
+
+  public componentDidUpdate(prevProps: TagModalProps) {
+    const { fetchReport, queryString, reportPathsType } = this.props;
+    if (prevProps.queryString !== queryString) {
+      fetchReport(reportPathsType, reportType, queryString);
+    }
+  }
+
   public shouldComponentUpdate(nextProps: TagModalProps) {
     const { filterBy, isOpen } = this.props;
     return nextProps.filterBy !== filterBy || nextProps.isOpen !== isOpen;
   }
+
+  private getTagValueCount = () => {
+    const { report } = this.props;
+    let count = 0;
+
+    if (report) {
+      for (const tag of report.data) {
+        for (const {} of tag.values) {
+          count++;
+        }
+      }
+    }
+    return count;
+  };
 
   private handleClose = () => {
     this.props.onClose(false);
   };
 
   public render() {
-    const { filterBy, groupBy, isOpen, reportPathsType, t } = this.props;
+    const { filterBy, groupBy, isOpen, report, t } = this.props;
 
     return (
       <Modal
-        className={modalOverride}
         isOpen={isOpen}
         onClose={this.handleClose}
-        title={t('details.tags_modal_title', {
-          groupBy,
-          name: filterBy,
+        title={t('tag.title', {
+          value: this.getTagValueCount()
         })}
         width={'50%'}
       >
         <TagView
           filterBy={filterBy}
           groupBy={groupBy}
-          reportPathsType={reportPathsType}
+          report={report}
         />
       </Modal>
     );
   }
 }
 
-const TagModal = translate()(TagModalBase);
+const mapStateToProps = createMapStateToProps<
+  TagModalOwnProps,
+  TagModalStateProps
+  >((state, { filterBy, groupBy, reportPathsType }) => {
+  const queryFromRoute = parseQuery<Query>(location.search);
+  const queryString = getQuery({
+    filter: {
+      [groupBy]: filterBy,
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
+      ...(queryFromRoute.filter.account && {account: queryFromRoute.filter.account})
+    },
+  });
+  const report = reportSelectors.selectReport(
+    state,
+    reportPathsType,
+    reportType,
+    queryString
+  );
+  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+    state,
+    reportPathsType,
+    reportType,
+    queryString
+  );
+  return {
+    queryString,
+    report,
+    reportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: TagModalDispatchProps = {
+  fetchReport: reportActions.fetchReport,
+};
+
+const TagModal = translate()(
+  connect(mapStateToProps, mapDispatchToProps)(TagModalBase)
+);
 
 export { TagModal };

--- a/src/pages/details/components/tag/tagModal.tsx
+++ b/src/pages/details/components/tag/tagModal.tsx
@@ -62,8 +62,8 @@ class TagModalBase extends React.Component<TagModalProps> {
 
     if (report) {
       for (const tag of report.data) {
-        for (const {} of tag.values) {
-          count++;
+        if (tag.values) {
+          count += tag.values.length;
         }
       }
     }

--- a/src/pages/details/components/tag/tagView.tsx
+++ b/src/pages/details/components/tag/tagView.tsx
@@ -29,14 +29,14 @@ class TagViewBase extends React.Component<TagViewProps> {
         for (const val of tag.values) {
           const id = `${(tag as any).key}:${val}`;
           result.push(
-            <DataListItem aria-labelledby={id}>
+            <DataListItem aria-labelledby={id} key={`${id}-item`} >
               <DataListItemRow>
                 <DataListItemCells
                   dataListCells={[
-                      <DataListCell key={`${id}-col1`}>
+                      <DataListCell key={`${id}-cell1`}>
                         <span id={id}>{(tag as any).key}</span>
                       </DataListCell>,
-                      <DataListCell key={`${id}-col2`}>
+                      <DataListCell key={`${id}-cell2`}>
                         {val}
                       </DataListCell>
                     ]}

--- a/src/pages/details/components/tag/tagView.tsx
+++ b/src/pages/details/components/tag/tagView.tsx
@@ -1,110 +1,89 @@
-import {getQuery, parseQuery, Query} from 'api/queries/query';
+import {
+  DataList,
+  DataListCell,
+  DataListItem,
+  DataListItemCells,
+  DataListItemRow,
+} from '@patternfly/react-core';
 import { Report } from 'api/reports/report';
-import { ReportPathsType, ReportType } from 'api/reports/report';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
-import { createMapStateToProps, FetchStatus } from 'store/common';
-import { reportActions, reportSelectors } from 'store/reports';
+import { styles } from './tag.styles';
 
 interface TagViewOwnProps {
   filterBy: string | number;
   groupBy: string;
-  reportPathsType: ReportPathsType;
-}
-
-interface TagViewStateProps {
-  queryString?: string;
   report?: Report;
-  reportFetchStatus?: FetchStatus;
 }
 
-interface TagViewDispatchProps {
-  fetchReport?: typeof reportActions.fetchReport;
-}
+type TagViewProps = TagViewOwnProps & InjectedTranslateProps;
 
-type TagViewProps = TagViewOwnProps &
-  TagViewStateProps &
-  TagViewDispatchProps &
-  InjectedTranslateProps;
-
-const reportType = ReportType.tag;
-
-class TagViewBase<T extends ReportPathsType> extends React.Component<
-  TagViewProps
-> {
-  public componentDidMount() {
-    const { fetchReport, queryString, reportPathsType } = this.props;
-    fetchReport(reportPathsType, reportType, queryString);
-  }
-
-  public componentDidUpdate(prevProps: TagViewProps) {
-    const { fetchReport, queryString, reportPathsType } = this.props;
-    if (prevProps.queryString !== queryString) {
-      fetchReport(reportPathsType, reportType, queryString);
-    }
-  }
-
-  private getTags = () => {
+class TagViewBase extends React.Component<TagViewProps> {
+  private getDataListItems = () => {
     const { report } = this.props;
-    const tags = [];
+    const result = [];
 
     if (report) {
       for (const tag of report.data) {
         for (const val of tag.values) {
-          tags.push(`${(tag as any).key}: ${val}`);
+          const id = `${(tag as any).key}:${val}`;
+          result.push(
+            <DataListItem aria-labelledby={id}>
+              <DataListItemRow>
+                <DataListItemCells
+                  dataListCells={[
+                      <DataListCell key={`${id}-col1`}>
+                        <span id={id}>{(tag as any).key}</span>
+                      </DataListCell>,
+                      <DataListCell key={`${id}-col2`}>
+                        {val}
+                      </DataListCell>
+                    ]}
+                />
+              </DataListItemRow>
+            </DataListItem>
+          );
         }
       }
     }
-    return tags;
+    return result;
   };
 
   public render() {
-    const tags = this.getTags();
+    const { filterBy, groupBy, t } = this.props;
+    const dataListItems = this.getDataListItems();
 
-    return tags.map((tag, index) => <div key={`tag-${index}`}>{tag}</div>);
+    return (
+      <>
+        <div>
+          <span style={styles.dataListHeading}>{t(`group_by.values.${groupBy}`)}</span>
+        </div>
+        <div style={styles.groupByHeading}>
+          <span>{filterBy}</span>
+        </div>
+        <DataList aria-label="Simple data list example" isCompact>
+          <DataListItem aria-labelledby="heading1">
+            <DataListItemRow>
+              <DataListItemCells
+                dataListCells={[
+                  <DataListCell key="primary content">
+                    <span id="heading1" style={styles.dataListHeading}>{t('tag.heading_key')}</span>
+                  </DataListCell>,
+                  <DataListCell key="secondary content">
+                    <span id="heading2" style={styles.dataListHeading}>{t('tag.heading_value')}</span>
+                  </DataListCell>
+                ]}
+              />
+            </DataListItemRow>
+          </DataListItem>
+          {dataListItems.map(item => item)}
+        </DataList>
+      </>
+    );
   }
 }
 
-const mapStateToProps = createMapStateToProps<
-  TagViewOwnProps,
-  TagViewStateProps
->((state, { filterBy, groupBy, reportPathsType }) => {
-  const queryFromRoute = parseQuery<Query>(location.search);
-  const queryString = getQuery({
-    filter: {
-      [groupBy]: filterBy,
-      resolution: 'monthly',
-      time_scope_units: 'month',
-      time_scope_value: -1,
-      ...(queryFromRoute.filter.account && {account: queryFromRoute.filter.account})
-    },
-  });
-  const report = reportSelectors.selectReport(
-    state,
-    reportPathsType,
-    reportType,
-    queryString
-  );
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
-    state,
-    reportPathsType,
-    reportType,
-    queryString
-  );
-  return {
-    queryString,
-    report,
-    reportFetchStatus,
-  };
-});
-
-const mapDispatchToProps: TagViewDispatchProps = {
-  fetchReport: reportActions.fetchReport,
-};
-
-const TagView = translate()(
-  connect(mapStateToProps, mapDispatchToProps)(TagViewBase)
-);
+const TagView = translate()(connect()(TagViewBase));
 
 export { TagView, TagViewProps };


### PR DESCRIPTION
Updated tags modal shown on details page per new mocks. However, we're using PatternFly's data list component instead of a simple HTML table -- reviewed with Natalie.

https://issues.redhat.com/browse/COST-134

<img width="1001" alt="Screen Shot 2020-07-16 at 3 29 18 PM" src="https://user-images.githubusercontent.com/17481322/87714799-51c4a200-c77a-11ea-944a-817e885582b6.png">
