### PR TITLE
Inactive sources cookie

### DIFF
--- a/src/components/sources/InactiveSources/InactiveSources.tsx
+++ b/src/components/sources/InactiveSources/InactiveSources.tsx
@@ -188,17 +188,13 @@ class InactiveSourcesBase extends React.Component<InactiveSourcesProps> {
   };
 
   private isAlertClosed = () => {
-    const session = getCookieValue(tokenID);
-    const inactiveSources = getCookieValue(inactiveSourcesID);
-
     // Keep closed if token matches current session
-    return session === inactiveSources;
+    return getCookieValue(tokenID) === getCookieValue(inactiveSourcesID);
   };
 
   private resetAlert = () => {
-    const inactiveSources = getCookieValue(inactiveSourcesID);
-
-    if (inactiveSources) {
+    // Delete only if cookie exists
+    if (getCookieValue(inactiveSourcesID)) {
       deleteSessionCookie(inactiveSourcesID);
     }
   };
@@ -214,14 +210,14 @@ class InactiveSourcesBase extends React.Component<InactiveSourcesProps> {
         : t('inactive_sources.title_multiple');
 
     if (names.length === 0) {
-      this.resetAlert(); // reset for new alerts
+      this.resetAlert(); // Reset cookie for new alerts
       return null;
     }
     if (this.isAlertClosed()) {
-      return null;
-    } else {
-      this.resetAlert(); // clear previous values, if any
+      return null; // Don't display alert
     }
+    this.resetAlert(); // Clean up previous cookie, if any
+
     return (
       <Alert
         isInline

--- a/src/utils/cookie.ts
+++ b/src/utils/cookie.ts
@@ -1,0 +1,14 @@
+export function deleteSessionCookie(name) {
+  const now = new Date();
+  now.setTime(now.getTime() - 3600);
+  document.cookie = `${name}=; expires=${now.toUTCString()}; path=/`;
+}
+
+export function getCookieValue(name) {
+  const cookie = document.cookie.match('(^|;)\\s*' + name + '\\s*=\\s*([^;]+)');
+  return cookie ? cookie.pop() : '';
+}
+
+export function setSessionCookie(name, value) {
+  document.cookie = `${name}=${value}; path=/`;
+}


### PR DESCRIPTION
This sets a session cookie to ensure the inactive sources alert will remain closed while the user is logged in. That is, providing the user closed the inline alert.

If the user logs out or closes the browser, the session cookie will be invalid and removed upon a new login. In this scenario, the alert will be shown, again.

If there are no longer inactive sources, the cookie is also removed. Thus, allowing new alerts to be shown.

https://issues.redhat.com/browse/COST-463

![demo2](https://user-images.githubusercontent.com/17481322/92297966-8e0eb600-ef12-11ea-8160-d56c92e4a600.gif)
