### PR TITLE
Full page AWS error state blocks access to Azure

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -486,6 +486,7 @@
   },
   "error_state": {
     "unauthorized_desc": "Contact the cost management administrator to provide access to this application",
+    "unauthorized_service_name": "this resource in Cost Management",
     "unauthorized_title": "You don't have access to the Cost management application",
     "unexpected_desc": "We encountered an unexpected error. Contact your administrator.",
     "unexpected_title": "Oops!"

--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -422,22 +422,25 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     });
 
     const isLoading = providersFetchStatus === FetchStatus.inProgress || reportFetchStatus === FetchStatus.inProgress;
+    if (isLoading) {
+      return <Loading/>;
+    }
+
     const noProviders =
       providers &&
       providers.meta &&
       providers.meta.count === 0 &&
       providersFetchStatus === FetchStatus.complete;
 
-    if (isLoading) {
-      return <Loading/>;
-    } else if (reportError) {
+    let errorState = null;
+    if (reportError) {
       if (reportError.response && reportError.response.status === 403) {
-        return <NotAuthorized />;
+        errorState = <NotAuthorized />;
       } else {
-        return <NotAvailable />;
+        errorState = <NotAvailable />;
       }
     } else if (noProviders && reportFetchStatus === FetchStatus.complete) {
-      return <NoProviders />;
+      errorState = <NoProviders />;
     }
     return (
       <div style={styles.awsDetails}>
@@ -446,14 +449,16 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
           onGroupByClicked={this.handleGroupByClick}
           report={report}
         />
-        <div style={styles.content}>
-          {this.getToolbar()}
-          {this.getExportModal(computedItems)}
-          <div style={styles.tableContainer}>{this.getTable()}</div>
-          <div style={styles.paginationContainer}>
-            <div style={styles.pagination}>{this.getPagination(true)}</div>
+        {Boolean(errorState !== null) ? errorState : (
+          <div style={styles.content}>
+            {this.getToolbar()}
+            {this.getExportModal(computedItems)}
+            <div style={styles.tableContainer}>{this.getTable()}</div>
+            <div style={styles.paginationContainer}>
+              <div style={styles.pagination}>{this.getPagination(true)}</div>
+            </div>
           </div>
-        </div>
+        )}
       </div>
     );
   }

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -397,22 +397,25 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     });
 
     const isLoading = providersFetchStatus === FetchStatus.inProgress || reportFetchStatus === FetchStatus.inProgress;
+    if (isLoading) {
+      return <Loading />;
+    }
+
     const noProviders =
       providers &&
       providers.meta &&
       providers.meta.count === 0 &&
       providersFetchStatus === FetchStatus.complete;
 
-    if (isLoading) {
-      return <Loading />;
-    } else if (reportError) {
+    let errorState = null;
+    if (reportError) {
       if (reportError.response && reportError.response.status === 403) {
-        return <NotAuthorized />;
+        errorState = <NotAuthorized />;
       } else {
-        return <NotAvailable />;
+        errorState = <NotAvailable />;
       }
     } else if (noProviders && reportFetchStatus === FetchStatus.complete) {
-      return <NoProviders />;
+      errorState = <NoProviders />;
     }
     return (
       <div style={styles.azureDetails}>
@@ -421,14 +424,16 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
           onGroupByClicked={this.handleGroupByClick}
           report={report}
         />
-        <div style={styles.content}>
-          {this.getToolbar()}
-          {this.getExportModal(computedItems)}
-          <div style={styles.tableContainer}>{this.getTable()}</div>
-          <div style={styles.paginationContainer}>
-            <div style={styles.pagination}>{this.getPagination(true)}</div>
+        {Boolean(errorState !== null) ? errorState : (
+          <div style={styles.content}>
+            {this.getToolbar()}
+            {this.getExportModal(computedItems)}
+            <div style={styles.tableContainer}>{this.getTable()}</div>
+            <div style={styles.paginationContainer}>
+              <div style={styles.pagination}>{this.getPagination(true)}</div>
+            </div>
           </div>
-        </div>
+        )}
       </div>
     );
   }

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -393,15 +393,17 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     });
 
     const isLoading = providersFetchStatus === FetchStatus.inProgress || reportFetchStatus === FetchStatus.inProgress;
+    if (isLoading) {
+      return <Loading/>;
+    }
+
     const noProviders =
       providers &&
       providers.meta &&
       providers.meta.count === 0 &&
       providersFetchStatus === FetchStatus.complete;
 
-    if (isLoading) {
-      return <Loading/>;
-    } else if (reportError) {
+    if (reportError) {
       if (reportError.response && reportError.response.status === 403) {
         return <NotAuthorized />;
       } else {

--- a/src/pages/state/notAuthorized/notAuthorized.tsx
+++ b/src/pages/state/notAuthorized/notAuthorized.tsx
@@ -1,12 +1,18 @@
 import { Main } from '@redhat-cloud-services/frontend-components/components/Main';
 import React from 'react';
-import { withRouter } from 'react-router';
+import { RouteComponentProps, withRouter } from 'react-router';
 import { NotAuthorizedState } from './notAuthorizedState';
 
-const NotAuthorized = () => {
+interface NotAuthorizedOwnProps {
+  serviceName?: string;
+}
+
+type NotAuthorizedProps = NotAuthorizedOwnProps & RouteComponentProps<void>;
+
+const NotAuthorized = ({serviceName }: NotAuthorizedProps) => {
   return (
     <Main>
-      <NotAuthorizedState />
+      <NotAuthorizedState serviceName={serviceName}/>
     </Main>
   );
 };

--- a/src/pages/state/notAuthorized/notAuthorizedState.tsx
+++ b/src/pages/state/notAuthorized/notAuthorizedState.tsx
@@ -2,11 +2,19 @@ import { NotAuthorized as _NotAuthorized } from '@redhat-cloud-services/frontend
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 
-const NotAuthorizedStateBase: React.SFC<InjectedTranslateProps> = ({
-  t
+interface NotAuthorizedStateOwnProps {
+  serviceName?: string;
+}
+
+type NotAuthorizedStateProps = NotAuthorizedStateOwnProps &
+  InjectedTranslateProps;
+
+const NotAuthorizedStateBase: React.SFC<NotAuthorizedStateProps> = ({
+  t,
+  serviceName = t('error_state.unauthorized_service_name')
 }) => {
   return (
-    <_NotAuthorized serviceName={t('cost_management')} />
+    <_NotAuthorized serviceName={serviceName} />
   );
 };
 


### PR DESCRIPTION
QE found that the full page AWS error state blocks access to Azure and vice versa. In this test scenario, the user did not have RBAC access to AWS, but does have access to Azure.

This change simply moves the error state to the page body in order to show the page header. Thus, allowing the Azure tab to be selected -- reviewed with Natalie.

https://issues.redhat.com/browse/COST-390

<img width="1730" alt="Screen Shot 2020-08-03 at 2 06 58 PM" src="https://user-images.githubusercontent.com/17481322/89213720-823a7780-d593-11ea-85fb-90a9145fdc68.png">
