### PR TITLE
Fix misaligned "Month over month change" column

### DIFF
--- a/src/pages/details/awsDetails/detailsTable.styles.ts
+++ b/src/pages/details/awsDetails/detailsTable.styles.ts
@@ -60,7 +60,7 @@ export const monthOverMonthOverride = css`
 
 export const tableOverride = css`
   &.pf-c-table {
-    thead th + th + th {
+    thead th + th + th + th {
       .pf-c-table__button {
         margin-left: auto;
       }

--- a/src/pages/details/azureDetails/detailsTable.styles.ts
+++ b/src/pages/details/azureDetails/detailsTable.styles.ts
@@ -60,7 +60,7 @@ export const monthOverMonthOverride = css`
 
 export const tableOverride = css`
   &.pf-c-table {
-    thead th + th + th {
+    thead th + th + th + th {
       .pf-c-table__button {
         margin-left: auto;
       }

--- a/src/pages/details/ocpDetails/detailsTable.styles.ts
+++ b/src/pages/details/ocpDetails/detailsTable.styles.ts
@@ -60,7 +60,7 @@ export const monthOverMonthOverride = css`
 
 export const tableOverride = css`
   &.pf-c-table {
-    thead th + th + th {
+    thead th + th + th + th {
       .pf-c-table__button {
         margin-left: auto;
       }


### PR DESCRIPTION
Fix misaligned "Month over month change" column.

https://issues.redhat.com/browse/COST-515

<img width="1749" alt="Screen Shot 2020-09-09 at 1 19 49 PM" src="https://user-images.githubusercontent.com/17481322/92631495-6f584880-f29f-11ea-9383-ab916cd4b6dc.png">
