### PR TITLE
Chart legends use Overpass font

### DIFF
--- a/src/components/charts/costChart/costChart.styles.ts
+++ b/src/components/charts/costChart/costChart.styles.ts
@@ -5,7 +5,6 @@ import {
   chart_color_green_400,
   chart_color_green_500,
   global_disabled_color_200,
-  global_FontFamily_sans_serif,
 } from '@patternfly/react-tokens';
 
 export const chartStyles = {
@@ -25,13 +24,6 @@ export const chartStyles = {
     strokeDasharray: '3,3',
   },
   itemsPerRow: 2,
-  legend: {
-    labels: {
-      fontFamily: global_FontFamily_sans_serif.value,
-      fontSize: 14,
-    },
-    minWidth: 200,
-  },
   previousCostData: {
     fill: 'none',
   },

--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -339,7 +339,6 @@ class CostChart extends React.Component<CostChartProps, State> {
         itemsPerRow={itemsPerRow}
         name="legend"
         responsive={false}
-        style={chartStyles.legend}
       />
     );
   };

--- a/src/components/charts/historicalCostChart/historicalCostChart.styles.ts
+++ b/src/components/charts/historicalCostChart/historicalCostChart.styles.ts
@@ -9,7 +9,6 @@ import {
   chart_color_green_300,
   chart_color_green_400,
   chart_color_green_500,
-  global_FontFamily_sans_serif,
   global_spacer_lg,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
@@ -33,12 +32,6 @@ export const chartStyles = {
   },
   currentCostData: {
     fill: 'none',
-  },
-  legend: {
-    labels: {
-      fontFamily: global_FontFamily_sans_serif.value,
-      fontSize: 12,
-    },
   },
   itemsPerRow: 0,
   previousCapacityData: {

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -314,7 +314,6 @@ class HistoricalCostChart extends React.Component<
         height={25}
         itemsPerRow={itemsPerRow}
         name="legend"
-        style={chartStyles.legend}
       />
     );
   };

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.styles.ts
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.styles.ts
@@ -9,7 +9,6 @@ import {
   chart_color_green_300,
   chart_color_green_400,
   chart_color_green_500,
-  global_FontFamily_sans_serif,
   global_spacer_lg,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
@@ -26,12 +25,6 @@ export const chartStyles = {
   ],
   currentMonthData: {
     fill: 'none',
-  },
-  legend: {
-    labels: {
-      fontFamily: global_FontFamily_sans_serif.value,
-      fontSize: 12,
-    },
   },
   itemsPerRow: 0,
   // See: https://github.com/project-koku/koku-ui/issues/241

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -236,7 +236,6 @@ class HistoricalTrendChart extends React.Component<
         height={25}
         itemsPerRow={legendItemsPerRow}
         name="legend"
-        style={chartStyles.legend}
       />
     );
   };

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.styles.ts
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.styles.ts
@@ -9,7 +9,6 @@ import {
   chart_color_green_300,
   chart_color_green_400,
   chart_color_green_500,
-  global_FontFamily_sans_serif,
   global_spacer_lg,
   global_spacer_sm,
 } from '@patternfly/react-tokens';
@@ -38,12 +37,6 @@ export const chartStyles = {
     fill: 'none',
   },
   itemsPerRow: 0,
-  legend: {
-    labels: {
-      fontFamily: global_FontFamily_sans_serif.value,
-      fontSize: 12,
-    },
-  },
   previousCapacityData: {
     fill: 'none',
   },

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -392,7 +392,6 @@ class HistoricalUsageChart extends React.Component<
         height={25}
         itemsPerRow={itemsPerRow}
         name="legend"
-        style={chartStyles.legend}
       />
     );
   };

--- a/src/components/charts/trendChart/trendChart.styles.ts
+++ b/src/components/charts/trendChart/trendChart.styles.ts
@@ -4,8 +4,7 @@ import {
   chart_color_green_300,
   chart_color_green_400,
   chart_color_green_500,
-  global_disabled_color_200,
-  global_FontFamily_sans_serif,
+  global_disabled_color_200
 } from '@patternfly/react-tokens';
 
 export const chartStyles = {
@@ -19,13 +18,6 @@ export const chartStyles = {
   ],
   currentMonthData: {
     fill: 'none',
-  },
-  legend: {
-    labels: {
-      fontFamily: global_FontFamily_sans_serif.value,
-      fontSize: 14,
-    },
-    minWidth: 175,
   },
   // See: https://github.com/project-koku/koku-ui/issues/241
   previousColorScale: [

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -248,7 +248,6 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         height={25}
         name="legend"
         orientation={width > 150 ? 'horizontal' : 'vertical'}
-        style={chartStyles.legend}
       />
     );
   };

--- a/src/components/charts/usageChart/usageChart.styles.ts
+++ b/src/components/charts/usageChart/usageChart.styles.ts
@@ -5,7 +5,6 @@ import {
   chart_color_green_400,
   chart_color_green_500,
   global_disabled_color_200,
-  global_FontFamily_sans_serif,
   global_spacer_lg,
 } from '@patternfly/react-tokens';
 
@@ -27,13 +26,6 @@ export const chartStyles = {
     },
   },
   itemsPerRow: 2,
-  legend: {
-    labels: {
-      fontFamily: global_FontFamily_sans_serif.value,
-      fontSize: 14,
-    },
-    minWidth: 380,
-  },
   // See: https://github.com/project-koku/koku-ui/issues/241
   legendColorScale: [
     global_disabled_color_200.value,

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -324,7 +324,6 @@ class UsageChart extends React.Component<UsageChartProps, State> {
         gutter={10}
         itemsPerRow={itemsPerRow}
         name="legend"
-        style={chartStyles.legend}
       />
     );
   };

--- a/src/pages/details/components/historicalData/historicalChart.styles.ts
+++ b/src/pages/details/components/historicalData/historicalChart.styles.ts
@@ -21,15 +21,17 @@ export const styles = {
     marginTop: global_spacer_3xl.value,
   },
   costChart: {
+    marginBottom: global_spacer_sm.value,
     marginTop: global_spacer_sm.value,
-  },
-  instanceChart: {
-    marginTop: global_spacer_md.value,
   },
   legendSkeleton: {
     marginTop: global_spacer_md.value,
   },
-  storageChart: {
-    marginTop: global_spacer_md.value,
+  trendChart: {
+    marginBottom: global_spacer_sm.value,
+    marginTop: global_spacer_sm.value,
+  },
+  usageChart: {
+    marginTop: global_spacer_sm.value,
   },
 } as { [className: string]: React.CSSProperties };

--- a/src/pages/details/components/historicalData/historicalDataTrendChart.tsx
+++ b/src/pages/details/components/historicalData/historicalDataTrendChart.tsx
@@ -150,7 +150,7 @@ class HistoricalDataTrendChartBase extends React.Component<
 
     return (
       <div style={styles.chartContainer}>
-        <div style={styles.costChart}>
+        <div style={styles.trendChart}>
           {currentReportFetchStatus === FetchStatus.inProgress &&
           previousReportFetchStatus === FetchStatus.inProgress ? (
             this.getSkeleton()

--- a/src/pages/details/components/historicalData/historicalDataUsageChart.tsx
+++ b/src/pages/details/components/historicalData/historicalDataUsageChart.tsx
@@ -145,28 +145,30 @@ class HistoricalDataUsageChartBase extends React.Component<
 
     return (
       <div style={styles.chartContainer}>
-        {currentReportFetchStatus === FetchStatus.inProgress &&
-        previousReportFetchStatus === FetchStatus.inProgress ? (
-          this.getSkeleton()
-        ) : (
-          <HistoricalUsageChart
-            adjustContainerHeight
-            containerHeight={chartStyles.chartContainerHeight}
-            currentLimitData={currentLimitData}
-            currentRequestData={currentRequestData}
-            currentUsageData={currentUsageData}
-            formatDatumValue={formatValue}
-            formatDatumOptions={{}}
-            height={chartStyles.chartHeight}
-            previousLimitData={previousLimitData}
-            previousRequestData={previousRequestData}
-            previousUsageData={previousUsageData}
-            xAxisLabel={t(`breakdown.historical_chart.day_of_month_label`)}
-            yAxisLabel={t(`breakdown.historical_chart.units_label`, {
-              units: t(`units.${unitLookupKey(usageUnits)}`),
-            })}
-          />
-        )}
+        <div style={styles.usageChart}>
+          {currentReportFetchStatus === FetchStatus.inProgress &&
+          previousReportFetchStatus === FetchStatus.inProgress ? (
+            this.getSkeleton()
+          ) : (
+            <HistoricalUsageChart
+              adjustContainerHeight
+              containerHeight={chartStyles.chartContainerHeight}
+              currentLimitData={currentLimitData}
+              currentRequestData={currentRequestData}
+              currentUsageData={currentUsageData}
+              formatDatumValue={formatValue}
+              formatDatumOptions={{}}
+              height={chartStyles.chartHeight}
+              previousLimitData={previousLimitData}
+              previousRequestData={previousRequestData}
+              previousUsageData={previousUsageData}
+              xAxisLabel={t(`breakdown.historical_chart.day_of_month_label`)}
+              yAxisLabel={t(`breakdown.historical_chart.units_label`, {
+                units: t(`units.${unitLookupKey(usageUnits)}`),
+              })}
+            />
+          )}
+        </div>
       </div>
     );
   }


### PR DESCRIPTION
Chart legends appear to be using Overpass fonts instead of the new Red Hat fonts. At one time, we had to override the labels prop for legends, but we can remove that now.

The debugger should show PatternFly's `--pf-chart-global--FontFamily` variable as the `font-family` value.

https://issues.redhat.com/browse/COST-416

**Before**
<img width="670" alt="Screen Shot 2020-08-07 at 5 08 46 PM" src="https://user-images.githubusercontent.com/17481322/89689271-0497a400-d8d2-11ea-928f-a9e815b1698f.png">

**After**
<img width="701" alt="Screen Shot 2020-08-07 at 5 08 33 PM" src="https://user-images.githubusercontent.com/17481322/89689275-082b2b00-d8d2-11ea-96db-11b27ebdf3c8.png">

The difference is slight, but noticeable.