### PR TITLE
Historical legend item spacing

### DIFF
--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -267,7 +267,7 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
 
     const itemsPerRow = legendItemsPerRow ? legendItemsPerRow : width > 700 ? chartStyles.itemsPerRow : 2;
 
-    return <ChartLegend data={this.getLegendData()} gutter={0} height={25} itemsPerRow={itemsPerRow} name="legend" />;
+    return <ChartLegend data={this.getLegendData()} height={25} itemsPerRow={itemsPerRow} name="legend" />;
   };
 
   private getTooltipLabel = ({ datum }) => {

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -206,9 +206,7 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
   private getLegend = () => {
     const { legendItemsPerRow } = this.props;
 
-    return (
-      <ChartLegend data={this.getLegendData()} gutter={10} height={25} itemsPerRow={legendItemsPerRow} name="legend" />
-    );
+    return <ChartLegend data={this.getLegendData()} height={25} itemsPerRow={legendItemsPerRow} name="legend" />;
   };
 
   private getTooltipLabel = ({ datum }) => {

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -318,7 +318,7 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
     const { width } = this.state;
     const itemsPerRow = legendItemsPerRow ? legendItemsPerRow : width > 800 ? chartStyles.itemsPerRow : 2;
 
-    return <ChartLegend data={this.getLegendData()} gutter={0} height={25} itemsPerRow={itemsPerRow} name="legend" />;
+    return <ChartLegend data={this.getLegendData()} height={25} itemsPerRow={itemsPerRow} name="legend" />;
   };
 
   private getTooltipLabel = ({ datum }) => {


### PR DESCRIPTION
Historical legend items are touching, overlapping labels in some cases.

https://issues.redhat.com/browse/COST-569

Before
<img width="1521" alt="Screen Shot 2020-09-25 at 10 55 39 AM" src="https://user-images.githubusercontent.com/17481322/94284183-05d36d80-ff20-11ea-9b51-4cbc75d19302.png">

After
<img width="1530" alt="Screen Shot 2020-09-25 at 11 09 37 AM" src="https://user-images.githubusercontent.com/17481322/94284204-09ff8b00-ff20-11ea-8185-f58266cfab7a.png">
