### PR TITLE
Wrong month label shown on breakdown page

### DIFF
--- a/src/pages/details/components/breakdown/breakdownHeader.tsx
+++ b/src/pages/details/components/breakdown/breakdownHeader.tsx
@@ -130,7 +130,7 @@ class BreakdownHeaderBase extends React.Component<BreakdownHeaderProps> {
               <span>{this.getTotalCost()}</span>
             </Title>
           </div>
-          <div style={styles.costLabelDate}>{getForDateRangeString(groupByKey, 'breakdown.total_cost_date')}</div>
+          <div style={styles.costLabelDate}>{getForDateRangeString(groupByKey, 'breakdown.total_cost_date', 0)}</div>
         </div>
       </header>
     );


### PR DESCRIPTION
We're currently showing the previous month instead of the current month in the breakdown page header. 

The problem is that default month offset should not be used here to display the current month.

https://issues.redhat.com/browse/COST-725

<img width="1872" alt="Screen Shot 2020-11-12 at 12 31 21 PM" src="https://user-images.githubusercontent.com/17481322/98974525-ff568080-24e2-11eb-934c-2b6d240eb93e.png">
