### PR TITLE
Allow rate or cost_model resource

### DIFF
--- a/src/store/rbac/selectors.ts
+++ b/src/store/rbac/selectors.ts
@@ -20,7 +20,7 @@ export const isCostModelWritePermission = (state: RootState) => {
   if (app === 'cost-management' && resource === '*' && operation === '*') {
     return true;
   }
-  if (resource === 'rate' && operation === 'write') {
+  if ((resource === 'rate' || resource === 'cost_model') && operation === 'write') {
     return true;
   }
   return false;


### PR DESCRIPTION
## Summary
We have renamed the rbac resource from rate to cost_mode. This will allow us to respect the new value and catch any existing rbac roles with rate in use instead. 