### PR TITLE
Bullet chart tooltips are cut off

### DIFF
--- a/src/components/charts/common/charts-common.scss
+++ b/src/components/charts/common/charts-common.scss
@@ -1,7 +1,7 @@
 @import url("~@patternfly/patternfly/base/patternfly-variables.css");
 
-.chartOverride:not(foo) {
-  svg {
+.chartOverride {
+  :not(foo) svg {
     overflow: visible;
   }
 }

--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -1,4 +1,4 @@
-import '../common/charts-common.scss';
+import 'components/charts/common/charts-common.scss';
 
 import {
   Chart,

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -1,4 +1,4 @@
-import '../common/charts-common.scss';
+import 'components/charts/common/charts-common.scss';
 
 import {
   Chart,

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -1,4 +1,4 @@
-import '../common/charts-common.scss';
+import 'components/charts/common/charts-common.scss';
 
 import {
   Chart,

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -1,4 +1,4 @@
-import '../common/charts-common.scss';
+import 'components/charts/common/charts-common.scss';
 
 import {
   Chart,

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -1,4 +1,4 @@
-import '../common/charts-common.scss';
+import 'components/charts/common/charts-common.scss';
 
 import {
   Chart,

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -1,4 +1,4 @@
-import '../common/charts-common.scss';
+import 'components/charts/common/charts-common.scss';
 
 import {
   Chart,

--- a/src/pages/costModels/costModelsDetails/components/table.tsx
+++ b/src/pages/costModels/costModelsDetails/components/table.tsx
@@ -3,13 +3,13 @@ import { DollarSignIcon } from '@patternfly/react-icons/dist/js/icons/dollar-sig
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import { addMultiValueQuery, removeMultiValueQuery } from 'pages/costModels/components/filterLogic';
 import { PaginationToolbarTemplate } from 'pages/costModels/components/paginationToolbarTemplate';
+import SourcesTable from 'pages/costModels/costModelsDetails/components/sourcesTable';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { rbacSelectors } from 'store/rbac';
 
-import SourcesTable from '../components/sourcesTable';
 import { SourcesToolbar } from './sourcesToolbar';
 import { styles } from './table.styles';
 

--- a/src/pages/costModels/costModelsDetails/costModelsPagination.tsx
+++ b/src/pages/costModels/costModelsDetails/costModelsPagination.tsx
@@ -1,10 +1,9 @@
 import { PaginationProps } from '@patternfly/react-core';
+import { PaginationToolbarTemplate } from 'pages/costModels/components/paginationToolbarTemplate';
 import { stringify } from 'qs';
 import { connect, Dispatch } from 'react-redux';
 import { RootState } from 'store';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
-
-import { PaginationToolbarTemplate } from '../components/paginationToolbarTemplate';
 
 type OwnProps = Pick<PaginationProps, 'variant'>;
 

--- a/src/pages/costModels/createCostModelWizard/table.tsx
+++ b/src/pages/costModels/createCostModelWizard/table.tsx
@@ -2,11 +2,11 @@ import { Checkbox, Stack, StackItem, Text, TextContent, TextVariants, Title } fr
 import { Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { LoadingState } from 'components/state/loadingState/loadingState';
 import { addMultiValueQuery, removeMultiValueQuery } from 'pages/costModels/components/filterLogic';
+import { PaginationToolbarTemplate } from 'pages/costModels/components/paginationToolbarTemplate';
 import { WarningIcon } from 'pages/costModels/components/warningIcon';
 import React from 'react';
 import { InjectedTranslateProps, translate } from 'react-i18next';
 
-import { PaginationToolbarTemplate } from '../components/paginationToolbarTemplate';
 import { AssignSourcesToolbar } from './assignSourcesToolbar';
 import { CostModelContext } from './context';
 

--- a/src/pages/details/components/costOverview/costOverviewBase.tsx
+++ b/src/pages/details/components/costOverview/costOverviewBase.tsx
@@ -16,11 +16,10 @@ import { Cluster } from 'pages/details/components/cluster/cluster';
 import { CostChart } from 'pages/details/components/costChart/costChart';
 import { SummaryCard } from 'pages/details/components/summary/summaryCard';
 import { UsageChart } from 'pages/details/components/usageChart/usageChart';
+import { styles } from 'pages/details/ocpDetails/detailsHeader.styles';
 import React from 'react';
 import { InjectedTranslateProps } from 'react-i18next';
 import { CostOverviewWidget, CostOverviewWidgetType } from 'store/costOverview/common/costOverviewCommon';
-
-import { styles } from '../../ocpDetails/detailsHeader.styles';
 
 interface CostOverviewOwnProps {
   filterBy: string | number;

--- a/src/pages/details/components/usageChart/usageChart.tsx
+++ b/src/pages/details/components/usageChart/usageChart.tsx
@@ -1,3 +1,5 @@
+import 'components/charts/common/charts-common.scss';
+
 import { ChartBullet } from '@patternfly/react-charts';
 import { Grid, GridItem } from '@patternfly/react-core';
 import { Skeleton } from '@redhat-cloud-services/frontend-components/components/Skeleton';
@@ -222,7 +224,7 @@ class UsageChartBase extends React.Component<UsageChartProps> {
     }
 
     return (
-      <div>
+      <div className="chartOverride">
         {reportFetchStatus === FetchStatus.inProgress ? (
           this.getSkeleton()
         ) : (
@@ -386,7 +388,11 @@ class UsageChartBase extends React.Component<UsageChartProps> {
   };
 
   public render() {
-    return <div ref={this.containerRef}>{this.getCpuChart()}</div>;
+    return (
+      <div className="chartOverride" ref={this.containerRef}>
+        {this.getCpuChart()}
+      </div>
+    );
   }
 }
 


### PR DESCRIPTION
Fixes the overflow so bullet chart (`usageChart.tsx`) tooltips are not cut off. Also cleaned up some relative paths.

Before
<img width="772" alt="Screen Shot 2020-09-25 at 10 40 33 AM" src="https://user-images.githubusercontent.com/17481322/94280681-aecb9980-ff1b-11ea-8057-b33038a5b4a2.png">

After
<img width="769" alt="Screen Shot 2020-09-25 at 10 41 48 AM" src="https://user-images.githubusercontent.com/17481322/94280722-bb4ff200-ff1b-11ea-87d4-d20444bddd98.png">
