### PR TITLE
Export dialog description is too large

### DIFF
--- a/src/pages/details/components/export/exportModal.styles.ts
+++ b/src/pages/details/components/export/exportModal.styles.ts
@@ -1,5 +1,5 @@
+import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
 import global_spacer_sm from '@patternfly/react-tokens/dist/js/global_spacer_sm';
-import global_spacer_xl from '@patternfly/react-tokens/dist/js/global_spacer_xl';
 import global_spacer_xs from '@patternfly/react-tokens/dist/js/global_spacer_xs';
 import React from 'react';
 
@@ -8,9 +8,6 @@ export const styles = {
     marginLeft: global_spacer_sm.var,
   },
   modal: {
-    h2: {
-      marginBottom: global_spacer_xl.value,
-    },
     input: {
       marginRight: global_spacer_xs.var,
     },
@@ -19,6 +16,6 @@ export const styles = {
     },
   },
   title: {
-    paddingBottom: global_spacer_xl.var,
+    marginBottom: global_spacer_md.var,
   },
 } as { [className: string]: React.CSSProperties };

--- a/src/pages/details/components/export/exportModal.tsx
+++ b/src/pages/details/components/export/exportModal.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonVariant, Form, FormGroup, Modal, Radio, Title } from '@patternfly/react-core';
+import { Button, ButtonVariant, Form, FormGroup, Modal, Radio } from '@patternfly/react-core';
 import { Query, tagPrefix } from 'api/queries/query';
 import { ReportPathsType } from 'api/reports/report';
 import { AxiosError } from 'axios';
@@ -143,9 +143,9 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
           </Button>,
         ]}
       >
-        <Title headingLevel="h2" style={styles.title} size="xl">
-          {t('export.heading', { groupBy })}
-        </Title>
+        <div style={styles.title}>
+          <span>{t('export.heading', { groupBy })}</span>
+        </div>
         <Form style={styles.form}>
           <FormGroup label={t('export.aggregate_type')} fieldId="aggregate-type">
             <React.Fragment>


### PR DESCRIPTION
The export dialog description should not use PatternFly's title component.

https://issues.redhat.com/browse/COST-583

<img width="582" alt="Screen Shot 2020-09-30 at 1 47 45 PM" src="https://user-images.githubusercontent.com/17481322/94721426-db205500-0323-11eb-8e1c-afdb0f5cd414.png">
