### PR TITLE
Breakdown chart shows markup and raw cost values switched

### DIFF
--- a/src/pages/details/components/costChart/costChart.tsx
+++ b/src/pages/details/components/costChart/costChart.tsx
@@ -103,7 +103,7 @@ class CostChartBase extends React.Component<CostChartProps> {
       <ChartLegend
         gutter={25}
         itemsPerRow={2}
-        labelComponent={<LegendLabel dy={10} lineHeight={1.5} values={[markup, raw, usage]} />}
+        labelComponent={<LegendLabel dy={10} lineHeight={1.5} values={[raw, markup, usage]} />}
         rowGutter={20}
       />
     );


### PR DESCRIPTION
The markup and raw cost values shown in the breakdown chart's legend are switched.

https://issues.redhat.com/browse/COST-640