### PR TITLE
Use RBAC permissions to show/hide tabs and perspective options

### DIFF
--- a/src/utils/permissions.ts
+++ b/src/utils/permissions.ts
@@ -30,11 +30,11 @@ const debugPermissions = (name, result) => {
 const hasPermissions = permissions => insights.chrome.visibilityFunctions.hasPermissions([permissions]);
 
 // Returns true if the user has permissions for AWS
-export const hasAWSPermissions = async () => {
+export const hasAwsPermissions = async () => {
   const all = await hasPermissions('cost-management:aws.account:*');
   const read = await hasPermissions('cost-management:aws.account:read');
   const result = all || read;
-  return debugPermissions('hasAWSPermissions', result);
+  return debugPermissions('hasAwsPermissions', result);
 };
 
 // Returns true if the user has permissions for Azure
@@ -104,7 +104,7 @@ export const hasOcpPermissions = async () => {
 
 // Returns true if the user has permissions for AWS, Azure, and Ocp
 export const hasOverviewPermissions = async () => {
-  const aws = await hasAWSPermissions();
+  const aws = await hasAwsPermissions();
   const azure = await hasAzurePermissions();
   const ocp = await hasOcpPermissions();
   return aws || azure || ocp;
@@ -121,7 +121,7 @@ export const hasPagePermissions = async (pathname: string) => {
       return await hasCostModelPermissions();
     case '/details/aws':
     case '/details/aws/breakdown':
-      return await hasAWSPermissions();
+      return await hasAwsPermissions();
     case '/details/azure':
     case '/details/azure/breakdown':
       return await hasAzurePermissions();


### PR DESCRIPTION
As a user, I expect Overview tabs and perspective options to be shown according to my user's entitlements and RBAC permissions. Items should only be shown if the following conditions are met.

1. If the user is an org admin, all items are available
2. An item is shown if the user has RBAC permissions for specific resource types
3. Sources are populated with data

https://issues.redhat.com/browse/COST-647