### PR TITLE
Show loading state while fetching details table data

### DIFF
--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -427,7 +427,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
 
-    let emptyState = null;
+    let emptyState = <Loading />;
     if (reportError) {
       if (reportError.response && (reportError.response.status === 401 || reportError.response.status === 403)) {
         emptyState = <NotAuthorized />;
@@ -440,9 +440,9 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 
       if (noProviders) {
         emptyState = <NoProviders />;
+      } else {
+        emptyState = null;
       }
-    } else if (providersFetchStatus === FetchStatus.inProgress) {
-      emptyState = <Loading />;
     }
     return (
       <div style={styles.awsDetails}>

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -420,7 +420,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
 
-    let emptyState = null;
+    let emptyState = <Loading />;
     if (reportError) {
       if (reportError.response && (reportError.response.status === 401 || reportError.response.status === 403)) {
         emptyState = <NotAuthorized />;
@@ -433,9 +433,9 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
 
       if (noProviders) {
         emptyState = <NoProviders />;
+      } else {
+        emptyState = null;
       }
-    } else if (providersFetchStatus === FetchStatus.inProgress) {
-      emptyState = <Loading />;
     }
     return (
       <div style={styles.azureDetails}>

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -417,7 +417,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
 
-    let emptyState = null;
+    let emptyState = <Loading />;
     if (reportError) {
       if (reportError.response && (reportError.response.status === 401 || reportError.response.status === 403)) {
         emptyState = <NotAuthorized />;
@@ -430,9 +430,9 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
       if (noProviders) {
         emptyState = <NoProviders />;
+      } else {
+        emptyState = null;
       }
-    } else if (providersFetchStatus === FetchStatus.inProgress) {
-      emptyState = <Loading />;
     }
     return (
       <div style={styles.ocpDetails}>


### PR DESCRIPTION
For the AWS/Azure/Ocp details page, a loading (spinning circle) is shown inside the table body. However, it's so brief that it looks like an empty table. It would be preferable to continue showing the loading state used while fetching providers.

https://issues.redhat.com/browse/COST-627