### PR TITLE
Updated our 404 "not found" page to use the Insights InvalidObject co…

### DIFF
--- a/src/pages/notFound/notFound.tsx
+++ b/src/pages/notFound/notFound.tsx
@@ -1,5 +1,15 @@
 import React from 'react';
+import { withRouter } from 'react-router-dom';
 
-const NotFound: React.SFC = () => <div>Not Found!</div>;
+import { InvalidObject } from '@redhat-cloud-services/frontend-components/components/InvalidObject';
+import { Main } from '@redhat-cloud-services/frontend-components/components/Main';
 
-export default NotFound;
+const NotFound = () => {
+  return (
+    <Main>
+      <InvalidObject />
+    </Main>
+  );
+};
+
+export default withRouter(NotFound);

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -13,3 +13,12 @@ body {
   min-height: 0;
   min-width: 0;
 }
+
+/* Todo: Workaround for https://projects.engineering.redhat.com/browse/RHCLOUD-7970 */
+.Icon404 {
+  height: 150px;
+}
+.Icon404 .cls-1 { fill:#fff; }
+.Icon404 .cls-1, .Icon404 .cls-3{ fill-rule:evenodd;}
+.Icon404 .cls-2{ opacity:0.5;}
+.Icon404 .cls-4{ mask:url(#mask); }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -53,7 +53,23 @@ module.exports = env => {
     devtool: isProduction ? 'source-maps' : 'eval',
     entry: [
       require.resolve(
+        '@redhat-cloud-services/frontend-components/components/Main.css'
+      ),
+      // Todo: Added to global.css as a workaround for https://projects.engineering.redhat.com/browse/RHCLOUD-7970
+      // require.resolve(
+      //   '@redhat-cloud-services/frontend-components/components/icon-404.css'
+      // ),
+      require.resolve(
+        '@redhat-cloud-services/frontend-components/components/InvalidObject.css'
+      ),
+      require.resolve(
+        '@redhat-cloud-services/frontend-components/components/NotAuthorized.css'
+      ),
+      require.resolve(
         '@redhat-cloud-services/frontend-components/components/Skeleton.css'
+      ),
+      require.resolve(
+        '@redhat-cloud-services/frontend-components/components/Unavailable.css'
       ),
       require.resolve(
         '@redhat-cloud-services/frontend-components-notifications/index.css'


### PR DESCRIPTION
Updated our 404 "not found" page to use the Insights `InvalidObject` component.

Note that since we're using an Insights component, some text does not match the mock exactly.

https://issues.redhat.com/browse/COST-154

<img width="1665" alt="Screen Shot 2020-07-17 at 4 22 21 PM" src="https://user-images.githubusercontent.com/17481322/87827975-feba2000-c849-11ea-99a7-d4a69c3c52c3.png">
