### PR TITLE
Fixed i18n key name for limits label on historical chart legend

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -145,7 +145,7 @@
     "date_range_plural": "{{startDate}}-{{endDate}} $t(months_abbr.{{month}}) {{year}}",
     "day_of_month_title": "Day of the month: {{day}}",
     "limit_legend_label": "Limit ({{startDate}} $t(months_abbr.{{month}}))",
-    "limit_legend_plural": "Limit ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
+    "limit_legend_label_plural": "Limit ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
     "limit_legend_tooltip": "Limit ($t(months_abbr.{{month}}))",
     "month_legend_label": "$t(months_abbr.{{month}})",
     "no_data": "no data",


### PR DESCRIPTION
Fixed legend for limit so it now shows date range

![Screen Shot 2020-11-19 at 8 32 06 AM](https://user-images.githubusercontent.com/57504257/99672828-f6653200-2a41-11eb-8ebb-2d3f352ac4eb.png)

![Screen Shot 2020-11-19 at 8 47 09 AM](https://user-images.githubusercontent.com/57504257/99674408-febe6c80-2a43-11eb-8da8-bcd8d10bcea3.png)

