### PR TITLE
fix(costmodels): update wizard step on clicking wizard nav

### DIFF
--- a/src/pages/costModels/createCostModelWizard/index.tsx
+++ b/src/pages/costModels/createCostModelWizard/index.tsx
@@ -68,6 +68,7 @@ const InternalWizardBase: React.SFC<InternalWizardBaseProps> = ({
       startAtStep={current}
       onNext={onMove}
       onBack={onMove}
+      onGoToStep={onMove}
       onClose={closeFnc}
       footer={isSuccess || isProcess || isAddingRate ? <div /> : null}
       onSave={() => {


### PR DESCRIPTION
closes COST 690

How to reproduce:
- Click on Cost model in the side navigation bar
- Click on create cost model
- Select OpenShift in type and enter any name
- Click Next till you get to the Review step
- Click on "Enter information" in the wizard navigation (on the left side)
- Change the type to AWS or Azure
- See error

However, if you click on Back (after reaching the Review step) till you get to the first step and change the type to anything but Openshift, everything is OK.

What happened here: when we click on the wizard navigation, the step state is not changed and that's because the Wizard is not updating it like when we clicked on the Next and Back buttons. To solve this, I had to pass the "onMove" function (which updates the step state) to the onGoToStep prop.