### PR TITLE
UI overview tooltip not working correctly

### DIFF
--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -55,7 +55,6 @@ interface CostChartSeries {
 }
 
 interface State {
-  CursorVoronoiContainer?: any;
   hiddenSeries: Set<number>;
   series?: CostChartSeries[];
   width: number;
@@ -114,8 +113,6 @@ class CostChart extends React.Component<CostChartProps, State> {
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
     this.setState({
-      // Note: Container order is important
-      CursorVoronoiContainer: createContainer('cursor', 'voronoi'),
       series: [
         {
           childName: 'previousCost',
@@ -218,11 +215,8 @@ class CostChart extends React.Component<CostChartProps, State> {
 
   // Returns CursorVoronoiContainer component
   private getContainer = () => {
-    const { CursorVoronoiContainer } = this.state;
-
-    if (!CursorVoronoiContainer) {
-      return undefined;
-    }
+    // Note: Container order is important
+    const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
 
     return (
       <CursorVoronoiContainer

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -57,7 +57,6 @@ interface HistoricalCostChartSeries {
 }
 
 interface State {
-  CursorVoronoiContainer?: any;
   hiddenSeries: Set<number>;
   series?: HistoricalCostChartSeries[];
   width: number;
@@ -111,8 +110,6 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
     this.setState({
-      // Note: Container order is important
-      CursorVoronoiContainer: createContainer('cursor', 'voronoi'),
       series: [
         {
           childName: 'previousCost',
@@ -211,11 +208,8 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
 
   // Returns CursorVoronoiContainer component
   private getContainer = () => {
-    const { CursorVoronoiContainer } = this.state;
-
-    if (!CursorVoronoiContainer) {
-      return undefined;
-    }
+    // Note: Container order is important
+    const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
 
     return (
       <CursorVoronoiContainer

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -55,7 +55,6 @@ interface HistoricalTrendChartSeries {
 }
 
 interface State {
-  CursorVoronoiContainer?: any;
   hiddenSeries: Set<number>;
   series?: HistoricalTrendChartSeries[];
   width: number;
@@ -97,8 +96,6 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
     this.setState({
-      // Note: Container order is important
-      CursorVoronoiContainer: createContainer('cursor', 'voronoi'),
       series: [
         {
           childName: 'previousCost',
@@ -161,11 +158,8 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
 
   // Returns CursorVoronoiContainer component
   private getContainer = () => {
-    const { CursorVoronoiContainer } = this.state;
-
-    if (!CursorVoronoiContainer) {
-      return undefined;
-    }
+    // Note: Container order is important
+    const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
 
     return (
       <CursorVoronoiContainer

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -59,7 +59,6 @@ interface HistoricalUsageChartSeries {
 }
 
 interface State {
-  CursorVoronoiContainer?: any;
   hiddenSeries: Set<number>;
   series?: HistoricalUsageChartSeries[];
   width: number;
@@ -119,8 +118,6 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
     this.setState({
-      // Note: Container order is important
-      CursorVoronoiContainer: createContainer('cursor', 'voronoi'),
       series: [
         {
           childName: 'previousUsage',
@@ -255,11 +252,8 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
 
   // Returns CursorVoronoiContainer component
   private getContainer = () => {
-    const { CursorVoronoiContainer } = this.state;
-
-    if (!CursorVoronoiContainer) {
-      return undefined;
-    }
+    // Note: Container order is important
+    const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
 
     return (
       <CursorVoronoiContainer

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -54,7 +54,6 @@ interface TrendChartSeries {
 }
 
 interface State {
-  CursorVoronoiContainer?: any;
   hiddenSeries: Set<number>;
   series?: TrendChartSeries[];
   width: number;
@@ -110,8 +109,6 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
     this.setState({
-      // Note: Container order is important
-      CursorVoronoiContainer: createContainer('cursor', 'voronoi'),
       series: [
         {
           childName: 'previousCost',
@@ -178,11 +175,8 @@ class TrendChart extends React.Component<TrendChartProps, State> {
 
   // Returns CursorVoronoiContainer component
   private getContainer = () => {
-    const { CursorVoronoiContainer } = this.state;
-
-    if (!CursorVoronoiContainer) {
-      return undefined;
-    }
+    // Note: Container order is important
+    const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
 
     return (
       <CursorVoronoiContainer

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -54,7 +54,6 @@ interface UsageChartSeries {
 }
 
 interface State {
-  CursorVoronoiContainer?: any;
   hiddenSeries: Set<number>;
   series?: UsageChartSeries[];
   width: number;
@@ -108,8 +107,6 @@ class UsageChart extends React.Component<UsageChartProps, State> {
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
     this.setState({
-      // Note: Container order is important
-      CursorVoronoiContainer: createContainer('cursor', 'voronoi'),
       series: [
         {
           childName: 'previousUsage',
@@ -192,11 +189,8 @@ class UsageChart extends React.Component<UsageChartProps, State> {
 
   // Returns CursorVoronoiContainer component
   private getContainer = () => {
-    const { CursorVoronoiContainer } = this.state;
-
-    if (!CursorVoronoiContainer) {
-      return undefined;
-    }
+    // Note: Container order is important
+    const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
 
     return (
       <CursorVoronoiContainer


### PR DESCRIPTION
When charts are re-rendered, the custom legend tooltip stops working. This happens whenever the user changes tabs or resizes the browser window.

The fix is to simply re-order how the "voronio" and "cursor" container properties are merged via Victory's `createContainer` function. Thus, saving the container state is no longer necessary.

https://issues.redhat.com/browse/COST-523

![chrome-capture](https://user-images.githubusercontent.com/17481322/95805867-67dbf300-0cd4-11eb-800c-4e0afe330c0c.gif)