### PR TITLE
Shorten chart tooltip title

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -150,7 +150,7 @@
     "cost_supplementary_legend_tooltip": "Supplementary cost ($t(months_abbr.{{month}}))",
     "date_range": "{{startDate}} $t(months_abbr.{{month}}) {{year}}",
     "date_range_plural": "{{startDate}}-{{endDate}} $t(months_abbr.{{month}}) {{year}}",
-    "day_of_month_title": "Day of the month: {{day}}",
+    "day_of_month_title": "Day {{day}}",
     "limit_legend_label": "Limit ({{startDate}} $t(months_abbr.{{month}}))",
     "limit_legend_label_plural": "Limit ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
     "limit_legend_tooltip": "Limit ($t(months_abbr.{{month}}))",


### PR DESCRIPTION
We want to shorten chart tooltip title from "Day of the month: 19" to "Day 19".

https://issues.redhat.com/browse/COST-753

<img width="749" alt="Screen Shot 2020-11-20 at 2 47 19 PM" src="https://user-images.githubusercontent.com/17481322/99843706-f9dee300-2b3f-11eb-96dc-be2577c8ff37.png">
