### PR TITLE
OpenShift cost forecast

### DIFF
--- a/src/api/forecasts/forecast.ts
+++ b/src/api/forecasts/forecast.ts
@@ -48,4 +48,6 @@ export const enum ForecastType {
 // eslint-disable-next-line no-shadow
 export const enum ForecastPathsType {
   aws = 'aws',
+  azure = 'azure',
+  ocp = 'ocp',
 }

--- a/src/api/forecasts/forecastUtils.ts
+++ b/src/api/forecasts/forecastUtils.ts
@@ -1,11 +1,18 @@
 import { runForecast as runAwsForecast } from './awsForecast';
 import { ForecastPathsType, ForecastType } from './forecast';
+import { runForecast as runOcpForecast } from './ocpForecast';
 
 export function runForecast(forecastPathsType: ForecastPathsType, forecastType: ForecastType, query: string) {
   let forecast;
   switch (forecastPathsType) {
     case ForecastPathsType.aws:
       forecast = runAwsForecast(forecastType, query);
+      break;
+    // case ForecastPathsType.azure:
+    //   forecast = runAzureForecast(forecastType, query);
+    //   break;
+    case ForecastPathsType.ocp:
+      forecast = runOcpForecast(forecastType, query);
       break;
   }
   return forecast;

--- a/src/api/forecasts/ocpForecast.ts
+++ b/src/api/forecasts/ocpForecast.ts
@@ -1,0 +1,12 @@
+import axios from 'axios';
+
+import { Forecast, ForecastType } from './forecast';
+
+export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
+  [ForecastType.cost]: 'forecasts/openshift/costs/',
+};
+
+export function runForecast(forecastType: ForecastType, query: string) {
+  const path = ForecastTypePaths[forecastType];
+  return axios.get<Forecast>(`${path}?${query}`);
+}

--- a/src/components/charts/costChart/costChart.styles.ts
+++ b/src/components/charts/costChart/costChart.styles.ts
@@ -21,10 +21,16 @@ export const chartStyles = {
     fill: 'none',
     strokeDasharray: '3,3',
   },
-  forecastCostData: {
-    fill: 'orange',
+  forecastColorScale: [chart_color_green_200.value],
+  forecastConeColorScale: [chart_color_green_100.value],
+  forecastData: {
+    fill: 'none',
   },
-  itemsPerRow: 2,
+  forecastConeData: {
+    fill: chart_color_green_100.value,
+    strokeWidth: 0,
+  },
+  itemsPerRow: 3,
   previousCostData: {
     fill: 'none',
   },

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -52,7 +52,6 @@ interface TrendChartLegendItem {
 interface TrendChartSeries {
   childName?: string;
   data?: [TrendChartData];
-  isForecast?: boolean;
   legendItem?: TrendChartLegendItem;
   style?: VictoryStyleInterface;
 }
@@ -163,11 +162,10 @@ class TrendChart extends React.Component<TrendChartProps, State> {
       },
     ];
 
-    if (forecastData) {
+    if (forecastData && forecastData.length) {
       series.push({
         childName: 'forecast',
         data: forecastData,
-        isForecast: true,
         legendItem: {
           name: getCostRangeString(forecastData, 'chart.cost_forecast_legend_label', false, false),
           symbol: {
@@ -184,11 +182,10 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         },
       });
     }
-    if (forecastConeData) {
+    if (forecastConeData && forecastConeData.length) {
       series.push({
         childName: 'forecastCone',
         data: forecastConeData,
-        isForecast: true,
         legendItem: {
           name: getCostRangeString(forecastConeData, 'chart.cost_forecast_cone_legend_label', false, false),
           symbol: {
@@ -221,17 +218,6 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   private getChart = (series: TrendChartSeries, index: number) => {
     const { hiddenSeries } = this.state;
 
-    if (series.isForecast) {
-      return (
-        <ChartArea
-          data={!hiddenSeries.has(index) ? series.data : [{ y: null }]}
-          interpolation="monotoneX"
-          key={series.childName}
-          name={series.childName}
-          style={series.style}
-        />
-      );
-    }
     return (
       <ChartArea
         data={!hiddenSeries.has(index) ? series.data : [{ y: null }]}
@@ -271,13 +257,14 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   };
 
   private getDomain() {
-    const { currentData, forecastData, previousData } = this.props;
+    const { currentData, forecastData, forecastConeData, previousData } = this.props;
     const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
 
     const maxCurrent = currentData ? getMaxValue(currentData) : 0;
-    const maxForecastCost = forecastData ? getMaxValue(forecastData) : 0;
+    const maxForecast = forecastData ? getMaxValue(forecastData) : 0;
+    const maxForecastCone = forecastConeData ? getMaxValue(forecastConeData) : 0;
     const maxPrevious = previousData ? getMaxValue(previousData) : 0;
-    const maxValue = Math.max(maxCurrent, maxForecastCost, maxPrevious);
+    const maxValue = Math.max(maxCurrent, maxForecast, maxForecastCone, maxPrevious);
     const max = maxValue > 0 ? Math.ceil(maxValue + maxValue * 0.1) : 0;
 
     if (max > 0) {

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -147,12 +147,17 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
       computedReportItemValue
     );
 
+    // Forecast data
+    const { forecastData, forecastConeData } = this.getForecastData();
+
     return (
       <ReportSummaryCost
         adjustContainerHeight={adjustContainerHeight}
         containerHeight={containerHeight}
         currentCostData={currentCostData}
         currentInfrastructureCostData={currentInfrastructureData}
+        forecastData={forecastData}
+        forecastConeData={forecastConeData}
         formatDatumValue={formatValue}
         formatDatumOptions={trend.formatOptions}
         height={height}
@@ -163,34 +168,13 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     );
   };
 
-  // This chart displays cost only
-  private getTrendChart = (
-    containerHeight: number,
-    height: number,
-    adjustContainerHeight: boolean = false,
-    showSupplementaryLabel: boolean = false
-  ) => {
-    const { currentReport, details, forecast, previousReport, t, trend } = this.props;
+  private getForecastData = () => {
+    const { currentReport, forecast, trend } = this.props;
 
-    const units = this.getUnits();
-    const title = t(trend.titleKey, { units: t(`units.${units}`) });
     const computedForecastItem = trend.computedForecastItem;
-    const computedReportItem = trend.computedReportItem || 'cost'; // cost, supplementaryCost, etc.
-    const computedReportItemValue = trend.computedReportItemValue || 'total';
-
-    // Data
-    const currentData = transformReport(currentReport, trend.type, 'date', computedReportItem, computedReportItemValue);
-    const previousData = transformReport(
-      previousReport,
-      trend.type,
-      'date',
-      computedReportItem,
-      computedReportItemValue
-    );
-
-    // Join forecast
     let forecastData;
     let forecastConeData;
+
     if (computedForecastItem) {
       const newForecast = cloneDeep(forecast);
       if (forecast && currentReport && currentReport.data) {
@@ -235,6 +219,35 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
       forecastData = transformForecast(newForecast, trend.type, computedForecastItem);
       forecastConeData = transformForecastCone(newForecast, trend.type, computedForecastItem);
     }
+    return { forecastData, forecastConeData };
+  };
+
+  // This chart displays cost only
+  private getTrendChart = (
+    containerHeight: number,
+    height: number,
+    adjustContainerHeight: boolean = false,
+    showSupplementaryLabel: boolean = false
+  ) => {
+    const { currentReport, details, previousReport, t, trend } = this.props;
+
+    const units = this.getUnits();
+    const title = t(trend.titleKey, { units: t(`units.${units}`) });
+    const computedReportItem = trend.computedReportItem || 'cost'; // cost, supplementaryCost, etc.
+    const computedReportItemValue = trend.computedReportItemValue || 'total';
+
+    // Cost data
+    const currentData = transformReport(currentReport, trend.type, 'date', computedReportItem, computedReportItemValue);
+    const previousData = transformReport(
+      previousReport,
+      trend.type,
+      'date',
+      computedReportItem,
+      computedReportItemValue
+    );
+
+    // Forecast data
+    const { forecastData, forecastConeData } = this.getForecastData();
 
     return (
       <ReportSummaryTrend

--- a/src/pages/dashboard/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/pages/dashboard/ocpDashboard/ocpDashboardWidget.tsx
@@ -7,12 +7,14 @@ import { withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { ocpDashboardActions, ocpDashboardSelectors, OcpDashboardTab } from 'store/dashboard/ocpDashboard';
+import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import { ComputedOcpReportItemsParams } from 'utils/computedReport/getComputedOcpReportItems';
 
 import { chartStyles } from './ocpDashboardWidget.styles';
 
 interface OcpDashboardWidgetDispatchProps {
+  fetchForecasts: typeof ocpDashboardActions.fetchWidgetForecasts;
   fetchReports: typeof ocpDashboardActions.fetchWidgetReports;
   updateTab: typeof ocpDashboardActions.changeWidgetTab;
 }
@@ -38,6 +40,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
       chartAltHeight: chartStyles.chartAltHeight,
       containerAltHeight: chartStyles.containerAltHeight,
       currentQuery: queries.current,
+      forecastQuery: queries.forecast,
       previousQuery: queries.previous,
       tabsQuery: queries.tabs,
       currentReport: reportSelectors.selectReport(state, widget.reportPathsType, widget.reportType, queries.current),
@@ -46,6 +49,12 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
         widget.reportPathsType,
         widget.reportType,
         queries.current
+      ),
+      forecast: forecastSelectors.selectForecast(
+        state,
+        widget.forecastPathsType,
+        widget.forecastType,
+        queries.forecast
       ),
       previousReport: reportSelectors.selectReport(state, widget.reportPathsType, widget.reportType, queries.previous),
       tabsReport: reportSelectors.selectReport(state, widget.reportPathsType, widget.reportType, queries.tabs),
@@ -60,6 +69,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
 );
 
 const mapDispatchToProps: OcpDashboardWidgetDispatchProps = {
+  fetchForecasts: ocpDashboardActions.fetchWidgetForecasts,
   fetchReports: ocpDashboardActions.fetchWidgetReports,
   updateTab: ocpDashboardActions.changeWidgetTab,
 };

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -14,6 +14,7 @@ export const costSummaryWidget: AzureDashboardWidget = {
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.cost,
   details: {
+    adjustContainerHeight: true,
     appNavId: 'aws',
     costKey: 'azure_dashboard.cumulative_cost_label',
     formatOptions: {

--- a/src/store/dashboard/ocpDashboard/ocpDashboardActions.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardActions.ts
@@ -1,9 +1,22 @@
 import { ThunkAction } from 'store/common';
+import { forecastActions } from 'store/forecasts';
 import { reportActions } from 'store/reports';
 import { createStandardAction } from 'typesafe-actions';
 
 import { OcpDashboardTab } from './ocpDashboardCommon';
 import { selectWidget, selectWidgetQueries } from './ocpDashboardSelectors';
+
+export const fetchWidgetForecasts = (id: number): ThunkAction => {
+  return (dispatch, getState) => {
+    const state = getState();
+    const widget = selectWidget(state, id);
+
+    if (widget.forecastPathsType && widget.forecastType) {
+      const { forecast } = selectWidgetQueries(state, id);
+      dispatch(forecastActions.fetchForecast(widget.forecastPathsType, widget.forecastType, forecast));
+    }
+  };
+};
 
 export const fetchWidgetReports = (id: number): ThunkAction => {
   return (dispatch, getState) => {

--- a/src/store/dashboard/ocpDashboard/ocpDashboardSelectors.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardSelectors.ts
@@ -34,6 +34,10 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       time_scope_value: -2,
     }),
     current: getQueryForWidget(defaultFilter),
+    forecast: getQueryForWidget({
+      limit: 31,
+      time_scope_value: -2,
+    }),
     tabs: getQueryForWidgetTabs(widget, {
       ...tabsFilter,
       resolution: 'monthly',

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -1,6 +1,11 @@
 import { ForecastPathsType, ForecastType } from 'api/forecasts/forecast';
 import { ReportPathsType, ReportType } from 'api/reports/report';
-import { ChartType, ComputedReportItemType, ComputedReportItemValueType } from 'components/charts/common/chartUtils';
+import {
+  ChartType,
+  ComputedForecastItemType,
+  ComputedReportItemType,
+  ComputedReportItemValueType,
+} from 'components/charts/common/chartUtils';
 import { paths } from 'routes';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 
@@ -12,7 +17,7 @@ const getId = () => currrentId++;
 export const costSummaryWidget: OcpDashboardWidget = {
   id: getId(),
   titleKey: 'ocp_dashboard.cost_title',
-  forecastPathsType: ForecastPathsType.aws, // Todo: For testing
+  forecastPathsType: ForecastPathsType.ocp,
   forecastType: ForecastType.cost,
   reportPathsType: ReportPathsType.ocp,
   reportType: ReportType.cost,
@@ -28,6 +33,7 @@ export const costSummaryWidget: OcpDashboardWidget = {
     viewAllPath: paths.ocpDetails,
   },
   trend: {
+    computedForecastItem: ComputedForecastItemType.cost,
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},


### PR DESCRIPTION
Created the initial Ocp cost forecast and cone of confidence.

https://issues.redhat.com/browse/COST-738

Note: There is an issue with the forecast data; thus, the forecast is currently a flat line.
See https://issues.redhat.com/browse/COST-760

<img width="1625" alt="Screen Shot 2020-11-23 at 12 11 19 AM" src="https://user-images.githubusercontent.com/17481322/99931203-aa580d00-2d21-11eb-8a0b-758bd9f1b172.png">
