### PR TITLE
Cost Details page displays empty state upon 403 response

### DIFF
--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -14,6 +14,7 @@ import { AxiosError } from 'axios';
 import { ExportModal } from 'pages/details/components/export/exportModal';
 import Loading from 'pages/state/loading';
 import NoProviders from 'pages/state/noProviders';
+import NotAuthorized from 'pages/state/notAuthorized/notAuthorized'
 import NotAvailable from 'pages/state/notAvailable';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -409,6 +410,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
       providersFetchStatus,
       report,
       reportError,
+      reportFetchStatus
     } = this.props;
 
     const groupById = this.getGroupById();
@@ -419,19 +421,23 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
       idKey: (groupByTag as any) || groupById,
     });
 
-    const isLoading = providersFetchStatus === FetchStatus.inProgress;
+    const isLoading = providersFetchStatus === FetchStatus.inProgress || reportFetchStatus === FetchStatus.inProgress;
     const noProviders =
       providers &&
       providers.meta &&
       providers.meta.count === 0 &&
       providersFetchStatus === FetchStatus.complete;
 
-    if (reportError) {
-      return <NotAvailable />;
-    } else if (noProviders) {
+    if (isLoading) {
+      return <Loading/>;
+    } else if (reportError) {
+      if (reportError.response && reportError.response.status === 403) {
+        return <NotAuthorized />;
+      } else {
+        return <NotAvailable />;
+      }
+    } else if (noProviders && reportFetchStatus === FetchStatus.complete) {
       return <NoProviders />;
-    } else if (isLoading) {
-      return <Loading />;
     }
     return (
       <div style={styles.awsDetails}>

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -14,6 +14,7 @@ import { AxiosError } from 'axios';
 import { ExportModal } from 'pages/details/components/export/exportModal';
 import Loading from 'pages/state/loading';
 import NoProviders from 'pages/state/noProviders';
+import NotAuthorized from 'pages/state/notAuthorized/notAuthorized';
 import NotAvailable from 'pages/state/notAvailable';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -384,6 +385,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
       query,
       report,
       reportError,
+      reportFetchStatus
     } = this.props;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
@@ -394,19 +396,23 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
       idKey: (groupByTag as any) || groupById,
     });
 
-    const isLoading = providersFetchStatus === FetchStatus.inProgress;
+    const isLoading = providersFetchStatus === FetchStatus.inProgress || reportFetchStatus === FetchStatus.inProgress;
     const noProviders =
       providers &&
       providers.meta &&
       providers.meta.count === 0 &&
       providersFetchStatus === FetchStatus.complete;
 
-    if (reportError) {
-      return <NotAvailable />;
-    } else if (noProviders) {
-      return <NoProviders />;
-    } else if (isLoading) {
+    if (isLoading) {
       return <Loading />;
+    } else if (reportError) {
+      if (reportError.response && reportError.response.status === 403) {
+        return <NotAuthorized />;
+      } else {
+        return <NotAvailable />;
+      }
+    } else if (noProviders && reportFetchStatus === FetchStatus.complete) {
+      return <NoProviders />;
     }
     return (
       <div style={styles.azureDetails}>

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -14,6 +14,7 @@ import { AxiosError } from 'axios';
 import { ExportModal } from 'pages/details/components/export/exportModal';
 import Loading from 'pages/state/loading';
 import NoProviders from 'pages/state/noProviders';
+import NotAuthorized from 'pages/state/notAuthorized/notAuthorized';
 import NotAvailable from 'pages/state/notAvailable';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
@@ -380,6 +381,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
       query,
       report,
       reportError,
+      reportFetchStatus
     } = this.props;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
@@ -390,19 +392,23 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
       idKey: (groupByTagKey as any) || groupById,
     });
 
-    const isLoading = providersFetchStatus === FetchStatus.inProgress;
+    const isLoading = providersFetchStatus === FetchStatus.inProgress || reportFetchStatus === FetchStatus.inProgress;
     const noProviders =
       providers &&
       providers.meta &&
       providers.meta.count === 0 &&
       providersFetchStatus === FetchStatus.complete;
 
-    if (reportError) {
-      return <NotAvailable />;
-    } else if (noProviders) {
+    if (isLoading) {
+      return <Loading/>;
+    } else if (reportError) {
+      if (reportError.response && reportError.response.status === 403) {
+        return <NotAuthorized />;
+      } else {
+        return <NotAvailable />;
+      }
+    } else if (noProviders && reportFetchStatus === FetchStatus.complete) {
       return <NoProviders />;
-    } else if (isLoading) {
-      return <Loading />;
     }
     return (
       <div style={styles.ocpDetails}>


### PR DESCRIPTION
Currently, app.tsx relies on the providers API to return an 403 (i.e., unauthorized) status. However, the providers API doesn't have RBAC on the `/sources/` endpoint. Therefore, each details page must test reports for 403 errors.

https://issues.redhat.com/browse/COST-390

<img width="1291" alt="Screen Shot 2020-08-03 at 9 55 49 AM" src="https://user-images.githubusercontent.com/17481322/89193200-a4240200-d573-11ea-8b2e-7335cf54294c.png">
