### PR TITLE
Added loading state to table body

### DIFF
--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -226,11 +226,12 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
   }
 
   private getTable = () => {
-    const { query, report } = this.props;
+    const { query, report, reportFetchStatus } = this.props;
 
     return (
       <DetailsTable
         groupBy={this.getGroupById()}
+        isLoading={reportFetchStatus === FetchStatus.inProgress}
         onSelected={this.handleSelected}
         onSort={this.handleSort}
         query={query}
@@ -421,11 +422,6 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
       idKey: (groupByTag as any) || groupById,
     });
 
-    const isLoading = providersFetchStatus === FetchStatus.inProgress;
-    if (isLoading) {
-      return <Loading/>;
-    }
-
     let emptyState = null;
     if (reportError) {
       if (reportError.response && (reportError.response.status === 401 || reportError.response.status === 403)) {
@@ -443,7 +439,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
       if (noProviders) {
         emptyState = <NoProviders/>;
       }
-    } else if (reportFetchStatus === FetchStatus.inProgress) {
+    } else if (providersFetchStatus === FetchStatus.inProgress) {
       emptyState = <Loading/>;
     }
     return (

--- a/src/pages/details/awsDetails/detailsTable.tsx
+++ b/src/pages/details/awsDetails/detailsTable.tsx
@@ -1,7 +1,8 @@
 import {
+  Bullseye,
   EmptyState,
   EmptyStateBody,
-  EmptyStateIcon,
+  EmptyStateIcon, Spinner,
 } from '@patternfly/react-core';
 import { CalculatorIcon } from '@patternfly/react-icons/dist/js/icons/calculator-icon';
 import {
@@ -45,6 +46,7 @@ import {
 
 interface DetailsTableOwnProps {
   groupBy: string;
+  isLoading?: boolean;
   onSelected(selectedItems: ComputedReportItem[]);
   onSort(value: string, isSortAscending: boolean);
   query: AwsQuery;
@@ -53,6 +55,7 @@ interface DetailsTableOwnProps {
 
 interface DetailsTableState {
   columns?: any[];
+  loadingRows?: any[];
   rows?: any[];
 }
 
@@ -243,8 +246,23 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       });
     });
 
+    const loadingRows = [{
+      heightAuto: true,
+      cells: [
+        {
+          props: { colSpan: 5 },
+          title: (
+            <Bullseye>
+              <div style={{textAlign: 'center'}}><Spinner size="xl"/></div>
+            </Bullseye>
+          )
+        },
+      ]
+    }];
+
     this.setState({
       columns,
+      loadingRows,
       rows,
       sortBy: {},
     });
@@ -478,7 +496,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   public render() {
-    const { columns, rows } = this.state;
+    const { isLoading } = this.props;
+    const { columns, loadingRows, rows } = this.state;
 
     return (
       <>
@@ -486,9 +505,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           aria-label="details-table"
           cells={columns}
           className={tableOverride}
-          rows={rows}
+          rows={isLoading ? loadingRows : rows}
           sortBy={this.getSortBy()}
-          onSelect={this.handleOnSelect}
+          onSelect={isLoading ? undefined : this.handleOnSelect}
           onSort={this.handleOnSort}
           gridBreakPoint="grid-2xl"
         >

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -199,7 +199,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
   }
 
   private getTable = () => {
-    const { query, report } = this.props;
+    const { query, report, reportFetchStatus } = this.props;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByTagKey = this.getGroupByTagKey();
@@ -207,6 +207,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     return (
       <DetailsTable
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
+        isLoading={reportFetchStatus === FetchStatus.inProgress}
         onSelected={this.handleSelected}
         onSort={this.handleSort}
         query={query}
@@ -396,11 +397,6 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
       idKey: (groupByTag as any) || groupById,
     });
 
-    const isLoading = providersFetchStatus === FetchStatus.inProgress;
-    if (isLoading) {
-      return <Loading />;
-    }
-
     let emptyState = null;
     if (reportError) {
       if (reportError.response && (reportError.response.status === 401 || reportError.response.status === 403)) {
@@ -418,7 +414,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
       if (noProviders) {
         emptyState = <NoProviders/>;
       }
-    } else if (reportFetchStatus === FetchStatus.inProgress) {
+    } else if (providersFetchStatus === FetchStatus.inProgress) {
       emptyState = <Loading/>;
     }
     return (

--- a/src/pages/details/azureDetails/detailsTable.tsx
+++ b/src/pages/details/azureDetails/detailsTable.tsx
@@ -1,7 +1,8 @@
 import {
+  Bullseye,
   EmptyState,
   EmptyStateBody,
-  EmptyStateIcon,
+  EmptyStateIcon, Spinner,
 } from '@patternfly/react-core';
 import { CalculatorIcon } from '@patternfly/react-icons/dist/js/icons/calculator-icon';
 import {
@@ -40,6 +41,7 @@ import {
 
 interface DetailsTableOwnProps {
   groupBy: string;
+  isLoading?: boolean;
   onSelected(selectedItems: ComputedReportItem[]);
   onSort(value: string, isSortAscending: boolean);
   query: AzureQuery;
@@ -48,6 +50,7 @@ interface DetailsTableOwnProps {
 
 interface DetailsTableState {
   columns?: any[];
+  loadingRows?: any[];
   rows?: any[];
 }
 
@@ -184,8 +187,23 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       });
     });
 
+    const loadingRows = [{
+      heightAuto: true,
+      cells: [
+        {
+          props: { colSpan: 5 },
+          title: (
+            <Bullseye>
+              <div style={{textAlign: 'center'}}><Spinner size="xl"/></div>
+            </Bullseye>
+          )
+        },
+      ]
+    }];
+
     this.setState({
       columns,
+      loadingRows,
       rows,
       sortBy: {},
     });
@@ -387,7 +405,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   public render() {
-    const { columns, rows } = this.state;
+    const { isLoading } = this.props;
+    const { columns, loadingRows, rows } = this.state;
 
     return (
       <>
@@ -395,9 +414,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           aria-label="details-table"
           cells={columns}
           className={tableOverride}
-          rows={rows}
+          rows={isLoading ? loadingRows : rows}
           sortBy={this.getSortBy()}
-          onSelect={this.handleOnSelect}
+          onSelect={isLoading ? undefined : this.handleOnSelect}
           onSort={this.handleOnSort}
           gridBreakPoint="grid-2xl"
         >

--- a/src/pages/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/details/ocpDetails/detailsTable.tsx
@@ -1,7 +1,9 @@
 import {
+  Bullseye,
   EmptyState,
   EmptyStateBody,
   EmptyStateIcon,
+  Spinner
 } from '@patternfly/react-core';
 import { CalculatorIcon } from '@patternfly/react-icons/dist/js/icons/calculator-icon';
 import {
@@ -40,6 +42,7 @@ import {
 
 interface DetailsTableOwnProps {
   groupBy: string;
+  isLoading?: boolean;
   onSelected(selectedItems: ComputedReportItem[]);
   onSort(value: string, isSortAscending: boolean);
   query: OcpQuery;
@@ -48,6 +51,7 @@ interface DetailsTableOwnProps {
 
 interface DetailsTableState {
   columns?: any[];
+  loadingRows?: any[];
   rows?: any[];
 }
 
@@ -209,8 +213,23 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       });
     });
 
+    const loadingRows = [{
+      heightAuto: true,
+      cells: [
+        {
+          props: { colSpan: 7 },
+          title: (
+            <Bullseye>
+              <div style={{textAlign: 'center'}}><Spinner size="xl"/></div>
+            </Bullseye>
+          )
+        },
+      ]
+    }];
+
     this.setState({
       columns,
+      loadingRows,
       rows,
       sortBy: {},
     });
@@ -458,7 +477,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   public render() {
-    const { columns, rows } = this.state;
+    const { isLoading } = this.props;
+    const { columns, loadingRows, rows } = this.state;
 
     return (
       <>
@@ -466,9 +486,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           aria-label="details-table"
           cells={columns}
           className={tableOverride}
-          rows={rows}
+          rows={isLoading ? loadingRows : rows}
           sortBy={this.getSortBy()}
-          onSelect={this.handleOnSelect}
+          onSelect={isLoading ? undefined : this.handleOnSelect}
           onSort={this.handleOnSort}
           gridBreakPoint="grid-2xl"
         >

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -199,7 +199,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
   }
 
   private getTable = () => {
-    const { query, report } = this.props;
+    const { query, report, reportFetchStatus } = this.props;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByTagKey = this.getGroupByTagKey();
@@ -207,6 +207,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     return (
       <DetailsTable
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
+        isLoading={reportFetchStatus === FetchStatus.inProgress}
         onSelected={this.handleSelected}
         onSort={this.handleSort}
         query={query}
@@ -392,11 +393,6 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
       idKey: (groupByTagKey as any) || groupById,
     });
 
-    const isLoading = providersFetchStatus === FetchStatus.inProgress;
-    if (isLoading) {
-      return <Loading/>;
-    }
-
     let emptyState = null;
     if (reportError) {
       if (reportError.response && (reportError.response.status === 401 || reportError.response.status === 403)) {
@@ -414,7 +410,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
       if (noProviders) {
         emptyState = <NoProviders/>;
       }
-    } else if (reportFetchStatus === FetchStatus.inProgress) {
+    } else if (providersFetchStatus === FetchStatus.inProgress) {
       emptyState = <Loading/>;
     }
     return (


### PR DESCRIPTION
This adds a loading state to the table body, which follows PatternFly's examples. This is displayed during pagination, when a new report is fetched.

<img width="1711" alt="Screen Shot 2020-08-10 at 3 00 40 PM (2)" src="https://user-images.githubusercontent.com/17481322/89820156-92fe6680-db1a-11ea-9e83-f1bed3c989d1.png">
