### PR TITLE
Default CSV export

### DIFF
--- a/src/pages/details/components/export/exportModal.tsx
+++ b/src/pages/details/components/export/exportModal.tsx
@@ -59,7 +59,7 @@ export class ExportModalBase extends React.Component<
   ExportModalState
 > {
   protected defaultState: ExportModalState = {
-    resolution: 'daily',
+    resolution: 'monthly',
   };
   public state: ExportModalState = { ...this.defaultState };
 


### PR DESCRIPTION
This changes the default CSV export to monthly instead of daily

> Multiple internal customers have mentioned that they generally always collect the monthly reports. We should make that the default selection in the UI so they don't have to click to change the majority of times.

https://issues.redhat.com/browse/COST-486

<img width="595" alt="Screen Shot 2020-09-02 at 10 10 26 AM" src="https://user-images.githubusercontent.com/17481322/91994759-f9833880-ed04-11ea-8856-68751e1a03a8.png">
