### PR TITLE
Overview chart width

### DIFF
--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -345,7 +345,7 @@ class CostChart extends React.Component<CostChartProps, State> {
     const { width } = this.state;
 
     // Todo: use PF legendAllowWrap feature
-    const itemsPerRow = legendItemsPerRow ? legendItemsPerRow : width > 400 ? chartStyles.itemsPerRow : 1;
+    const itemsPerRow = legendItemsPerRow ? legendItemsPerRow : width > 450 ? chartStyles.itemsPerRow : 1;
 
     return <ChartLegend height={25} gutter={20} itemsPerRow={itemsPerRow} name="legend" responsive={false} />;
   };
@@ -451,7 +451,7 @@ class CostChart extends React.Component<CostChartProps, State> {
     const midDate = Math.floor(endDate / 2);
 
     const adjustedContainerHeight = adjustContainerHeight
-      ? width > 400
+      ? width > 450
         ? containerHeight
         : containerHeight + 75
       : containerHeight;

--- a/src/components/charts/trendChart/trendChart.styles.ts
+++ b/src/components/charts/trendChart/trendChart.styles.ts
@@ -26,6 +26,7 @@ export const chartStyles = {
     fill: chart_color_green_100.value,
     strokeWidth: 0,
   },
+  itemsPerRow: 4,
   // See: https://github.com/project-koku/koku-ui/issues/241
   previousColorScale: [chart_color_black_200.value, chart_color_black_200.value],
   previousMonthData: {

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -28,6 +28,7 @@ interface TrendChartProps {
   forecastData?: any;
   forecastConeData?: any;
   height?: number;
+  legendItemsPerRow?: number;
   previousData?: any;
   formatDatumValue: ValueFormatter;
   formatDatumOptions?: FormatOptions;
@@ -295,7 +296,10 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   }
 
   private getLegend = () => {
+    const { legendItemsPerRow } = this.props;
     const { width } = this.state;
+
+    const itemsPerRow = legendItemsPerRow ? legendItemsPerRow : width > 700 ? chartStyles.itemsPerRow : 2;
 
     // Todo: use PF legendAllowWrap feature
     return (
@@ -303,6 +307,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         data={this.getLegendData()}
         gutter={20}
         height={25}
+        itemsPerRow={itemsPerRow}
         name="legend"
         orientation={width > 150 ? 'horizontal' : 'vertical'}
       />
@@ -421,7 +426,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     const midDate = Math.floor(endDate / 2);
 
     const adjustedContainerHeight = adjustContainerHeight
-      ? width > 400
+      ? width > 700
         ? containerHeight
         : containerHeight + 20
       : containerHeight;

--- a/src/components/reports/reportSummary/reportSummaryAlt.scss
+++ b/src/components/reports/reportSummary/reportSummaryAlt.scss
@@ -6,10 +6,6 @@
   margin-top: var(--pf-global--spacer--md);
 }
 
-.container {
-  display: flex;
-}
-
 .cost {
   flex-grow: 1;
   min-height: 470px;
@@ -32,6 +28,5 @@
 }
 
 .tops {
-  flex-grow: 1;
   margin-top: var(--pf-global--spacer--lg),
 }

--- a/src/components/reports/reportSummary/reportSummaryAlt.tsx
+++ b/src/components/reports/reportSummary/reportSummaryAlt.tsx
@@ -25,7 +25,7 @@ const OcpCloudReportSummaryAltBase: React.SFC<OcpCloudReportSummaryAltProps> = (
 }) => (
   <Card className="reportSummary">
     <Grid hasGutter>
-      <GridItem lg={5} xl={6}>
+      <GridItem xl={7} xl2={8}>
         <div className="cost">
           <CardTitle>
             <Title headingLevel="h2" size="lg">
@@ -47,7 +47,7 @@ const OcpCloudReportSummaryAltBase: React.SFC<OcpCloudReportSummaryAltProps> = (
           </CardBody>
         </div>
       </GridItem>
-      <GridItem lg={7} xl={6}>
+      <GridItem xl={5} xl2={4}>
         <div className="container">
           <div className="tops">
             {status !== FetchStatus.inProgress && (

--- a/src/components/reports/reportSummary/reportSummaryAlt.tsx
+++ b/src/components/reports/reportSummary/reportSummaryAlt.tsx
@@ -25,7 +25,7 @@ const OcpCloudReportSummaryAltBase: React.SFC<OcpCloudReportSummaryAltProps> = (
 }) => (
   <Card className="reportSummary">
     <Grid hasGutter>
-      <GridItem xl={7} xl2={8}>
+      <GridItem xl={8}>
         <div className="cost">
           <CardTitle>
             <Title headingLevel="h2" size="lg">
@@ -47,16 +47,14 @@ const OcpCloudReportSummaryAltBase: React.SFC<OcpCloudReportSummaryAltProps> = (
           </CardBody>
         </div>
       </GridItem>
-      <GridItem xl={5} xl2={4}>
-        <div className="container">
-          <div className="tops">
-            {status !== FetchStatus.inProgress && (
-              <>
-                {Boolean(tabs) && <CardBody>{tabs}</CardBody>}
-                {Boolean(detailsLink) && <CardFooter>{detailsLink}</CardFooter>}
-              </>
-            )}
-          </div>
+      <GridItem xl={4}>
+        <div className="tops">
+          {status !== FetchStatus.inProgress && (
+            <>
+              {Boolean(tabs) && <CardBody>{tabs}</CardBody>}
+              {Boolean(detailsLink) && <CardFooter>{detailsLink}</CardFooter>}
+            </>
+          )}
         </div>
       </GridItem>
     </Grid>

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -351,7 +351,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         title={this.getTitle()}
       >
         {this.getDetails()}
-        {this.getChart(containerAltHeight, chartAltHeight, details.adjustChartContainerHeight)}
+        {this.getChart(containerAltHeight, chartAltHeight, details.adjustContainerHeight)}
       </ReportSummaryAlt>
     );
   };
@@ -502,7 +502,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         title={this.getTitle()}
       >
         {this.getDetails()}
-        {this.getChart(chartStyles.containerTrendHeight, chartStyles.chartHeight, details.adjustChartContainerHeight)}
+        {this.getChart(chartStyles.containerTrendHeight, chartStyles.chartHeight, details.adjustContainerHeight)}
         {Boolean(availableTabs) && <div style={styles.tabs}>{this.getTabs()}</div>}
       </ReportSummary>
     );

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -67,6 +67,7 @@ export const costSummaryWidget: AwsDashboardWidget = {
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.cost,
   details: {
+    adjustContainerHeight: true,
     appNavId: 'aws',
     costKey: 'aws_dashboard.cumulative_cost_label',
     formatOptions: {

--- a/src/store/dashboard/common/dashboardCommon.ts
+++ b/src/store/dashboard/common/dashboardCommon.ts
@@ -18,7 +18,7 @@ export interface DashboardWidget<T> {
   chartType?: DashboardChartType;
   currentTab?: T;
   details: {
-    adjustChartContainerHeight?: boolean; // Adjust chart container height for responsiveness
+    adjustContainerHeight?: boolean; // Adjust chart container height for responsiveness
     appNavId?: string; // Highlights Insights nav-item when view all link is clicked
     costKey?: string; // i18n key
     formatOptions: ValueFormatOptions;

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -17,7 +17,7 @@ export const costSummaryWidget: OcpDashboardWidget = {
   reportPathsType: ReportPathsType.ocp,
   reportType: ReportType.cost,
   details: {
-    adjustChartContainerHeight: true,
+    adjustContainerHeight: true,
     appNavId: 'ocp',
     costKey: 'ocp_dashboard.cumulative_cost_label',
     formatOptions: {


### PR DESCRIPTION
Instead of splitting the screen in half, we would like to have the chart take up about 2/3 of the available width. The progress bars can be shortened to use the remaining 1/3.


<img width="1919" alt="Screen Shot 2020-11-20 at 9 04 16 PM" src="https://user-images.githubusercontent.com/17481322/99864876-f82f1280-2b73-11eb-84eb-7f2bd7710fad.png">
