### PR TITLE
Overview heading padding

### DIFF
--- a/src/pages/overview/overview.styles.ts
+++ b/src/pages/overview/overview.styles.ts
@@ -10,7 +10,6 @@ export const styles = {
     fontWeight: 'bold',
   },
   perspective: {
-    marginBottom: global_spacer_lg.value,
     marginTop: global_spacer_lg.value,
   },
   tabs: {


### PR DESCRIPTION
Overview heading padding is too large.

https://issues.redhat.com/browse/COST-745

<img width="1843" alt="Screen Shot 2020-11-18 at 4 10 09 PM" src="https://user-images.githubusercontent.com/17481322/99588523-b5750b00-29b8-11eb-8fa3-853528c91064.png">
