### PR TITLE
Specifying directories for codeQL to scan

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -5,6 +5,12 @@
 # or to provide custom queries or build logic.
 name: "CodeQL"
 
+paths:
+  - src
+paths-ignore:
+  - node_modules
+  - '**/*.test.ts'
+
 on:
   push:
     branches: [master, ci-stable, prod-beta, prod-stable, qa-beta, qa-stable]
@@ -47,7 +53,7 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
+        # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
         # queries: ./path/to/local/query, your-org/your-repo/queries@main
 


### PR DESCRIPTION
>For the interpreted languages that CodeQL supports (Python and JavaScript/TypeScript), you can restrict code scanning to files in specific directories by adding a paths array to the configuration file. You can exclude the files in specific directories from scans by adding a paths-ignore array.

https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning