### PR TITLE
Inactive sources padding

### DIFF
--- a/src/components/sources/InactiveSources/InactiveSources.tsx
+++ b/src/components/sources/InactiveSources/InactiveSources.tsx
@@ -19,6 +19,7 @@ import {
   setSessionCookie,
 } from 'utils/cookie';
 import { getReleasePath } from 'utils/pathname';
+import { styles } from './inactiveSources.styles';
 
 interface InactiveSourcesOwnProps {
   // TBD...
@@ -219,21 +220,23 @@ class InactiveSourcesBase extends React.Component<InactiveSourcesProps> {
     this.resetAlert(); // Clean up previous cookie, if any
 
     return (
-      <Alert
-        isInline
-        variant="danger"
-        title={title}
-        actionClose={<AlertActionCloseButton onClose={this.handleOnClose} />}
-        actionLinks={
-          <React.Fragment>
-            <a href={`${release}/settings/sources`}>
-              {t('inactive_sources.go_to_sources')}
-            </a>
-          </React.Fragment>
-        }
-      >
-        {this.getInactiveSources(names)}
-      </Alert>
+      <div style={styles.alert}>
+        <Alert
+          isInline
+          variant="danger"
+          title={title}
+          actionClose={<AlertActionCloseButton onClose={this.handleOnClose} />}
+          actionLinks={
+            <React.Fragment>
+              <a href={`${release}/settings/sources`}>
+                {t('inactive_sources.go_to_sources')}
+              </a>
+            </React.Fragment>
+          }
+        >
+          {this.getInactiveSources(names)}
+        </Alert>
+      </div>
     );
   }
 }

--- a/src/components/sources/InactiveSources/inactiveSources.styles.ts
+++ b/src/components/sources/InactiveSources/inactiveSources.styles.ts
@@ -1,0 +1,12 @@
+import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
+import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
+import React from 'react';
+
+export const styles = {
+  alert: {
+    backgroundColor: global_BackgroundColor_light_100.var,
+    paddingLeft: global_spacer_lg.var,
+    paddingRight: global_spacer_lg.var,
+    paddingTop: global_spacer_lg.var,
+  },
+} as { [className: string]: React.CSSProperties };


### PR DESCRIPTION
Added 24px padding around the inactive sources alert, per review feedback.

https://issues.redhat.com/browse/COST-463

<img width="1647" alt="Screen Shot 2020-09-09 at 10 13 58 AM" src="https://user-images.githubusercontent.com/17481322/92610647-eed91e00-f285-11ea-97f9-c15c47296de4.png">
