### PR TITLE
Refactor computed items data structure

### DIFF
--- a/src/api/forecasts/forecast.ts
+++ b/src/api/forecasts/forecast.ts
@@ -1,26 +1,26 @@
-export interface ForecastItemValue {
+export interface ForecastValue {
   units?: string;
   value?: number | string;
 }
 
-export interface ForecastItem {
-  confidence_max?: ForecastItemValue;
-  confidence_min?: ForecastItemValue;
-  rsquared?: ForecastItemValue;
-  pvalues?: ForecastItemValue;
-  total?: ForecastItemValue;
+export interface ForecastItemValue {
+  confidence_max?: ForecastValue;
+  confidence_min?: ForecastValue;
+  rsquared?: ForecastValue;
+  pvalues?: ForecastValue;
+  total?: ForecastValue;
 }
 
-export interface ForecastValue {
-  cost?: ForecastItem;
+export interface ForecastItem {
+  cost?: ForecastItemValue;
   date?: string;
-  infrastructure?: ForecastItem;
-  supplementary?: ForecastItem;
+  infrastructure?: ForecastItemValue;
+  supplementary?: ForecastItemValue;
 }
 
 export interface ForecastData {
   date?: string;
-  values?: ForecastValue[]; // tags
+  values?: ForecastItem[];
 }
 
 export interface ForecastMeta {

--- a/src/api/reports/awsCloudReports.ts
+++ b/src/api/reports/awsCloudReports.ts
@@ -1,9 +1,9 @@
 import axios from 'axios';
 import { Omit } from 'react-redux';
 
-import { Report, ReportCostTypeDatum, ReportData, ReportDatum, ReportMeta, ReportType, ReportValue } from './report';
+import { Report, ReportData, ReportItem, ReportItemValue, ReportMeta, ReportType, ReportValue } from './report';
 
-export interface AwsCloudReportValue extends ReportValue {
+export interface AwsCloudReportItem extends ReportItem {
   account?: string;
   account_alias?: string;
   instance_type?: string;
@@ -36,10 +36,10 @@ export interface AwsCloudReportData extends ReportData {
 
 export interface AwsCloudReportMeta extends ReportMeta {
   total?: {
-    cost: ReportCostTypeDatum;
-    infrastructure: ReportCostTypeDatum;
-    supplementary: ReportCostTypeDatum;
-    usage?: ReportDatum;
+    cost?: ReportItemValue;
+    infrastructure?: ReportItemValue;
+    supplementary?: ReportItemValue;
+    usage?: ReportValue;
   };
 }
 

--- a/src/api/reports/awsReports.ts
+++ b/src/api/reports/awsReports.ts
@@ -1,9 +1,9 @@
 import axios from 'axios';
 import { Omit } from 'react-redux';
 
-import { Report, ReportCostTypeDatum, ReportData, ReportDatum, ReportMeta, ReportType, ReportValue } from './report';
+import { Report, ReportData, ReportItem, ReportItemValue, ReportMeta, ReportType, ReportValue } from './report';
 
-export interface AwsReportValue extends ReportValue {
+export interface AwsReportItem extends ReportItem {
   account?: string;
   account_alias?: string;
   instance_type?: string;
@@ -37,10 +37,10 @@ export interface AwsReportData extends ReportData {
 
 export interface AwsReportMeta extends ReportMeta {
   total?: {
-    cost: ReportCostTypeDatum;
-    infrastructure: ReportCostTypeDatum;
-    supplementary: ReportCostTypeDatum;
-    usage?: ReportDatum;
+    cost?: ReportItemValue;
+    infrastructure?: ReportItemValue;
+    supplementary?: ReportItemValue;
+    usage?: ReportValue;
   };
 }
 

--- a/src/api/reports/azureCloudReports.ts
+++ b/src/api/reports/azureCloudReports.ts
@@ -1,10 +1,9 @@
 import axios from 'axios';
 import { Omit } from 'react-redux';
 
-import { ReportType } from './report';
-import { Report, ReportCostTypeDatum, ReportData, ReportDatum, ReportMeta, ReportValue } from './report';
+import { Report, ReportData, ReportItem, ReportItemValue, ReportMeta, ReportType, ReportValue } from './report';
 
-export interface AzureCloudReportValue extends ReportValue {
+export interface AzureCloudReportItem extends ReportItem {
   instance_type?: string;
   resource_location?: string;
   service_name?: string;
@@ -36,11 +35,10 @@ export interface AzureCloudReportData extends ReportData {
 
 export interface AzureCloudReportMeta extends ReportMeta {
   total?: {
-    cost: ReportCostTypeDatum;
-    count?: ReportDatum;
-    infrastructure: ReportCostTypeDatum;
-    supplementary: ReportCostTypeDatum;
-    usage?: ReportDatum;
+    cost?: ReportItemValue;
+    infrastructure?: ReportItemValue;
+    supplementary?: ReportItemValue;
+    usage?: ReportValue;
   };
 }
 

--- a/src/api/reports/azureReports.ts
+++ b/src/api/reports/azureReports.ts
@@ -2,9 +2,9 @@ import axios from 'axios';
 import { Omit } from 'react-redux';
 
 import { ReportType } from './report';
-import { Report, ReportCostTypeDatum, ReportData, ReportDatum, ReportMeta, ReportValue } from './report';
+import { Report, ReportData, ReportItem, ReportItemValue, ReportMeta, ReportValue } from './report';
 
-export interface AzureReportValue extends ReportValue {
+export interface AzureReportItem extends ReportItem {
   instance_type?: string;
   resource_location?: string;
   service_name?: string;
@@ -36,11 +36,11 @@ export interface AzureReportData extends ReportData {
 
 export interface AzureReportMeta extends ReportMeta {
   total?: {
-    cost: ReportCostTypeDatum;
-    count?: ReportDatum;
-    infrastructure: ReportCostTypeDatum;
-    supplementary: ReportCostTypeDatum;
-    usage?: ReportDatum;
+    cost?: ReportItemValue;
+    count?: ReportValue; // Workaround for https://github.com/project-koku/koku/issues/1395
+    infrastructure?: ReportItemValue;
+    supplementary?: ReportItemValue;
+    usage?: ReportValue;
   };
 }
 

--- a/src/api/reports/gcpReports.ts
+++ b/src/api/reports/gcpReports.ts
@@ -1,9 +1,9 @@
 import axios from 'axios';
 import { Omit } from 'react-redux';
 
-import { Report, ReportCostTypeDatum, ReportData, ReportDatum, ReportMeta, ReportType, ReportValue } from './report';
+import { Report, ReportData, ReportItem, ReportItemValue, ReportMeta, ReportType, ReportValue } from './report';
 
-export interface GcpReportValue extends ReportValue {
+export interface GcpReportItem extends ReportItem {
   account?: string;
   account_alias?: string;
   instance_type?: string;
@@ -36,10 +36,10 @@ export interface GcpReportData extends ReportData {
 
 export interface GcpReportMeta extends ReportMeta {
   total?: {
-    cost: ReportCostTypeDatum;
-    infrastructure: ReportCostTypeDatum;
-    supplementary: ReportCostTypeDatum;
-    usage?: ReportDatum;
+    cost?: ReportItemValue;
+    infrastructure?: ReportItemValue;
+    supplementary?: ReportItemValue;
+    usage?: ReportValue;
   };
 }
 

--- a/src/api/reports/ocpCloudReports.ts
+++ b/src/api/reports/ocpCloudReports.ts
@@ -1,21 +1,21 @@
 import axios from 'axios';
 import { Omit } from 'react-redux';
 
-import { Report, ReportCostTypeDatum, ReportData, ReportDatum, ReportMeta, ReportType, ReportValue } from './report';
+import { Report, ReportData, ReportItem, ReportItemValue, ReportMeta, ReportType, ReportValue } from './report';
 
 // Todo: Remove capacity, limit, & request?
-export interface OcpCloudReportValue extends ReportValue {
+export interface OcpCloudReportItem extends ReportItem {
   account?: string;
   account_alias?: string;
-  capacity?: ReportDatum;
+  capacity?: ReportValue;
   cluster?: string;
   clusters?: string[];
   instance_type?: string;
-  limit?: ReportDatum;
+  limit?: ReportValue;
   node?: string;
   project?: string;
   region?: string;
-  request?: ReportDatum;
+  request?: ReportValue;
   service?: string;
 }
 
@@ -59,13 +59,13 @@ export interface OcpCloudReportData extends ReportData {
 
 export interface OcpCloudReportMeta extends ReportMeta {
   total?: {
-    cost: ReportCostTypeDatum;
-    infrastructure: ReportCostTypeDatum;
-    supplementary: ReportCostTypeDatum;
-    capacity?: ReportDatum;
-    limit?: ReportDatum;
-    request?: ReportDatum;
-    usage?: ReportDatum;
+    capacity?: ReportValue;
+    cost?: ReportItemValue;
+    infrastructure?: ReportItemValue;
+    limit?: ReportValue;
+    request?: ReportValue;
+    supplementary?: ReportItemValue;
+    usage?: ReportValue;
   };
 }
 

--- a/src/api/reports/ocpReports.ts
+++ b/src/api/reports/ocpReports.ts
@@ -1,16 +1,16 @@
 import axios from 'axios';
 import { Omit } from 'react-redux';
 
-import { Report, ReportCostTypeDatum, ReportData, ReportDatum, ReportMeta, ReportType, ReportValue } from './report';
+import { Report, ReportData, ReportItem, ReportItemValue, ReportMeta, ReportType, ReportValue } from './report';
 
-export interface OcpReportValue extends ReportValue {
-  capacity?: ReportDatum;
+export interface OcpReportItem extends ReportItem {
+  capacity?: ReportValue;
   cluster?: string;
   clusters?: string[];
-  limit?: ReportDatum;
+  limit?: ReportValue;
   node?: string;
   project?: string;
-  request?: ReportDatum;
+  request?: ReportValue;
 }
 
 export interface GroupByClusterData extends Omit<OcpReportData, 'clusters'> {
@@ -33,13 +33,13 @@ export interface OcpReportData extends ReportData {
 
 export interface OcpReportMeta extends ReportMeta {
   total?: {
-    capacity?: ReportDatum;
-    cost: ReportCostTypeDatum;
-    infrastructure: ReportCostTypeDatum;
-    limit?: ReportDatum;
-    request?: ReportDatum;
-    supplementary: ReportCostTypeDatum;
-    usage?: ReportDatum;
+    capacity?: ReportValue;
+    cost?: ReportItemValue;
+    infrastructure?: ReportItemValue;
+    limit?: ReportValue;
+    request?: ReportValue;
+    supplementary?: ReportItemValue;
+    usage?: ReportValue;
   };
 }
 

--- a/src/api/reports/ocpUsageReports.ts
+++ b/src/api/reports/ocpUsageReports.ts
@@ -1,21 +1,21 @@
 import axios from 'axios';
 import { Omit } from 'react-redux';
 
-import { Report, ReportCostTypeDatum, ReportData, ReportDatum, ReportMeta, ReportType, ReportValue } from './report';
+import { Report, ReportData, ReportItem, ReportItemValue, ReportMeta, ReportType, ReportValue } from './report';
 
 // Todo: Remove capacity, limit, & request?
-export interface OcpUsageReportValue extends ReportValue {
+export interface OcpUsageReportItem extends ReportItem {
   account?: string;
   account_alias?: string;
-  capacity?: ReportDatum;
+  capacity?: ReportValue;
   cluster?: string;
   clusters?: string[];
   instance_type?: string;
-  limit?: ReportDatum;
+  limit?: ReportValue;
   node?: string;
   project?: string;
   region?: string;
-  request?: ReportDatum;
+  request?: ReportValue;
   service?: string;
 }
 
@@ -59,13 +59,13 @@ export interface OcpUsageReportData extends ReportData {
 
 export interface OcpUsageReportMeta extends ReportMeta {
   total?: {
-    cost: ReportCostTypeDatum;
-    infrastructure: ReportCostTypeDatum;
-    supplementary: ReportCostTypeDatum;
-    capacity?: ReportDatum;
-    limit?: ReportDatum;
-    request?: ReportDatum;
-    usage?: ReportDatum;
+    capacity?: ReportValue;
+    cost?: ReportItemValue;
+    infrastructure?: ReportItemValue;
+    limit?: ReportValue;
+    request?: ReportValue;
+    supplementary?: ReportItemValue;
+    usage?: ReportValue;
   };
 }
 

--- a/src/api/reports/report.ts
+++ b/src/api/reports/report.ts
@@ -1,35 +1,69 @@
-export interface ReportDatum {
-  value: number;
-  units: string;
-}
-
-export interface ReportCostTypeDatum {
-  raw: ReportDatum;
-  markup: ReportDatum;
-  usage: ReportDatum;
-  total: ReportDatum;
-}
-
 export interface ReportValue {
-  cluster?: string;
-  cost: ReportCostTypeDatum;
-  count?: ReportDatum;
-  date?: string;
-  delta_percent?: number;
-  delta_value?: number;
-  supplementary?: ReportCostTypeDatum;
-  infrastructure?: ReportCostTypeDatum;
-  usage?: ReportDatum;
+  units?: string;
+  value?: number;
 }
 
-export interface ReportData {
+export interface ReportItemValue {
+  markup?: ReportValue;
+  raw?: ReportValue;
+  total?: ReportValue;
+  usage: ReportValue;
+}
+
+export interface ReportItem {
+  cost?: ReportItemValue;
   date?: string;
   delta_percent?: number;
   delta_value?: number;
-  key?: string; // tags
-  level?: number; // org units
-  type?: string; // account or organizational_unit
-  values?: ReportValue[]; // tags
+  infrastructure?: ReportItemValue;
+  source_uuid?: string;
+  supplementary?: ReportItemValue;
+}
+
+export interface ReportAwsItem extends ReportItem {
+  account?: string;
+  account_alias?: string;
+  region?: string;
+  service?: string;
+}
+
+export interface ReportAzureItem extends ReportItem {
+  resource_location?: string; // 'region'
+  service_name?: string; // 'service'
+  subscription_guid?: string; // 'account'
+}
+
+export interface ReportOcpItem extends ReportItem {
+  capacity: ReportValue;
+  cluster?: string;
+  clusters?: string[];
+  limit: ReportValue;
+  node?: string;
+  project?: string;
+  request: ReportValue;
+  usage: ReportValue;
+}
+
+export interface ReportOrgItem extends ReportItem {
+  alias?: string;
+  id?: string;
+}
+
+export interface ReportOrgData {
+  id?: string;
+  level?: number;
+  org_unit_id?: string;
+  type?: string; // 'account' or 'organizational_unit'
+}
+
+export interface ReportTagData {
+  enabled?: boolean;
+  key?: string;
+}
+
+export interface ReportData extends ReportOrgData, ReportTagData {
+  date?: string;
+  values?: ReportAwsItem[] | ReportAzureItem[] | ReportOcpItem[] | ReportOrgItem[] | string[]; // tags use string[]
 }
 
 export interface ReportMeta {
@@ -48,14 +82,14 @@ export interface ReportMeta {
     [filter: string]: any;
   };
   total?: {
-    capacity?: ReportDatum;
-    cost: ReportCostTypeDatum;
-    count?: ReportDatum;
-    infrastructure: ReportCostTypeDatum;
-    limit?: ReportDatum;
-    request?: ReportDatum;
-    supplementary: ReportCostTypeDatum;
-    usage?: ReportDatum;
+    capacity?: ReportValue;
+    cost?: ReportItemValue;
+    count?: ReportValue; // Workaround for https://github.com/project-koku/koku/issues/1395
+    infrastructure?: ReportItemValue;
+    limit?: ReportValue;
+    request?: ReportValue;
+    supplementary?: ReportItemValue;
+    usage?: ReportValue;
   };
 }
 
@@ -67,9 +101,9 @@ export interface ReportLinks {
 }
 
 export interface Report {
-  meta: ReportMeta;
-  links: ReportLinks;
   data: ReportData[];
+  links?: ReportLinks;
+  meta: ReportMeta;
 }
 
 // eslint-disable-next-line no-shadow

--- a/src/components/charts/historicalCostChart/__snapshots__/historicalCostChart.test.tsx.snap
+++ b/src/components/charts/historicalCostChart/__snapshots__/historicalCostChart.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`reports are formatted to datums: current month cost data 1`] = `
 Array [
   Object {
     "key": "12-15-17",
-    "units": "USD",
+    "units": null,
     "x": 15,
     "y": 0,
   },
@@ -15,7 +15,7 @@ exports[`reports are formatted to datums: current month infrastructure cost data
 Array [
   Object {
     "key": "1-15-18",
-    "units": "USD",
+    "units": null,
     "x": 15,
     "y": 0,
   },
@@ -26,7 +26,7 @@ exports[`reports are formatted to datums: previous month cost data 1`] = `
 Array [
   Object {
     "key": "12-15-17",
-    "units": undefined,
+    "units": null,
     "x": 15,
     "y": 0,
   },
@@ -37,7 +37,7 @@ exports[`reports are formatted to datums: previous month infrastructure cost dat
 Array [
   Object {
     "key": "1-15-18",
-    "units": undefined,
+    "units": null,
     "x": 15,
     "y": 0,
   },

--- a/src/components/charts/historicalTrendChart/__snapshots__/historicalTrendChart.test.tsx.snap
+++ b/src/components/charts/historicalTrendChart/__snapshots__/historicalTrendChart.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`reports are formatted to datums: current month data 1`] = `
 Array [
   Object {
     "key": "1-15-18",
-    "units": "USD",
+    "units": null,
     "x": 15,
     "y": 0,
   },
@@ -15,7 +15,7 @@ exports[`reports are formatted to datums: previous month data 1`] = `
 Array [
   Object {
     "key": "12-15-17",
-    "units": "USD",
+    "units": null,
     "x": 15,
     "y": 0,
   },
@@ -26,13 +26,13 @@ exports[`trend is a daily value: current month data 1`] = `
 Array [
   Object {
     "key": "1-15-18",
-    "units": "USD",
+    "units": null,
     "x": 15,
     "y": 0,
   },
   Object {
     "key": "1-16-18",
-    "units": "USD",
+    "units": null,
     "x": 16,
     "y": 0,
   },
@@ -43,13 +43,13 @@ exports[`trend is a running total: current month data 1`] = `
 Array [
   Object {
     "key": "1-15-18",
-    "units": "USD",
+    "units": null,
     "x": 15,
     "y": 0,
   },
   Object {
     "key": "1-16-18",
-    "units": "USD",
+    "units": null,
     "x": 16,
     "y": 0,
   },

--- a/src/components/charts/historicalUsageChart/__snapshots__/historicalUsageChart.test.tsx.snap
+++ b/src/components/charts/historicalUsageChart/__snapshots__/historicalUsageChart.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`reports are formatted to datums: previous month request data 1`] = `
 Array [
   Object {
     "key": "1-15-18",
-    "units": undefined,
+    "units": "Core-Hours",
     "x": 15,
     "y": 0,
   },
@@ -37,7 +37,7 @@ exports[`reports are formatted to datums: previous month usage data 1`] = `
 Array [
   Object {
     "key": "12-15-17",
-    "units": undefined,
+    "units": "Core-Hours",
     "x": 15,
     "y": 0,
   },

--- a/src/components/charts/trendChart/__snapshots__/trendChart.test.tsx.snap
+++ b/src/components/charts/trendChart/__snapshots__/trendChart.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`reports are formatted to datums: current month data 1`] = `
 Array [
   Object {
     "key": "1-15-18",
-    "units": "USD",
+    "units": null,
     "x": 15,
     "y": 0,
   },
@@ -15,7 +15,7 @@ exports[`reports are formatted to datums: previous month data 1`] = `
 Array [
   Object {
     "key": "12-15-17",
-    "units": "USD",
+    "units": null,
     "x": 15,
     "y": 0,
   },
@@ -26,13 +26,13 @@ exports[`trend is a daily value: current month data 1`] = `
 Array [
   Object {
     "key": "1-15-18",
-    "units": "USD",
+    "units": null,
     "x": 15,
     "y": 0,
   },
   Object {
     "key": "1-16-18",
-    "units": "USD",
+    "units": null,
     "x": 16,
     "y": 0,
   },
@@ -43,13 +43,13 @@ exports[`trend is a running total: current month data 1`] = `
 Array [
   Object {
     "key": "1-15-18",
-    "units": "USD",
+    "units": null,
     "x": 15,
     "y": 0,
   },
   Object {
     "key": "1-16-18",
-    "units": "USD",
+    "units": null,
     "x": 16,
     "y": 0,
   },

--- a/src/components/charts/usageChart/__snapshots__/usageChart.test.tsx.snap
+++ b/src/components/charts/usageChart/__snapshots__/usageChart.test.tsx.snap
@@ -26,7 +26,7 @@ exports[`reports are formatted to datums: previous month request data 1`] = `
 Array [
   Object {
     "key": "1-15-18",
-    "units": undefined,
+    "units": "Core-Hours",
     "x": 15,
     "y": 0,
   },
@@ -37,7 +37,7 @@ exports[`reports are formatted to datums: previous month usage data 1`] = `
 Array [
   Object {
     "key": "12-15-17",
-    "units": undefined,
+    "units": "Core-Hours",
     "x": 15,
     "y": 0,
   },

--- a/src/components/reports/reportSummary/reportSummaryItems.test.tsx
+++ b/src/components/reports/reportSummary/reportSummaryItems.test.tsx
@@ -18,7 +18,6 @@ test('computes report items', () => {
   expect(utils.getComputedReportItems).toBeCalledWith({
     report: props.report,
     idKey: props.idKey,
-    reportItemValue: 'total',
   });
   expect(props.children).toBeCalledWith({ items: [] });
 });

--- a/src/components/reports/reportSummary/reportSummaryItems.test.tsx
+++ b/src/components/reports/reportSummary/reportSummaryItems.test.tsx
@@ -9,7 +9,6 @@ jest.spyOn(utils, 'getComputedReportItems');
 const props: ReportSummaryItemsProps = {
   report: { data: [] },
   idKey: 'date',
-  labelKey: 'account',
   children: jest.fn(() => null),
   t: jest.fn(v => `t(${v})`),
 };
@@ -19,7 +18,6 @@ test('computes report items', () => {
   expect(utils.getComputedReportItems).toBeCalledWith({
     report: props.report,
     idKey: props.idKey,
-    labelKey: props.labelKey,
     reportItemValue: 'total',
   });
   expect(props.children).toBeCalledWith({ items: [] });

--- a/src/components/reports/reportSummary/reportSummaryItems.tsx
+++ b/src/components/reports/reportSummary/reportSummaryItems.tsx
@@ -1,7 +1,7 @@
 import './reportSummaryItems.scss';
 
 import { Skeleton } from '@redhat-cloud-services/frontend-components/components/Skeleton';
-import { Report, ReportValue } from 'api/reports/report';
+import { Report, ReportItem } from 'api/reports/report';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { FetchStatus } from 'store/common';
@@ -15,8 +15,7 @@ interface ReportSummaryItemsRenderProps {
   items: ComputedReportItem[];
 }
 
-interface ReportSummaryItemsOwnProps extends ComputedReportItemsParams<Report, ReportValue> {
-  computedReportItemValue?: string;
+interface ReportSummaryItemsOwnProps extends ComputedReportItemsParams<Report, ReportItem> {
   children?(props: ReportSummaryItemsRenderProps): React.ReactNode;
   status?: number;
 }
@@ -29,13 +28,11 @@ class ReportSummaryItemsBase extends React.Component<ReportSummaryItemsProps> {
   }
 
   private getItems() {
-    const { computedReportItemValue = 'total', idKey, labelKey, report } = this.props;
+    const { idKey, report } = this.props;
 
     const computedItems = getComputedReportItems({
       report,
       idKey,
-      labelKey,
-      reportItemValue: computedReportItemValue,
     });
 
     const otherIndex = computedItems.findIndex(i => {

--- a/src/pages/dashboard/components/__snapshots__/dashboardWidget.test.tsx.snap
+++ b/src/pages/dashboard/components/__snapshots__/dashboardWidget.test.tsx.snap
@@ -1,7 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`detail label is translated 1`] = `undefined`;
-
 exports[`subtitle is translated with date range 1`] = `
 Array [
   "aws_dashboard.widget_subtitle",

--- a/src/pages/dashboard/components/dashboardWidget.test.tsx
+++ b/src/pages/dashboard/components/dashboardWidget.test.tsx
@@ -35,8 +35,6 @@ const props: DashboardWidgetProps = {
   previousQuery: '',
   tabsQuery: '',
   details: {
-    labelKey: 'detail label',
-    labelKeyContext: 'label context',
     breakdownDescKeyRange: 'detail description range',
     breakdownDescKeySingle: 'detail description single',
     formatOptions: {},
@@ -65,11 +63,6 @@ test('reports are fetched on mount', () => {
 test('title is translated', () => {
   shallow(<DashboardWidgetBase {...props} />);
   expect(getTranslateCallForKey(props.titleKey)).toMatchSnapshot();
-});
-
-test('detail label is translated', () => {
-  shallow(<DashboardWidgetBase {...props} />);
-  expect(getTranslateCallForKey(props.details.labelKey)).toMatchSnapshot();
 });
 
 test('subtitle is translated with single date', () => {

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -112,8 +112,8 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
 
     const units = this.getUnits();
     const title = t(trend.titleKey, { units: t(`units.${units}`) });
-    const computedReportItem = trend.computedReportItem || 'cost'; // cost, supplementaryCost, etc.
-    const computedReportItemValue = trend.computedReportItemValue || 'total';
+    const computedReportItem = trend.computedReportItem; // cost, supplementary cost, etc.
+    const computedReportItemValue = trend.computedReportItemValue; // infrastructure usage cost
 
     // Infrastructure data
     const currentInfrastructureData = transformReport(
@@ -233,8 +233,8 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
 
     const units = this.getUnits();
     const title = t(trend.titleKey, { units: t(`units.${units}`) });
-    const computedReportItem = trend.computedReportItem || 'cost'; // cost, supplementaryCost, etc.
-    const computedReportItemValue = trend.computedReportItemValue || 'total';
+    const computedReportItem = trend.computedReportItem; // cost, supplementary cost, etc.
+    const computedReportItemValue = trend.computedReportItemValue; // infrastructure usage cost
 
     // Cost data
     const currentData = transformReport(currentReport, trend.type, 'date', computedReportItem, computedReportItemValue);
@@ -389,9 +389,8 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   };
 
   private getTab = <T extends DashboardWidget<any>>(tab: T, index: number) => {
-    const { getIdKeyForTab, tabsReport, tabsReportFetchStatus, trend } = this.props;
+    const { getIdKeyForTab, tabsReport, tabsReportFetchStatus } = this.props;
     const currentTab: any = getIdKeyForTab(tab);
-    const computedReportItemValue = trend.computedReportItemValue || 'total';
 
     return (
       <Tab
@@ -401,7 +400,6 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
       >
         <div style={styles.tabItems}>
           <ReportSummaryItems
-            computedReportItemValue={computedReportItemValue}
             idKey={currentTab}
             key={`${currentTab}-items`}
             report={tabsReport}
@@ -448,7 +446,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
           label={reportItem.label ? reportItem.label.toString() : ''}
           totalValue={totalValue}
           units={details.units ? details.units : this.getUnits()}
-          value={reportItem[computedReportItem]}
+          value={reportItem[computedReportItem][computedReportItemValue].value}
         />
       );
     } else {

--- a/src/pages/details/awsDetails/detailsTable.tsx
+++ b/src/pages/details/awsDetails/detailsTable.tsx
@@ -297,19 +297,19 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
   private getMonthOverMonthCost = (item: ComputedReportItem, index: number) => {
     const { t } = this.props;
-    const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
-    const percentage = item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
+    const value = formatCurrency(Math.abs(item.cost.total.value - item.delta_value));
+    const percentage = item.delta_percent !== null ? Math.abs(item.delta_percent).toFixed(2) : 0;
 
     const showPercentage = !(percentage === 0 || percentage === '0.00');
-    const showValue = item.deltaPercent !== null; // Workaround for https://github.com/project-koku/koku/issues/1395
+    const showValue = item.delta_percent !== null; // Workaround for https://github.com/project-koku/koku/issues/1395
 
     let iconOverride;
     if (showPercentage) {
       iconOverride = 'iconOverride';
-      if (item.deltaPercent !== null && item.deltaValue < 0) {
+      if (item.delta_percent !== null && item.delta_value < 0) {
         iconOverride += ' decrease';
       }
-      if (item.deltaPercent !== null && item.deltaValue > 0) {
+      if (item.delta_percent !== null && item.delta_value > 0) {
         iconOverride += ' increase';
       }
     }
@@ -321,10 +321,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         <div className="monthOverMonthOverride">
           <div className={iconOverride} key={`month-over-month-cost-${index}`}>
             {showPercentage ? t('percent', { value: percentage }) : <EmptyValueState />}
-            {Boolean(showPercentage && item.deltaPercent !== null && item.deltaValue > 0) && (
+            {Boolean(showPercentage && item.delta_percent !== null && item.delta_value > 0) && (
               <span className="fa fa-sort-up" style={styles.infoArrow} key={`month-over-month-icon-${index}`} />
             )}
-            {Boolean(showPercentage && item.deltaPercent !== null && item.deltaValue < 0) && (
+            {Boolean(showPercentage && item.delta_percent !== null && item.delta_value < 0) && (
               <span
                 className="fa fa-sort-down"
                 style={{
@@ -373,10 +373,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
     return (
       <>
-        {formatCurrency(item.cost)}
+        {formatCurrency(item.cost.total.value)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
-            value: ((item.cost / cost) * 100).toFixed(2),
+            value: ((item.cost.total.value / cost) * 100).toFixed(2),
           })}
         </div>
       </>

--- a/src/pages/details/azureDetails/detailsTable.tsx
+++ b/src/pages/details/azureDetails/detailsTable.tsx
@@ -230,19 +230,19 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
   private getMonthOverMonthCost = (item: ComputedReportItem, index: number) => {
     const { t } = this.props;
-    const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
-    const percentage = item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
+    const value = formatCurrency(Math.abs(item.cost.total.value - item.delta_value));
+    const percentage = item.delta_percent !== null ? Math.abs(item.delta_percent).toFixed(2) : 0;
 
     const showPercentage = !(percentage === 0 || percentage === '0.00');
-    const showValue = item.deltaPercent !== null; // Workaround for https://github.com/project-koku/koku/issues/1395
+    const showValue = item.delta_percent !== null; // Workaround for https://github.com/project-koku/koku/issues/1395
 
     let iconOverride;
     if (showPercentage) {
       iconOverride = 'iconOverride';
-      if (item.deltaPercent !== null && item.deltaValue < 0) {
+      if (item.delta_percent !== null && item.delta_value < 0) {
         iconOverride += ' decrease';
       }
-      if (item.deltaPercent !== null && item.deltaValue > 0) {
+      if (item.delta_percent !== null && item.delta_value > 0) {
         iconOverride += ' increase';
       }
     }
@@ -254,10 +254,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         <div className="monthOverMonthOverride">
           <div className={iconOverride} key={`month-over-month-cost-${index}`}>
             {showPercentage ? t('percent', { value: percentage }) : <EmptyValueState />}
-            {Boolean(showPercentage && item.deltaPercent !== null && item.deltaValue > 0) && (
+            {Boolean(showPercentage && item.delta_percent !== null && item.delta_value > 0) && (
               <span className="fa fa-sort-up" style={styles.infoArrow} key={`month-over-month-icon-${index}`} />
             )}
-            {Boolean(showPercentage && item.deltaPercent !== null && item.deltaValue < 0) && (
+            {Boolean(showPercentage && item.delta_percent !== null && item.delta_value < 0) && (
               <span
                 className="fa fa-sort-down"
                 style={{
@@ -306,10 +306,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
     return (
       <>
-        {formatCurrency(item.cost)}
+        {formatCurrency(item.cost.total.value)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
-            value: ((item.cost / cost) * 100).toFixed(2),
+            value: ((item.cost.total.value / cost) * 100).toFixed(2),
           })}
         </div>
       </>

--- a/src/pages/details/components/summary/summaryCard.tsx
+++ b/src/pages/details/components/summary/summaryCard.tsx
@@ -90,7 +90,7 @@ class SummaryBase extends React.Component<SummaryProps> {
               label={reportItem.label ? reportItem.label.toString() : undefined}
               totalValue={report.meta.total.cost.total.value}
               units={report.meta.total.cost.total.units}
-              value={reportItem.cost}
+              value={reportItem.cost.total.value}
             />
           ))
         }

--- a/src/pages/details/components/summary/summaryModalView.tsx
+++ b/src/pages/details/components/summary/summaryModalView.tsx
@@ -77,7 +77,7 @@ class SummaryModalViewBase extends React.Component<SummaryModalViewProps> {
                   label={_item.label ? _item.label.toString() : ''}
                   totalValue={report.meta.total.cost.total.value}
                   units={report.meta.total.cost.total.units}
-                  value={_item.cost}
+                  value={_item.cost.total.value}
                 />
               ))
             }

--- a/src/pages/details/gcpDetails/detailsTable.tsx
+++ b/src/pages/details/gcpDetails/detailsTable.tsx
@@ -230,19 +230,19 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
   private getMonthOverMonthCost = (item: ComputedReportItem, index: number) => {
     const { t } = this.props;
-    const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
-    const percentage = item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
+    const value = formatCurrency(Math.abs(item.cost.total.value - item.delta_value));
+    const percentage = item.delta_percent !== null ? Math.abs(item.delta_percent).toFixed(2) : 0;
 
     const showPercentage = !(percentage === 0 || percentage === '0.00');
-    const showValue = item.deltaPercent !== null; // Workaround for https://github.com/project-koku/koku/issues/1395
+    const showValue = item.delta_percent !== null; // Workaround for https://github.com/project-koku/koku/issues/1395
 
     let iconOverride;
     if (showPercentage) {
       iconOverride = 'iconOverride';
-      if (item.deltaPercent !== null && item.deltaValue < 0) {
+      if (item.delta_percent !== null && item.delta_value < 0) {
         iconOverride += ' decrease';
       }
-      if (item.deltaPercent !== null && item.deltaValue > 0) {
+      if (item.delta_percent !== null && item.delta_value > 0) {
         iconOverride += ' increase';
       }
     }
@@ -254,10 +254,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         <div className="monthOverMonthOverride">
           <div className={iconOverride} key={`month-over-month-cost-${index}`}>
             {showPercentage ? t('percent', { value: percentage }) : <EmptyValueState />}
-            {Boolean(showPercentage && item.deltaPercent !== null && item.deltaValue > 0) && (
+            {Boolean(showPercentage && item.delta_percent !== null && item.delta_value > 0) && (
               <span className="fa fa-sort-up" style={styles.infoArrow} key={`month-over-month-icon-${index}`} />
             )}
-            {Boolean(showPercentage && item.deltaPercent !== null && item.deltaValue < 0) && (
+            {Boolean(showPercentage && item.delta_percent !== null && item.delta_value < 0) && (
               <span
                 className="fa fa-sort-down"
                 style={{
@@ -306,10 +306,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
     return (
       <>
-        {formatCurrency(item.cost)}
+        {formatCurrency(item.cost.total.value)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
-            value: ((item.cost / cost) * 100).toFixed(2),
+            value: ((item.cost.total.value / cost) * 100).toFixed(2),
           })}
         </div>
       </>

--- a/src/pages/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/details/ocpDetails/detailsTable.tsx
@@ -261,10 +261,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
     return (
       <>
-        {formatCurrency(item.supplementary)}
+        {formatCurrency(item.supplementary.total.value)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
-            value: ((item.supplementary / total) * 100).toFixed(2),
+            value: ((item.supplementary.total.value / total) * 100).toFixed(2),
           })}
         </div>
       </>
@@ -299,10 +299,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
     return (
       <>
-        {formatCurrency(item.infrastructure)}
+        {formatCurrency(item.infrastructure.total.value)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
-            value: ((item.infrastructure / total) * 100).toFixed(2),
+            value: ((item.infrastructure.total.value / total) * 100).toFixed(2),
           })}
         </div>
       </>
@@ -311,19 +311,19 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
   private getMonthOverMonthCost = (item: ComputedReportItem, index: number) => {
     const { t } = this.props;
-    const value = formatCurrency(Math.abs(item.cost - item.deltaValue));
-    const percentage = item.deltaPercent !== null ? Math.abs(item.deltaPercent).toFixed(2) : 0;
+    const value = formatCurrency(Math.abs(item.cost.total.value - item.delta_value));
+    const percentage = item.delta_percent !== null ? Math.abs(item.delta_percent).toFixed(2) : 0;
 
     const showPercentage = !(percentage === 0 || percentage === '0.00');
-    const showValue = item.deltaPercent !== null; // Workaround for https://github.com/project-koku/koku/issues/1395
+    const showValue = item.delta_percent !== null; // Workaround for https://github.com/project-koku/koku/issues/1395
 
     let iconOverride;
     if (showPercentage) {
       iconOverride = 'iconOverride';
-      if (item.deltaPercent !== null && item.deltaValue < 0) {
+      if (item.delta_percent !== null && item.delta_value < 0) {
         iconOverride += ' decrease';
       }
-      if (item.deltaPercent !== null && item.deltaValue > 0) {
+      if (item.delta_percent !== null && item.delta_value > 0) {
         iconOverride += ' increase';
       }
     }
@@ -335,10 +335,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         <div className="monthOverMonthOverride">
           <div className={iconOverride} key={`month-over-month-cost-${index}`}>
             {showPercentage ? t('percent', { value: percentage }) : <EmptyValueState />}
-            {Boolean(showPercentage && item.deltaPercent !== null && item.deltaValue > 0) && (
+            {Boolean(showPercentage && item.delta_percent !== null && item.delta_value > 0) && (
               <span className="fa fa-sort-up" style={styles.infoArrow} key={`month-over-month-icon-${index}`} />
             )}
-            {Boolean(showPercentage && item.deltaPercent !== null && item.deltaValue < 0) && (
+            {Boolean(showPercentage && item.delta_percent !== null && item.delta_value < 0) && (
               <span
                 className="fa fa-sort-down"
                 style={{ ...styles.ininfoArrow, ...styles.infoArrowDesc }}
@@ -384,10 +384,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
     return (
       <>
-        {formatCurrency(item.cost)}
+        {formatCurrency(item.cost.total.value)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
-            value: ((item.cost / cost) * 100).toFixed(2),
+            value: ((item.cost.total.value / cost) * 100).toFixed(2),
           })}
         </div>
       </>

--- a/src/store/dashboard/awsDashboard/awsDashboard.test.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboard.test.ts
@@ -77,7 +77,7 @@ test('getQueryForWidget', () => {
     reportType: ReportType.cost,
     availableTabs: [AwsDashboardTab.accounts],
     currentTab: AwsDashboardTab.accounts,
-    details: { labelKey: '', formatOptions: {} },
+    details: { formatOptions: {} },
     trend: {
       titleKey: '',
       type: ChartType.daily,

--- a/src/store/dashboard/azureDashboard/azureDashboard.test.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboard.test.ts
@@ -88,7 +88,7 @@ test('getQueryForWidget', () => {
     reportType: ReportType.cost,
     availableTabs: [AzureDashboardTab.subscription_guids],
     currentTab: AzureDashboardTab.subscription_guids,
-    details: { labelKey: '', formatOptions: {} },
+    details: { formatOptions: {} },
     trend: {
       titleKey: '',
       type: ChartType.daily,

--- a/src/store/dashboard/common/dashboardCommon.ts
+++ b/src/store/dashboard/common/dashboardCommon.ts
@@ -22,7 +22,6 @@ export interface DashboardWidget<T> {
     appNavId?: string; // Highlights Insights nav-item when view all link is clicked
     costKey?: string; // i18n key
     formatOptions: ValueFormatOptions;
-    labelKey?: string; // i18n key
     requestFormatOptions?: {
       fractionDigits?: number;
     };

--- a/src/store/dashboard/gcpDashboard/gcpDashboard.test.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboard.test.ts
@@ -77,7 +77,7 @@ test('getQueryForWidget', () => {
     reportType: ReportType.cost,
     availableTabs: [GcpDashboardTab.accounts],
     currentTab: GcpDashboardTab.accounts,
-    details: { labelKey: '', formatOptions: {} },
+    details: { formatOptions: {} },
     trend: {
       titleKey: '',
       type: ChartType.daily,

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboard.test.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboard.test.ts
@@ -84,7 +84,7 @@ test('getQueryForWidget', () => {
     reportType: ReportType.cost,
     availableTabs: [OcpCloudDashboardTab.accounts],
     currentTab: OcpCloudDashboardTab.accounts,
-    details: { labelKey: '', formatOptions: {} },
+    details: { formatOptions: {} },
     trend: {
       computedReportItem: ComputedReportItemType.cost,
       titleKey: '',

--- a/src/store/dashboard/ocpDashboard/ocpDashboard.test.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboard.test.ts
@@ -72,7 +72,7 @@ test('getQueryForWidget', () => {
     reportType: ReportType.cost,
     availableTabs: [OcpDashboardTab.projects],
     currentTab: OcpDashboardTab.projects,
-    details: { labelKey: '', formatOptions: {} },
+    details: { formatOptions: {} },
     trend: {
       computedReportItem: ComputedReportItemType.cost,
       titleKey: '',

--- a/src/utils/computedForecast/getComputedForecastItems.ts
+++ b/src/utils/computedForecast/getComputedForecastItems.ts
@@ -94,6 +94,7 @@ export function getUnsortedComputedForecastItems<F extends Forecast>({
 
         const item = itemMap.get(date);
         if (item) {
+          // This code block is typically entered with filter[resolution]=monthly
           itemMap.set(date, {
             ...item,
             date,
@@ -102,6 +103,7 @@ export function getUnsortedComputedForecastItems<F extends Forecast>({
             supplementary: getCostData(val, 'supplementary', item),
           });
         } else {
+          // This code block is typically entered with filter[resolution]=daily
           itemMap.set(date, {
             date,
             cost: getCostData(val, 'cost'),

--- a/src/utils/computedReport/getComputedAwsReportItems.ts
+++ b/src/utils/computedReport/getComputedAwsReportItems.ts
@@ -1,9 +1,9 @@
 import { AwsQuery } from 'api/queries/awsQuery';
-import { AwsReport, AwsReportValue } from 'api/reports/awsReports';
+import { AwsReport, AwsReportItem } from 'api/reports/awsReports';
 
 import { ComputedReportItemsParams } from './getComputedReportItems';
 
-export interface ComputedAwsReportItemsParams extends ComputedReportItemsParams<AwsReport, AwsReportValue> {}
+export interface ComputedAwsReportItemsParams extends ComputedReportItemsParams<AwsReport, AwsReportItem> {}
 
 export function getIdKeyForGroupBy(groupBy: AwsQuery['group_by'] = {}): ComputedAwsReportItemsParams['idKey'] {
   if (groupBy.account) {

--- a/src/utils/computedReport/getComputedAzureReportItems.ts
+++ b/src/utils/computedReport/getComputedAzureReportItems.ts
@@ -1,9 +1,9 @@
 import { AzureQuery } from 'api/queries/azureQuery';
-import { AzureReport, AzureReportValue } from 'api/reports/azureReports';
+import { AzureReport, AzureReportItem } from 'api/reports/azureReports';
 
 import { ComputedReportItemsParams } from './getComputedReportItems';
 
-export interface ComputedAzureReportItemsParams extends ComputedReportItemsParams<AzureReport, AzureReportValue> {}
+export interface ComputedAzureReportItemsParams extends ComputedReportItemsParams<AzureReport, AzureReportItem> {}
 
 export function getIdKeyForGroupBy(groupBy: AzureQuery['group_by'] = {}): ComputedAzureReportItemsParams['idKey'] {
   if (groupBy.subscription_guid) {

--- a/src/utils/computedReport/getComputedGcpReportItems.ts
+++ b/src/utils/computedReport/getComputedGcpReportItems.ts
@@ -1,9 +1,9 @@
 import { GcpQuery } from 'api/queries/gcpQuery';
-import { GcpReport, GcpReportValue } from 'api/reports/gcpReports';
+import { GcpReport, GcpReportItem } from 'api/reports/gcpReports';
 
 import { ComputedReportItemsParams } from './getComputedReportItems';
 
-export interface ComputedGcpReportItemsParams extends ComputedReportItemsParams<GcpReport, GcpReportValue> {}
+export interface ComputedGcpReportItemsParams extends ComputedReportItemsParams<GcpReport, GcpReportItem> {}
 
 export function getIdKeyForGroupBy(groupBy: GcpQuery['group_by'] = {}): ComputedGcpReportItemsParams['idKey'] {
   if (groupBy.account) {

--- a/src/utils/computedReport/getComputedOcpCloudReportItems.ts
+++ b/src/utils/computedReport/getComputedOcpCloudReportItems.ts
@@ -1,10 +1,10 @@
 import { OcpCloudQuery } from 'api/queries/ocpCloudQuery';
-import { OcpCloudReport, OcpCloudReportValue } from 'api/reports/ocpCloudReports';
+import { OcpCloudReport, OcpCloudReportItem } from 'api/reports/ocpCloudReports';
 
 import { ComputedReportItemsParams } from './getComputedReportItems';
 
 export interface ComputedOcpCloudReportItemsParams
-  extends ComputedReportItemsParams<OcpCloudReport, OcpCloudReportValue> {}
+  extends ComputedReportItemsParams<OcpCloudReport, OcpCloudReportItem> {}
 
 export function getIdKeyForGroupBy(
   groupBy: OcpCloudQuery['group_by'] = {}

--- a/src/utils/computedReport/getComputedOcpReportItems.ts
+++ b/src/utils/computedReport/getComputedOcpReportItems.ts
@@ -1,9 +1,9 @@
 import { OcpQuery } from 'api/queries/ocpQuery';
-import { OcpReport, OcpReportValue } from 'api/reports/ocpReports';
+import { OcpReport, OcpReportItem } from 'api/reports/ocpReports';
 
 import { ComputedReportItemsParams } from './getComputedReportItems';
 
-export interface ComputedOcpReportItemsParams extends ComputedReportItemsParams<OcpReport, OcpReportValue> {}
+export interface ComputedOcpReportItemsParams extends ComputedReportItemsParams<OcpReport, OcpReportItem> {}
 
 export function getIdKeyForGroupBy(groupBy: OcpQuery['group_by'] = {}): ComputedOcpReportItemsParams['idKey'] {
   if (groupBy.project) {

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -1,60 +1,62 @@
-import { Report, ReportData, ReportValue } from 'api/reports/report';
-import { ReportDatum } from 'api/reports/report';
+import { Report, ReportData, ReportItem, ReportItemValue, ReportValue } from 'api/reports/report';
 import { sort, SortDirection } from 'utils/sort';
 
 import { getItemLabel } from './getItemLabel';
 
-export interface ComputedReportItem {
-  capacity?: number;
-  cluster?: string | number;
-  clusters?: string[];
-  cost?: number;
-  deltaPercent?: number;
-  deltaValue?: number;
-  id?: string | number;
-  infrastructure?: number;
-  label?: string | number;
-  limit?: number;
-  request?: number;
-  source_uuid?: string[];
-  supplementary?: number;
-  type?: string; // account or organizational_unit
-  units?: {
-    capacity?: string;
-    cost: string;
-    infrastructure?: string;
-    limit?: string;
-    request?: string;
-    supplementary?: string;
-    usage?: string;
-  };
-  usage?: number;
-  x?: string;
+export interface ComputedReportValue {
+  units?: string;
+  value?: number | string;
 }
 
-export interface ComputedReportItemsParams<R extends Report, T extends ReportValue> {
-  report: R;
+export interface ComputedReportItemValue {
+  markup?: ReportValue;
+  raw?: ReportValue;
+  total?: ReportValue;
+  usage?: ReportValue;
+}
+
+export interface ComputedReportOcpItem extends ReportItem {
+  capacity?: ReportValue;
+  cluster?: string;
+  clusters?: string[];
+  limit?: ReportValue;
+  request?: ReportValue;
+  usage?: ReportValue;
+}
+
+export interface ComputedReportOrgItem extends ReportItem {
+  id?: string;
+}
+
+export interface ComputedReportItem extends ComputedReportOcpItem, ComputedReportOrgItem {
+  cost?: ReportItemValue;
+  date?: string;
+  delta_percent?: number;
+  delta_value?: number;
+  infrastructure?: ReportItemValue;
+  label?: string; // helper for item label
+  source_uuid?: string;
+  supplementary?: ReportItemValue;
+  type?: string; // 'account' or 'organizational_unit'
+}
+
+export interface ComputedReportItemsParams<R extends Report, T extends ReportItem> {
   idKey: keyof T;
-  reportItemValue?: string; // Only supported for infrastructure values
+  report: R;
   sortKey?: keyof ComputedReportItem;
-  labelKey?: keyof T;
   sortDirection?: SortDirection;
 }
 
-export function getComputedReportItems<R extends Report, T extends ReportValue>({
+export function getComputedReportItems<R extends Report, T extends ReportItem>({
   idKey,
-  labelKey = idKey,
   report,
-  reportItemValue = 'total',
   sortDirection = SortDirection.asc,
-  sortKey = 'cost',
+  sortKey = 'date',
 }: ComputedReportItemsParams<R, T>) {
   return sort(
     getUnsortedComputedReportItems<R, T>({
       idKey,
-      labelKey,
       report,
-      reportItemValue,
       sortDirection,
       sortKey,
     }),
@@ -65,11 +67,51 @@ export function getComputedReportItems<R extends Report, T extends ReportValue>(
   );
 }
 
-export function getUnsortedComputedReportItems<R extends Report, T extends ReportValue>({
+function getCostData(val, key, item?: any) {
+  return {
+    markup: {
+      value: item ? item[key].markup.value : 0 + val[key] && val[key].markup ? val[key].markup.value : 0,
+      units: val[key] && val[key].markup ? val[key].markup.units : 'USD',
+    },
+    raw: {
+      value: item ? item[key].raw.value : 0 + val[key] && val[key].raw ? val[key].raw.value : 0,
+      units: val[key] && val[key].raw ? val[key].raw.units : 'USD',
+    },
+    total: {
+      value: item ? item[key].total.value : 0 + val[key] && val[key].total ? Number(val[key].total.value) : 0,
+      units: val[key] && val[key].total ? val[key].total.units : null,
+    },
+    usage: {
+      value: item ? item[key].usage.value : 0 + val[key] && val[key].usage ? Number(val[key].usage.value) : 0,
+      units: val[key] && val[key].usage ? val[key].usage.units : null,
+    },
+  };
+}
+
+function getUsageData(val, item?: any) {
+  return {
+    capacity: {
+      value: item ? item.capacity.value : 0 + val.capacity ? val.capacity.value : 0,
+      units: val.capacity ? val.capacity.units : 'Core-Hours',
+    },
+    limit: {
+      value: item ? item.limit.value : 0 + val.limit ? val.limit.value : 0,
+      units: val.limit ? val.limit.units : 'Core-Hours',
+    },
+    request: {
+      value: item ? item.request.value : 0 + val.request ? val.request.value : 0,
+      units: val.request ? val.request.units : 'Core-Hours',
+    },
+    usage: {
+      value: item ? item.usage.value : 0 + val.usage ? val.usage.value : 0,
+      units: val.usage ? val.usage.units : 'Core-Hours',
+    },
+  };
+}
+
+export function getUnsortedComputedReportItems<R extends Report, T extends ReportItem>({
   report,
   idKey,
-  labelKey = idKey,
-  reportItemValue = 'total',
 }: ComputedReportItemsParams<R, T>) {
   if (!report) {
     return [];
@@ -87,25 +129,21 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
         // org_unit_id workaround for storage and instance-type APIs
         let id = idKey === 'org_entities' ? val.org_unit_id : val[idKey];
         if (id === undefined) {
-          id = val.id;
+          id = val.id || val.date;
         }
         const mapId = `${id}${idSuffix}`;
 
-        // clusters will either contain the cluster alias or default to cluster ID
+        // 'clusters' will contain either the cluster alias or default cluster ID
         const cluster_alias = val.clusters && val.clusters.length > 0 ? val.clusters[0] : undefined;
         const cluster = cluster_alias || val.cluster;
         const clusters = val.clusters ? val.clusters : [];
-        const capacity = val.capacity ? val.capacity.value : 0;
-        const cost = val.cost && val.cost.total ? val.cost.total.value : 0;
-        const deltaPercent = val.delta_percent ? val.delta_percent : 0;
-        const deltaValue = val.delta_value ? val.delta_value : 0;
+        const date = val.date;
+        const delta_percent = val.delta_percent ? val.delta_percent : 0;
+        const delta_value = val.delta_value ? val.delta_value : 0;
         const source_uuid = val.source_uuid ? val.source_uuid : [];
-        const supplementary = val.supplementary && val.supplementary.total ? val.supplementary.total.value : 0;
-        const infrastructure =
-          val.infrastructure && val.infrastructure[reportItemValue] ? val.infrastructure[reportItemValue].value : 0;
 
         let label;
-        const itemLabelKey = getItemLabel({ report, labelKey, value: val });
+        const itemLabelKey = getItemLabel({ report, idKey, value: val });
         if (itemLabelKey === 'org_entities' && val.alias) {
           label = val.alias;
         } else if (itemLabelKey === 'account' && val.account_alias) {
@@ -113,62 +151,49 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
         } else if (itemLabelKey === 'cluster' && cluster_alias) {
           label = cluster_alias;
         } else if (val[itemLabelKey] instanceof Object) {
-          label = (val[itemLabelKey] as ReportDatum).value;
+          label = val[itemLabelKey].value;
         } else {
           label = val[itemLabelKey];
         }
         if (label === undefined) {
           label = val.alias ? val.alias : val.id;
         }
-        const limit = val.limit ? val.limit.value : 0;
-        const request = val.request ? val.request.value : 0;
-        const usage = val.usage ? val.usage.value : 0;
-        const units = {
-          ...(val.capacity && { capacity: val.capacity.units }),
-          cost: val.cost && val.cost.total ? val.cost.total.units : 'USD',
-          ...(val.limit && { limit: val.limit.units }),
-          ...(val.infrastructure &&
-            val.infrastructure.total && {
-              infrastructure: val.infrastructure.total.units,
-            }),
-          ...(val.request && { request: val.request.units }),
-          ...(val.supplementary &&
-            val.supplementary.total && {
-              supplementary: val.supplementary.total.units,
-            }),
-          ...(val.usage && { usage: val.usage.units }),
-        };
 
         const item = itemMap.get(mapId);
         if (item) {
+          // This code block is typically entered with filter[resolution]=monthly
           itemMap.set(mapId, {
             ...item,
-            capacity: item.capacity + capacity,
-            cost: item.cost + cost,
-            supplementary: item.supplementary + supplementary,
-            infrastructure: item.infrastructure + infrastructure,
-            limit: item.limit + limit,
-            request: item.request + request,
-            usage: item.usage + usage,
-          });
-        } else {
-          itemMap.set(mapId, {
-            capacity,
+            ...getUsageData(val, item), // capacity, limit, request, & usage
             cluster,
             clusters,
-            cost,
-            deltaPercent,
-            deltaValue,
-            source_uuid,
-            supplementary,
+            date,
+            delta_percent,
+            delta_value,
+            cost: getCostData(val, 'cost', item),
             id,
-            infrastructure,
+            infrastructure: getCostData(val, 'infrastructure', item),
             label,
-            limit,
-            request,
+            source_uuid,
+            supplementary: getCostData(val, 'supplementary', item),
             type,
-            units,
-            usage,
+          });
+        } else {
+          // This code block is typically entered with filter[resolution]=daily
+          itemMap.set(mapId, {
+            ...getUsageData(val), // capacity, limit, request, & usage
+            cluster,
+            clusters,
+            cost: getCostData(val, 'cost'),
+            date,
+            delta_percent,
+            delta_value,
+            id,
+            infrastructure: getCostData(val, 'infrastructure'),
+            label,
+            source_uuid,
+            supplementary: getCostData(val, 'supplementary'),
+            type,
           });
         }
       });

--- a/src/utils/computedReport/getItemLabel.ts
+++ b/src/utils/computedReport/getItemLabel.ts
@@ -1,18 +1,18 @@
 import { tagPrefix } from 'api/queries/query';
 
 export interface GetItemLabelParams {
+  idKey: any;
   report: any;
-  labelKey: any;
   value: any;
 }
 
-export function getItemLabel({ report, labelKey, value }: GetItemLabelParams) {
-  let itemLabelKey = String(labelKey);
+export function getItemLabel({ idKey, report, value }: GetItemLabelParams) {
+  let itemLabelKey = String(idKey);
   if (report.meta && report.meta.group_by) {
     const group_by = report.meta.group_by;
     for (const key of Object.keys(group_by)) {
       if (key.indexOf(tagPrefix)) {
-        const tagPrefixKey = tagPrefix + labelKey;
+        const tagPrefixKey = tagPrefix + idKey;
         if (value.hasOwnProperty(tagPrefixKey)) {
           itemLabelKey = tagPrefixKey;
         }


### PR DESCRIPTION
Refactored our computed items data structure to reflect the API data structure. The flat data structure we had previously is somewhat confusing, especially how we store units for each cost type. The report API data structures have evolved and it would be ideal if we updated as well.

Nothing changes visually. We should see that same overview and historical charts, tooltips, units, etc.

https://issues.redhat.com/browse/COST-765

Our computed items now mimic this API data structure
<img width="422" alt="Screen Shot 2020-11-24 at 1 30 59 PM" src="https://user-images.githubusercontent.com/17481322/100136759-7253e580-2e59-11eb-9319-56234e0a83c4.png">
