### PR TITLE
Use RBAC permissions to provide user access to pages

### DIFF
--- a/src/app.tsx
+++ b/src/app.tsx
@@ -3,9 +3,9 @@ import { getProvidersQuery } from 'api/queries/providersQuery';
 import { AxiosError } from 'axios';
 import { I18nProvider } from 'components/i18n';
 import { InactiveSources } from 'components/sources/InactiveSources/InactiveSources';
-import Maintenance from 'pages/state/maintenance/maintenance';
-import NotAuthorized from 'pages/state/notAuthorized/notAuthorized';
-import NotAvailable from 'pages/state/notAvailable/notAvailable';
+import Maintenance from 'pages/state/maintenance';
+import NotAuthorized from 'pages/state/notAuthorized';
+import NotAvailable from 'pages/state/notAvailable';
 import React from 'react';
 import { connect } from 'react-redux';
 import { RouteComponentProps } from 'react-router';
@@ -79,6 +79,7 @@ export class App extends React.Component<AppProps, AppState> {
       }
     });
 
+    // Must fetch for all pages where InactiveSources may be shown
     if (!awsProviders && awsProvidersFetchStatus !== FetchStatus.inProgress) {
       this.fetchAwsProviders();
     }
@@ -104,6 +105,7 @@ export class App extends React.Component<AppProps, AppState> {
       ocpProvidersFetchStatus,
     } = this.props;
 
+    // Must fetch for all pages where InactiveSources may be shown
     if (!awsProviders && awsProvidersFetchStatus !== FetchStatus.inProgress && !awsProvidersError) {
       this.fetchAwsProviders();
     }
@@ -113,7 +115,7 @@ export class App extends React.Component<AppProps, AppState> {
     if (!ocpProviders && ocpProvidersFetchStatus !== FetchStatus.inProgress && !ocpProvidersError) {
       this.fetchOcpProviders();
     }
-    if (location.pathname !== prevProps.location.pathname) {
+    if (location && location.pathname !== prevProps.location.pathname) {
       window.scrollTo(0, 0);
     }
   }
@@ -145,7 +147,7 @@ export class App extends React.Component<AppProps, AppState> {
     if (maintenanceMode) {
       route = <Maintenance />;
     } else {
-      // The providers API should error while under maintenance
+      // Note that the sources API will return 403 when the user doesn't have entitlements
       const error = awsProvidersError || azureProvidersError || ocpProvidersError;
 
       if (error) {
@@ -158,7 +160,7 @@ export class App extends React.Component<AppProps, AppState> {
     }
     return (
       <I18nProvider locale={this.state.locale}>
-        {<InactiveSources />}
+        <InactiveSources />
         {route}
       </I18nProvider>
     );

--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -9,7 +9,7 @@ import { AxiosError } from 'axios';
 import { ExportModal } from 'pages/details/components/export/exportModal';
 import Loading from 'pages/state/loading';
 import NoProviders from 'pages/state/noProviders';
-import NotAuthorized from 'pages/state/notAuthorized/notAuthorized';
+import NotAuthorized from 'pages/state/notAuthorized';
 import NotAvailable from 'pages/state/notAvailable';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -9,7 +9,7 @@ import { AxiosError } from 'axios';
 import { ExportModal } from 'pages/details/components/export/exportModal';
 import Loading from 'pages/state/loading';
 import NoProviders from 'pages/state/noProviders';
-import NotAuthorized from 'pages/state/notAuthorized/notAuthorized';
+import NotAuthorized from 'pages/state/notAuthorized';
 import NotAvailable from 'pages/state/notAvailable';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -9,7 +9,7 @@ import { AxiosError } from 'axios';
 import { ExportModal } from 'pages/details/components/export/exportModal';
 import Loading from 'pages/state/loading';
 import NoProviders from 'pages/state/noProviders';
-import NotAuthorized from 'pages/state/notAuthorized/notAuthorized';
+import NotAuthorized from 'pages/state/notAuthorized';
 import NotAvailable from 'pages/state/notAvailable';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Route, Switch } from 'react-router-dom';
 
 import { asyncComponent } from './utils/asyncComponent';
+import { permissionsComponent } from './utils/permissionsComponent';
 
 const NotFound = asyncComponent(() => import(/* webpackChunkName: "notFound" */ './pages/state/notFound'));
 const AwsBreakdown = asyncComponent(() => import(/* webpackChunkName: "aws" */ './pages/details/awsBreakdown'));
@@ -16,61 +17,61 @@ const CostModelsDetails = asyncComponent(() =>
 );
 const CostModel = asyncComponent(() => import(/* webpackChunkName: "costModel" */ './pages/costModels/costModel'));
 
+const getRouteProps = ({ path, labelKey, component }) => {
+  return {
+    path,
+    labelKey,
+    component: permissionsComponent(component, path), // Returns NoAuthorized if user doesn't have entitlements and permissions to view page
+    exact: true,
+  };
+};
+
 const routes = [
-  {
+  getRouteProps({
     path: '/',
     labelKey: 'navigation.overview',
     component: Overview,
-    exact: true,
-  },
-  {
-    path: '/details/aws',
-    labelKey: 'navigation.aws_details',
-    component: AwsDetails,
-    exact: true,
-  },
-  {
-    path: '/details/aws/breakdown',
-    labelKey: 'navigation.aws_details_cost',
-    component: AwsBreakdown,
-    exact: true,
-  },
-  {
-    path: '/details/azure',
-    labelKey: 'navigation.azure_details',
-    component: AzureDetails,
-    exact: true,
-  },
-  {
-    path: '/details/azure/breakdown',
-    labelKey: 'navigation.azure_details_cost',
-    component: AzureBreakdown,
-    exact: true,
-  },
-  {
-    path: '/details/ocp',
-    labelKey: 'navigation.ocp_details',
-    component: OcpDetails,
-    exact: true,
-  },
-  {
-    path: '/details/ocp/breakdown',
-    labelKey: 'navigation.ocp_details_cost',
-    component: OcpBreakdown,
-    exact: true,
-  },
-  {
+  }),
+  getRouteProps({
     path: '/cost-models',
     labelKey: 'navigation.cost_models',
     component: CostModelsDetails,
-    exact: true,
-  },
-  {
+  }),
+  getRouteProps({
     path: '/cost-models/:uuid',
     labelKey: 'navigation.cost_models',
     component: CostModel,
-    exact: true,
-  },
+  }),
+  getRouteProps({
+    path: '/details/aws',
+    labelKey: 'navigation.aws_details',
+    component: AwsDetails,
+  }),
+  getRouteProps({
+    path: '/details/aws/breakdown',
+    labelKey: 'navigation.aws_details_cost',
+    component: AwsBreakdown,
+  }),
+  getRouteProps({
+    path: '/details/azure',
+    labelKey: 'navigation.azure_details',
+    component: AzureDetails,
+  }),
+  getRouteProps({
+    path: '/details/azure/breakdown',
+    labelKey: 'navigation.azure_details_cost',
+    component: AzureBreakdown,
+  }),
+  getRouteProps({
+    path: '/details/ocp',
+    labelKey: 'navigation.ocp_details',
+    component: OcpDetails,
+  }),
+  getRouteProps({
+    path: '/details/ocp/breakdown',
+    labelKey: 'navigation.ocp_details_cost',
+    component: OcpBreakdown,
+  }),
 ];
 
 const Routes = () => (

--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -1,0 +1,142 @@
+// For resource types, see https://github.com/project-koku/koku/blob/master/koku/koku/rbac.py#L37-L43
+
+import { routes } from 'routes';
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+export const debugUserPermissions = async () => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const userPermissions = await insights.chrome.getUserPermissions('cost-management');
+  if (userPermissions) {
+    for (const item of userPermissions) {
+      // eslint-disable-next-line no-console
+      console.log(item);
+    }
+  }
+};
+
+const debug = false; // For testing purposes
+const debugPermissions = (name, result) => {
+  if (debug) {
+    // eslint-disable-next-line no-console
+    console.log(`${name}: ${result}`);
+  }
+  return result;
+};
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore
+const hasPermissions = permissions => insights.chrome.visibilityFunctions.hasPermissions([permissions]);
+
+// Returns true if the user has permissions for AWS
+export const hasAWSPermissions = async () => {
+  const all = await hasPermissions('cost-management:aws.account:*');
+  const read = await hasPermissions('cost-management:aws.account:read');
+  const result = all || read;
+  return debugPermissions('hasAWSPermissions', result);
+};
+
+// Returns true if the user has permissions for Azure
+export const hasAzurePermissions = async () => {
+  const all = await hasPermissions('cost-management:azure.subscription_guid:*');
+  const read = await hasPermissions('cost-management:azure.subscription_guid:read');
+  const result = all || read;
+  return debugPermissions('hasAzurePermissions', result);
+};
+
+// Returns true if the user has permissions for cost models
+export const hasCostModelPermissions = async () => {
+  const all = await hasPermissions('cost-management:cost_model:*');
+  const read = await hasPermissions('cost-management:cost_model:read');
+  const write = await hasPermissions('cost-management:cost_model:write');
+  const result = all || read || write;
+  return debugPermissions('hasCostModelPermissions', result);
+};
+
+// Returns true if the user has entitlements
+export const hasEntitledPermissions = async () => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const result = await insights.chrome.visibilityFunctions.isEntitled('cost_management');
+  return debugPermissions('isEntitled', result);
+};
+
+// Returns true if the user is an org admin
+export const hasOrgAdminPermissions = async () => {
+  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+  // @ts-ignore
+  const result = await insights.chrome.visibilityFunctions.isOrgAdmin();
+  return debugPermissions('isOrgAdmin', result);
+};
+
+// Returns true if the user has permissions for Ocp clusters
+export const hasOcpClusterPermissions = async () => {
+  const all = await hasPermissions('cost-management:openshift.cluster:*');
+  const read = await hasPermissions('cost-management:openshift.cluster:read');
+  const result = all || read;
+  return debugPermissions('hasOcpClusterPermissions', result);
+};
+
+// Returns true if the user has permissions for Ocp nodes
+export const hasOcpNodePermissions = async () => {
+  const all = await hasPermissions('cost-management:openshift.node:*');
+  const read = await hasPermissions('cost-management:openshift.node:read');
+  const result = all || read;
+  return debugPermissions('hasOcpNodePermissions', result);
+};
+
+// Returns true if the user has permissions for Ocp projects
+export const hasOcpProjectPermissions = async () => {
+  const all = await hasPermissions('cost-management:openshift.project:*');
+  const read = await hasPermissions('cost-management:openshift.project:read');
+  const result = all || read;
+  return debugPermissions('hasOcpProjectPermissions', result);
+};
+
+// Returns true if the user has permissions for Ocp; clusters, nodes, and projects
+export const hasOcpPermissions = async () => {
+  const cluster = await hasOcpClusterPermissions();
+  const node = await hasOcpNodePermissions();
+  const project = await hasOcpProjectPermissions();
+  return cluster || node || project;
+};
+
+// Returns true if the user has permissions for AWS, Azure, and Ocp
+export const hasOverviewPermissions = async () => {
+  const aws = await hasAWSPermissions();
+  const azure = await hasAzurePermissions();
+  const ocp = await hasOcpPermissions();
+  return aws || azure || ocp;
+};
+
+// Returns true if the user has permissions for the given page path
+export const hasPagePermissions = async (pathname: string) => {
+  const currRoute = routes.find(({ path }) => path.includes(pathname));
+
+  switch (currRoute.path) {
+    case '/':
+      return await hasOverviewPermissions();
+    case '/cost-models':
+      return await hasCostModelPermissions();
+    case '/details/aws':
+    case '/details/aws/breakdown':
+      return await hasAWSPermissions();
+    case '/details/azure':
+    case '/details/azure/breakdown':
+      return await hasAzurePermissions();
+    case '/details/ocp':
+    case '/details/ocp/breakdown':
+      return await hasOcpPermissions();
+    default:
+      return false;
+  }
+};
+
+// Returns true if the user has entitlements and is either an org admin or has permissions for the given page path
+export const isPageAccessAllowed = async (pathname: string) => {
+  const entitled = await hasEntitledPermissions();
+  const orgAdmin = await hasOrgAdminPermissions();
+  const permissions = await hasPagePermissions(pathname);
+  return entitled && (orgAdmin || permissions);
+};

--- a/src/utils/permissionsComponent.tsx
+++ b/src/utils/permissionsComponent.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import { asyncComponent } from './asyncComponent';
+import { isPageAccessAllowed } from './permissions';
+
+const NotAuthorized = asyncComponent(() => import(/* webpackChunkName: "notFound" */ 'pages/state/notAuthorized'));
+
+interface State {
+  isLoading: boolean;
+}
+
+export function permissionsComponent<Props>(component, path: string) {
+  let LoadedComponent: React.ComponentType<Props> = null;
+
+  class PermissionsComponent extends React.Component<Props, State> {
+    public state: State = {
+      isLoading: !LoadedComponent,
+    };
+
+    public componentDidMount() {
+      if (!this.state.isLoading) {
+        return;
+      }
+
+      // Return NoAuthorized if the user doesn't have entitlements, permissions, and is not an org admin
+      isPageAccessAllowed(path).then(hasPermissions => {
+        LoadedComponent = hasPermissions ? component : NotAuthorized;
+        this.setState({ isLoading: false });
+      });
+    }
+
+    public render() {
+      const { isLoading } = this.state;
+      return isLoading ? null : <LoadedComponent {...this.props} />;
+    }
+  }
+
+  return PermissionsComponent;
+}


### PR DESCRIPTION
As a user, I expect UI pages to be shown according to my user's entitlements and RBAC permissions. Pages should only be shown if the following conditions are met.

1. The user has entitlements
2. If the user is an org admin, all pages are available
3. A page is shown if the user has RBAC permissions for specific resource types

As an example, consider the `cost-demo` user. Since that user is an org admin, they should have access to all pages.

The `cost-user` user is not an org admin and only has the `cost_model` resource type defined as read/write permissions. In this scenario, the user only has access to the cost models page. 

When users don't have permissions, they see the `NotAuthorized` empty state.

For more details, see https://issues.redhat.com/browse/COST-646

**The `cost-user` user and the overview page**
<img width="1412" alt="Screen Shot 2020-10-22 at 11 34 43 PM" src="https://user-images.githubusercontent.com/17481322/96955896-b8b5cd80-14c4-11eb-85b7-e91ba80ee5ad.png">

**The `cost-user` user and the cost models page**
<img width="1565" alt="Screen Shot 2020-10-22 at 11 34 58 PM" src="https://user-images.githubusercontent.com/17481322/96955899-bbb0be00-14c4-11eb-9932-33c5c95e574c.png">
