### PR TITLE
Fix empty state alignment

### DIFF
--- a/src/components/state/emptyValueState/emptyValueState.scss
+++ b/src/components/state/emptyValueState/emptyValueState.scss
@@ -1,5 +1,5 @@
 @import url("~@patternfly/patternfly/base/patternfly-variables.css");
 
-.container {
+.emptyValueContainer {
   font-size: var(--pf-global--FontSize--sm);
 }

--- a/src/components/state/emptyValueState/emptyValueState.tsx
+++ b/src/components/state/emptyValueState/emptyValueState.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 
 export const EmptyValueState: React.SFC = () => {
   return (
-    <span className="container">
+    <span className="emptyValueContainer">
       <MinusIcon />
     </span>
   );


### PR DESCRIPTION
The empty state is picking up another `container` style. I simply changed the name to fix the alignment foe the "Month over month change" column.

https://issues.redhat.com/browse/COST-635

<img width="1488" alt="Screen Shot 2020-10-19 at 4 48 45 PM" src="https://user-images.githubusercontent.com/17481322/96510052-f8fa1f00-122a-11eb-8c29-4de714830c28.png">
