### PR TITLE
Column name is incorrect when grouped by AWS Organization Units

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -53,8 +53,7 @@
       "tag_select": "Tag"
     },
     "more_tags": ", {{value}} more...",
-    "name_column_title": "$t(group_by.values.{{groupBy}}) names",
-    "names_column_title": "Names",
+    "name_column_title": "Names",
     "show_more": "Show more",
     "tag_column_title": "Tag names",
     "tags_label": "Related tags:",

--- a/src/pages/details/awsDetails/detailsTable.tsx
+++ b/src/pages/details/awsDetails/detailsTable.tsx
@@ -166,7 +166,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       groupByTagKey || groupByOrg
         ? [
             {
-              title: groupByOrg ? t('aws_details.name_column_title') : t('aws_details.tag_column_title'),
+              title: groupByOrg
+                ? t('aws_details.name_column_title')
+                : t('aws_details.tag_column_title'),
             },
             {
               title: t('aws_details.change_column_title'),

--- a/src/pages/details/awsDetails/detailsTable.tsx
+++ b/src/pages/details/awsDetails/detailsTable.tsx
@@ -166,7 +166,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       groupByTagKey || groupByOrg
         ? [
             {
-              title: t('ocp_details.tag_column_title'),
+              title: groupByOrg ? t('aws_details.name_column_title') : t('aws_details.tag_column_title'),
             },
             {
               title: t('aws_details.change_column_title'),


### PR DESCRIPTION
When grouping by AWS Organization Units the column name for Organizations and Accounts should say "Names", not "Tag names".

https://issues.redhat.com/browse/COST-485

<img width="1017" alt="Screen Shot 2020-09-02 at 10 23 33 AM" src="https://user-images.githubusercontent.com/17481322/91996151-aad69e00-ed06-11ea-9714-2d24dab4c1c1.png">
