### PR TITLE
Cost models no auth state

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -749,6 +749,7 @@
   "no_auth_state": {
     "aws_service_name": "Amazon Web Services in Cost Management",
     "azure_service_name": "Microsoft Azure in Cost Management",
+    "cost_models_service_name": "Cost Models in Cost Management",
     "gcp_service_name": "Google Cloud Platform in Cost Management",
     "ocp_service_name": "OpenShift in Cost Management"
   },

--- a/src/pages/state/notAuthorized/notAuthorized.tsx
+++ b/src/pages/state/notAuthorized/notAuthorized.tsx
@@ -1,19 +1,18 @@
 import { Main } from '@redhat-cloud-services/frontend-components/components/Main';
 import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components/components/PageHeader';
-import { ProviderType } from 'api/providers';
 import React from 'react';
 import { RouteComponentProps, withRouter } from 'react-router';
 
 import { NotAuthorizedState } from './notAuthorizedState';
 
 interface NotAuthorizedOwnProps {
-  providerType?: ProviderType;
+  pathname?: string;
   title?: string;
 }
 
 type NotAuthorizedProps = NotAuthorizedOwnProps & RouteComponentProps<void>;
 
-const NotAuthorized = ({ providerType, title }: NotAuthorizedProps) => {
+const NotAuthorized = ({ pathname, title }: NotAuthorizedProps) => {
   return (
     <>
       {title && (
@@ -22,7 +21,7 @@ const NotAuthorized = ({ providerType, title }: NotAuthorizedProps) => {
         </PageHeader>
       )}
       <Main>
-        <NotAuthorizedState providerType={providerType} />
+        <NotAuthorizedState pathname={pathname} />
       </Main>
     </>
   );

--- a/src/pages/state/notAuthorized/notAuthorizedState.tsx
+++ b/src/pages/state/notAuthorized/notAuthorizedState.tsx
@@ -1,29 +1,35 @@
 import { NotAuthorized as _NotAuthorized } from '@redhat-cloud-services/frontend-components/components/NotAuthorized';
-import { ProviderType } from 'api/providers';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { RouteComponentProps, withRouter } from 'react-router';
+import { paths } from 'routes';
 
 interface NotAuthorizedStateOwnProps {
-  providerType?: ProviderType;
+  pathname?: string;
 }
 
 type NotAuthorizedStateProps = NotAuthorizedStateOwnProps & WithTranslation & RouteComponentProps<void>;
 
 class NotAuthorizedStateBase extends React.Component<NotAuthorizedStateProps> {
   public render() {
-    const { providerType, t } = this.props;
+    const { pathname, t } = this.props;
 
     let serviceName = 'cost_management';
 
-    switch (providerType) {
-      case ProviderType.aws:
+    switch (pathname) {
+      case paths.awsDetails:
+      case paths.awsDetailsBreakdown:
         serviceName = 'no_auth_state.aws_service_name';
         break;
-      case ProviderType.azure:
+      case paths.azureDetails:
+      case paths.azureDetailsBreakdown:
         serviceName = 'no_auth_state.azure_service_name';
         break;
-      case ProviderType.ocp:
+      case paths.costModels:
+        serviceName = 'no_auth_state.cost_models_service_name';
+        break;
+      case paths.ocpDetails:
+      case paths.ocpDetailsBreakdown:
         serviceName = 'no_auth_state.ocp_service_name';
         break;
     }

--- a/src/utils/permissionsComponent.tsx
+++ b/src/utils/permissionsComponent.tsx
@@ -1,6 +1,4 @@
-import { ProviderType } from 'api/providers';
 import React from 'react';
-import { paths } from 'routes';
 
 import { asyncComponent } from './asyncComponent';
 import { hasEntitledPermissions, hasOrgAdminPermissions, hasPagePermissions } from './permissions';
@@ -64,22 +62,7 @@ export function permissionsComponent<Props>(AysncComponent) {
         );
       }
       // Page access denied because user doesn't have entitlements, permissions, and is not an org admin
-      let providerType;
-      switch (location.pathname) {
-        case paths.awsDetails:
-        case paths.awsDetailsBreakdown:
-          providerType = ProviderType.aws;
-          break;
-        case paths.azureDetails:
-        case paths.azureDetailsBreakdown:
-          providerType = ProviderType.azure;
-          break;
-        case paths.ocpDetails:
-        case paths.ocpDetailsBreakdown:
-          providerType = ProviderType.ocp;
-          break;
-      }
-      return <NotAuthorized providerType={providerType} />;
+      return <NotAuthorized pathname={location.pathname} />;
     }
   }
   return PermissionsComponent;


### PR DESCRIPTION
The no auth state for cost models should display "You do not have access to Cost Models in Cost Management" as the title.

Currently, we show the default title used for the overview page - "You do not have access to Cost Management"

https://issues.redhat.com/browse/COST-675

<img width="1466" alt="Screen Shot 2020-10-29 at 10 47 37 AM" src="https://user-images.githubusercontent.com/17481322/97591059-9ac0ff00-19d5-11eb-8388-0b51aae586c5.png">
