### PR TITLE
Add bulk selector for CSV export

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -498,6 +498,7 @@
   },
   "export": {
     "aggregate_type": "Select aggregate type",
+    "all": "All",
     "cancel": "Cancel",
     "confirm": "Generate and download",
     "daily": "Daily",
@@ -1099,6 +1100,13 @@
     "title": "Tags ({{value}})"
   },
   "toolbar": {
+    "bulk_select": {
+      "aria_deselect": "Deselect all items",
+      "aria_select": "Select all items",
+      "select_all": "Select all ({{value}} items)",
+      "select_none": "Select none (0 items)",
+      "select_page": "Select all ({{value}} items)"
+    },
     "filterby": "Filter by {{ name }}",
     "pricelist": {
       "add_rate": "Add rate",

--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -377,7 +377,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 
   private handleBulkSelected = (action: string) => {
     // TODO
-  }
+  };
 
   private handleSelected = (selectedItems: ComputedReportItem[]) => {
     this.setState({ selectedItems });

--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -92,6 +92,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 
   constructor(stateProps, dispatchProps) {
     super(stateProps, dispatchProps);
+    this.handleBulkSelected = this.handleBulkSelected.bind(this);
     this.handleExportModalClose = this.handleExportModalClose.bind(this);
     this.handleExportModalOpen = this.handleExportModalOpen.bind(this);
     this.handleFilterAdded = this.handleFilterAdded.bind(this);
@@ -241,16 +242,31 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
   };
 
   private getToolbar = () => {
+    const { query, report } = this.props;
     const { selectedItems } = this.state;
-    const { query } = this.props;
+
+    const groupById = getIdKeyForGroupBy(query.group_by);
+    const groupByTagKey = this.getGroupByTagKey();
+    const computedItems = getUnsortedComputedReportItems({
+      report,
+      idKey: (groupByTagKey as any) || groupById,
+    });
+    const computedItemsPerPage =
+      report && report.meta && report.meta.filter && report.meta.filter.limit
+        ? report.meta.filter.limit
+        : baseQuery.filter.limit;
 
     return (
       <DetailsToolbar
         groupBy={this.getGroupById()}
         isExportDisabled={selectedItems.length === 0}
+        items={computedItems}
+        itemsPerPage={computedItemsPerPage}
+        onBulkSelected={this.handleBulkSelected}
         onExportClicked={this.handleExportModalOpen}
         onFilterAdded={this.handleFilterAdded}
         onFilterRemoved={this.handleFilterRemoved}
+        onSelected={this.handleSelected}
         pagination={this.getPagination()}
         query={query}
       />
@@ -358,6 +374,10 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     const filteredQuery = this.getRouteForQuery(newQuery, true);
     history.replace(filteredQuery);
   };
+
+  private handleBulkSelected = (action: string) => {
+    // TODO
+  }
 
   private handleSelected = (selectedItems: ComputedReportItem[]) => {
     this.setState({ selectedItems });

--- a/src/pages/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/details/awsDetails/detailsToolbar.tsx
@@ -9,16 +9,22 @@ import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
 import { isEqual } from 'utils/equal';
+import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 
 interface DetailsToolbarOwnProps {
   isExportDisabled: boolean;
+  items?: ComputedReportItem[];
+  itemsPerPage?: number;
   groupBy: string;
+  onBulkSelected(action: string);
   onExportClicked();
   onFilterAdded(filterType: string, filterValue: string);
   onFilterRemoved(filterType: string, filterValue?: string);
+  onSelected(selectedItems: ComputedReportItem[]);
   pagination?: React.ReactNode;
   query?: AwsQuery;
   queryString?: string;
+  selectedItems?: ComputedReportItem[];
 }
 
 interface DetailsToolbarStateProps {
@@ -104,12 +110,15 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     const {
       groupBy,
       isExportDisabled,
+      itemsPerPage,
+      onBulkSelected,
       onExportClicked,
       onFilterAdded,
       onFilterRemoved,
       orgReport,
       pagination,
       query,
+      selectedItems,
       tagReport,
     } = this.props;
     const { categoryOptions } = this.state;
@@ -119,14 +128,17 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         categoryOptions={categoryOptions}
         groupBy={groupBy}
         isExportDisabled={isExportDisabled}
+        itemsPerPage={itemsPerPage}
+        onBulkSelected={onBulkSelected}
         onExportClicked={onExportClicked}
         onFilterAdded={onFilterAdded}
         onFilterRemoved={onFilterRemoved}
         orgReport={orgReport}
         pagination={pagination}
         query={query}
-        tagReport={tagReport}
+        selectedItems={selectedItems}
         showExport
+        tagReport={tagReport}
       />
     );
   }

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -341,7 +341,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
 
   private handleBulkSelected = (action: string) => {
     // TODO
-  }
+  };
 
   private handleSelected = (selectedItems: ComputedReportItem[]) => {
     this.setState({ selectedItems });

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -92,6 +92,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
 
   constructor(stateProps, dispatchProps) {
     super(stateProps, dispatchProps);
+    this.handleBulkSelected = this.handleBulkSelected.bind(this);
     this.handleExportModalClose = this.handleExportModalClose.bind(this);
     this.handleExportModalOpen = this.handleExportModalOpen.bind(this);
     this.handleFilterAdded = this.handleFilterAdded.bind(this);
@@ -217,22 +218,27 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
   };
 
   private getToolbar = () => {
-    const { selectedItems } = this.state;
     const { query, report } = this.props;
+    const { selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByTagKey = this.getGroupByTagKey();
+    const computedItemsPerPage =
+      report && report.meta && report.meta.filter && report.meta.filter.limit
+        ? report.meta.filter.limit
+        : baseQuery.filter.limit;
 
     return (
       <DetailsToolbar
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isExportDisabled={selectedItems.length === 0}
+        itemsPerPage={computedItemsPerPage}
+        onBulkSelected={this.handleBulkSelected}
         onExportClicked={this.handleExportModalOpen}
         onFilterAdded={this.handleFilterAdded}
         onFilterRemoved={this.handleFilterRemoved}
         pagination={this.getPagination()}
         query={query}
-        report={report}
       />
     );
   };
@@ -332,6 +338,10 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     const filteredQuery = this.getRouteForQuery(newQuery, true);
     history.replace(filteredQuery);
   };
+
+  private handleBulkSelected = (action: string) => {
+    // TODO
+  }
 
   private handleSelected = (selectedItems: ComputedReportItem[]) => {
     this.setState({ selectedItems });

--- a/src/pages/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/details/azureDetails/detailsToolbar.tsx
@@ -154,7 +154,7 @@ const mapStateToProps = createMapStateToProps<
   return {
     queryString,
     reportFetchStatus,
-    tagReport
+    tagReport,
   };
 });
 

--- a/src/pages/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/details/azureDetails/detailsToolbar.tsx
@@ -10,21 +10,24 @@ import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
 import { isEqual } from 'utils/equal';
+import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 
 interface DetailsToolbarOwnProps {
   isExportDisabled: boolean;
+  items?: ComputedReportItem[];
+  itemsPerPage?: number;
   groupBy: string;
+  onBulkSelected(action: string);
   onExportClicked();
   onFilterAdded(filterType: string, filterValue: string);
   onFilterRemoved(filterType: string, filterValue?: string);
   pagination?: React.ReactNode;
   query?: AzureQuery;
   queryString?: string;
-  report?: AzureReport;
 }
 
 interface DetailsToolbarStateProps {
-  report?: AzureReport;
+  tagReport?: AzureReport;
   reportFetchStatus?: FetchStatus;
 }
 
@@ -57,11 +60,11 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps, prevState) {
-    const { fetchReport, query, queryString, report } = this.props;
+    const { fetchReport, query, queryString, tagReport } = this.props;
     if (query && !isEqual(query, prevProps.query)) {
       fetchReport(reportPathsType, reportType, queryString);
     }
-    if (!isEqual(report, prevProps.report)) {
+    if (!isEqual(tagReport, prevProps.tagReport)) {
       this.setState({
         categoryOptions: this.getCategoryOptions(),
       });
@@ -69,7 +72,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   private getCategoryOptions = (): ToolbarChipGroup[] => {
-    const { report, t } = this.props;
+    const { tagReport, t } = this.props;
 
     const options = [
       {
@@ -84,7 +87,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       { name: t('filter_by.values.tag'), key: tagKey },
     ];
 
-    return report && report.data && report.data.length
+    return tagReport && tagReport.data && tagReport.data.length
       ? options
       : options.filter(option => option.key !== tagKey);
   };
@@ -93,12 +96,14 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     const {
       groupBy,
       isExportDisabled,
+      itemsPerPage,
+      onBulkSelected,
       onExportClicked,
       onFilterAdded,
       onFilterRemoved,
       pagination,
       query,
-      report,
+      tagReport,
     } = this.props;
     const { categoryOptions } = this.state;
 
@@ -107,13 +112,15 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         categoryOptions={categoryOptions}
         groupBy={groupBy}
         isExportDisabled={isExportDisabled}
+        itemsPerPage={itemsPerPage}
+        onBulkSelected={onBulkSelected}
         onExportClicked={onExportClicked}
         onFilterAdded={onFilterAdded}
         onFilterRemoved={onFilterRemoved}
         pagination={pagination}
         query={query}
-        tagReport={report}
         showExport
+        tagReport={tagReport}
       />
     );
   }
@@ -132,7 +139,7 @@ const mapStateToProps = createMapStateToProps<
     },
     // key_only: true
   });
-  const report = reportSelectors.selectReport(
+  const tagReport = reportSelectors.selectReport(
     state,
     reportPathsType,
     reportType,
@@ -146,8 +153,8 @@ const mapStateToProps = createMapStateToProps<
   );
   return {
     queryString,
-    report,
     reportFetchStatus,
+    tagReport
   };
 });
 

--- a/src/pages/details/components/dataToolbar/dataToolbar.tsx
+++ b/src/pages/details/components/dataToolbar/dataToolbar.tsx
@@ -233,7 +233,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
     const { isBulkSelectOpen } = this.state;
 
     const numSelected = isAllSelected ? itemsTotal : selectedItems ? selectedItems.length : 0;
-    const allSelected = isAllSelected || numSelected === itemsTotal;
+    const allSelected = (isAllSelected || numSelected === itemsTotal) && itemsTotal > 0;
     const anySelected = numSelected > 0;
     const someChecked = anySelected ? null : false;
     const isChecked = allSelected ? true : someChecked;
@@ -243,9 +243,9 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
         {t('toolbar.bulk_select.select_none')}
       </DropdownItem>,
       <DropdownItem key="item-2" onClick={() => this.onBulkSelectClicked('page')}>
-        {t('toolbar.bulk_select.select_page', {value: itemsPerPage})}
+        {t('toolbar.bulk_select.select_page', {value: itemsTotal > 0 ? itemsPerPage : 0})}
       </DropdownItem>,
-      <DropdownItem key="item-2" onClick={() => this.onBulkSelectClicked('all')}>
+      <DropdownItem key="item-3" onClick={() => this.onBulkSelectClicked('all')}>
         {t('toolbar.bulk_select.select_page', {value: itemsTotal})}
       </DropdownItem>,
     ];

--- a/src/pages/details/components/dataToolbar/dataToolbar.tsx
+++ b/src/pages/details/components/dataToolbar/dataToolbar.tsx
@@ -229,24 +229,46 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
   // Bulk select
 
   public getBulkSelect = () => {
-    const { isAllSelected, itemsPerPage, itemsTotal, selectedItems, t } = this.props;
+    const {
+      isAllSelected,
+      itemsPerPage,
+      itemsTotal,
+      selectedItems,
+      t,
+    } = this.props;
     const { isBulkSelectOpen } = this.state;
 
-    const numSelected = isAllSelected ? itemsTotal : selectedItems ? selectedItems.length : 0;
-    const allSelected = (isAllSelected || numSelected === itemsTotal) && itemsTotal > 0;
+    const numSelected = isAllSelected
+      ? itemsTotal
+      : selectedItems
+      ? selectedItems.length
+      : 0;
+    const allSelected =
+      (isAllSelected || numSelected === itemsTotal) && itemsTotal > 0;
     const anySelected = numSelected > 0;
     const someChecked = anySelected ? null : false;
     const isChecked = allSelected ? true : someChecked;
 
     const dropdownItems = [
-      <DropdownItem key="item-1" onClick={() => this.onBulkSelectClicked('none')}>
+      <DropdownItem
+        key="item-1"
+        onClick={() => this.onBulkSelectClicked('none')}
+      >
         {t('toolbar.bulk_select.select_none')}
       </DropdownItem>,
-      <DropdownItem key="item-2" onClick={() => this.onBulkSelectClicked('page')}>
-        {t('toolbar.bulk_select.select_page', {value: itemsTotal > 0 ? itemsPerPage : 0})}
+      <DropdownItem
+        key="item-2"
+        onClick={() => this.onBulkSelectClicked('page')}
+      >
+        {t('toolbar.bulk_select.select_page', {
+          value: itemsTotal > 0 ? itemsPerPage : 0,
+        })}
       </DropdownItem>,
-      <DropdownItem key="item-3" onClick={() => this.onBulkSelectClicked('all')}>
-        {t('toolbar.bulk_select.select_page', {value: itemsTotal})}
+      <DropdownItem
+        key="item-3"
+        onClick={() => this.onBulkSelectClicked('all')}
+      >
+        {t('toolbar.bulk_select.select_page', { value: itemsTotal })}
       </DropdownItem>,
     ];
 
@@ -260,16 +282,24 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
               <DropdownToggleCheckbox
                 id="bulk-select"
                 key="bulk-select"
-                aria-label={anySelected ? t('toolbar.bulk_select.aria_deselect') : t('toolbar.bulk_select.aria_select')}
+                aria-label={
+                  anySelected
+                    ? t('toolbar.bulk_select.aria_deselect')
+                    : t('toolbar.bulk_select.aria_select')
+                }
                 isChecked={isChecked}
                 onClick={() => {
-                  anySelected ? this.onBulkSelectClicked('none') : this.onBulkSelectClicked('all');
+                  anySelected
+                    ? this.onBulkSelectClicked('none')
+                    : this.onBulkSelectClicked('all');
                 }}
-              ></DropdownToggleCheckbox>
+              ></DropdownToggleCheckbox>,
             ]}
             onToggle={this.onBulkSelectToggle}
           >
-            {numSelected !== 0 && <React.Fragment>{numSelected} selected</React.Fragment>}
+            {numSelected !== 0 && (
+              <React.Fragment>{numSelected} selected</React.Fragment>
+            )}
           </DropdownToggle>
         }
         isOpen={isBulkSelectOpen}

--- a/src/pages/details/components/dataToolbar/dataToolbar.tsx
+++ b/src/pages/details/components/dataToolbar/dataToolbar.tsx
@@ -5,6 +5,7 @@ import {
   DropdownItem,
   DropdownPosition,
   DropdownToggle,
+  DropdownToggleCheckbox,
   InputGroup,
   Select,
   SelectOption,
@@ -35,6 +36,8 @@ import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { isEqual } from 'utils/equal';
 import { selectOverride, styles } from './dataToolbar.styles';
+import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
+import { Report } from 'api/reports/report';
 
 interface Filters {
   [key: string]: string[] | { [key: string]: string[] };
@@ -43,14 +46,19 @@ interface Filters {
 interface DataToolbarOwnProps {
   categoryOptions?: ToolbarChipGroup[]; // Options for category menu
   groupBy?: string; // Sync category selection with groupBy value
+  isAllSelected?: boolean;
   isExportDisabled?: boolean; // Show export icon as disabled
+  itemsPerPage?: number;
+  itemsTotal?: number;
+  onBulkSelected(action: string);
   onExportClicked();
   onFilterAdded(filterType: string, filterValue: string);
   onFilterRemoved(filterType: string, filterValue?: string);
-  orgReport?: { data: any[] }; // Report containing AWS organizational unit data
+  orgReport?: Report; // Report containing AWS organizational unit data
   pagination?: React.ReactNode; // Optional pagination controls to display in toolbar
   query?: Query; // Query containing filter_by params used to restore state upon page refresh
-  tagReport?: { data: any[] }; // Report containing tag key and value data
+  tagReport?: Report; // Report containing tag key and value data
+  selectedItems?: ComputedReportItem[];
   showExport?: boolean; // Show export icon
 }
 
@@ -60,6 +68,7 @@ interface DataToolbarState {
   currentOrgUnit?: string;
   currentTagKey?: string;
   filters: Filters;
+  isBulkSelectOpen: boolean;
   isCategoryDropdownOpen: boolean;
   isOrgUnitSelectExpanded: boolean;
   isTagValueDropdownOpen: boolean;
@@ -86,6 +95,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
   protected defaultState: DataToolbarState = {
     categoryInput: '',
     filters: cloneDeep(defaultFilters),
+    isBulkSelectOpen: false,
     isCategoryDropdownOpen: false,
     isOrgUnitSelectExpanded: false,
     isTagValueDropdownOpen: false,
@@ -214,6 +224,78 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
         }
       );
     }
+  };
+
+  // Bulk select
+
+  public getBulkSelect = () => {
+    const { isAllSelected, itemsPerPage, itemsTotal, selectedItems, t } = this.props;
+    const { isBulkSelectOpen } = this.state;
+
+    const numSelected = isAllSelected ? itemsTotal : selectedItems ? selectedItems.length : 0;
+    const allSelected = isAllSelected || numSelected === itemsTotal;
+    const anySelected = numSelected > 0;
+    const someChecked = anySelected ? null : false;
+    const isChecked = allSelected ? true : someChecked;
+
+    const dropdownItems = [
+      <DropdownItem key="item-1" onClick={() => this.onBulkSelectClicked('none')}>
+        {t('toolbar.bulk_select.select_none')}
+      </DropdownItem>,
+      <DropdownItem key="item-2" onClick={() => this.onBulkSelectClicked('page')}>
+        {t('toolbar.bulk_select.select_page', {value: itemsPerPage})}
+      </DropdownItem>,
+      <DropdownItem key="item-2" onClick={() => this.onBulkSelectClicked('all')}>
+        {t('toolbar.bulk_select.select_page', {value: itemsTotal})}
+      </DropdownItem>,
+    ];
+
+    return (
+      <Dropdown
+        onSelect={this.onBulkSelect}
+        position={DropdownPosition.left}
+        toggle={
+          <DropdownToggle
+            splitButtonItems={[
+              <DropdownToggleCheckbox
+                id="bulk-select"
+                key="bulk-select"
+                aria-label={anySelected ? t('toolbar.bulk_select.aria_deselect') : t('toolbar.bulk_select.aria_select')}
+                isChecked={isChecked}
+                onClick={() => {
+                  anySelected ? this.onBulkSelectClicked('none') : this.onBulkSelectClicked('all');
+                }}
+              ></DropdownToggleCheckbox>
+            ]}
+            onToggle={this.onBulkSelectToggle}
+          >
+            {numSelected !== 0 && <React.Fragment>{numSelected} selected</React.Fragment>}
+          </DropdownToggle>
+        }
+        isOpen={isBulkSelectOpen}
+        dropdownItems={dropdownItems}
+      />
+    );
+  };
+
+  private onBulkSelectClicked = (action: string) => {
+    const { onBulkSelected } = this.props;
+
+    if (onBulkSelected) {
+      onBulkSelected(action);
+    }
+  };
+
+  private onBulkSelect = event => {
+    this.setState({
+      isBulkSelectOpen: !this.state.isBulkSelectOpen,
+    });
+  };
+
+  private onBulkSelectToggle = isOpen => {
+    this.setState({
+      isBulkSelectOpen: isOpen,
+    });
   };
 
   // Category dropdown
@@ -810,6 +892,9 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
         >
           <ToolbarContent>
             <ToolbarToggleGroup breakpoint="xl" toggleIcon={<FilterIcon />}>
+              <ToolbarItem variant="bulk-select">
+                {this.getBulkSelect()}
+              </ToolbarItem>
               <ToolbarGroup variant="filter-group">
                 {this.getCategoryDropdown()}
                 {this.getTagKeySelect()}

--- a/src/pages/details/components/export/exportModal.tsx
+++ b/src/pages/details/components/export/exportModal.tsx
@@ -98,9 +98,11 @@ export class ExportModalBase extends React.Component<
     let sortedItems = [...items];
     if (this.props.isOpen) {
       if (isAllItems) {
-        sortedItems = [{
-          label: t('export.all')
-        }];
+        sortedItems = [
+          {
+            label: t('export.all'),
+          },
+        ];
       } else {
         sortedItems = orderBy(sortedItems, ['label'], ['asc']);
       }

--- a/src/pages/details/components/export/exportModal.tsx
+++ b/src/pages/details/components/export/exportModal.tsx
@@ -17,9 +17,9 @@ import { createMapStateToProps } from 'store/common';
 import { exportActions } from 'store/exports';
 import { getTestProps, testIds } from 'testIds';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
-import { sort, SortDirection } from 'utils/sort';
 import { styles } from './exportModal.styles';
 import { ExportSubmit } from './exportSubmit';
+import { orderBy } from 'lodash';
 
 export interface ExportModalOwnProps extends InjectedTranslateProps {
   error?: AxiosError;
@@ -95,12 +95,15 @@ export class ExportModalBase extends React.Component<
     } = this.props;
     const { resolution } = this.state;
 
-    const sortedItems = [...items];
+    let sortedItems = [...items];
     if (this.props.isOpen) {
-      sort(sortedItems, {
-        key: 'id',
-        direction: SortDirection.asc,
-      });
+      if (isAllItems) {
+        sortedItems = [{
+          label: t('export.all')
+        }];
+      } else {
+        sortedItems = orderBy(sortedItems, ['label'], ['asc']);
+      }
     }
 
     let selectedLabel = t('export.selected', { groupBy });

--- a/src/pages/details/components/export/exportSubmit.tsx
+++ b/src/pages/details/components/export/exportSubmit.tsx
@@ -145,6 +145,8 @@ const mapStateToProps = createMapStateToProps<
       group_by: undefined,
       order_by: undefined,
     };
+    newQuery.filter.limit = undefined;
+    newQuery.filter.offset = undefined;
     newQuery.filter.resolution = resolution as any;
     let newQueryString = getQuery(newQuery);
 

--- a/src/pages/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/details/ocpDetails/detailsTable.tsx
@@ -214,7 +214,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         disableCheckbox: isAllSelected,
         isOpen: false,
         item,
-        selected: isAllSelected || selectedItems && selectedItems.find(val => val.id === item.id) !== undefined
+        selected:
+          isAllSelected ||
+          (selectedItems &&
+            selectedItems.find(val => val.id === item.id) !== undefined),
       });
     });
 

--- a/src/pages/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/details/ocpDetails/detailsTable.tsx
@@ -42,11 +42,13 @@ import {
 
 interface DetailsTableOwnProps {
   groupBy: string;
+  isAllSelected?: boolean;
   isLoading?: boolean;
-  onSelected(selectedItems: ComputedReportItem[]);
+  onSelected(items: ComputedReportItem[], isSelected: boolean);
   onSort(value: string, isSortAscending: boolean);
   query: OcpQuery;
   report: OcpReport;
+  selectedItems?: ComputedReportItem[];
 }
 
 interface DetailsTableState {
@@ -76,7 +78,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   }
 
   public componentDidUpdate(prevProps: DetailsTableProps) {
-    const { query, report } = this.props;
+    const { selectedItems, query, report } = this.props;
     const currentReport =
       report && report.data ? JSON.stringify(report.data) : '';
     const previousReport =
@@ -86,7 +88,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
     if (
       getQuery(prevProps.query) !== getQuery(query) ||
-      previousReport !== currentReport
+      previousReport !== currentReport ||
+      prevProps.selectedItems !== selectedItems
     ) {
       this.initDatum();
     }
@@ -105,7 +108,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private initDatum = () => {
-    const { query, report, t } = this.props;
+    const { isAllSelected, query, report, selectedItems, t } = this.props;
     if (!query || !report) {
       return;
     }
@@ -208,8 +211,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           { title: <div>{cost}</div> },
           { title: <div>{actions}</div> },
         ],
+        disableCheckbox: isAllSelected,
         isOpen: false,
         item,
+        selected: isAllSelected || selectedItems && selectedItems.find(val => val.id === item.id) !== undefined
       });
     });
 
@@ -447,6 +452,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const { onSelected } = this.props;
 
     let rows;
+    let items = [];
     if (rowId === -1) {
       rows = this.state.rows.map(row => {
         row.selected = isSelected;
@@ -455,18 +461,13 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     } else {
       rows = [...this.state.rows];
       rows[rowId].selected = isSelected;
+      items = [rows[rowId].item];
     }
-
-    if (onSelected) {
-      const selectedItems = [];
-      for (const row of rows) {
-        if (row.selected && row.item && !row.parent) {
-          selectedItems.push(row.item);
-        }
+    this.setState({ rows }, () => {
+      if (onSelected) {
+        onSelected(items, isSelected);
       }
-      onSelected(selectedItems);
-    }
-    this.setState({ rows });
+    });
   };
 
   private handleOnSort = (event, index, direction) => {
@@ -488,6 +489,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       <>
         <Table
           aria-label="details-table"
+          canSelectAll={false}
           cells={columns}
           className={tableOverride}
           rows={isLoading ? loadingRows : rows}

--- a/src/pages/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpDetails/detailsToolbar.tsx
@@ -10,10 +10,15 @@ import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
 import { isEqual } from 'utils/equal';
+import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 
 interface DetailsToolbarOwnProps {
+  isAllSelected?: boolean;
   isExportDisabled: boolean;
+  itemsPerPage?: number;
+  itemsTotal?: number;
   groupBy: string;
+  onBulkSelected(action: string);
   onExportClicked();
   onFilterAdded(filterType: string, filterValue: string);
   onFilterRemoved(filterType: string, filterValue?: string);
@@ -21,6 +26,7 @@ interface DetailsToolbarOwnProps {
   query?: OcpQuery;
   queryString?: string;
   report?: OcpReport;
+  selectedItems?: ComputedReportItem[];
 }
 
 interface DetailsToolbarStateProps {
@@ -57,7 +63,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps, prevState) {
-    const { fetchReport, query, queryString, report } = this.props;
+    const { fetchReport, queryString, query, report } = this.props;
     if (query && !isEqual(query, prevProps.query)) {
       fetchReport(reportPathsType, reportType, queryString);
     }
@@ -86,13 +92,17 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   public render() {
     const {
       groupBy,
+      isAllSelected,
       isExportDisabled,
+      itemsPerPage,
+      itemsTotal,
+      onBulkSelected,
       onExportClicked,
       onFilterAdded,
       onFilterRemoved,
       pagination,
       query,
-      report,
+      selectedItems
     } = this.props;
     const { categoryOptions } = this.state;
 
@@ -100,13 +110,17 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       <DataToolbar
         categoryOptions={categoryOptions}
         groupBy={groupBy}
+        isAllSelected={isAllSelected}
         isExportDisabled={isExportDisabled}
+        itemsPerPage={itemsPerPage}
+        itemsTotal={itemsTotal}
+        onBulkSelected={onBulkSelected}
         onExportClicked={onExportClicked}
         onFilterAdded={onFilterAdded}
         onFilterRemoved={onFilterRemoved}
         pagination={pagination}
         query={query}
-        tagReport={report}
+        selectedItems={selectedItems}
         showExport
       />
     );
@@ -140,8 +154,8 @@ const mapStateToProps = createMapStateToProps<
   );
   return {
     queryString,
-    report,
     reportFetchStatus,
+    report
   };
 });
 

--- a/src/pages/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpDetails/detailsToolbar.tsx
@@ -102,7 +102,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       onFilterRemoved,
       pagination,
       query,
-      selectedItems
+      selectedItems,
     } = this.props;
     const { categoryOptions } = this.state;
 
@@ -155,7 +155,7 @@ const mapStateToProps = createMapStateToProps<
   return {
     queryString,
     reportFetchStatus,
-    report
+    report,
   };
 });
 

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -135,7 +135,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
     return (
       <ExportModal
-        isAllItems={isAllSelected || selectedItems.length === computedItems.length}
+        isAllItems={(isAllSelected || selectedItems.length === computedItems.length) && computedItems.length > 0 }
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isOpen={isExportModalOpen}
         items={selectedItems}
@@ -222,7 +222,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     );
   };
 
-  private getToolbar = () => {
+  private getToolbar = (computedItems: ComputedReportItem[]) => {
     const { query, report } = this.props;
     const { isAllSelected, selectedItems } = this.state;
 
@@ -238,7 +238,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
       <DetailsToolbar
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isAllSelected={isAllSelected}
-        isExportDisabled={!isAllSelected && selectedItems.length === 0}
+        isExportDisabled={computedItems.length === 0 || !isAllSelected && selectedItems.length === 0}
         itemsPerPage={itemsPerPage}
         itemsTotal={itemsTotal}
         onBulkSelected={this.handleBulkSelected}
@@ -474,7 +474,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
           emptyState
         ) : (
           <div style={styles.content}>
-            {this.getToolbar()}
+            {this.getToolbar(computedItems)}
             {this.getExportModal(computedItems)}
             <div style={styles.tableContainer}>{this.getTable()}</div>
             <div style={styles.paginationContainer}>

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -135,7 +135,10 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
     return (
       <ExportModal
-        isAllItems={(isAllSelected || selectedItems.length === computedItems.length) && computedItems.length > 0 }
+        isAllItems={
+          (isAllSelected || selectedItems.length === computedItems.length) &&
+          computedItems.length > 0
+        }
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isOpen={isExportModalOpen}
         items={selectedItems}
@@ -238,7 +241,10 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
       <DetailsToolbar
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isAllSelected={isAllSelected}
-        isExportDisabled={computedItems.length === 0 || !isAllSelected && selectedItems.length === 0}
+        isExportDisabled={
+          computedItems.length === 0 ||
+          (!isAllSelected && selectedItems.length === 0)
+        }
         itemsPerPage={itemsPerPage}
         itemsTotal={itemsTotal}
         onBulkSelected={this.handleBulkSelected}
@@ -363,7 +369,10 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     history.replace(filteredQuery);
   };
 
-  private handleSelected = (items: ComputedReportItem[], isSelected: boolean = false) => {
+  private handleSelected = (
+    items: ComputedReportItem[],
+    isSelected: boolean = false
+  ) => {
     const { selectedItems } = this.state;
 
     let newItems = [...selectedItems];

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -49,6 +49,7 @@ interface OcpDetailsDispatchProps {
 
 interface OcpDetailsState {
   columns: any[];
+  isAllSelected: boolean;
   isExportModalOpen: boolean;
   rows: any[];
   selectedItems: ComputedReportItem[];
@@ -60,7 +61,7 @@ type OcpDetailsProps = OcpDetailsStateProps &
   OcpDetailsOwnProps &
   OcpDetailsDispatchProps;
 
-const baseQuery: OcpQuery = {
+export const baseQuery: OcpQuery = {
   delta: 'cost',
   filter: {
     limit: 10,
@@ -84,6 +85,7 @@ const reportPathsType = ReportPathsType.ocp;
 class OcpDetails extends React.Component<OcpDetailsProps> {
   protected defaultState: OcpDetailsState = {
     columns: [],
+    isAllSelected: false,
     isExportModalOpen: false,
     rows: [],
     selectedItems: [],
@@ -92,6 +94,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
   constructor(stateProps, dispatchProps) {
     super(stateProps, dispatchProps);
+    this.handleBulkSelected = this.handleBulkSelected.bind(this);
     this.handleExportModalClose = this.handleExportModalClose.bind(this);
     this.handleExportModalOpen = this.handleExportModalOpen.bind(this);
     this.handleFilterAdded = this.handleFilterAdded.bind(this);
@@ -124,7 +127,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
   }
 
   private getExportModal = (computedItems: ComputedReportItem[]) => {
-    const { isExportModalOpen, selectedItems } = this.state;
+    const { isAllSelected, isExportModalOpen, selectedItems } = this.state;
     const { query } = this.props;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
@@ -132,7 +135,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
     return (
       <ExportModal
-        isAllItems={selectedItems.length === computedItems.length}
+        isAllItems={isAllSelected || selectedItems.length === computedItems.length}
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isOpen={isExportModalOpen}
         items={selectedItems}
@@ -200,6 +203,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
   private getTable = () => {
     const { query, report, reportFetchStatus } = this.props;
+    const { isAllSelected, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByTagKey = this.getGroupByTagKey();
@@ -207,34 +211,64 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     return (
       <DetailsTable
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
+        isAllSelected={isAllSelected}
         isLoading={reportFetchStatus === FetchStatus.inProgress}
         onSelected={this.handleSelected}
         onSort={this.handleSort}
         query={query}
         report={report}
+        selectedItems={selectedItems}
       />
     );
   };
 
   private getToolbar = () => {
-    const { selectedItems } = this.state;
     const { query, report } = this.props;
+    const { isAllSelected, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByTagKey = this.getGroupByTagKey();
+    const itemsPerPage =
+      report && report.meta && report.meta.filter && report.meta.filter.limit
+        ? report.meta.filter.limit
+        : baseQuery.filter.limit;
+    const itemsTotal = report && report.meta ? report.meta.count : 0;
 
     return (
       <DetailsToolbar
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
-        isExportDisabled={selectedItems.length === 0}
+        isAllSelected={isAllSelected}
+        isExportDisabled={!isAllSelected && selectedItems.length === 0}
+        itemsPerPage={itemsPerPage}
+        itemsTotal={itemsTotal}
+        onBulkSelected={this.handleBulkSelected}
         onExportClicked={this.handleExportModalOpen}
         onFilterAdded={this.handleFilterAdded}
         onFilterRemoved={this.handleFilterRemoved}
         pagination={this.getPagination()}
         query={query}
-        report={report}
+        selectedItems={selectedItems}
       />
     );
+  };
+
+  private handleBulkSelected = (action: string) => {
+    const { query, report } = this.props;
+    const { isAllSelected } = this.state;
+
+    if (action === 'none') {
+      this.setState({ isAllSelected: false, selectedItems: [] });
+    } else if (action === 'page') {
+      const groupById = getIdKeyForGroupBy(query.group_by);
+      const groupByTagKey = this.getGroupByTagKey();
+      const computedItems = getUnsortedComputedReportItems({
+        report,
+        idKey: (groupByTagKey as any) || groupById,
+      });
+      this.handleSelected(computedItems, true);
+    } else if (action === 'all') {
+      this.setState({ isAllSelected: !isAllSelected, selectedItems: [] });
+    }
   };
 
   public handleExportModalClose = (isOpen: boolean) => {
@@ -329,8 +363,20 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     history.replace(filteredQuery);
   };
 
-  private handleSelected = (selectedItems: ComputedReportItem[]) => {
-    this.setState({ selectedItems });
+  private handleSelected = (items: ComputedReportItem[], isSelected: boolean = false) => {
+    const { selectedItems } = this.state;
+
+    let newItems = [...selectedItems];
+    if (items && items.length > 0) {
+      if (isSelected) {
+        items.map(item => newItems.push(item));
+      } else {
+        items.map(item => {
+          newItems = newItems.filter(val => val.id !== item.id);
+        });
+      }
+    }
+    this.setState({ isAllSelected: false, selectedItems: newItems });
   };
 
   private handleSetPage = (event, pageNumber) => {


### PR DESCRIPTION
Added a bulk selector in the OpenShift details page to support our CSV exports. 

This maintains selections while paginating. Thus, when the export modal is opened, it shows selections made across all pages.

Note that the AWS and Azure pages will be updated next.

https://issues.redhat.com/browse/COST-422

![chrome-capture](https://user-images.githubusercontent.com/17481322/91775532-4a861600-ebb9-11ea-9c14-178597abffdd.gif)
