### PR TITLE
Cost card hero numbers should be smaller

### DIFF
--- a/src/components/reports/reportSummary/reportSummaryDetails.scss
+++ b/src/components/reports/reportSummary/reportSummaryDetails.scss
@@ -1,11 +1,5 @@
 @import url("~@patternfly/patternfly/base/patternfly-variables.css");
 
-.costValue {
-  color: var(--pf-global--Color--100);
-  margin-right: var(--pf-global--spacer--sm);
-  font-size: var(--pf-global--FontSize--4xl);
-}
-
 .reportSummaryDetails {
     margin-bottom: var(--pf-global--spacer--md);
     display: flex;
@@ -30,6 +24,12 @@
   color: var(--pf-global--Color--100);
   margin-right: var(--pf-global--spacer--sm);
   font-size: var(--pf-global--FontSize--2xl);
+}
+
+.valueAlt {
+  color: var(--pf-global--Color--100);
+  margin-right: var(--pf-global--spacer--sm);
+  font-size: var(--pf-global--FontSize--4xl);
 }
 
 .valueContainer {

--- a/src/components/reports/reportSummary/reportSummaryDetails.tsx
+++ b/src/components/reports/reportSummary/reportSummaryDetails.tsx
@@ -105,13 +105,15 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
     }
   }
 
-  const getCostLayout = () => {
+  const getCostLayout = (showAltHeroFont: boolean = false) => {
     let value = cost;
     if (computedReportItem === ComputedReportItemType.infrastructure) {
       value = infrastructureCost;
     } else if (computedReportItem === ComputedReportItemType.supplementary) {
       value = supplementaryCost;
     }
+
+    const altHeroFont = showAltHeroFont ? 'Alt' : '';
 
     return (
       <div className="valueContainer">
@@ -123,10 +125,10 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
             })}
             enableFlip
           >
-            <div className="costValue">{value}</div>
+            <div className={`value${altHeroFont}`}>{value}</div>
           </Tooltip>
         ) : (
-          <div className="costValue">{value}</div>
+          <div className={`value${altHeroFont}`}>{value}</div>
         )}
         <div className="text">
           <div>{costLabel}</div>
@@ -179,7 +181,7 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
   };
 
   if (chartType === DashboardChartType.cost || chartType === DashboardChartType.supplementary) {
-    return <>{getCostLayout()}</>;
+    return <>{getCostLayout(true)}</>;
   } else if (chartType === DashboardChartType.trend) {
     if (showUsageFirst) {
       return (


### PR DESCRIPTION
The AWS and Azure overview have cards that show cost. The hero numbers in these cards should be the same size font.

When we updated the cost card, on the top of all overview pages, that inadvertently affected the style reused by the AWS and Azure overview cards that also show cost.

https://issues.redhat.com/browse/COST-605

**Before**
<img width="489" alt="Screen Shot 2020-10-07 at 10 55 10 AM" src="https://user-images.githubusercontent.com/17481322/95348701-48843680-088c-11eb-8c68-3a0b3ad4a3bd.png">

**After**
<img width="494" alt="Screen Shot 2020-10-07 at 10 55 21 AM" src="https://user-images.githubusercontent.com/17481322/95348722-4e7a1780-088c-11eb-9541-05a14514fe93.png">
