### PR TITLE
Wizard non-localized metric string

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -166,6 +166,7 @@
     "Infrastructure": "Infrastructure",
     "Memory": "Memory",
     "Node": "Node",
+    "Persistent volume claims": "Persistent volume claims",
     "Request": "Request ({{units}})",
     "Storage": "Storage",
     "Supplementary": "Supplementary",


### PR DESCRIPTION
This is a quick fix for production.

https://issues.redhat.com/browse/COST-755

Before
<img width="1120" alt="create a price list" src="https://user-images.githubusercontent.com/17481322/99693446-5ddaac00-2a59-11eb-8a06-9a6d6b7aa402.png">


After
<img width="1122" alt="Screen Shot 2020-11-19 at 11 19 02 AM" src="https://user-images.githubusercontent.com/17481322/99693408-53b8ad80-2a59-11eb-8391-7a0fcd6a2efd.png">
