### PR TITLE
Font styles on the Cost Management pages are not consistent

### DIFF
--- a/src/components/reports/reportSummary/reportSummaryDetails.scss
+++ b/src/components/reports/reportSummary/reportSummaryDetails.scss
@@ -9,21 +9,21 @@
 .text {
   padding-bottom: var(--pf-global--spacer--sm);
   line-height: var(--pf-global--LineHeight--sm);
-  font-size: var(--pf-global--icon--FontSize--xs);
+  font-size: var(--pf-global--FontSize--xs);
 }
 
 .units {
   padding-left: var(--pf-global--spacer--xs);
   padding-bottom: var(--pf-global--spacer--sm);
   line-height: var(--pf-global--LineHeight--sm);
-  font-size: var(--pf-global--icon--FontSize--xs);
-  white-space: nowrap,
+  font-size: var(--pf-global--FontSize--xs);
+  white-space: nowrap;
 }
 
 .value {
   color: var(--pf-global--Color--100);
   margin-right: var(--pf-global--spacer--sm);
-  font-size: var(--pf-global--icon--FontSize--4xl);
+  font-size: var(--pf-global--FontSize--4xl);
 }
 
 .valueContainer {

--- a/src/components/reports/reportSummary/reportSummaryDetails.tsx
+++ b/src/components/reports/reportSummary/reportSummaryDetails.tsx
@@ -145,12 +145,10 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
 
     return (
       <div className="valueContainer">
-        <div className="value">
-          {request}
-          {Boolean(showUnits && (units || (hasRequest && report.meta.total.request.value >= 0))) && (
-            <span className="units">{unitsLabel}</span>
-          )}
-        </div>
+        <span className="value">{request}</span>
+        {Boolean(showUnits && (units || (hasRequest && report.meta.total.request.value >= 0))) && (
+          <span className="units">{unitsLabel}</span>
+        )}
         <div className="text">
           <div>{requestLabel}</div>
         </div>
@@ -169,12 +167,10 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
 
     return (
       <div className="valueContainer">
-        <div className="value">
-          {usage}
-          {Boolean(showUnits && (units || (hasUsage && report.meta.total.usage.value >= 0))) && (
-            <span className="units">{unitsLabel}</span>
-          )}
-        </div>
+        <span className="value">{usage}</span>
+        {Boolean(showUnits && (units || (hasUsage && report.meta.total.usage.value >= 0))) && (
+          <span className="units">{unitsLabel}</span>
+        )}
         <div className="text">
           <div>{usageLabel}</div>
         </div>

--- a/src/pages/details/awsDetails/detailsHeader.tsx
+++ b/src/pages/details/awsDetails/detailsHeader.tsx
@@ -64,7 +64,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     return (
       <header style={styles.header}>
         <div>
-          <Title headingLevel="h2" style={styles.title} size="xl">
+          <Title headingLevel="h2" style={styles.title} size="2xl">
             {t('navigation.infrastructure_details')}
           </Title>
           <div style={styles.nav}>

--- a/src/pages/details/azureDetails/detailsHeader.tsx
+++ b/src/pages/details/azureDetails/detailsHeader.tsx
@@ -64,7 +64,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     return (
       <header style={styles.header}>
         <div>
-          <Title headingLevel="h2" style={styles.title} size="xl">
+          <Title headingLevel="h2" style={styles.title} size="2xl">
             {t('navigation.infrastructure_details')}
           </Title>
           <div style={styles.nav}>

--- a/src/pages/details/components/breakdown/breakdownHeader.tsx
+++ b/src/pages/details/components/breakdown/breakdownHeader.tsx
@@ -111,7 +111,7 @@ class BreakdownHeaderBase extends React.Component<BreakdownHeaderProps> {
               </li>
             </ol>
           </nav>
-          <Title headingLevel="h2" style={styles.title} size="xl">
+          <Title headingLevel="h2" style={styles.title} size="2xl">
             {t('breakdown.title', { value: title })}
             {description && <div style={styles.infoDescription}>{description}</div>}
           </Title>

--- a/src/pages/details/components/costOverview/costOverviewBase.tsx
+++ b/src/pages/details/components/costOverview/costOverviewBase.tsx
@@ -55,7 +55,7 @@ class CostOverviewBase extends React.Component<CostOverviewProps> {
       return (
         <Card>
           <CardTitle>
-            <Title headingLevel="h2" size="md">
+            <Title headingLevel="h2" size="lg">
               {t('breakdown.cluster_title')}
             </Title>
           </CardTitle>
@@ -75,7 +75,7 @@ class CostOverviewBase extends React.Component<CostOverviewProps> {
     return (
       <Card>
         <CardTitle>
-          <Title headingLevel="h2" size="md">
+          <Title headingLevel="h2" size="lg">
             {t('breakdown.cost_breakdown_title')}
             <Popover
               aria-label={t('breakdown.cost_breakdown_aria_label')}
@@ -117,7 +117,7 @@ class CostOverviewBase extends React.Component<CostOverviewProps> {
     return (
       <Card>
         <CardTitle>
-          <Title headingLevel="h2" size="md">
+          <Title headingLevel="h2" size="lg">
             {t(`breakdown.cpu_title`)}
           </Title>
         </CardTitle>
@@ -140,7 +140,7 @@ class CostOverviewBase extends React.Component<CostOverviewProps> {
     return (
       <Card>
         <CardTitle>
-          <Title headingLevel="h2" size="md">
+          <Title headingLevel="h2" size="lg">
             {t(`breakdown.memory_title`)}
           </Title>
         </CardTitle>

--- a/src/pages/details/components/historicalData/historicalDataBase.tsx
+++ b/src/pages/details/components/historicalData/historicalDataBase.tsx
@@ -29,7 +29,7 @@ class HistoricalDataBase extends React.Component<HistoricalDataProps> {
     return (
       <Card>
         <CardTitle>
-          <Title headingLevel="h2" size="md">
+          <Title headingLevel="h2" size="lg">
             {t(`breakdown.historical_chart.${widget.reportType}_title`)}
           </Title>
         </CardTitle>
@@ -52,7 +52,7 @@ class HistoricalDataBase extends React.Component<HistoricalDataProps> {
     return (
       <Card>
         <CardTitle>
-          <Title headingLevel="h2" size="md">
+          <Title headingLevel="h2" size="lg">
             {t(`breakdown.historical_chart.${widget.reportType}_title`)}
           </Title>
         </CardTitle>
@@ -76,7 +76,7 @@ class HistoricalDataBase extends React.Component<HistoricalDataProps> {
     return (
       <Card>
         <CardTitle>
-          <Title headingLevel="h2" size="md">
+          <Title headingLevel="h2" size="lg">
             {t(`breakdown.historical_chart.${widget.reportType}_title`)}
           </Title>
         </CardTitle>

--- a/src/pages/details/components/summary/summaryCard.tsx
+++ b/src/pages/details/components/summary/summaryCard.tsx
@@ -152,7 +152,7 @@ class SummaryBase extends React.Component<SummaryProps> {
     return (
       <Card style={styles.card}>
         <CardTitle>
-          <Title headingLevel="h2" size="md">
+          <Title headingLevel="h2" size="lg">
             {t('breakdown.summary_title', { groupBy })}
           </Title>
         </CardTitle>

--- a/src/pages/details/ocpDetails/detailsHeader.tsx
+++ b/src/pages/details/ocpDetails/detailsHeader.tsx
@@ -89,7 +89,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     return (
       <header style={styles.header}>
         <div>
-          <Title headingLevel="h2" style={styles.title} size="xl">
+          <Title headingLevel="h2" style={styles.title} size="2xl">
             {t('ocp_details.title')}
           </Title>
           <GroupBy

--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -390,7 +390,7 @@ class OverviewBase extends React.Component<OverviewProps> {
           }`}
         >
           <header className="pf-u-display-flex pf-u-justify-content-space-between pf-u-align-items-center">
-            <Title headingLevel="h2" size="xl">
+            <Title headingLevel="h2" size="2xl">
               {t('overview.title')}
               {Boolean(showTabs) && (
                 <span style={styles.infoIcon}>


### PR DESCRIPTION
- All page titles should be 24px
- All card titles should be 18px
- All "hero" numbers should be 36px

**Overview**
<img width="1618" alt="Screen Shot 2020-10-06 at 10 11 25 AM" src="https://user-images.githubusercontent.com/17481322/95212999-5074a580-07bc-11eb-94e9-ba700a1d1475.png">

**Cost breakdown**
<img width="1794" alt="Screen Shot 2020-10-06 at 10 08 29 AM" src="https://user-images.githubusercontent.com/17481322/95212808-14d9db80-07bc-11eb-8989-12c8d8bda780.png">

**Historical charts**
<img width="1796" alt="Screen Shot 2020-10-06 at 10 08 39 AM" src="https://user-images.githubusercontent.com/17481322/95212796-12778180-07bc-11eb-90f1-57de8cf4a565.png">


