### PR TITLE
Fixed tag names being used in Azure widgets

### DIFF
--- a/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
+++ b/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
@@ -13,7 +13,7 @@ export const costSummaryWidget: AzureCloudDashboardWidget = {
   reportPathsType: ReportPathsType.azureCloud,
   reportType: ReportType.cost,
   details: {
-    costKey: 'aws_dashboard.cumulative_cost_label',
+    costKey: 'azure_cloud_dashboard.cumulative_cost_label',
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -15,7 +15,7 @@ export const costSummaryWidget: AzureDashboardWidget = {
   reportType: ReportType.cost,
   details: {
     appNavId: 'aws',
-    costKey: 'aws_dashboard.cumulative_cost_label',
+    costKey: 'azure_dashboard.cumulative_cost_label',
     formatOptions: {
       fractionDigits: 2,
     },


### PR DESCRIPTION
We had a AWS i18n tag being used in the Azure widgets. This was not causing any issues as the key values are the same.