### PR TITLE
Moved loading state to page body

### DIFF
--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -421,17 +421,17 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
       idKey: (groupByTag as any) || groupById,
     });
 
-    const isLoading = providersFetchStatus === FetchStatus.inProgress || reportFetchStatus === FetchStatus.inProgress;
+    const isLoading = providersFetchStatus === FetchStatus.inProgress;
     if (isLoading) {
       return <Loading/>;
     }
 
-    let errorState = null;
+    let emptyState = null;
     if (reportError) {
       if (reportError.response && (reportError.response.status === 401 || reportError.response.status === 403)) {
-        errorState = <NotAuthorized />;
+        emptyState = <NotAuthorized />;
       } else {
-        errorState = <NotAvailable />;
+        emptyState = <NotAvailable />;
       }
     } else if (reportFetchStatus === FetchStatus.complete) {
       const noProviders =
@@ -441,8 +441,10 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
         providersFetchStatus === FetchStatus.complete;
 
       if (noProviders) {
-        errorState = <NoProviders/>;
+        emptyState = <NoProviders/>;
       }
+    } else if (reportFetchStatus === FetchStatus.inProgress) {
+      emptyState = <Loading/>;
     }
     return (
       <div style={styles.awsDetails}>
@@ -451,7 +453,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
           onGroupByClicked={this.handleGroupByClick}
           report={report}
         />
-        {Boolean(errorState !== null) ? errorState : (
+        {Boolean(emptyState !== null) ? emptyState : (
           <div style={styles.content}>
             {this.getToolbar()}
             {this.getExportModal(computedItems)}

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -396,17 +396,17 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
       idKey: (groupByTag as any) || groupById,
     });
 
-    const isLoading = providersFetchStatus === FetchStatus.inProgress || reportFetchStatus === FetchStatus.inProgress;
+    const isLoading = providersFetchStatus === FetchStatus.inProgress;
     if (isLoading) {
       return <Loading />;
     }
 
-    let errorState = null;
+    let emptyState = null;
     if (reportError) {
       if (reportError.response && (reportError.response.status === 401 || reportError.response.status === 403)) {
-        errorState = <NotAuthorized />;
+        emptyState = <NotAuthorized />;
       } else {
-        errorState = <NotAvailable />;
+        emptyState = <NotAvailable />;
       }
     } else if (reportFetchStatus === FetchStatus.complete) {
       const noProviders =
@@ -416,8 +416,10 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
         providersFetchStatus === FetchStatus.complete;
 
       if (noProviders) {
-        errorState = <NoProviders/>;
+        emptyState = <NoProviders/>;
       }
+    } else if (reportFetchStatus === FetchStatus.inProgress) {
+      emptyState = <Loading/>;
     }
     return (
       <div style={styles.azureDetails}>
@@ -426,7 +428,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
           onGroupByClicked={this.handleGroupByClick}
           report={report}
         />
-        {Boolean(errorState !== null) ? errorState : (
+        {Boolean(emptyState !== null) ? emptyState : (
           <div style={styles.content}>
             {this.getToolbar()}
             {this.getExportModal(computedItems)}

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -392,16 +392,17 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
       idKey: (groupByTagKey as any) || groupById,
     });
 
-    const isLoading = providersFetchStatus === FetchStatus.inProgress || reportFetchStatus === FetchStatus.inProgress;
+    const isLoading = providersFetchStatus === FetchStatus.inProgress;
     if (isLoading) {
       return <Loading/>;
     }
 
+    let emptyState = null;
     if (reportError) {
       if (reportError.response && (reportError.response.status === 401 || reportError.response.status === 403)) {
-        return <NotAuthorized />;
+        emptyState = <NotAuthorized />;
       } else {
-        return <NotAvailable />;
+        emptyState = <NotAvailable />;
       }
     } else if (reportFetchStatus === FetchStatus.complete) {
       const noProviders =
@@ -411,8 +412,10 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
         providersFetchStatus === FetchStatus.complete;
 
       if (noProviders) {
-        return <NoProviders/>;
+        emptyState = <NoProviders/>;
       }
+    } else if (reportFetchStatus === FetchStatus.inProgress) {
+      emptyState = <Loading/>;
     }
     return (
       <div style={styles.ocpDetails}>
@@ -421,14 +424,16 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
           onGroupByClicked={this.handleGroupByClick}
           report={report}
         />
-        <div style={styles.content}>
-          {this.getToolbar()}
-          {this.getExportModal(computedItems)}
-          <div style={styles.tableContainer}>{this.getTable()}</div>
-          <div style={styles.paginationContainer}>
-            <div style={styles.pagination}>{this.getPagination(true)}</div>
+        {Boolean(emptyState !== null) ? emptyState : (
+          <div style={styles.content}>
+            {this.getToolbar()}
+            {this.getExportModal(computedItems)}
+            <div style={styles.tableContainer}>{this.getTable()}</div>
+            <div style={styles.paginationContainer}>
+              <div style={styles.pagination}>{this.getPagination(true)}</div>
+            </div>
           </div>
-        </div>
+        )}
       </div>
     );
   }


### PR DESCRIPTION
When the "View by" menu is selected, we see a full page loading state, which is a bit annoying. This moves the loading state to the page body when a report is fetched. Thus, the header remains in view while the "View by" menu is disabled.

https://issues.redhat.com/browse/COST-390

<img width="1021" alt="Screen Shot 2020-08-05 at 5 06 49 PM" src="https://user-images.githubusercontent.com/17481322/89464826-1432b380-d73f-11ea-8780-16426b284db5.png">
