### PR TITLE
Add a title to chart tooltips

### DIFF
--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -44,6 +44,7 @@ interface CostChartLegendItem {
   childName?: string;
   name?: string;
   symbol?: any;
+  tooltip?: string;
 }
 
 interface CostChartSeries {
@@ -107,6 +108,8 @@ class CostChart extends React.Component<CostChartProps, State> {
 
     const costKey = 'chart.cost_legend_label';
     const costInfrastructureKey = 'chart.cost_infrastructure_legend_label';
+    const costInfrastructureTooltipKey = 'chart.cost_infrastructure_legend_tooltip';
+    const costTooltipKey = 'chart.cost_legend_tooltip';
 
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
@@ -123,6 +126,7 @@ class CostChart extends React.Component<CostChartProps, State> {
               fill: chartStyles.previousColorScale[0],
               type: 'minus',
             },
+            tooltip: getCostRangeString(previousCostData, costTooltipKey, false, false, 1),
           },
           style: {
             data: {
@@ -140,6 +144,7 @@ class CostChart extends React.Component<CostChartProps, State> {
               fill: chartStyles.currentColorScale[0],
               type: 'minus',
             },
+            tooltip: getCostRangeString(currentCostData, costTooltipKey, false, false),
           },
           style: {
             data: {
@@ -157,6 +162,7 @@ class CostChart extends React.Component<CostChartProps, State> {
               fill: chartStyles.previousColorScale[1],
               type: 'dash',
             },
+            tooltip: getCostRangeString(previousInfrastructureCostData, costInfrastructureTooltipKey, false, false, 1),
           },
           style: {
             data: {
@@ -174,6 +180,7 @@ class CostChart extends React.Component<CostChartProps, State> {
               fill: chartStyles.currentColorScale[1],
               type: 'dash',
             },
+            tooltip: getCostRangeString(currentInfrastructureCostData, costInfrastructureTooltipKey, false, false),
           },
           style: {
             data: {
@@ -221,7 +228,12 @@ class CostChart extends React.Component<CostChartProps, State> {
       <CursorVoronoiContainer
         cursorDimension="x"
         labels={this.isDataAvailable() ? this.getTooltipLabel : undefined}
-        labelComponent={<ChartLegendTooltip legendData={this.getLegendData()} />}
+        labelComponent={
+          <ChartLegendTooltip
+            legendData={this.getLegendData(true)}
+            title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
+          />
+        }
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{
@@ -354,15 +366,17 @@ class CostChart extends React.Component<CostChartProps, State> {
   };
 
   // Returns legend data styled per hiddenSeries
-  private getLegendData = () => {
+  private getLegendData = (tooltip: boolean = false) => {
     const { hiddenSeries, series } = this.state;
     if (series) {
       const result = series.map((s, index) => {
-        return {
+        const data = {
           childName: s.childName,
           ...s.legendItem, // name property
+          ...(tooltip && { name: s.legendItem.tooltip }), // Override name property for tooltip
           ...getInteractiveLegendItemStyles(hiddenSeries.has(index)), // hidden styles
         };
+        return data;
       });
       return result;
     }

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -46,6 +46,7 @@ interface HistoricalCostChartData {
 interface HistoricalCostChartLegendItem {
   name?: string;
   symbol?: any;
+  tooltip?: string;
 }
 
 interface HistoricalCostChartSeries {
@@ -104,6 +105,8 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
 
     const costKey = 'chart.cost_legend_label';
     const costInfrastructureKey = 'chart.cost_infrastructure_legend_label';
+    const costInfrastructureTooltipKey = 'chart.cost_infrastructure_legend_tooltip';
+    const costTooltipKey = 'chart.cost_legend_tooltip';
 
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
@@ -120,6 +123,7 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
               fill: chartStyles.previousColorScale[0],
               type: 'minus',
             },
+            tooltip: getCostRangeString(previousCostData, costTooltipKey, false, false, 1),
           },
           style: {
             data: {
@@ -137,6 +141,7 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
               fill: chartStyles.currentColorScale[0],
               type: 'minus',
             },
+            tooltip: getCostRangeString(currentCostData, costTooltipKey, false, false),
           },
           style: {
             data: {
@@ -154,6 +159,7 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
               fill: chartStyles.previousColorScale[1],
               type: 'dash',
             },
+            tooltip: getCostRangeString(previousInfrastructureCostData, costInfrastructureTooltipKey, false, false, 1),
           },
           style: {
             data: {
@@ -171,6 +177,7 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
               fill: chartStyles.currentColorScale[1],
               type: 'dash',
             },
+            tooltip: getCostRangeString(currentInfrastructureCostData, costInfrastructureTooltipKey, false, false),
           },
           style: {
             data: {
@@ -214,7 +221,12 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
       <CursorVoronoiContainer
         cursorDimension="x"
         labels={this.isDataAvailable() ? this.getTooltipLabel : undefined}
-        labelComponent={<ChartLegendTooltip legendData={this.getLegendData()} />}
+        labelComponent={
+          <ChartLegendTooltip
+            legendData={this.getLegendData(true)}
+            title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
+          />
+        }
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{
@@ -333,13 +345,14 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
   };
 
   // Returns legend data styled per hiddenSeries
-  private getLegendData = () => {
+  private getLegendData = (tooltip: boolean = false) => {
     const { hiddenSeries, series } = this.state;
     if (series) {
       const result = series.map((s, index) => {
         return {
           childName: s.childName,
           ...s.legendItem, // name property
+          ...(tooltip && { name: s.legendItem.tooltip }), // Override name property for tooltip
           ...getInteractiveLegendItemStyles(hiddenSeries.has(index)), // hidden styles
         };
       });

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -48,6 +48,7 @@ interface HistoricalUsageChartData {
 interface HistoricalUsageChartLegendItem {
   name?: string;
   symbol?: any;
+  tooltip?: string;
 }
 
 interface HistoricalUsageChartSeries {
@@ -109,8 +110,11 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
     } = this.props;
 
     const limitKey = 'chart.limit_legend_label';
-    const usageKey = 'chart.usage_legend_label';
+    const limitTooltipKey = 'chart.limit_legend_tooltip';
     const requestKey = 'chart.requests_legend_label';
+    const requestTooltipKey = 'chart.requests_legend_tooltip';
+    const usageKey = 'chart.usage_legend_label';
+    const usageTooltipKey = 'chart.usage_legend_tooltip';
 
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
@@ -127,6 +131,7 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
               fill: chartStyles.previousColorScale[0],
               type: 'minus',
             },
+            tooltip: getUsageRangeString(previousUsageData, usageTooltipKey, false, false, 1),
           },
           style: {
             data: {
@@ -144,6 +149,7 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
               fill: chartStyles.currentColorScale[0],
               type: 'minus',
             },
+            tooltip: getUsageRangeString(currentUsageData, usageTooltipKey, false, false),
           },
           style: {
             data: {
@@ -161,6 +167,7 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
               fill: chartStyles.previousColorScale[1],
               type: 'dash',
             },
+            tooltip: getUsageRangeString(previousRequestData, requestTooltipKey, false, false, 1),
           },
           style: {
             data: {
@@ -178,6 +185,7 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
               fill: chartStyles.currentColorScale[1],
               type: 'dash',
             },
+            tooltip: getUsageRangeString(currentRequestData, requestTooltipKey, false, false),
           },
           style: {
             data: {
@@ -195,6 +203,7 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
               fill: chartStyles.previousColorScale[2],
               type: 'minus',
             },
+            tooltip: getUsageRangeString(previousLimitData, limitTooltipKey, false, false, 1),
           },
           style: {
             data: {
@@ -212,6 +221,7 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
               fill: chartStyles.currentColorScale[2],
               type: 'minus',
             },
+            tooltip: getUsageRangeString(currentLimitData, limitTooltipKey, false, false),
           },
           style: {
             data: {
@@ -255,7 +265,12 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
       <CursorVoronoiContainer
         cursorDimension="x"
         labels={this.isDataAvailable() ? this.getTooltipLabel : undefined}
-        labelComponent={<ChartLegendTooltip legendData={this.getLegendData()} />}
+        labelComponent={
+          <ChartLegendTooltip
+            legendData={this.getLegendData(true)}
+            title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
+          />
+        }
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{
@@ -384,13 +399,14 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
   };
 
   // Returns legend data styled per hiddenSeries
-  private getLegendData = () => {
+  private getLegendData = (tooltip: boolean = false) => {
     const { hiddenSeries, series } = this.state;
     if (series) {
       const result = series.map((s, index) => {
         return {
           childName: s.childName,
           ...s.legendItem, // name property
+          ...(tooltip && { name: s.legendItem.tooltip }), // Override name property for tooltip
           ...getInteractiveLegendItemStyles(hiddenSeries.has(index)), // hidden styles
         };
       });

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -43,6 +43,7 @@ interface UsageChartData {
 interface UsageChartLegendItem {
   name?: string;
   symbol?: any;
+  tooltip?: string;
 }
 
 interface UsageChartSeries {
@@ -100,7 +101,9 @@ class UsageChart extends React.Component<UsageChartProps, State> {
     const { currentRequestData, currentUsageData, previousRequestData, previousUsageData } = this.props;
 
     const usageKey = 'chart.usage_legend_label';
+    const usageTooltipKey = 'chart.usage_legend_tooltip';
     const requestKey = 'chart.requests_legend_label';
+    const requestTooltipKey = 'chart.requests_legend_tooltip';
 
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
@@ -117,6 +120,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
               fill: chartStyles.legendColorScale[0],
               type: 'minus',
             },
+            tooltip: getUsageRangeString(previousUsageData, usageTooltipKey, false, false, 1),
           },
           style: chartStyles.previousUsageData,
         },
@@ -129,6 +133,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
               fill: chartStyles.legendColorScale[1],
               type: 'minus',
             },
+            tooltip: getUsageRangeString(currentUsageData, usageTooltipKey, false, false),
           },
           style: chartStyles.currentUsageData,
         },
@@ -141,6 +146,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
               fill: chartStyles.legendColorScale[2],
               type: 'dash',
             },
+            tooltip: getUsageRangeString(previousRequestData, requestTooltipKey, false, false, 1),
           },
           style: chartStyles.previousRequestData,
         },
@@ -153,6 +159,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
               fill: chartStyles.legendColorScale[3],
               type: 'dash',
             },
+            tooltip: getUsageRangeString(currentRequestData, requestTooltipKey, false, false),
           },
           style: chartStyles.currentRequestData,
         },
@@ -195,7 +202,12 @@ class UsageChart extends React.Component<UsageChartProps, State> {
       <CursorVoronoiContainer
         cursorDimension="x"
         labels={this.isDataAvailable() ? this.getTooltipLabel : undefined}
-        labelComponent={<ChartLegendTooltip legendData={this.getLegendData()} />}
+        labelComponent={
+          <ChartLegendTooltip
+            legendData={this.getLegendData(true)}
+            title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
+          />
+        }
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{
@@ -310,13 +322,14 @@ class UsageChart extends React.Component<UsageChartProps, State> {
   };
 
   // Returns legend data styled per hiddenSeries
-  private getLegendData = () => {
+  private getLegendData = (tooltip: boolean = false) => {
     const { hiddenSeries, series } = this.state;
     if (series) {
       const result = series.map((s, index) => {
         return {
           childName: s.childName,
           ...s.legendItem, // name property
+          ...(tooltip && { name: s.legendItem.tooltip }), // Override name property for tooltip
           ...getInteractiveLegendItemStyles(hiddenSeries.has(index)), // hidden styles
         };
       });

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -183,20 +183,27 @@
   "chart": {
     "cost_infrastructure_legend_label": "Infrastructure cost ({{startDate}} $t(months_abbr.{{month}}))",
     "cost_infrastructure_legend_label_plural": "Infrastructure cost ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
+    "cost_infrastructure_legend_tooltip": "Infrastructure cost ($t(months_abbr.{{month}}))",
     "cost_legend_label": "Cost ({{startDate}} $t(months_abbr.{{month}}))",
     "cost_legend_label_plural": "Cost ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
+    "cost_legend_tooltip": "Cost ($t(months_abbr.{{month}}))",
     "cost_supplementary_legend_label": "Supplementary cost ({{startDate}} $t(months_abbr.{{month}}))",
     "cost_supplementary_legend_label_plural": "Supplementary cost ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
+    "cost_supplementary_legend_tooltip": "Supplementary cost ($t(months_abbr.{{month}}))",
     "date_range": "{{startDate}} $t(months_abbr.{{month}}) {{year}}",
     "date_range_plural": "{{startDate}}-{{endDate}} $t(months_abbr.{{month}}) {{year}}",
+    "day_of_month_title": "Day of the month: {{day}}",
     "limit_legend_label": "Limit ({{startDate}} $t(months_abbr.{{month}}))",
     "limit_legend_plural": "Limit ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
+    "limit_legend_tooltip": "Limit ($t(months_abbr.{{month}}))",
     "month_legend_label": "$t(months_abbr.{{month}})",
     "no_data": "no data",
     "requests_legend_label": "Requests ({{startDate}} $t(months_abbr.{{month}}))",
     "requests_legend_label_plural": "Requests ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
+    "requests_legend_tooltip": "Requests ($t(months_abbr.{{month}}))",
     "usage_legend_label": "Usage ({{startDate}} $t(months_abbr.{{month}}))",
-    "usage_legend_label_plural": "Usage ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))"
+    "usage_legend_label_plural": "Usage ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
+    "usage_legend_tooltip": "Usage ($t(months_abbr.{{month}}))"
   },
   "cost_management": "Cost Management",
   "cost_models": {


### PR DESCRIPTION
Replaces date range with a chart tooltip title

https://issues.redhat.com/browse/COST-606

**Overview cost chart**
![chart-overview](https://user-images.githubusercontent.com/17481322/95235721-f089f900-07d3-11eb-91d2-78b2cb780d69.gif)

**Overview trend chart**
![chart-overview-trend](https://user-images.githubusercontent.com/17481322/95235792-0ac3d700-07d4-11eb-8b58-636f85399ebb.gif)

**Historical chart**
![chart-historical](https://user-images.githubusercontent.com/17481322/95235856-1b744d00-07d4-11eb-95f7-b99fd02326a9.gif)
