### PR TITLE
Incorrect hIstorical usage charts

### DIFF
--- a/src/store/historicalData/awsHistoricalData/awsHistoricalDataWidgets.ts
+++ b/src/store/historicalData/awsHistoricalData/awsHistoricalDataWidgets.ts
@@ -17,12 +17,12 @@ export const computeUsageWidget: AwsHistoricalDataWidget = {
   id: getId(),
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.instanceType,
-  type: HistoricalDataWidgetType.trend,
+  type: HistoricalDataWidgetType.usage,
 };
 
 export const storageUsageWidget: AwsHistoricalDataWidget = {
   id: getId(),
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.storage,
-  type: HistoricalDataWidgetType.trend,
+  type: HistoricalDataWidgetType.usage,
 };

--- a/src/store/historicalData/azureHistoricalData/azureHistoricalDataWidgets.ts
+++ b/src/store/historicalData/azureHistoricalData/azureHistoricalDataWidgets.ts
@@ -17,12 +17,12 @@ export const computeUsageWidget: AzureHistoricalDataWidget = {
   id: getId(),
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.instanceType,
-  type: HistoricalDataWidgetType.trend,
+  type: HistoricalDataWidgetType.usage,
 };
 
 export const storageUsageWidget: AzureHistoricalDataWidget = {
   id: getId(),
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.storage,
-  type: HistoricalDataWidgetType.trend,
+  type: HistoricalDataWidgetType.usage,
 };

--- a/src/store/historicalData/common/historicalDataCommon.ts
+++ b/src/store/historicalData/common/historicalDataCommon.ts
@@ -3,7 +3,7 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 // eslint-disable-next-line no-shadow
 export const enum HistoricalDataWidgetType {
   cost = 'cost', // This type displays historical cost chart
-  trend = 'tend', // This type displays historical trend chart
+  trend = 'trend', // This type displays historical trend chart
   usage = 'usage', // This type displays historical usage chart
 }
 


### PR DESCRIPTION
The AWS and Azure historical pages are only showing the wrong chart type. Should be showing a usage chart, not trend charts.

https://issues.redhat.com/browse/COST-746

AWS
<img width="1838" alt="Screen Shot 2020-11-18 at 4 03 44 PM" src="https://user-images.githubusercontent.com/17481322/99588074-0df7d880-29b8-11eb-829d-ea688b46a52b.png">


Azure
<img width="1835" alt="Screen Shot 2020-11-18 at 4 03 32 PM" src="https://user-images.githubusercontent.com/17481322/99588034-033d4380-29b8-11eb-8b1a-22590d2a3488.png">
