### PR TITLE
Update "Learn more" links in UI to latest OpenShift version 4.5

### DIFF
--- a/src/pages/costModels/createCostModelWizard/generalInformation.tsx
+++ b/src/pages/costModels/createCostModelWizard/generalInformation.tsx
@@ -16,7 +16,7 @@ import { styles } from './wizard.styles';
 
 const GeneralInformation: React.SFC<InjectedTranslateProps> = ({ t }) => {
   const docLink =
-    'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.4/html/using_cost_models/configuring-cost-models';
+    'https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/using_cost_models/configuring-cost-models';
   return (
     <CostModelContext.Consumer>
       {({


### PR DESCRIPTION
Updated the "Learn more" links in UI's cost model wizard to latest OpenShift version 4.5

https://issues.redhat.com/browse/COST-403