### PR TITLE
Remove dead i18n keys

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "lint:locales:fix": "node scripts/syncLocales",
     "lint:ts": "node --max-old-space-size=4096 node_modules/.bin/eslint --ext ts,tsx src/",
     "lint:ts:fix": "yarn lint:ts --fix",
+    "i18n:key:check:full": "scripts/utils/i18n_key_tool.py --json-file src/locales/en.json --search-path src --exclude-file scripts/utils/i18n_excludes",
+    "i18n:key:check:notfound": "scripts/utils/i18n_key_tool.py --Xreport-found --json-file src/locales/en.json --search-path src --exclude-file scripts/utils/i18n_excludes",
     "start": "node --max-old-space-size=8192 node_modules/webpack-dev-server/bin/webpack-dev-server.js",
     "start:dev": "APP_ENV=proxy yarn start",
     "stats": "webpack --mode production --profile --json > stats.json",

--- a/scripts/utils/i18n_excludes
+++ b/scripts/utils/i18n_excludes
@@ -1,0 +1,8 @@
+units.gb
+units.gb-hours
+units.gb-mo
+units.hours
+units.hrs
+units.tag-mo
+units.usd
+units.vm-hours

--- a/scripts/utils/i18n_key_tool.py
+++ b/scripts/utils/i18n_key_tool.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+
+import argparse
+import glob
+import json
+import os
+
+not_found_cnt = 0
+found_cnt = 0
+exclude_cnt = 0
+
+def check_dir(dir_name):
+    dir = os.path.join(os.getcwd(), dir_name)
+
+    if os.path.isdir(dir):
+        return dir
+    else:
+        raise NotADirectoryError(dir)
+
+
+def check_file(filename):
+    file = os.path.join(os.getcwd(), filename)
+
+    if os.path.isfile(file):
+        return file
+    else:
+        raise FileNotFoundError(file)
+
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--search-path', type=check_dir, required=True, help='parent directory to start searching')
+parser.add_argument('--json-file', type=check_file, required=True, help='i18n json file location')
+parser.add_argument('--exclude-file', type=check_file, help='file that lists i18n tags in dot notation to exclude'
+                                                            'from reporting')
+parser.add_argument('--Xreport-found', action='store_false', help='do not report any "Found" keys')
+parser.add_argument('--Xreport-not-found', action='store_false', help='do not report any "Not Found" keys')
+args = parser.parse_args()
+
+
+class Colors:
+    OKBLUE = '\033[94m'
+    OKCYAN = '\033[96m'
+    FAIL = '\033[91m'
+    WARN = '\033[93m'
+    ENDC = '\033[0m'
+    BOLD = '\033[1m'
+    UNDERLINE = '\033[4m'
+
+
+# get keys from json file
+def walk_keys(obj, path=""):
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            for r in walk_keys(v, path + "." + k if path else k):
+                yield r
+    elif isinstance(obj, list):
+        for i, v in enumerate(obj):
+            s = ""
+            for r in walk_keys(v, path if path else s):
+                yield r
+    else:
+        yield path
+
+
+# search all files starting at path for key
+def search_for_key(path, key):
+    results = []
+    for file in glob.glob(os.path.join(path, "**", "*.ts*"), recursive=True):
+        with open(file) as f:
+            contents = f.read()
+        if key in contents:
+            results.append(f.name)
+
+    return results
+
+
+json_data = json.load(open(args.json_file))
+
+for i18n_key in sorted(list(set(walk_keys(json_data)))):
+    exclude_data = []
+
+    if args.exclude_file is not None:
+        with open(args.exclude_file) as f:
+            exclude_data = f.read().splitlines()
+
+    if exclude_data.__contains__(i18n_key):
+        print('{:<80s}{:>10s}'.format(Colors.OKCYAN + i18n_key, Colors.WARN + '[TAG EXCLUDED]') + Colors.ENDC)
+        exclude_cnt += 1
+    else:
+        result = search_for_key(args.search_path, i18n_key)
+
+        if len(result) <= 0 and args.Xreport_not_found:
+            print('{:<80s}{:>10s}'.format(Colors.OKCYAN + i18n_key, Colors.FAIL + '[NOT FOUND]') + Colors.ENDC)
+            not_found_cnt += 1
+
+        if args.Xreport_found:
+            print(Colors.OKCYAN + i18n_key + Colors.ENDC)
+            found_cnt += 1
+            for f in result:
+                print(Colors.OKBLUE + "\tFOUND IN: " + f + Colors.ENDC)
+
+print("\n")
+print('{:>25s}'.format(Colors.OKCYAN + "TOTALS" + Colors.ENDC))
+print('{:<30s}{:>10s}'.format(Colors.OKCYAN + "FOUND", Colors.OKBLUE + str(found_cnt) + Colors.ENDC))
+print('{:<30s}{:>10s}'.format(Colors.OKCYAN + "NOT FOUND", Colors.FAIL + str(not_found_cnt) + Colors.ENDC))
+print('{:<30s}{:>10s}'.format(Colors.OKCYAN + "EXCLUDED", Colors.WARN + str(exclude_cnt) + Colors.ENDC))

--- a/scripts/utils/i18n_key_tool.py
+++ b/scripts/utils/i18n_key_tool.py
@@ -43,8 +43,6 @@ class Colors:
     FAIL = '\033[91m'
     WARN = '\033[93m'
     ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
 
 
 # get keys from json file
@@ -86,12 +84,14 @@ for i18n_key in sorted(list(set(walk_keys(json_data)))):
     if exclude_data.__contains__(i18n_key):
         print('{:<80s}{:>10s}'.format(Colors.OKCYAN + i18n_key, Colors.WARN + '[TAG EXCLUDED]') + Colors.ENDC)
         exclude_cnt += 1
+        continue
     else:
         result = search_for_key(args.search_path, i18n_key)
 
         if len(result) <= 0 and args.Xreport_not_found:
             print('{:<80s}{:>10s}'.format(Colors.OKCYAN + i18n_key, Colors.FAIL + '[NOT FOUND]') + Colors.ENDC)
             not_found_cnt += 1
+            continue
 
         if args.Xreport_found:
             print(Colors.OKCYAN + i18n_key + Colors.ENDC)


### PR DESCRIPTION
A tool that will help us find dead i18n keys.

targets:
- `yarn i18n:key:check:full`
- `yarn i18n:key:check:notfound`

example output of full report:
....
```
toolbar.sources.secondary.ocp
	FOUND IN: /Users/dougdonahue/WebstormProjects/koku-ui/src/pages/costModels/costModelsDetails/components/costModelsDetailsToolbar.tsx
unit_tooltips.core-hours                                                   [NOT FOUND]
unit_tooltips.gb
	FOUND IN: /Users/dougdonahue/WebstormProjects/koku-ui/src/components/charts/common/chartUtils.test.ts
unit_tooltips.gb-hours                                                     [NOT FOUND]
unit_tooltips.gb-mo                                                        [NOT FOUND]
unit_tooltips.hours                                                        [NOT FOUND]
unit_tooltips.hrs
	FOUND IN: /Users/dougdonahue/WebstormProjects/koku-ui/src/components/charts/common/chartUtils.test.ts
unit_tooltips.usd                                                          [NOT FOUND]
unit_tooltips.vm-hours                                                     [NOT FOUND]
units.
	FOUND IN: /Users/dougdonahue/WebstormProjects/koku-ui/src/components/reports/reportSummary/reportSummaryDetails.tsx
	FOUND IN: /Users/dougdonahue/WebstormProjects/koku-ui/src/components/reports/reportSummary/reportSummaryItem.tsx
	FOUND IN: /Users/dougdonahue/WebstormProjects/koku-ui/src/pages/details/components/usageChart/usageChart.tsx
	FOUND IN: /Users/dougdonahue/WebstormProjects/koku-ui/src/pages/details/components/historicalData/historicalDataTrendChart.tsx
	FOUND IN: /Users/dougdonahue/WebstormProjects/koku-ui/src/pages/details/components/historicalData/historicalDataUsageChart.tsx
	FOUND IN: /Users/dougdonahue/WebstormProjects/koku-ui/src/pages/details/components/historicalData/historicalDataCostChart.tsx
	FOUND IN: /Users/dougdonahue/WebstormProjects/koku-ui/src/pages/dashboard/components/dashboardWidgetBase.tsx
units.core-hours                                                           [NOT FOUND]
units.gb                                                                   [TAG EXCLUDED]
units.gb-hours                                                             [TAG EXCLUDED]
units.gb-mo                                                                [TAG EXCLUDED]
units.hours                                                                [TAG EXCLUDED]
units.hrs                                                                  [TAG EXCLUDED]
units.tag-mo                                                               [TAG EXCLUDED]
units.usd                                                                  [TAG EXCLUDED]
units.vm-hours                                                             [TAG EXCLUDED]


          TOTALS
FOUND                    501
NOT FOUND                507
EXCLUDED                 8
```