### PR TITLE
COST-375: Update lodash dependency

### DIFF
--- a/koku-ui-manifest
+++ b/koku-ui-manifest
@@ -990,6 +990,7 @@ mgmt_services/cost-mgmt:koku-ui/lodash:4.17.15.yarnlock
 mgmt_services/cost-mgmt:koku-ui/lodash:4.17.15.yarnlock
 mgmt_services/cost-mgmt:koku-ui/lodash:4.17.15.yarnlock
 mgmt_services/cost-mgmt:koku-ui/lodash:4.17.15.yarnlock
+mgmt_services/cost-mgmt:koku-ui/lodash:4.17.19.yarnlock
 mgmt_services/cost-mgmt:koku-ui/log-symbols:1.0.2.yarnlock
 mgmt_services/cost-mgmt:koku-ui/log-symbols:2.2.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/log-update:2.3.0.yarnlock

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "i18next-json-sync": "2.2.0",
     "i18next-xhr-backend": "1.5.1",
     "js-file-download": "0.4.4",
-    "lodash": "^4.17.15",
+    "lodash": "^4.17.19",
     "mini-css-extract-plugin": "0.4.5",
     "qs": "6.5.2",
     "react": "16.8.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6084,6 +6084,11 @@ lodash@^4.15.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.13, lodash@^4.17.
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==
 
+lodash@^4.17.19:
+  version "4.17.19"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
+  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
 log-symbols@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/log-symbols/-/log-symbols-1.0.2.tgz#376ff7b58ea3086a0f09facc74617eca501e1a18"


### PR DESCRIPTION
Dependabot is reporting a security issue with lodash. We need to upgrade lodash to version 4.17.19 or later.

https://issues.redhat.com/browse/COST-375