### PR TITLE
Account for dates with empty values

### DIFF
--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -193,14 +193,17 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     let forecastConeData;
     if (computedForecastItem) {
       const newForecast = cloneDeep(forecast);
-      if (forecast && currentReport) {
-        const date = currentReport.data ? currentReport.data[currentReport.data.length - 1].date : undefined;
+      if (forecast && currentReport && currentReport.data) {
         const total =
           currentReport.meta && currentReport.meta.total && currentReport.meta.total.cost
             ? currentReport.meta.total.cost.total.value
             : 0;
 
-        // Remove overlapping dates, if any
+        // Find last currentData date with values
+        const populatedValues = currentReport.data.filter(val => val.values.length);
+        const date = populatedValues[populatedValues.length - 1].date;
+
+        // Remove overlapping forecast dates, if any
         for (const item of forecast.data) {
           if (new Date(date) >= new Date(item.date)) {
             newForecast.data.shift();


### PR DESCRIPTION
Encountered a date with empty values, which may result in a disconnected line between the forecast and current month.

https://issues.redhat.com/browse/COST-736

<img width="1811" alt="Screen Shot 2020-11-20 at 10 14 25 PM" src="https://user-images.githubusercontent.com/17481322/99866263-c4f18100-2b7d-11eb-90ae-9f91de01cf31.png">