### PR TITLE
createMapStateToProps requires props

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -165,7 +165,8 @@ export class App extends React.Component<AppProps, AppState> {
   }
 }
 
-const mapStateToProps = createMapStateToProps<AppOwnProps, AppStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<AppOwnProps, AppStateProps>((state, props) => {
   const awsProvidersQueryString = getProvidersQuery(awsProvidersQuery);
   const awsProviders = providersSelectors.selectProviders(state, ProviderType.aws, awsProvidersQueryString);
   const awsProvidersError = providersSelectors.selectProvidersError(state, ProviderType.aws, awsProvidersQueryString);

--- a/src/components/sources/InactiveSources/InactiveSources.tsx
+++ b/src/components/sources/InactiveSources/InactiveSources.tsx
@@ -219,7 +219,8 @@ class InactiveSourcesBase extends React.Component<InactiveSourcesProps> {
   }
 }
 
-const mapStateToProps = createMapStateToProps<InactiveSourcesOwnProps, InactiveSourcesStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<InactiveSourcesOwnProps, InactiveSourcesStateProps>((state, props) => {
   const awsProvidersQueryString = getProvidersQuery(awsProvidersQuery);
   const awsProviders = providersSelectors.selectProviders(state, ProviderType.aws, awsProvidersQueryString);
   const awsProvidersError = providersSelectors.selectProvidersError(state, ProviderType.aws, awsProvidersQueryString);

--- a/src/pages/dashboard/awsCloudDashboard/awsCloudDashboard.tsx
+++ b/src/pages/dashboard/awsCloudDashboard/awsCloudDashboard.tsx
@@ -13,13 +13,16 @@ interface AwsCloudDashboardStateProps {
   widgets: number[];
 }
 
-const mapStateToProps = createMapStateToProps<AwsCloudDashboardOwnProps, AwsCloudDashboardStateProps>(state => {
-  return {
-    DashboardWidget: AwsCloudDashboardWidget,
-    selectWidgets: awsCloudDashboardSelectors.selectWidgets(state),
-    widgets: awsCloudDashboardSelectors.selectCurrentWidgets(state),
-  };
-});
+const mapStateToProps = createMapStateToProps<AwsCloudDashboardOwnProps, AwsCloudDashboardStateProps>(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  (state, props) => {
+    return {
+      DashboardWidget: AwsCloudDashboardWidget,
+      selectWidgets: awsCloudDashboardSelectors.selectWidgets(state),
+      widgets: awsCloudDashboardSelectors.selectCurrentWidgets(state),
+    };
+  }
+);
 
 const AwsCloudDashboard = translate()(connect(mapStateToProps, {})(DashboardBase));
 

--- a/src/pages/dashboard/awsDashboard/awsDashboard.tsx
+++ b/src/pages/dashboard/awsDashboard/awsDashboard.tsx
@@ -13,7 +13,8 @@ interface AwsDashboardStateProps {
   widgets: number[];
 }
 
-const mapStateToProps = createMapStateToProps<AwsDashboardOwnProps, AwsDashboardStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<AwsDashboardOwnProps, AwsDashboardStateProps>((state, props) => {
   return {
     DashboardWidget: AwsDashboardWidget,
     selectWidgets: awsDashboardSelectors.selectWidgets(state),

--- a/src/pages/dashboard/azureCloudDashboard/azureCloudDashboard.tsx
+++ b/src/pages/dashboard/azureCloudDashboard/azureCloudDashboard.tsx
@@ -13,13 +13,16 @@ interface AzureCloudDashboardStateProps {
   widgets: number[];
 }
 
-const mapStateToProps = createMapStateToProps<AzureCloudDashboardOwnProps, AzureCloudDashboardStateProps>(state => {
-  return {
-    DashboardWidget: AzureCloudDashboardWidget,
-    selectWidgets: azureCloudDashboardSelectors.selectWidgets(state),
-    widgets: azureCloudDashboardSelectors.selectCurrentWidgets(state),
-  };
-});
+const mapStateToProps = createMapStateToProps<AzureCloudDashboardOwnProps, AzureCloudDashboardStateProps>(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  (state, props) => {
+    return {
+      DashboardWidget: AzureCloudDashboardWidget,
+      selectWidgets: azureCloudDashboardSelectors.selectWidgets(state),
+      widgets: azureCloudDashboardSelectors.selectCurrentWidgets(state),
+    };
+  }
+);
 
 const AzureCloudDashboard = translate()(connect(mapStateToProps, {})(DashboardBase));
 

--- a/src/pages/dashboard/azureDashboard/azureDashboard.tsx
+++ b/src/pages/dashboard/azureDashboard/azureDashboard.tsx
@@ -13,7 +13,8 @@ interface AzureDashboardStateProps {
   widgets: number[];
 }
 
-const mapStateToProps = createMapStateToProps<AzureDashboardOwnProps, AzureDashboardStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<AzureDashboardOwnProps, AzureDashboardStateProps>((state, props) => {
   return {
     DashboardWidget: AzureDashboardWidget,
     selectWidgets: azureDashboardSelectors.selectWidgets(state),

--- a/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboard.tsx
+++ b/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboard.tsx
@@ -13,13 +13,16 @@ interface OcpCloudDashboardStateProps {
   widgets: number[];
 }
 
-const mapStateToProps = createMapStateToProps<OcpCloudDashboardOwnProps, OcpCloudDashboardStateProps>(state => {
-  return {
-    DashboardWidget: OcpCloudDashboardWidget,
-    selectWidgets: ocpCloudDashboardSelectors.selectWidgets(state),
-    widgets: ocpCloudDashboardSelectors.selectCurrentWidgets(state),
-  };
-});
+const mapStateToProps = createMapStateToProps<OcpCloudDashboardOwnProps, OcpCloudDashboardStateProps>(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  (state, props) => {
+    return {
+      DashboardWidget: OcpCloudDashboardWidget,
+      selectWidgets: ocpCloudDashboardSelectors.selectWidgets(state),
+      widgets: ocpCloudDashboardSelectors.selectCurrentWidgets(state),
+    };
+  }
+);
 
 const OcpCloudDashboard = translate()(connect(mapStateToProps, {})(DashboardBase));
 

--- a/src/pages/dashboard/ocpDashboard/ocpDashboard.tsx
+++ b/src/pages/dashboard/ocpDashboard/ocpDashboard.tsx
@@ -13,7 +13,8 @@ interface OcpDashboardStateProps {
   widgets: number[];
 }
 
-const mapStateToProps = createMapStateToProps<OcpDashboardOwnProps, OcpDashboardStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<OcpDashboardOwnProps, OcpDashboardStateProps>((state, props) => {
   return {
     DashboardWidget: OcpDashboardWidget,
     selectWidgets: ocpDashboardSelectors.selectWidgets(state),

--- a/src/pages/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboard.tsx
+++ b/src/pages/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboard.tsx
@@ -11,8 +11,10 @@ type OcpSupplementaryDashboardOwnProps = InjectedTranslateProps;
 interface OcpSupplementaryDashboardStateProps {
   widgets: number[];
 }
+
 const mapStateToProps = createMapStateToProps<OcpSupplementaryDashboardOwnProps, OcpSupplementaryDashboardStateProps>(
-  state => {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  (state, props) => {
     return {
       DashboardWidget: OcpSupplementaryDashboardWidget,
       selectWidgets: ocpSupplementaryDashboardSelectors.selectWidgets(state),

--- a/src/pages/dashboard/ocpUsageDashboard/ocpUsageDashboard.tsx
+++ b/src/pages/dashboard/ocpUsageDashboard/ocpUsageDashboard.tsx
@@ -13,13 +13,16 @@ interface OcpUsageDashboardStateProps {
   widgets: number[];
 }
 
-const mapStateToProps = createMapStateToProps<OcpUsageDashboardOwnProps, OcpUsageDashboardStateProps>(state => {
-  return {
-    DashboardWidget: OcpUsageDashboardWidget,
-    selectWidgets: ocpUsageDashboardSelectors.selectWidgets(state),
-    widgets: ocpUsageDashboardSelectors.selectCurrentWidgets(state),
-  };
-});
+const mapStateToProps = createMapStateToProps<OcpUsageDashboardOwnProps, OcpUsageDashboardStateProps>(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  (state, props) => {
+    return {
+      DashboardWidget: OcpUsageDashboardWidget,
+      selectWidgets: ocpUsageDashboardSelectors.selectWidgets(state),
+      widgets: ocpUsageDashboardSelectors.selectCurrentWidgets(state),
+    };
+  }
+);
 
 const OcpUsageDashboard = translate()(connect(mapStateToProps, {})(DashboardBase));
 

--- a/src/pages/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/pages/details/awsBreakdown/awsBreakdown.tsx
@@ -36,7 +36,8 @@ const detailsURL = '/details/aws';
 const reportType = ReportType.cost;
 const reportPathsType = ReportPathsType.aws;
 
-const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdownStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdownStateProps>((state, props) => {
   const queryFromRoute = parseQuery<AwsQuery>(location.search);
   const query = queryFromRoute;
   const filterBy = getGroupByValue(query);

--- a/src/pages/details/awsBreakdown/costOverview.tsx
+++ b/src/pages/details/awsBreakdown/costOverview.tsx
@@ -10,7 +10,8 @@ interface CostOverviewStateProps {
 
 type CostOverviewOwnProps = InjectedTranslateProps;
 
-const mapStateToProps = createMapStateToProps<CostOverviewOwnProps, CostOverviewStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<CostOverviewOwnProps, CostOverviewStateProps>((state, props) => {
   return {
     selectWidgets: awsCostOverviewSelectors.selectWidgets(state),
     widgets: awsCostOverviewSelectors.selectCurrentWidgets(state),

--- a/src/pages/details/awsBreakdown/historicalData.tsx
+++ b/src/pages/details/awsBreakdown/historicalData.tsx
@@ -10,7 +10,8 @@ interface HistoricalDataStateProps {
 
 type HistoricalDataOwnProps = InjectedTranslateProps;
 
-const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, HistoricalDataStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, HistoricalDataStateProps>((state, props) => {
   return {
     selectWidgets: awsHistoricalDataSelectors.selectWidgets(state),
     widgets: awsHistoricalDataSelectors.selectCurrentWidgets(state),

--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -464,7 +464,8 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
   }
 }
 
-const mapStateToProps = createMapStateToProps<AwsDetailsOwnProps, AwsDetailsStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<AwsDetailsOwnProps, AwsDetailsStateProps>((state, props) => {
   const queryFromRoute = parseQuery<AwsQuery>(location.search);
   const query = {
     delta: 'cost',

--- a/src/pages/details/awsDetails/detailsHeader.tsx
+++ b/src/pages/details/awsDetails/detailsHeader.tsx
@@ -97,7 +97,8 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
   }
 }
 
-const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHeaderStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHeaderStateProps>((state, props) => {
   const queryString = getQuery(baseQuery);
   const providersQueryString = getProvidersQuery(awsProvidersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.aws, providersQueryString);

--- a/src/pages/details/awsDetails/detailsTable.tsx
+++ b/src/pages/details/awsDetails/detailsTable.tsx
@@ -167,7 +167,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const rows = [];
     const computedItems = getUnsortedComputedReportItems({
       report,
-      idKey: groupByTagKey ? groupByTagKey : groupByOrg ? orgUnitIdKey : groupById,
+      idKey: groupByTagKey ? groupByTagKey : groupByOrg ? 'org_entities' : groupById,
     });
 
     computedItems.map((item, index) => {

--- a/src/pages/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/details/awsDetails/detailsToolbar.tsx
@@ -143,7 +143,8 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 }
 
-const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
   // Omitting key_only to share a single request -- the toolbar needs key values
   const queryString = getQuery({
     // key_only: true

--- a/src/pages/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/pages/details/azureBreakdown/azureBreakdown.tsx
@@ -36,7 +36,8 @@ const detailsURL = '/details/azure';
 const reportType = ReportType.cost;
 const reportPathsType = ReportPathsType.azure;
 
-const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateProps>((state, props) => {
   const queryFromRoute = parseQuery<OcpQuery>(location.search);
   const query = queryFromRoute;
   const queryString = getQuery(query);

--- a/src/pages/details/azureBreakdown/costOverview.tsx
+++ b/src/pages/details/azureBreakdown/costOverview.tsx
@@ -10,7 +10,8 @@ interface CostOverviewStateProps {
 
 type CostOverviewOwnProps = InjectedTranslateProps;
 
-const mapStateToProps = createMapStateToProps<CostOverviewOwnProps, CostOverviewStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<CostOverviewOwnProps, CostOverviewStateProps>((state, props) => {
   return {
     selectWidgets: azureCostOverviewSelectors.selectWidgets(state),
     widgets: azureCostOverviewSelectors.selectCurrentWidgets(state),

--- a/src/pages/details/azureBreakdown/historicalData.tsx
+++ b/src/pages/details/azureBreakdown/historicalData.tsx
@@ -10,7 +10,8 @@ interface HistoricalDataStateProps {
 
 type HistoricalDataOwnProps = InjectedTranslateProps;
 
-const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, HistoricalDataStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, HistoricalDataStateProps>((state, props) => {
   return {
     selectWidgets: azureHistoricalDataSelectors.selectWidgets(state),
     widgets: azureHistoricalDataSelectors.selectCurrentWidgets(state),

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -457,7 +457,8 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
   }
 }
 
-const mapStateToProps = createMapStateToProps<AzureDetailsOwnProps, AzureDetailsStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<AzureDetailsOwnProps, AzureDetailsStateProps>((state, props) => {
   const queryFromRoute = parseQuery<AzureQuery>(location.search);
   const query = {
     delta: 'cost',

--- a/src/pages/details/azureDetails/detailsHeader.tsx
+++ b/src/pages/details/azureDetails/detailsHeader.tsx
@@ -96,7 +96,8 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
   }
 }
 
-const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHeaderStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHeaderStateProps>((state, props) => {
   const queryString = getQuery(baseQuery);
   const providersQueryString = getProvidersQuery(azureProvidersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.azure, providersQueryString);

--- a/src/pages/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/details/azureDetails/detailsToolbar.tsx
@@ -135,7 +135,8 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 }
 
-const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
   // Omitting key_only to share a single request -- the toolbar needs key values
   const queryString = getQuery({
     filter: {

--- a/src/pages/details/components/export/exportModal.tsx
+++ b/src/pages/details/components/export/exportModal.tsx
@@ -156,7 +156,7 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
   }
 }
 
-const mapStateToProps = createMapStateToProps<ExportModalOwnProps, void>(() => {
+const mapStateToProps = createMapStateToProps<ExportModalOwnProps, unknown>(() => {
   return {};
 });
 

--- a/src/pages/details/ocpBreakdown/costOverview.tsx
+++ b/src/pages/details/ocpBreakdown/costOverview.tsx
@@ -10,7 +10,8 @@ interface CostOverviewStateProps {
 
 type CostOverviewOwnProps = InjectedTranslateProps;
 
-const mapStateToProps = createMapStateToProps<CostOverviewOwnProps, CostOverviewStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<CostOverviewOwnProps, CostOverviewStateProps>((state, props) => {
   return {
     selectWidgets: ocpCostOverviewSelectors.selectWidgets(state),
     widgets: ocpCostOverviewSelectors.selectCurrentWidgets(state),

--- a/src/pages/details/ocpBreakdown/historicalData.tsx
+++ b/src/pages/details/ocpBreakdown/historicalData.tsx
@@ -10,7 +10,8 @@ interface HistoricalDataStateProps {
 
 type HistoricalDataOwnProps = InjectedTranslateProps;
 
-const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, HistoricalDataStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, HistoricalDataStateProps>((state, props) => {
   return {
     selectWidgets: ocpHistoricalDataSelectors.selectWidgets(state),
     widgets: ocpHistoricalDataSelectors.selectCurrentWidgets(state),

--- a/src/pages/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/pages/details/ocpBreakdown/ocpBreakdown.tsx
@@ -36,7 +36,8 @@ const detailsURL = '/details/ocp';
 const reportType = ReportType.cost;
 const reportPathsType = ReportPathsType.ocp;
 
-const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdownStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdownStateProps>((state, props) => {
   const queryFromRoute = parseQuery<OcpQuery>(location.search);
   const query = queryFromRoute;
   const queryString = getQuery(query);

--- a/src/pages/details/ocpDetails/detailsHeader.tsx
+++ b/src/pages/details/ocpDetails/detailsHeader.tsx
@@ -155,7 +155,8 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
   }
 }
 
-const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHeaderStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHeaderStateProps>((state, props) => {
   const queryString = getQuery(baseQuery);
   const providersQueryString = getProvidersQuery(ocpProvidersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.ocp, providersQueryString);

--- a/src/pages/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpDetails/detailsToolbar.tsx
@@ -125,7 +125,8 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 }
 
-const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
   // Omitting key_only to share a single request -- the toolbar needs key values
   const queryString = getQuery({
     filter: {

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -454,7 +454,8 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
   }
 }
 
-const mapStateToProps = createMapStateToProps<OcpDetailsOwnProps, OcpDetailsStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<OcpDetailsOwnProps, OcpDetailsStateProps>((state, props) => {
   const queryFromRoute = parseQuery<OcpQuery>(location.search);
   const query = {
     delta: 'cost',

--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -442,7 +442,8 @@ class OverviewBase extends React.Component<OverviewProps> {
   }
 }
 
-const mapStateToProps = createMapStateToProps<OverviewOwnProps, OverviewStateProps>(state => {
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<OverviewOwnProps, OverviewStateProps>((state, props) => {
   const awsProvidersQueryString = getProvidersQuery(awsProvidersQuery);
   const awsProviders = providersSelectors.selectProviders(state, ProviderType.aws, awsProvidersQueryString);
   const awsProvidersFetchStatus = providersSelectors.selectProvidersFetchStatus(

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -1,4 +1,3 @@
-import { orgUnitIdKey } from 'api/queries/query';
 import { Report, ReportData, ReportValue } from 'api/reports/report';
 import { ReportDatum } from 'api/reports/report';
 import { sort, SortDirection } from 'utils/sort';
@@ -86,7 +85,7 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
         const idSuffix = idKey !== 'date' && idKey !== 'cluster' && value.cluster ? `-${value.cluster}` : '';
 
         // org_unit_id workaround for storage and instance-type APIs
-        const id = idKey === orgUnitIdKey ? value.id || value.org_unit_id : value[idKey];
+        const id = idKey === 'org_entities' ? value.id || value.org_unit_id : value[idKey];
         const mapId = `${id}${idSuffix}`;
 
         // clusters will either contain the cluster alias or default to cluster ID
@@ -106,7 +105,7 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
 
         let label;
         const itemLabelKey = getItemLabel({ report, labelKey, value });
-        if (itemLabelKey === orgUnitIdKey && value.alias) {
+        if (itemLabelKey === 'org_entities' && value.alias) {
           label = value.alias;
         } else if (itemLabelKey === 'account' && value.account_alias) {
           label = value.account_alias;


### PR DESCRIPTION
It appears that `createMapStateToProps` requires `props` in order to update the page properly. Without, users cannot update the details table with a new group by selection.