### PR TITLE
remove "app_title" i18n key

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,5 +1,4 @@
 {
-  "app_title": "Koku",
   "aws_cloud_dashboard": {
     "compute_title": "Compute (EC2) instances usage",
     "compute_trend_title": "Daily usage comparison ({{units}})",


### PR DESCRIPTION
The only reference to the "app_title" tag is found in the archive directory. Removing in favor of cleanup