### PR TITLE
Maintenance state update

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -157,19 +157,20 @@ export class App extends React.Component<AppProps, AppState> {
       ocpProvidersError,
     } = this.props;
     const { maintenanceMode } = this.state;
-
-    // The providers API should error while under maintenance
-    const error = awsProvidersError || azureProvidersError || ocpProvidersError;
-
     let route = <Routes />;
 
-    if (error) {
-      if (maintenanceMode) {
-        route = <Maintenance/>;
-      } else if (error.response && (error.response.status === 401 || error.response.status === 403)) {
-        route = <NotAuthorized />;
-      } else {
-        route = <NotAvailable />;
+    if (maintenanceMode) {
+      route = <Maintenance/>;
+    } else {
+      // The providers API should error while under maintenance
+      const error = awsProvidersError || azureProvidersError || ocpProvidersError;
+
+      if (error) {
+        if (error.response && (error.response.status === 401 || error.response.status === 403)) {
+          route = <NotAuthorized />;
+        } else {
+          route = <NotAvailable />;
+        }
       }
     }
     return (

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -657,8 +657,9 @@
   },
   "logout": "Log Out",
   "maintenance": {
-    "empty_state_desc": "We are currently undergoing scheduled maintenance from 6am-9am EST. We will be back shortly, thank you for your patience",
-    "empty_state_title": "Maintenance in progress"
+    "empty_state_desc": "Cost Management is currently undergoing scheduled maintenance and will be unavailable from 13:00 - 19:00 UTC (09:00 AM - 03:00 PM EDT).",
+    "empty_state_info": "For more information visit ",
+    "empty_state_thanks": "We will be back soon. Thank you for your patience!."
   },
   "months": [
     "January",

--- a/src/pages/state/maintenance/maintenanceState.tsx
+++ b/src/pages/state/maintenance/maintenanceState.tsx
@@ -1,11 +1,8 @@
 import {
-  EmptyState,
-  EmptyStateBody,
-  EmptyStateIcon,
-  EmptyStateVariant,
-  Title,
+  Stack,
+  StackItem
 } from '@patternfly/react-core';
-import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-triangle-icon';
+import { Maintenance } from '@redhat-cloud-services/frontend-components/components/Maintenance';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 
@@ -17,13 +14,15 @@ class MaintenanceStateBase extends React.Component<MaintenanceStateProps> {
     const { t } = this.props;
 
     return (
-      <EmptyState variant={EmptyStateVariant.large} className="pf-m-redhat-font">
-        <EmptyStateIcon icon={ExclamationTriangleIcon} />
-        <Title headingLevel="h5" size="lg">
-          {t('maintenance.empty_state_title')}
-        </Title>
-        <EmptyStateBody>{t('maintenance.empty_state_desc')}</EmptyStateBody>
-      </EmptyState>
+      <Maintenance
+        description={
+          <Stack>
+            <StackItem>{t('maintenance.empty_state_desc')}</StackItem>
+            <StackItem>{t('maintenance.empty_state_info')} <a href="https://status.redhat.com">status.redhat.com</a>.</StackItem>
+            <StackItem>{t('maintenance.empty_state_thanks')}</StackItem>
+          </Stack>
+        }
+      />
     );
   }
 }


### PR DESCRIPTION
Updated our maintenance state to use the Insights Maintenance component from the frontend-components package.

In anticipation of our upcoming outage, the text was updated to match Natalie's comments: https://docs.google.com/document/d/1i7KUJxbS6CBcKrr9gapGCxqjYNehSpMLYLSq2ID6w2U/edit#heading=h.hrfxvpk2r425

https://issues.redhat.com/browse/COST-427

<img width="1512" alt="Screen Shot 2020-08-12 at 10 39 41 AM" src="https://user-images.githubusercontent.com/17481322/90033761-d2998f80-dc8d-11ea-8602-157518b8028b.png">
