### PR TITLE
AWS details not displaying OU names on filtered data

### DIFF
--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -85,7 +85,10 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
         const idSuffix = idKey !== 'date' && idKey !== 'cluster' && value.cluster ? `-${value.cluster}` : '';
 
         // org_unit_id workaround for storage and instance-type APIs
-        const id = idKey === 'org_entities' ? value.id || value.org_unit_id : value[idKey];
+        let id = idKey === 'org_entities' ? value.org_unit_id : value[idKey];
+        if (id === undefined) {
+          id = value.id;
+        }
         const mapId = `${id}${idSuffix}`;
 
         // clusters will either contain the cluster alias or default to cluster ID
@@ -116,7 +119,9 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
         } else {
           label = value[itemLabelKey];
         }
-
+        if (label === undefined) {
+          label = value.alias ? value.alias : value.id;
+        }
         const limit = value.limit ? value.limit.value : 0;
         const request = value.request ? value.request.value : 0;
         const usage = value.usage ? value.usage.value : 0;


### PR DESCRIPTION
The API returns different property names if we're filtering AWS org units. This ensures the ID is always used as a fallback.

https://issues.redhat.com/browse/COST-524

<img width="1524" alt="Screen Shot 2020-09-15 at 2 39 06 PM" src="https://user-images.githubusercontent.com/17481322/93250816-59e09400-f761-11ea-9b14-949ae89bb0ce.png">
