### PR TITLE
Clean up es-lint warnings

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -188,7 +188,7 @@ export class App extends React.Component<AppProps, AppState> {
 }
 
 const mapStateToProps = createMapStateToProps<AppOwnProps, AppStateProps>(
-  (state, props) => {
+  state => {
     const awsProvidersQueryString = getProvidersQuery(awsProvidersQuery);
     const awsProviders = providersSelectors.selectProviders(
       state,

--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -389,7 +389,7 @@ class CostChart extends React.Component<CostChartProps, State> {
     const { series } = this.state;
     const result = [];
     if (series) {
-      series.map((serie, index) => {
+      series.map(serie => {
         // Each group of chart names are hidden / shown together
         result.push(serie.childName);
       });

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -363,7 +363,7 @@ class HistoricalCostChart extends React.Component<
     const { series } = this.state;
     const result = [];
     if (series) {
-      series.map((serie, index) => {
+      series.map(serie => {
         // Each group of chart names are hidden / shown together
         result.push(serie.childName);
       });

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -285,7 +285,7 @@ class HistoricalTrendChart extends React.Component<
     const { series } = this.state;
     const result = [];
     if (series) {
-      series.map((serie, index) => {
+      series.map(serie => {
         // Each group of chart names are hidden / shown together
         result.push(serie.childName);
       });

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -441,7 +441,7 @@ class HistoricalUsageChart extends React.Component<
     const { series } = this.state;
     const result = [];
     if (series) {
-      series.map((serie, index) => {
+      series.map(serie => {
         // Each group of chart names are hidden / shown together
         result.push(serie.childName);
       });

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -304,7 +304,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     const result = [];
 
     if (series) {
-      series.map((serie, index) => {
+      series.map(serie => {
         // Each group of chart names are hidden / shown together
         result.push(serie.childName);
       });

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -373,7 +373,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
     const { series } = this.state;
     const result = [];
     if (series) {
-      series.map((serie, index) => {
+      series.map(serie => {
         // Each group of chart names are hidden / shown together
         result.push(serie.childName);
       });

--- a/src/components/reports/reportSummary/reportSummary.tsx
+++ b/src/components/reports/reportSummary/reportSummary.tsx
@@ -25,7 +25,6 @@ const ReportSummaryBase: React.SFC<ReportSummaryProps> = ({
   title,
   subTitle,
   status,
-  t,
 }) => (
   <Card style={styles.reportSummary}>
     <CardTitle>

--- a/src/components/reports/reportSummary/reportSummaryAlt.tsx
+++ b/src/components/reports/reportSummary/reportSummaryAlt.tsx
@@ -27,7 +27,6 @@ const OcpCloudReportSummaryAltBase: React.SFC<OcpCloudReportSummaryAltProps> = (
   detailsLink,
   status,
   subTitle,
-  t,
   tabs,
   title,
 }) => (

--- a/src/components/reports/reportSummary/reportSummaryItem.test.tsx
+++ b/src/components/reports/reportSummary/reportSummaryItem.test.tsx
@@ -2,7 +2,6 @@ import { Progress } from '@patternfly/react-core';
 import { shallow } from 'enzyme';
 import React from 'react';
 import { ReportSummaryItem, ReportSummaryItemProps } from './reportSummaryItem';
-import { styles } from './reportSummaryItem.styles';
 
 const props: ReportSummaryItemProps = {
   formatOptions: {},

--- a/src/components/sources/InactiveSources/InactiveSources.tsx
+++ b/src/components/sources/InactiveSources/InactiveSources.tsx
@@ -86,7 +86,7 @@ class InactiveSourcesBase extends React.Component<InactiveSourcesProps> {
     }
   }
 
-  public componentDidUpdate(prevProps: InactiveSourcesProps) {
+  public componentDidUpdate() {
     const {
       awsProviders,
       awsProvidersError,
@@ -244,7 +244,7 @@ class InactiveSourcesBase extends React.Component<InactiveSourcesProps> {
 const mapStateToProps = createMapStateToProps<
   InactiveSourcesOwnProps,
   InactiveSourcesStateProps
->((state, props) => {
+>(state => {
   const awsProvidersQueryString = getProvidersQuery(awsProvidersQuery);
   const awsProviders = providersSelectors.selectProviders(
     state,

--- a/src/components/state/loadingState/loadingState.tsx
+++ b/src/components/state/loadingState/loadingState.tsx
@@ -5,7 +5,6 @@ import {
   Spinner,
   Title,
 } from '@patternfly/react-core';
-import { BinocularsIcon } from '@patternfly/react-icons/dist/js/icons/binoculars-icon';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 
@@ -13,10 +12,7 @@ interface LoadingStateProps extends InjectedTranslateProps {
   icon?: string;
 }
 
-const LoadingStateBase: React.SFC<LoadingStateProps> = ({
-  icon = BinocularsIcon,
-  t,
-}) => {
+const LoadingStateBase: React.SFC<LoadingStateProps> = ({ t }) => {
   const title = t('loading_state.sources_title');
   const subTitle = t('loading_state.sources_desc');
 

--- a/src/pages/costModels/components/addPriceList.tsx
+++ b/src/pages/costModels/components/addPriceList.tsx
@@ -198,8 +198,8 @@ export const addRateMachine = Machine<
         rate: (_ctx, evt) => evt.payload && evt.payload.rate,
       }),
       resetMeasurement: assign({
-        measurement: (_ctx, _evt) => '',
-        costType: (_ctx, _evt) => 'Supplementary',
+        measurement: () => '',
+        costType: () => 'Supplementary',
       }),
       cost_type: assign({
         costType: (_ctx, evt) => evt.payload && evt.payload.costType,

--- a/src/pages/costModels/components/costModelRateItem.test.tsx
+++ b/src/pages/costModels/components/costModelRateItem.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { CostModelRateItemBase } from './costModelRateItem';
 
 test('', () => {
-  const { debug, queryAllByRole } = render(
+  const { queryAllByRole } = render(
     <CostModelRateItemBase
       index={3}
       units={'gb_hours'}

--- a/src/pages/costModels/components/filterLogic.ts
+++ b/src/pages/costModels/components/filterLogic.ts
@@ -27,7 +27,7 @@ export const removeMultiValueQuery = query => (key, value) => {
   };
 };
 
-export const removeSingleValueQuery = query => (key, _value) => {
+export const removeSingleValueQuery = query => key => {
   return Object.keys(query).reduce((acc, cur) => {
     if (cur === key) {
       return acc;

--- a/src/pages/costModels/components/hoc/withPriceListSearch.test.tsx
+++ b/src/pages/costModels/components/hoc/withPriceListSearch.test.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { WithPriceListSearch } from './withPriceListSearch';
 
 test('with price list search', () => {
-  const { debug, getByRole, getByText } = render(
+  const { getByRole, getByText } = render(
     <WithPriceListSearch
       initialFilters={{ primary: 'metrics', metrics: [], measurements: [] }}
     >

--- a/src/pages/costModels/components/hoc/withStateMachine.test.tsx
+++ b/src/pages/costModels/components/hoc/withStateMachine.test.tsx
@@ -20,7 +20,7 @@ test('with state machine', () => {
     },
   });
 
-  const { debug, getByRole } = render(
+  const { getByRole } = render(
     <WithStateMachine machine={toggleMachine}>
       {({ current, send }) => {
         return (

--- a/src/pages/costModels/components/toolbar/checkboxSelector.test.tsx
+++ b/src/pages/costModels/components/toolbar/checkboxSelector.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, queryByAltText, render } from '@testing-library/react';
+import { fireEvent, render } from '@testing-library/react';
 import React from 'react';
 import { CheckboxSelector } from './checkboxSelector';
 

--- a/src/pages/costModels/components/toolbar/primarySelector.test.tsx
+++ b/src/pages/costModels/components/toolbar/primarySelector.test.tsx
@@ -4,7 +4,7 @@ import { PrimarySelector } from './primarySelector';
 
 test('primary selector', () => {
   const setPrimary = jest.fn();
-  const { debug, queryAllByText, getByRole, getAllByRole } = render(
+  const { queryAllByText, getByRole, getAllByRole } = render(
     <PrimarySelector
       primary={'metrics'}
       setPrimary={setPrimary}

--- a/src/pages/costModels/components/warningIcon.test.tsx
+++ b/src/pages/costModels/components/warningIcon.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 import { WarningIcon } from './warningIcon';
 

--- a/src/pages/costModels/costModelsDetails/addSourceStep.tsx
+++ b/src/pages/costModels/costModelsDetails/addSourceStep.tsx
@@ -73,7 +73,7 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
         },
       });
     };
-    const sources = this.props.providers.map((providerData, ix) => {
+    const sources = this.props.providers.map(providerData => {
       const isSelected = this.props.checked[providerData.uuid]
         ? this.props.checked[providerData.uuid].selected
         : false;
@@ -144,7 +144,7 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
                 currentFilterValue: value,
               }),
             value: this.props.currentFilter.value,
-            onSearch: _evt => {
+            onSearch: () => {
               const curQuery = this.props.query.name
                 ? this.props.query.name.split(',')
                 : [];

--- a/src/pages/costModels/costModelsDetails/components/costModelsDetailsToolbar.tsx
+++ b/src/pages/costModels/costModelsDetails/components/costModelsDetailsToolbar.tsx
@@ -237,7 +237,7 @@ class CostModelsDetailsToolbarStateful extends React.Component<
             newQuery = removeMultiValueQuery(query)('description', chip);
           }
           if (category === t('toolbar.sources.primary.source_type')) {
-            newQuery = removeSingleValueQuery(query)('source_type', chip);
+            newQuery = removeSingleValueQuery(query)('source_type');
           }
           return onSearch(newQuery);
         }}
@@ -277,7 +277,7 @@ class CostModelsDetailsToolbarStateful extends React.Component<
                       secondaryValue: value,
                     });
                   }}
-                  onSearch={_evt => {
+                  onSearch={() => {
                     const newQuery = addMultiValueQuery(query)(
                       primarySelected,
                       secondaryValue
@@ -308,7 +308,7 @@ class CostModelsDetailsToolbarStateful extends React.Component<
                       secondaryValue: value,
                     });
                   }}
-                  onSearch={_evt => {
+                  onSearch={() => {
                     const newQuery = addMultiValueQuery(query)(
                       primarySelected,
                       secondaryValue

--- a/src/pages/costModels/costModelsDetails/components/priceListTable.tsx
+++ b/src/pages/costModels/costModelsDetails/components/priceListTable.tsx
@@ -416,7 +416,7 @@ class PriceListTable extends React.Component<Props, State> {
                           ) : (
                             undefined
                           ),
-                          onClick: (_evt, rowIndex, _rowData, _extra) => {
+                          onClick: (_evt, rowIndex) => {
                             this.setState({
                               deleteRate: null,
                               index: rowIndex + from,
@@ -441,7 +441,7 @@ class PriceListTable extends React.Component<Props, State> {
                           ) : (
                             undefined
                           ),
-                          onClick: (_evt, rowIndex, _rowData, _extra) => {
+                          onClick: (_evt, rowIndex) => {
                             this.setState({
                               deleteRate: filtered[rowIndex],
                               index: rowIndex + from,

--- a/src/pages/costModels/costModelsDetails/components/readOnlyTooltip.test.tsx
+++ b/src/pages/costModels/costModelsDetails/components/readOnlyTooltip.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, queryAllByText, render } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import React from 'react';
 import { ReadOnlyTooltipBase } from './readOnlyTooltip';
 

--- a/src/pages/costModels/costModelsDetails/components/updateCostModel.tsx
+++ b/src/pages/costModels/costModelsDetails/components/updateCostModel.tsx
@@ -60,13 +60,7 @@ class UpdateCostModelBase extends React.Component<Props, State> {
             key="proceed"
             variant="primary"
             onClick={() => {
-              const {
-                uuid,
-                sources,
-                created_timestamp,
-                updated_timestamp,
-                ...previous
-              } = current;
+              const { uuid, sources, ...previous } = current;
               updateCostModel(
                 uuid,
                 {

--- a/src/pages/costModels/costModelsDetails/costModelsPagination.tsx
+++ b/src/pages/costModels/costModelsDetails/costModelsPagination.tsx
@@ -36,6 +36,7 @@ const CostModelsPagination = connect(
         };
         dispatchProps.fetch(stringify(newQuery));
       },
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       onPerPageSelect: (_evt, perPage: number, _page: number) => {
         const newQuery = {
           ...stateProps.query,

--- a/src/pages/costModels/createCostModelWizard/context.ts
+++ b/src/pages/costModels/createCostModelWizard/context.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
 import { MetricHash } from 'api/metrics';
 import React from 'react';
 

--- a/src/pages/costModels/createCostModelWizard/index.tsx
+++ b/src/pages/costModels/createCostModelWizard/index.tsx
@@ -101,7 +101,7 @@ const InternalWizardBase: React.SFC<InternalWizardBaseProps> = ({
           },
           source_uuids: sources.map(src => src.uuid),
         })
-          .then(resp => {
+          .then(() => {
             setSuccess();
             updateCostModel();
           })

--- a/src/pages/costModels/createCostModelWizard/priceList.tsx
+++ b/src/pages/costModels/createCostModelWizard/priceList.tsx
@@ -89,7 +89,7 @@ const priceListMachine = ({
     },
     {
       actions: {
-        enableNext: (ctx, _evt) => {
+        enableNext: ctx => {
           if (sideEffectSubmit) {
             sideEffectSubmit(ctx.items);
           }
@@ -97,7 +97,7 @@ const priceListMachine = ({
             sideEffectEnabler(true);
           }
         },
-        disableNext: (_ctx, _evt) => {
+        disableNext: () => {
           if (sideEffectEnabler) {
             sideEffectEnabler(false);
           }

--- a/src/pages/costModels/createCostModelWizard/priceListTable.tsx
+++ b/src/pages/costModels/createCostModelWizard/priceListTable.tsx
@@ -241,7 +241,7 @@ class PriceListTable extends React.Component<Props, State> {
                             actions={[
                               {
                                 title: 'Remove',
-                                onClick: (_evt, rowId, _rowData, _extra) => {
+                                onClick: (_evt, rowId) => {
                                   deleteRateAction(res[rowId]);
                                 },
                               },

--- a/src/pages/costModels/createCostModelWizard/steps.tsx
+++ b/src/pages/costModels/createCostModelWizard/steps.tsx
@@ -87,24 +87,24 @@ export const stepsHash = (t: (text: string) => string) => ({
 });
 
 export const validatorsHash = {
-  '': [ctx => false],
+  '': [() => false],
   AWS: [
     ctx => ctx.name !== '' && ctx.type !== '',
     ctx => ctx.markup !== '' && !isNaN(Number(ctx.markup)),
-    ctx => true,
-    ctx => true,
+    () => true,
+    () => true,
   ],
   AZURE: [
     ctx => ctx.name !== '' && ctx.type !== '',
     ctx => ctx.markup !== '' && !isNaN(Number(ctx.markup)),
-    ctx => true,
-    ctx => true,
+    () => true,
+    () => true,
   ],
   OCP: [
     ctx => ctx.name !== '' && ctx.type !== '',
     ctx => ctx.priceListCurrent.justSaved,
     ctx => ctx.markup !== '' && !isNaN(Number(ctx.markup)),
-    ctx => true,
-    ctx => true,
+    () => true,
+    () => true,
   ],
 };

--- a/src/pages/costModels/createCostModelWizard/table.tsx
+++ b/src/pages/costModels/createCostModelWizard/table.tsx
@@ -76,7 +76,7 @@ const SourcesTable: React.SFC<InjectedTranslateProps> = ({ t }) => {
                   id: 'assign-source-search-input',
                   value: filterName,
                   onChange: onFilterChange,
-                  onSearch: _evt => {
+                  onSearch: () => {
                     fetchSources(
                       sourceType,
                       addMultiValueQuery(query)('name', filterName),

--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -511,7 +511,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 const mapStateToProps = createMapStateToProps<
   AwsDetailsOwnProps,
   AwsDetailsStateProps
->((state, props) => {
+>(state => {
   const queryFromRoute = parseQuery<AwsQuery>(location.search);
   const query = {
     delta: 'cost',

--- a/src/pages/details/awsDetails/detailsHeader.tsx
+++ b/src/pages/details/awsDetails/detailsHeader.tsx
@@ -127,7 +127,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
 const mapStateToProps = createMapStateToProps<
   DetailsHeaderOwnProps,
   DetailsHeaderStateProps
->((state, props) => {
+>(state => {
   const queryString = getQuery(baseQuery);
   const providersQueryString = getProvidersQuery(awsProvidersQuery);
   const providers = providersSelectors.selectProviders(

--- a/src/pages/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/details/awsDetails/detailsToolbar.tsx
@@ -66,7 +66,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     });
   }
 
-  public componentDidUpdate(prevProps: DetailsToolbarProps, prevState) {
+  public componentDidUpdate(prevProps: DetailsToolbarProps) {
     const {
       fetchReport,
       orgReport,

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -505,7 +505,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
 const mapStateToProps = createMapStateToProps<
   AzureDetailsOwnProps,
   AzureDetailsStateProps
->((state, props) => {
+>(state => {
   const queryFromRoute = parseQuery<AzureQuery>(location.search);
   const query = {
     delta: 'cost',

--- a/src/pages/details/azureDetails/detailsHeader.tsx
+++ b/src/pages/details/azureDetails/detailsHeader.tsx
@@ -126,7 +126,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
 const mapStateToProps = createMapStateToProps<
   DetailsHeaderOwnProps,
   DetailsHeaderStateProps
->((state, props) => {
+>(state => {
   const queryString = getQuery(baseQuery);
   const providersQueryString = getProvidersQuery(azureProvidersQuery);
   const providers = providersSelectors.selectProviders(

--- a/src/pages/details/azureDetails/detailsTable.tsx
+++ b/src/pages/details/azureDetails/detailsTable.tsx
@@ -172,7 +172,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       const label = item && item.label !== null ? item.label : '';
       const monthOverMonth = this.getMonthOverMonthCost(item, index);
       const cost = this.getTotalCost(item, index);
-      const actions = this.getActions(item, index);
+      const actions = this.getActions(item);
 
       let name = <Link to={this.buildCostLink(label.toString())}>{label}</Link>;
       if (label === `no-${groupById}` || label === `no-${groupByTagKey}`) {
@@ -221,7 +221,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     });
   };
 
-  private getActions = (item: ComputedReportItem, index: number) => {
+  private getActions = (item: ComputedReportItem) => {
     const { groupBy, query } = this.props;
 
     return (

--- a/src/pages/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/details/azureDetails/detailsToolbar.tsx
@@ -62,7 +62,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     });
   }
 
-  public componentDidUpdate(prevProps: DetailsToolbarProps, prevState) {
+  public componentDidUpdate(prevProps: DetailsToolbarProps) {
     const { fetchReport, query, queryString, tagReport } = this.props;
     if (query && !isEqual(query, prevProps.query)) {
       fetchReport(reportPathsType, reportType, queryString);

--- a/src/pages/details/components/breakdown/breakdownBase.tsx
+++ b/src/pages/details/components/breakdown/breakdownBase.tsx
@@ -70,10 +70,7 @@ class BreakdownBase extends React.Component<BreakdownProps> {
     this.updateReport();
   }
 
-  public componentDidUpdate(
-    prevProps: BreakdownProps,
-    prevState: BreakdownState
-  ) {
+  public componentDidUpdate(prevProps: BreakdownProps) {
     const { location, report, reportError, queryString } = this.props;
 
     const newQuery = prevProps.queryString !== queryString;

--- a/src/pages/details/components/costOverview/costOverviewBase.tsx
+++ b/src/pages/details/components/costOverview/costOverviewBase.tsx
@@ -70,7 +70,7 @@ class CostOverviewBase extends React.Component<CostOverviewProps> {
   };
 
   // Returns cost breakdown chart
-  private getCostChart = (widget: CostOverviewWidget) => {
+  private getCostChart = () => {
     const { report, t } = this.props;
 
     return (
@@ -203,7 +203,7 @@ class CostOverviewBase extends React.Component<CostOverviewProps> {
       case CostOverviewWidgetType.cluster:
         return this.getClusterChart(widget);
       case CostOverviewWidgetType.cost:
-        return this.getCostChart(widget);
+        return this.getCostChart();
       case CostOverviewWidgetType.cpuUsage:
         return this.getCpuUsageChart(widget);
       case CostOverviewWidgetType.memoryUsage:

--- a/src/pages/details/components/dataToolbar/dataToolbar.tsx
+++ b/src/pages/details/components/dataToolbar/dataToolbar.tsx
@@ -112,7 +112,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
     });
   }
 
-  public componentDidUpdate(prevProps: DataToolbarProps, prevState) {
+  public componentDidUpdate(prevProps: DataToolbarProps) {
     const {
       categoryOptions,
       groupBy,
@@ -319,7 +319,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
     }
   };
 
-  private onBulkSelect = event => {
+  private onBulkSelect = () => {
     this.setState({
       isBulkSelectOpen: !this.state.isBulkSelectOpen,
     });
@@ -392,7 +392,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
     });
   };
 
-  private onCategorySelect = event => {
+  private onCategorySelect = () => {
     this.setState({
       categoryInput: '',
       currentTagKey: undefined,
@@ -682,6 +682,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
     // Workaround for https://github.com/project-koku/koku/issues/1797
     if (hasTagKeys) {
       const keepData = tagReport.data.map(
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         ({ type, ...keepProps }) => keepProps
       );
       data = uniqBy(keepData, 'key');
@@ -708,7 +709,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
     });
   };
 
-  private onTagKeySelect = (event, selection, isPlaceholder) => {
+  private onTagKeySelect = (event, selection) => {
     this.setState({
       currentTagKey: selection,
       isTagKeySelectExpanded: !this.state.isTagKeySelectExpanded,

--- a/src/pages/details/components/export/exportModal.tsx
+++ b/src/pages/details/components/export/exportModal.tsx
@@ -178,11 +178,9 @@ export class ExportModalBase extends React.Component<
   }
 }
 
-const mapStateToProps = createMapStateToProps<ExportModalOwnProps, {}>(
-  (state, props) => {
-    return {};
-  }
-);
+const mapStateToProps = createMapStateToProps<ExportModalOwnProps, {}>(() => {
+  return {};
+});
 
 const mapDispatchToProps: ExportModalDispatchProps = {
   exportReport: exportActions.exportReport,

--- a/src/pages/details/components/groupBy/groupBy.tsx
+++ b/src/pages/details/components/groupBy/groupBy.tsx
@@ -202,7 +202,7 @@ class GroupByBase extends React.Component<GroupByProps> {
     return groupBy !== 'date' ? groupBy : defaultItem;
   };
 
-  private handleGroupBySelect = event => {
+  private handleGroupBySelect = () => {
     this.setState({
       isGroupByOpen: !this.state.isGroupByOpen,
     });

--- a/src/pages/details/components/groupBy/groupByTag.tsx
+++ b/src/pages/details/components/groupBy/groupByTag.tsx
@@ -70,6 +70,7 @@ class GroupByTagBase extends React.Component<GroupByTagProps> {
     let data = [];
     if (hasTagKeys) {
       const keepData = report.data.map(
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
         ({ type, ...keepProps }: any) => keepProps
       );
       data = uniqBy(keepData, 'key');

--- a/src/pages/details/components/nav/tertiaryNav.tsx
+++ b/src/pages/details/components/nav/tertiaryNav.tsx
@@ -53,7 +53,7 @@ export class TertiaryNavBase extends React.Component<TertiaryNavProps> {
     }
   };
 
-  private getNavItem = (navItem: TertiaryNavItem, index: number) => {
+  private getNavItem = (navItem: TertiaryNavItem) => {
     const { activeItem } = this.props;
     const navItemKey = getIdKeyForNavItem(navItem);
 
@@ -92,8 +92,8 @@ export class TertiaryNavBase extends React.Component<TertiaryNavProps> {
     return (
       <Nav onSelect={this.handleOnSelect} variant="tertiary">
         <NavList>
-          {availableNavItems.map((val, index) =>
-            this.getNavItem(val.navItem, index)
+          {availableNavItems.map(val =>
+            this.getNavItem(val.navItem)
           )}
         </NavList>
       </Nav>

--- a/src/pages/details/components/nav/tertiaryNav.tsx
+++ b/src/pages/details/components/nav/tertiaryNav.tsx
@@ -92,9 +92,7 @@ export class TertiaryNavBase extends React.Component<TertiaryNavProps> {
     return (
       <Nav onSelect={this.handleOnSelect} variant="tertiary">
         <NavList>
-          {availableNavItems.map(val =>
-            this.getNavItem(val.navItem)
-          )}
+          {availableNavItems.map(val => this.getNavItem(val.navItem))}
         </NavList>
       </Nav>
     );

--- a/src/pages/details/ocpDetails/detailsHeader.tsx
+++ b/src/pages/details/ocpDetails/detailsHeader.tsx
@@ -193,7 +193,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
 const mapStateToProps = createMapStateToProps<
   DetailsHeaderOwnProps,
   DetailsHeaderStateProps
->((state, props) => {
+>(state => {
   const queryString = getQuery(baseQuery);
   const providersQueryString = getProvidersQuery(ocpProvidersQuery);
   const providers = providersSelectors.selectProviders(

--- a/src/pages/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/details/ocpDetails/detailsTable.tsx
@@ -195,7 +195,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       const InfrastructureCost = this.getInfrastructureCost(item, index);
       const supplementaryCost = this.getSupplementaryCost(item, index);
       const cost = this.getTotalCost(item, index);
-      const actions = this.getActions(item, index);
+      const actions = this.getActions(item);
 
       let name = <Link to={this.buildCostLink(label.toString())}>{label}</Link>;
       if (label === `no-${groupById}` || label === `no-${groupByTagKey}`) {
@@ -246,7 +246,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     });
   };
 
-  private getActions = (item: ComputedReportItem, index: number) => {
+  private getActions = (item: ComputedReportItem) => {
     const { groupBy, query } = this.props;
 
     return (

--- a/src/pages/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpDetails/detailsToolbar.tsx
@@ -62,7 +62,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     });
   }
 
-  public componentDidUpdate(prevProps: DetailsToolbarProps, prevState) {
+  public componentDidUpdate(prevProps: DetailsToolbarProps) {
     const { fetchReport, query, queryString, report } = this.props;
     if (query && !isEqual(query, prevProps.query)) {
       fetchReport(reportPathsType, reportType, queryString);

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -501,7 +501,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 const mapStateToProps = createMapStateToProps<
   OcpDetailsOwnProps,
   OcpDetailsStateProps
->((state, props) => {
+>(state => {
   const queryFromRoute = parseQuery<OcpQuery>(location.search);
   const query = {
     delta: 'cost',

--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -131,10 +131,7 @@ class OverviewBase extends React.Component<OverviewProps> {
     });
   }
 
-  public componentDidUpdate(
-    prevProps: OverviewProps,
-    prevState: OverviewState
-  ) {
+  public componentDidUpdate(prevProps: OverviewProps) {
     const { awsProviders, azureProviders, ocpProviders } = this.props;
 
     if (

--- a/src/pages/overview/perspective.tsx
+++ b/src/pages/overview/perspective.tsx
@@ -58,7 +58,7 @@ class PerspectiveBase extends React.Component<PerspectiveProps> {
     }
   };
 
-  private handleSelect = event => {
+  private handleSelect = () => {
     this.setState({
       isPerspectiveOpen: !this.state.isPerspectiveOpen,
     });

--- a/src/store/costModels/actions.ts
+++ b/src/store/costModels/actions.ts
@@ -112,7 +112,7 @@ export const deleteCostModel = (
     dispatch(deleteCostModelsRequest());
 
     return apiDeleteCostModel(uuid)
-      .then(res => {
+      .then(() => {
         dispatch(deleteCostModelsSuccess());
         dispatch(resetCostModel());
         fetchCostModels()(dispatch);
@@ -140,7 +140,7 @@ export const redirectToCostModelFromSourceUuid = (
         insights.chrome.appNavClick({ id: 'cost-models', secondaryNav: null });
         history.push(`/cost-models/${uuid}`);
       })
-      .catch(err => {
+      .catch(() => {
         dispatch(
           addNotification({
             title: i18next.t('cost_models_router.error_title'),

--- a/src/store/costOverview/awsCostOverview/awsCostOverviewReducer.ts
+++ b/src/store/costOverview/awsCostOverview/awsCostOverviewReducer.ts
@@ -27,8 +27,7 @@ export const defaultState: AwsCostOverviewState = {
 };
 
 export function awsCostOverviewReducer(
-  state = defaultState,
-  action: any
+  state = defaultState
 ): AwsCostOverviewState {
   return state;
 }

--- a/src/store/costOverview/azureCostOverview/azureCostOverviewReducer.ts
+++ b/src/store/costOverview/azureCostOverview/azureCostOverviewReducer.ts
@@ -27,8 +27,7 @@ export const defaultState: AzureCostOverviewState = {
 };
 
 export function azureCostOverviewReducer(
-  state = defaultState,
-  action: any
+  state = defaultState
 ): AzureCostOverviewState {
   return state;
 }

--- a/src/store/costOverview/ocpCostOverview/ocpCostOverviewReducer.ts
+++ b/src/store/costOverview/ocpCostOverview/ocpCostOverviewReducer.ts
@@ -30,8 +30,7 @@ export const defaultState: OcpCostOverviewState = {
 };
 
 export function ocpCostOverviewReducer(
-  state = defaultState,
-  action: any
+  state = defaultState
 ): OcpCostOverviewState {
   return state;
 }

--- a/src/store/historicalData/awsHistoricalData/awsHistoricalDataReducer.ts
+++ b/src/store/historicalData/awsHistoricalData/awsHistoricalDataReducer.ts
@@ -20,8 +20,7 @@ export const defaultState: AwsHistoricalDataState = {
 };
 
 export function awsHistoricalDataReducer(
-  state = defaultState,
-  action: any
+  state = defaultState
 ): AwsHistoricalDataState {
   return state;
 }

--- a/src/store/historicalData/azureHistoricalData/azureHistoricalDataReducer.ts
+++ b/src/store/historicalData/azureHistoricalData/azureHistoricalDataReducer.ts
@@ -20,8 +20,7 @@ export const defaultState: AzureHistoricalDataState = {
 };
 
 export function azureHistoricalDataReducer(
-  state = defaultState,
-  action: any
+  state = defaultState
 ): AzureHistoricalDataState {
   return state;
 }

--- a/src/store/historicalData/ocpHistoricalData/ocpHistoricalDataReducer.ts
+++ b/src/store/historicalData/ocpHistoricalData/ocpHistoricalDataReducer.ts
@@ -20,8 +20,7 @@ export const defaultState: OcpHistoricalDataState = {
 };
 
 export function ocpHistoricalDataReducer(
-  state = defaultState,
-  action: any
+  state = defaultState
 ): OcpHistoricalDataState {
   return state;
 }

--- a/src/store/providers/providersActions.ts
+++ b/src/store/providers/providersActions.ts
@@ -19,7 +19,7 @@ export const fetchProvidersFailure = createStandardAction(
 )<AxiosError, ProvidersActionMeta>();
 
 export function fetchProviders(reportType: ProviderType, query: string) {
-  return (dispatch, getState) => {
+  return dispatch => {
     const meta: ProvidersActionMeta = {
       reportId: getReportId(reportType, query),
     };

--- a/src/store/rbac/store.test.ts
+++ b/src/store/rbac/store.test.ts
@@ -1,7 +1,6 @@
 jest.mock('api/rbac');
 
 import { getRBAC } from 'api/rbac';
-import { FetchStatus } from 'store/common';
 import { createMockStoreCreator } from 'store/mockStore';
 import * as actions from './actions';
 import { reducer, stateKey } from './reducer';


### PR DESCRIPTION
Es-lint is currently showing 107 "unused prop" warnings. This simple change makes the es-lint output much easier to read.