### PR TITLE
Reduce page & header padding to 24px

### DIFF
--- a/src/pages/costModels/costModel/costModelInfo.styles.ts
+++ b/src/pages/costModels/costModel/costModelInfo.styles.ts
@@ -2,7 +2,6 @@ import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/g
 import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
 import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
 import global_spacer_sm from '@patternfly/react-tokens/dist/js/global_spacer_sm';
-import global_spacer_xl from '@patternfly/react-tokens/dist/js/global_spacer_xl';
 import React from 'react';
 
 export const styles = {
@@ -11,12 +10,12 @@ export const styles = {
     wordWrap: 'break-word',
   },
   content: {
-    paddingTop: global_spacer_xl.value,
+    paddingTop: global_spacer_lg.value,
     height: '182vh',
   },
   costmodelsContainer: {
-    marginLeft: global_spacer_xl.value,
-    marginRight: global_spacer_xl.value,
+    marginLeft: global_spacer_lg.value,
+    marginRight: global_spacer_lg.value,
     backgroundColor: global_BackgroundColor_light_100.value,
     paddingBottom: global_spacer_md.value,
     paddingTop: global_spacer_md.value,

--- a/src/pages/costModels/costModelsDetails/components/markup.styles.ts
+++ b/src/pages/costModels/costModelsDetails/components/markup.styles.ts
@@ -1,12 +1,12 @@
 import global_FontSize_xl from '@patternfly/react-tokens/dist/js/global_FontSize_xl';
-import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
+import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
 import React from 'react';
 
 export const styles = {
   card: {
     minHeight: '130px',
-    marginLeft: global_spacer_md.value,
-    marginRight: global_spacer_md.value,
+    marginLeft: global_spacer_lg.value,
+    marginRight: global_spacer_lg.value,
   },
   cardBody: {
     fontSize: global_FontSize_xl.value,

--- a/src/pages/costModels/costModelsDetails/costModelsDetails.styles.ts
+++ b/src/pages/costModels/costModelsDetails/costModelsDetails.styles.ts
@@ -1,7 +1,7 @@
 import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
+import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
 import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
 import global_spacer_sm from '@patternfly/react-tokens/dist/js/global_spacer_sm';
-import global_spacer_xl from '@patternfly/react-tokens/dist/js/global_spacer_xl';
 import React from 'react';
 
 export const styles = {
@@ -10,44 +10,44 @@ export const styles = {
     wordWrap: 'break-word',
   },
   content: {
-    paddingTop: global_spacer_xl.value,
+    paddingTop: global_spacer_lg.value,
     height: '182vh',
   },
   costmodelsContainer: {
-    marginLeft: global_spacer_xl.value,
-    marginRight: global_spacer_xl.value,
+    marginLeft: global_spacer_lg.value,
+    marginRight: global_spacer_lg.value,
     paddingBottom: global_spacer_md.value,
     paddingTop: global_spacer_md.value,
-    paddingLeft: global_spacer_xl.value,
-    paddingRight: global_spacer_xl.value,
+    paddingLeft: global_spacer_lg.value,
+    paddingRight: global_spacer_lg.value,
   },
   tableContainer: {
-    marginLeft: global_spacer_xl.value,
-    marginRight: global_spacer_xl.value,
+    marginLeft: global_spacer_lg.value,
+    marginRight: global_spacer_lg.value,
   },
   paginationContainer: {
     paddingBottom: global_spacer_md.value,
     paddingTop: global_spacer_md.value,
-    paddingLeft: global_spacer_xl.value,
-    paddingRight: global_spacer_xl.value,
-    marginLeft: global_spacer_xl.value,
-    marginRight: global_spacer_xl.value,
-    marginBottom: global_spacer_xl.value,
+    paddingLeft: global_spacer_lg.value,
+    paddingRight: global_spacer_lg.value,
+    marginLeft: global_spacer_lg.value,
+    marginRight: global_spacer_lg.value,
+    marginBottom: global_spacer_lg.value,
     backgroundColor: global_BackgroundColor_light_100.value,
   },
   toolbarContainer: {
     paddingBottom: global_spacer_md.value,
     paddingTop: global_spacer_md.value,
-    marginLeft: global_spacer_xl.value,
-    marginRight: global_spacer_xl.value,
+    marginLeft: global_spacer_lg.value,
+    marginRight: global_spacer_lg.value,
     backgroundColor: global_BackgroundColor_light_100.value,
   },
   header: {
-    padding: global_spacer_xl.var,
+    padding: global_spacer_lg.var,
     backgroundColor: global_BackgroundColor_light_100.var,
   },
   headerCostModel: {
-    padding: global_spacer_md.value,
+    padding: global_spacer_lg.value,
     paddingBottom: 0,
     backgroundColor: global_BackgroundColor_light_100.var,
   },

--- a/src/pages/details/awsDetails/awsDetails.styles.ts
+++ b/src/pages/details/awsDetails/awsDetails.styles.ts
@@ -1,25 +1,25 @@
 import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
+import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
 import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
-import global_spacer_xl from '@patternfly/react-tokens/dist/js/global_spacer_xl';
 
 export const styles = {
   awsDetails: {
     minHeight: '100%',
   },
   content: {
-    paddingBottom: global_spacer_xl.value,
-    paddingTop: global_spacer_xl.value,
+    paddingBottom: global_spacer_lg.value,
+    paddingTop: global_spacer_lg.value,
   },
   paginationContainer: {
-    marginLeft: global_spacer_xl.value,
-    marginRight: global_spacer_xl.value,
+    marginLeft: global_spacer_lg.value,
+    marginRight: global_spacer_lg.value,
   },
   pagination: {
     backgroundColor: global_BackgroundColor_light_100.value,
     padding: global_spacer_md.value,
   },
   tableContainer: {
-    marginLeft: global_spacer_xl.value,
-    marginRight: global_spacer_xl.value,
+    marginLeft: global_spacer_lg.value,
+    marginRight: global_spacer_lg.value,
   },
 } as { [className: string]: React.CSSProperties };

--- a/src/pages/details/awsDetails/detailsHeader.styles.ts
+++ b/src/pages/details/awsDetails/detailsHeader.styles.ts
@@ -2,6 +2,7 @@ import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/g
 import global_Color_100 from '@patternfly/react-tokens/dist/js/global_Color_100';
 import global_Color_200 from '@patternfly/react-tokens/dist/js/global_Color_200';
 import global_FontSize_sm from '@patternfly/react-tokens/dist/js/global_FontSize_sm';
+import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
 import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
 import global_spacer_sm from '@patternfly/react-tokens/dist/js/global_spacer_sm';
 import global_spacer_xl from '@patternfly/react-tokens/dist/js/global_spacer_xl';
@@ -29,7 +30,7 @@ export const styles = {
   header: {
     display: 'flex',
     justifyContent: 'space-between',
-    padding: global_spacer_xl.var,
+    padding: global_spacer_lg.var,
     backgroundColor: global_BackgroundColor_light_100.var,
   },
   nav: {

--- a/src/pages/details/azureDetails/azureDetails.styles.ts
+++ b/src/pages/details/azureDetails/azureDetails.styles.ts
@@ -1,6 +1,6 @@
 import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
+import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
 import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
-import global_spacer_xl from '@patternfly/react-tokens/dist/js/global_spacer_xl';
 import React from 'react';
 
 export const styles = {
@@ -8,19 +8,19 @@ export const styles = {
     minHeight: '100%',
   },
   content: {
-    paddingBottom: global_spacer_xl.value,
-    paddingTop: global_spacer_xl.value,
+    paddingBottom: global_spacer_lg.value,
+    paddingTop: global_spacer_lg.value,
   },
   paginationContainer: {
-    marginLeft: global_spacer_xl.value,
-    marginRight: global_spacer_xl.value,
+    marginLeft: global_spacer_lg.value,
+    marginRight: global_spacer_lg.value,
   },
   pagination: {
     backgroundColor: global_BackgroundColor_light_100.value,
     padding: global_spacer_md.value,
   },
   tableContainer: {
-    marginLeft: global_spacer_xl.value,
-    marginRight: global_spacer_xl.value,
+    marginLeft: global_spacer_lg.value,
+    marginRight: global_spacer_lg.value,
   },
 } as { [className: string]: React.CSSProperties };

--- a/src/pages/details/azureDetails/detailsHeader.styles.ts
+++ b/src/pages/details/azureDetails/detailsHeader.styles.ts
@@ -2,6 +2,7 @@ import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/g
 import global_Color_100 from '@patternfly/react-tokens/dist/js/global_Color_100';
 import global_Color_200 from '@patternfly/react-tokens/dist/js/global_Color_200';
 import global_FontSize_sm from '@patternfly/react-tokens/dist/js/global_FontSize_sm';
+import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
 import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
 import global_spacer_sm from '@patternfly/react-tokens/dist/js/global_spacer_sm';
 import global_spacer_xl from '@patternfly/react-tokens/dist/js/global_spacer_xl';
@@ -30,7 +31,7 @@ export const styles = {
   header: {
     display: 'flex',
     justifyContent: 'space-between',
-    padding: global_spacer_xl.var,
+    padding: global_spacer_lg.var,
     backgroundColor: global_BackgroundColor_light_100.var,
   },
   nav: {

--- a/src/pages/details/components/breakdown/breakdownHeader.styles.ts
+++ b/src/pages/details/components/breakdown/breakdownHeader.styles.ts
@@ -30,9 +30,9 @@ export const styles = {
   header: {
     display: 'flex',
     justifyContent: 'space-between',
-    paddingLeft: global_spacer_xl.var,
-    paddingRight: global_spacer_xl.var,
-    paddingTop: global_spacer_xl.var,
+    paddingLeft: global_spacer_lg.var,
+    paddingRight: global_spacer_lg.var,
+    paddingTop: global_spacer_lg.var,
     backgroundColor: global_BackgroundColor_100.var,
   },
   infoDescription: {

--- a/src/pages/details/components/dataToolbar/dataToolbar.styles.ts
+++ b/src/pages/details/components/dataToolbar/dataToolbar.styles.ts
@@ -1,6 +1,6 @@
 import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
+import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
 import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
-import global_spacer_xl from '@patternfly/react-tokens/dist/js/global_spacer_xl';
 import { css } from 'emotion';
 import React from 'react';
 
@@ -12,8 +12,8 @@ export const styles = {
     backgroundColor: global_BackgroundColor_light_100.value,
     paddingBottom: global_spacer_md.value,
     paddingTop: global_spacer_md.value,
-    marginLeft: global_spacer_xl.value,
-    marginRight: global_spacer_xl.value,
+    marginLeft: global_spacer_lg.value,
+    marginRight: global_spacer_lg.value,
   },
 } as { [className: string]: React.CSSProperties };
 

--- a/src/pages/details/ocpDetails/detailsHeader.styles.ts
+++ b/src/pages/details/ocpDetails/detailsHeader.styles.ts
@@ -3,9 +3,9 @@ import global_Color_100 from '@patternfly/react-tokens/dist/js/global_Color_100'
 import global_Color_200 from '@patternfly/react-tokens/dist/js/global_Color_200';
 import global_FontSize_md from '@patternfly/react-tokens/dist/js/global_FontSize_md';
 import global_FontSize_sm from '@patternfly/react-tokens/dist/js/global_FontSize_sm';
+import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
 import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
 import global_spacer_sm from '@patternfly/react-tokens/dist/js/global_spacer_sm';
-import global_spacer_xl from '@patternfly/react-tokens/dist/js/global_spacer_xl';
 import React from 'react';
 
 export const styles = {
@@ -30,7 +30,7 @@ export const styles = {
   header: {
     display: 'flex',
     justifyContent: 'space-between',
-    padding: global_spacer_xl.var,
+    padding: global_spacer_lg.var,
     backgroundColor: global_BackgroundColor_light_100.var,
   },
   info: {

--- a/src/pages/details/ocpDetails/ocpDetails.styles.ts
+++ b/src/pages/details/ocpDetails/ocpDetails.styles.ts
@@ -1,26 +1,26 @@
 import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
+import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
 import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
-import global_spacer_xl from '@patternfly/react-tokens/dist/js/global_spacer_xl';
 import React from 'react';
 
 export const styles = {
   content: {
-    paddingBottom: global_spacer_xl.value,
-    paddingTop: global_spacer_xl.value,
+    paddingBottom: global_spacer_lg.value,
+    paddingTop: global_spacer_lg.value,
   },
   ocpDetails: {
     minHeight: '100%',
   },
   paginationContainer: {
-    marginLeft: global_spacer_xl.value,
-    marginRight: global_spacer_xl.value,
+    marginLeft: global_spacer_lg.value,
+    marginRight: global_spacer_lg.value,
   },
   pagination: {
     backgroundColor: global_BackgroundColor_light_100.value,
     padding: global_spacer_md.value,
   },
   tableContainer: {
-    marginLeft: global_spacer_xl.value,
-    marginRight: global_spacer_xl.value,
+    marginLeft: global_spacer_lg.value,
+    marginRight: global_spacer_lg.value,
   },
 } as { [className: string]: React.CSSProperties };


### PR DESCRIPTION
This reduces page (gray border) & header padding from 32px to 24px, per the latest PatternFly guidelines.

https://issues.redhat.com/browse/COST-519

<img width="1749" alt="Screen Shot 2020-09-09 at 1 58 49 PM" src="https://user-images.githubusercontent.com/17481322/92636116-d88e8a80-f2a4-11ea-8241-a77c1c12075c.png">
