### PR TITLE
COST-50: Price list depends on API labels for i18n keys

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -423,9 +423,9 @@
       "modal": {
         "applied_usage_date_range": "Applied usage date range",
         "applied_usage_range": "Applied usage range",
-        "metric_display": "{{display}} tier {{index}} ({{ unit }})",
         "hours": "hourly",
         "metric": "Metric",
+        "metric_display": "{{display}} tier {{index}} ({{ unit }})",
         "month": "monthly",
         "no_match": "No rates were found",
         "no_range_set": "No range set",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -423,26 +423,15 @@
       "modal": {
         "applied_usage_date_range": "Applied usage date range",
         "applied_usage_range": "Applied usage range",
-        "cluster currency rate": "Cluster price rate tier {{index}} ({{ unit }})",
-        "compute request rate": "Compute request rate tier {{ index }} ({{ unit }})",
-        "compute usage rate": "Compute usage rate tier {{ index }} ({{ unit }})",
-        "cpu request rate": "CPU request rate tier {{ index }} ({{ unit }})",
-        "cpu usage rate": "CPU usage rate tier {{ index }} ({{ unit }})",
+        "metric_display": "{{display}} tier {{index}} ({{ unit }})",
         "hours": "hourly",
-        "memory request rate": "Memory request rate tier {{ index }} ({{ unit }})",
-        "memory usage rate": "Memory usage rate tier {{ index }} ({{ unit }})",
         "metric": "Metric",
         "month": "monthly",
         "no_match": "No rates were found",
         "no_range_set": "No range set",
-        "node currency rate": "Node price rate tier {{index}} ({{ unit }})",
         "not_available": "N/A",
-        "storage request rate": "Storage request rate tier {{ index }} ({{ unit }})",
-        "storage usage rate": "Storage usage rate tier {{ index }} ({{ unit }})",
         "title": "{{name}} cluster price list",
-        "value": "Value",
-        "volume request rate": "Volume request rate tier {{ index }} ({{ unit }})",
-        "volume usage rate": "Volume usage rate tier {{ index }} ({{ unit }})"
+        "value": "Value"
       }
     },
     "summary_modal_title": "{{name}} $t(group_by.top_values.{{groupBy}})s",

--- a/src/pages/details/components/priceList/priceListTable.tsx
+++ b/src/pages/details/components/priceList/priceListTable.tsx
@@ -21,17 +21,22 @@ const PriceListTable = ({ rates, t }) => {
         t('details.price_list.modal.applied_usage_range'),
         t('details.price_list.modal.applied_usage_date_range'),
       ]}
-      rows={rates.map(metric => [
-        t(`details.price_list.modal.${metric.display}`, {
-          index: metric.index + 1,
-          unit: metric.range_unit,
-        }),
-        metric.value
-          ? formatCurrency(metric.value, metric.value_unit)
-          : notAvailableText,
-        getUsageRangeText(metric, t),
-        t(`details.price_list.modal.${metric.period}`),
-      ])}
+      rows={rates.map(metric => {
+        // Avoid relying on API labels as i18n keys -- see https://issues.redhat.com/browse/COST-50
+        const s = metric.display.replace(/cpu/g, 'CPU');
+        return [
+          t(`details.price_list.modal.metric_display`, {
+            display: s.replace(/(^\w)/g, m => m.toUpperCase()),
+            index: metric.index + 1,
+            unit: metric.range_unit,
+          }),
+          metric.value
+            ? formatCurrency(metric.value, metric.value_unit)
+            : notAvailableText,
+          getUsageRangeText(metric, t),
+          t(`details.price_list.modal.${metric.period}`),
+        ];
+      })}
     >
       <TableHeader />
       <TableBody />


### PR DESCRIPTION
This removes the price list dependency on API labels as i18n keys in the details page. Instead, the API's `metric.display` value is passed as a property to a single i18n string. That way, when a metric is added or changed, the UI won't break due to a missing i18n key.

Note that the details page price list will ultimately be replaced by https://issues.redhat.com/browse/COST-255.

https://issues.redhat.com/browse/COST-50

<img width="1239" alt="Screen Shot 2020-07-23 at 8 37 21 PM" src="https://user-images.githubusercontent.com/17481322/88352506-fcfbcb00-cd27-11ea-9a6e-58e53d78181a.png">
