### PR TITLE
Decreased hero font sizes for overview cards

### DIFF
--- a/src/components/reports/reportSummary/reportSummaryDetails.scss
+++ b/src/components/reports/reportSummary/reportSummaryDetails.scss
@@ -1,5 +1,11 @@
 @import url("~@patternfly/patternfly/base/patternfly-variables.css");
 
+.costValue {
+  color: var(--pf-global--Color--100);
+  margin-right: var(--pf-global--spacer--sm);
+  font-size: var(--pf-global--FontSize--4xl);
+}
+
 .reportSummaryDetails {
     margin-bottom: var(--pf-global--spacer--md);
     display: flex;
@@ -23,7 +29,7 @@
 .value {
   color: var(--pf-global--Color--100);
   margin-right: var(--pf-global--spacer--sm);
-  font-size: var(--pf-global--FontSize--4xl);
+  font-size: var(--pf-global--FontSize--2xl);
 }
 
 .valueContainer {

--- a/src/components/reports/reportSummary/reportSummaryDetails.tsx
+++ b/src/components/reports/reportSummary/reportSummaryDetails.tsx
@@ -123,10 +123,10 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
             })}
             enableFlip
           >
-            <div className="value">{value}</div>
+            <div className="costValue">{value}</div>
           </Tooltip>
         ) : (
-          <div className="value">{value}</div>
+          <div className="costValue">{value}</div>
         )}
         <div className="text">
           <div>{costLabel}</div>


### PR DESCRIPTION
Natalie requested that we reduce the hero font sizes for the overview cards. The cost card will remain at 36px (4xl) while the smaller cards use 24px (2xl). This will give the hero numbers more room to grow.

https://issues.redhat.com/browse/COST-605

<img width="1438" alt="Screen Shot 2020-10-06 at 11 15 27 AM" src="https://user-images.githubusercontent.com/17481322/95221845-df39f000-07c5-11eb-8e55-255094c45c48.png">
