### PR TITLE
Move tags API from Report to its own type

### DIFF
--- a/src/api/reports/awsCloudReports.ts
+++ b/src/api/reports/awsCloudReports.ts
@@ -54,7 +54,6 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
   [ReportType.network]: 'reports/openshift/infrastructures/aws/costs/',
   [ReportType.storage]: 'reports/openshift/infrastructures/aws/storage/',
   [ReportType.instanceType]: 'reports/openshift/infrastructures/aws/instance-types/',
-  [ReportType.tag]: 'tags/openshift/infrastructures/aws/',
 };
 
 export function runReport(reportType: ReportType, query: string) {

--- a/src/api/reports/awsReports.ts
+++ b/src/api/reports/awsReports.ts
@@ -56,7 +56,6 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
   [ReportType.org]: 'organizations/aws/',
   [ReportType.storage]: 'reports/aws/storage/',
   [ReportType.instanceType]: 'reports/aws/instance-types/',
-  [ReportType.tag]: 'tags/aws/',
 };
 
 export function runReport(reportType: ReportType, query: string) {

--- a/src/api/reports/azureCloudReports.ts
+++ b/src/api/reports/azureCloudReports.ts
@@ -53,7 +53,6 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
   [ReportType.network]: 'reports/openshift/infrastructures/azure/costs/',
   [ReportType.storage]: 'reports/openshift/infrastructures/azure/storage/',
   [ReportType.instanceType]: 'reports/openshift/infrastructures/azure/instance-types/',
-  [ReportType.tag]: 'tags/openshift/infrastructures/azure/',
 };
 
 export function runReport(reportType: ReportType, query: string) {

--- a/src/api/reports/azureReports.ts
+++ b/src/api/reports/azureReports.ts
@@ -55,7 +55,6 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
   [ReportType.network]: 'reports/azure/costs/',
   [ReportType.storage]: 'reports/azure/storage/',
   [ReportType.instanceType]: 'reports/azure/instance-types/',
-  [ReportType.tag]: 'tags/azure/',
 };
 
 export function runReport(reportType: ReportType, query: string) {

--- a/src/api/reports/gcpReports.ts
+++ b/src/api/reports/gcpReports.ts
@@ -55,7 +55,6 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
   [ReportType.network]: 'reports/aws/costs/',
   [ReportType.storage]: 'reports/aws/storage/',
   [ReportType.instanceType]: 'reports/aws/instance-types/',
-  [ReportType.tag]: 'tags/aws/',
 };
 
 export function runReport(reportType: ReportType, query: string) {

--- a/src/api/reports/ocpCloudReports.ts
+++ b/src/api/reports/ocpCloudReports.ts
@@ -82,7 +82,6 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
   [ReportType.memory]: 'reports/openshift/memory/',
   [ReportType.network]: 'reports/openshift/infrastructures/all/costs/',
   [ReportType.storage]: 'reports/openshift/infrastructures/all/storage/',
-  [ReportType.tag]: 'tags/openshift/infrastructures/all/',
   [ReportType.volume]: 'reports/openshift/volumes/',
 };
 

--- a/src/api/reports/ocpReports.ts
+++ b/src/api/reports/ocpReports.ts
@@ -52,7 +52,6 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
   [ReportType.cost]: 'reports/openshift/costs/',
   [ReportType.cpu]: 'reports/openshift/compute/',
   [ReportType.memory]: 'reports/openshift/memory/',
-  [ReportType.tag]: 'tags/openshift/',
   [ReportType.volume]: 'reports/openshift/volumes/',
 };
 

--- a/src/api/reports/ocpUsageReports.ts
+++ b/src/api/reports/ocpUsageReports.ts
@@ -78,7 +78,6 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
   [ReportType.cost]: 'reports/openshift/costs/',
   [ReportType.cpu]: 'reports/openshift/compute/',
   [ReportType.memory]: 'reports/openshift/memory/',
-  [ReportType.tag]: 'tags/openshift/',
   [ReportType.volume]: 'reports/openshift/volumes/',
 };
 

--- a/src/api/reports/report.ts
+++ b/src/api/reports/report.ts
@@ -56,14 +56,9 @@ export interface ReportOrgData {
   type?: string; // 'account' or 'organizational_unit'
 }
 
-export interface ReportTagData {
-  enabled?: boolean;
-  key?: string;
-}
-
-export interface ReportData extends ReportOrgData, ReportTagData {
+export interface ReportData extends ReportOrgData {
   date?: string;
-  values?: ReportAwsItem[] | ReportAzureItem[] | ReportOcpItem[] | ReportOrgItem[] | string[]; // tags use string[]
+  values?: ReportAwsItem[] | ReportAzureItem[] | ReportOcpItem[] | ReportOrgItem[];
 }
 
 export interface ReportMeta {
@@ -116,7 +111,6 @@ export const enum ReportType {
   network = 'network',
   org = 'org',
   storage = 'storage',
-  tag = 'tag',
   volume = 'volume',
 }
 

--- a/src/api/tags/awsTags.test.ts
+++ b/src/api/tags/awsTags.test.ts
@@ -1,0 +1,12 @@
+jest.mock('axios');
+
+import axios from 'axios';
+
+import { runTag } from './awsTags';
+import { TagType } from './tag';
+
+test('api run reports calls axios get', () => {
+  const query = 'filter[resolution]=daily';
+  runTag(TagType.tag, query);
+  expect(axios.get).toBeCalledWith(`tags/aws/?${query}`);
+});

--- a/src/api/tags/awsTags.ts
+++ b/src/api/tags/awsTags.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+import { Tag, TagType } from './tag';
+
+export interface AwsTag extends Tag {}
+
+export const TagTypePaths: Partial<Record<TagType, string>> = {
+  [TagType.tag]: 'tags/aws/',
+};
+
+export function runTag(tagType: TagType, query: string) {
+  const path = TagTypePaths[tagType];
+  return axios.get<AwsTag>(`${path}?${query}`);
+}

--- a/src/api/tags/azureTags.test.ts
+++ b/src/api/tags/azureTags.test.ts
@@ -1,0 +1,12 @@
+jest.mock('axios');
+
+import axios from 'axios';
+
+import { runTag } from './azureTags';
+import { TagType } from './tag';
+
+test('api run reports calls axios get', () => {
+  const query = 'filter[resolution]=daily';
+  runTag(TagType.tag, query);
+  expect(axios.get).toBeCalledWith(`tags/azure/?${query}`);
+});

--- a/src/api/tags/azureTags.ts
+++ b/src/api/tags/azureTags.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+import { Tag, TagType } from './tag';
+
+export interface AzureTag extends Tag {}
+
+export const TagTypePaths: Partial<Record<TagType, string>> = {
+  [TagType.tag]: 'tags/azure/',
+};
+
+export function runTag(tagType: TagType, query: string) {
+  const path = TagTypePaths[tagType];
+  return axios.get<AzureTag>(`${path}?${query}`);
+}

--- a/src/api/tags/gcpTags.test.ts
+++ b/src/api/tags/gcpTags.test.ts
@@ -1,0 +1,12 @@
+jest.mock('axios');
+
+import axios from 'axios';
+
+import { runTag } from './gcpTags';
+import { TagType } from './tag';
+
+test('api run reports calls axios get', () => {
+  const query = 'filter[resolution]=daily';
+  runTag(TagType.tag, query);
+  expect(axios.get).toBeCalledWith(`tags/aws/?${query}`);
+});

--- a/src/api/tags/gcpTags.ts
+++ b/src/api/tags/gcpTags.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+import { Tag, TagType } from './tag';
+
+export interface GcpTag extends Tag {}
+
+export const TagTypePaths: Partial<Record<TagType, string>> = {
+  [TagType.tag]: 'tags/aws/',
+};
+
+export function runTag(tagType: TagType, query: string) {
+  const path = TagTypePaths[tagType];
+  return axios.get<GcpTag>(`${path}?${query}`);
+}

--- a/src/api/tags/ocpTags.test.ts
+++ b/src/api/tags/ocpTags.test.ts
@@ -1,0 +1,12 @@
+jest.mock('axios');
+
+import axios from 'axios';
+
+import { runTag } from './ocpTags';
+import { TagType } from './tag';
+
+test('api run reports calls axios get', () => {
+  const query = 'filter[resolution]=daily';
+  runTag(TagType.tag, query);
+  expect(axios.get).toBeCalledWith(`tags/openshift/?${query}`);
+});

--- a/src/api/tags/ocpTags.ts
+++ b/src/api/tags/ocpTags.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+import { Tag, TagType } from './tag';
+
+export interface OcpTag extends Tag {}
+
+export const TagTypePaths: Partial<Record<TagType, string>> = {
+  [TagType.tag]: 'tags/openshift/',
+};
+
+export function runTag(tagType: TagType, query: string) {
+  const path = TagTypePaths[tagType];
+  return axios.get<OcpTag>(`${path}?${query}`);
+}

--- a/src/api/tags/tag.ts
+++ b/src/api/tags/tag.ts
@@ -1,0 +1,44 @@
+export interface TagData {
+  enabled?: boolean;
+  key?: string;
+  values?: string[];
+}
+
+export interface TagMeta {
+  count: number;
+  group_by?: {
+    [group: string]: string[];
+  };
+  order_by?: {
+    [order: string]: string;
+  };
+  filter?: {
+    [filter: string]: any;
+  };
+}
+
+export interface TagLinks {
+  first: string;
+  previous?: string;
+  next?: string;
+  last: string;
+}
+
+export interface Tag {
+  data: TagData[];
+  links?: TagLinks;
+  meta: TagMeta;
+}
+
+// eslint-disable-next-line no-shadow
+export const enum TagType {
+  tag = 'tag',
+}
+
+// eslint-disable-next-line no-shadow
+export const enum TagPathsType {
+  aws = 'aws',
+  azure = 'azure',
+  gcp = 'gcp',
+  ocp = 'ocp',
+}

--- a/src/api/tags/tagUtils.ts
+++ b/src/api/tags/tagUtils.ts
@@ -1,0 +1,24 @@
+import { runTag as runAwsTag } from './awsTags';
+import { runTag as runAzureTag } from './azureTags';
+import { runTag as runGcpTag } from './gcpTags';
+import { runTag as runOcpTag } from './ocpTags';
+import { TagPathsType, TagType } from './tag';
+
+export function runTag(tagPathsType: TagPathsType, tagType: TagType, query: string) {
+  let tagReport;
+  switch (tagPathsType) {
+    case TagPathsType.aws:
+      tagReport = runAwsTag(tagType, query);
+      break;
+    case TagPathsType.azure:
+      tagReport = runAzureTag(tagType, query);
+      break;
+    case TagPathsType.gcp:
+      tagReport = runGcpTag(tagType, query);
+      break;
+    case TagPathsType.ocp:
+      tagReport = runOcpTag(tagType, query);
+      break;
+  }
+  return tagReport;
+}

--- a/src/pages/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/pages/details/awsBreakdown/awsBreakdown.tsx
@@ -1,6 +1,7 @@
 import { AwsQuery, getQuery, parseQuery } from 'api/queries/awsQuery';
 import { breakdownDescKey, breakdownTitleKey, orgUnitIdKey, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
+import { TagPathsType } from 'api/tags/tag';
 import { AxiosError } from 'axios';
 import BreakdownBase from 'pages/details/components/breakdown/breakdownBase';
 import { getGroupById, getGroupByValue } from 'pages/details/components/utils/groupBy';
@@ -78,6 +79,7 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
     reportFetchStatus,
     reportType,
     reportPathsType,
+    tagReportPathsType: TagPathsType.aws,
     title: query[breakdownTitleKey] ? query[breakdownTitleKey] : filterBy,
   };
 });

--- a/src/pages/details/awsDetails/detailsHeader.tsx
+++ b/src/pages/details/awsDetails/detailsHeader.tsx
@@ -4,6 +4,7 @@ import { AwsQuery, getQuery } from 'api/queries/awsQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { AwsReport } from 'api/reports/awsReports';
 import { ReportPathsType } from 'api/reports/report';
+import { TagPathsType } from 'api/tags/tag';
 import { AxiosError } from 'axios';
 import { GroupBy } from 'pages/details/components/groupBy/groupBy';
 import React from 'react';
@@ -51,6 +52,7 @@ const groupByOptions: {
 ];
 
 const reportPathsType = ReportPathsType.aws;
+const tagReportPathsType = TagPathsType.aws;
 
 class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
   public render() {
@@ -75,6 +77,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             reportPathsType={reportPathsType}
             showOrgs
             showTags
+            tagReportPathsType={tagReportPathsType}
           />
         </div>
         {Boolean(showContent) && (

--- a/src/pages/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/details/awsDetails/detailsToolbar.tsx
@@ -2,12 +2,14 @@ import { ToolbarChipGroup } from '@patternfly/react-core';
 import { AwsQuery, getQuery } from 'api/queries/awsQuery';
 import { orgUnitIdKey, tagKey } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
+import { Tag, TagPathsType, TagType } from 'api/tags/tag';
 import { DataToolbar } from 'pages/details/components/dataToolbar/dataToolbar';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
+import { tagActions, tagSelectors } from 'store/tags';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { isEqual } from 'utils/equal';
 
@@ -32,12 +34,13 @@ interface DetailsToolbarOwnProps {
 interface DetailsToolbarStateProps {
   orgReport?: Report;
   orgReportFetchStatus?: FetchStatus;
-  tagReport?: Report;
+  tagReport?: Tag;
   tagReportFetchStatus?: FetchStatus;
 }
 
 interface DetailsToolbarDispatchProps {
   fetchReport?: typeof reportActions.fetchReport;
+  fetchTag?: typeof tagActions.fetchTag;
 }
 
 interface DetailsToolbarState {
@@ -49,28 +52,29 @@ type DetailsToolbarProps = DetailsToolbarOwnProps &
   DetailsToolbarDispatchProps &
   WithTranslation;
 
-const orgReportType = ReportType.org;
-const tagReportType = ReportType.tag;
 const reportPathsType = ReportPathsType.aws;
+const orgReportType = ReportType.org;
+const tagReportPathsType = TagPathsType.aws;
+const tagReportType = TagType.tag;
 
 export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   protected defaultState: DetailsToolbarState = {};
   public state: DetailsToolbarState = { ...this.defaultState };
 
   public componentDidMount() {
-    const { fetchReport, queryString } = this.props;
+    const { fetchReport, fetchTag, queryString } = this.props;
     fetchReport(reportPathsType, orgReportType, queryString);
-    fetchReport(reportPathsType, tagReportType, queryString);
+    fetchTag(tagReportPathsType, tagReportType, queryString);
     this.setState({
       categoryOptions: this.getCategoryOptions(),
     });
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps) {
-    const { fetchReport, orgReport, query, queryString, tagReport } = this.props;
+    const { fetchReport, fetchTag, orgReport, query, queryString, tagReport } = this.props;
     if (query && !isEqual(query, prevProps.query)) {
       fetchReport(reportPathsType, orgReportType, queryString);
-      fetchReport(reportPathsType, tagReportType, queryString);
+      fetchTag(tagReportPathsType, tagReportType, queryString);
     }
     if (!isEqual(orgReport, prevProps.orgReport) || !isEqual(tagReport, prevProps.tagReport)) {
       this.setState({
@@ -156,13 +160,8 @@ const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToo
     orgReportType,
     queryString
   );
-  const tagReport = reportSelectors.selectReport(state, reportPathsType, tagReportType, queryString);
-  const tagReportFetchStatus = reportSelectors.selectReportFetchStatus(
-    state,
-    reportPathsType,
-    tagReportType,
-    queryString
-  );
+  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
+  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);
   return {
     queryString,
     orgReport,
@@ -174,6 +173,7 @@ const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToo
 
 const mapDispatchToProps: DetailsToolbarDispatchProps = {
   fetchReport: reportActions.fetchReport,
+  fetchTag: tagActions.fetchTag,
 };
 
 const DetailsToolbar = withTranslation()(connect(mapStateToProps, mapDispatchToProps)(DetailsToolbarBase));

--- a/src/pages/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/pages/details/azureBreakdown/azureBreakdown.tsx
@@ -1,6 +1,7 @@
 import { getQuery, OcpQuery, parseQuery } from 'api/queries/ocpQuery';
 import { Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
+import { TagPathsType } from 'api/tags/tag';
 import { AxiosError } from 'axios';
 import BreakdownBase from 'pages/details/components/breakdown/breakdownBase';
 import { getGroupById, getGroupByValue } from 'pages/details/components/utils/groupBy';
@@ -61,6 +62,7 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateP
     reportFetchStatus,
     reportType,
     reportPathsType,
+    tagReportPathsType: TagPathsType.azure,
     title: filterBy,
   };
 });

--- a/src/pages/details/azureDetails/detailsHeader.tsx
+++ b/src/pages/details/azureDetails/detailsHeader.tsx
@@ -4,6 +4,7 @@ import { AzureQuery, getQuery } from 'api/queries/azureQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { AzureReport } from 'api/reports/azureReports';
 import { ReportPathsType } from 'api/reports/report';
+import { TagPathsType } from 'api/tags/tag';
 import { AxiosError } from 'axios';
 import { GroupBy } from 'pages/details/components/groupBy/groupBy';
 import React from 'react';
@@ -51,6 +52,7 @@ const groupByOptions: {
 ];
 
 const reportPathsType = ReportPathsType.azure;
+const tagReportPathsType = TagPathsType.azure;
 
 class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
   public render() {
@@ -74,6 +76,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             options={groupByOptions}
             reportPathsType={reportPathsType}
             showTags
+            tagReportPathsType={tagReportPathsType}
           />
         </div>
         {Boolean(showContent) && (

--- a/src/pages/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/details/azureDetails/detailsToolbar.tsx
@@ -1,14 +1,14 @@
 import { ToolbarChipGroup } from '@patternfly/react-core';
 import { AzureQuery, getQuery } from 'api/queries/azureQuery';
 import { tagKey } from 'api/queries/query';
-import { AzureReport } from 'api/reports/azureReports';
-import { ReportPathsType, ReportType } from 'api/reports/report';
+import { AzureTag } from 'api/tags/azureTags';
+import { TagPathsType, TagType } from 'api/tags/tag';
 import { DataToolbar } from 'pages/details/components/dataToolbar/dataToolbar';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { reportActions, reportSelectors } from 'store/reports';
+import { tagActions, tagSelectors } from 'store/tags';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { isEqual } from 'utils/equal';
 
@@ -30,12 +30,12 @@ interface DetailsToolbarOwnProps {
 }
 
 interface DetailsToolbarStateProps {
-  tagReport?: AzureReport;
-  reportFetchStatus?: FetchStatus;
+  tagReport?: AzureTag;
+  tagFetchStatus?: FetchStatus;
 }
 
 interface DetailsToolbarDispatchProps {
-  fetchReport?: typeof reportActions.fetchReport;
+  fetchTag?: typeof tagActions.fetchTag;
 }
 
 interface DetailsToolbarState {
@@ -47,25 +47,25 @@ type DetailsToolbarProps = DetailsToolbarOwnProps &
   DetailsToolbarDispatchProps &
   WithTranslation;
 
-const reportType = ReportType.tag;
-const reportPathsType = ReportPathsType.azure;
+const tagReportType = TagType.tag;
+const tagReportPathsType = TagPathsType.azure;
 
 export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   protected defaultState: DetailsToolbarState = {};
   public state: DetailsToolbarState = { ...this.defaultState };
 
   public componentDidMount() {
-    const { fetchReport, queryString } = this.props;
-    fetchReport(reportPathsType, reportType, queryString);
+    const { fetchTag, queryString } = this.props;
+    fetchTag(tagReportPathsType, tagReportType, queryString);
     this.setState({
       categoryOptions: this.getCategoryOptions(),
     });
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps) {
-    const { fetchReport, query, queryString, tagReport } = this.props;
+    const { fetchTag, query, queryString, tagReport } = this.props;
     if (query && !isEqual(query, prevProps.query)) {
-      fetchReport(reportPathsType, reportType, queryString);
+      fetchTag(tagReportPathsType, tagReportType, queryString);
     }
     if (!isEqual(tagReport, prevProps.tagReport)) {
       this.setState({
@@ -146,17 +146,17 @@ const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToo
     },
     // key_only: true
   });
-  const tagReport = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
+  const tagFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);
   return {
     queryString,
-    reportFetchStatus,
+    tagFetchStatus,
     tagReport,
   };
 });
 
 const mapDispatchToProps: DetailsToolbarDispatchProps = {
-  fetchReport: reportActions.fetchReport,
+  fetchTag: tagActions.fetchTag,
 };
 
 const DetailsToolbar = withTranslation()(connect(mapStateToProps, mapDispatchToProps)(DetailsToolbarBase));

--- a/src/pages/details/components/breakdown/breakdownBase.tsx
+++ b/src/pages/details/components/breakdown/breakdownBase.tsx
@@ -1,6 +1,7 @@
 import { Tab, TabContent, Tabs, TabTitleText } from '@patternfly/react-core';
 import { Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
+import { TagPathsType } from 'api/tags/tag';
 import { AxiosError } from 'axios';
 import React from 'react';
 import { WithTranslation } from 'react-i18next';
@@ -40,6 +41,7 @@ interface BreakdownStateProps {
   reportFetchStatus: FetchStatus;
   reportPathsType: ReportPathsType;
   reportType: ReportType;
+  tagReportPathsType: TagPathsType;
   title: string;
 }
 
@@ -178,7 +180,7 @@ class BreakdownBase extends React.Component<BreakdownProps> {
   };
 
   public render() {
-    const { description, detailsURL, filterBy, groupBy, query, report, reportPathsType, title } = this.props;
+    const { description, detailsURL, filterBy, groupBy, query, report, tagReportPathsType, title } = this.props;
     const availableTabs = this.getAvailableTabs();
 
     return (
@@ -190,8 +192,8 @@ class BreakdownBase extends React.Component<BreakdownProps> {
           groupBy={groupBy}
           query={query}
           report={report}
-          reportPathsType={reportPathsType}
           tabs={this.getTabs(availableTabs)}
+          tagReportPathsType={tagReportPathsType}
           title={title}
         />
         <div style={styles.content}>{this.getTabContent(availableTabs)}</div>

--- a/src/pages/details/components/breakdown/breakdownHeader.tsx
+++ b/src/pages/details/components/breakdown/breakdownHeader.tsx
@@ -3,7 +3,8 @@ import './breakdownHeader.scss';
 import { Title } from '@patternfly/react-core';
 import { AngleLeftIcon } from '@patternfly/react-icons/dist/js/icons/angle-left-icon';
 import { breakdownDescKey, breakdownTitleKey, getQueryRoute, orgUnitIdKey, Query } from 'api/queries/query';
-import { Report, ReportPathsType } from 'api/reports/report';
+import { Report } from 'api/reports/report';
+import { TagPathsType } from 'api/tags/tag';
 import { TagLink } from 'pages/details/components/tag/tagLink';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
@@ -20,8 +21,8 @@ interface BreakdownHeaderOwnProps {
   groupBy?: string;
   query: Query;
   report: Report;
-  reportPathsType: ReportPathsType;
   tabs: React.ReactNode;
+  tagReportPathsType: TagPathsType;
   title: string;
 }
 
@@ -83,7 +84,7 @@ class BreakdownHeaderBase extends React.Component<BreakdownHeaderProps> {
   };
 
   public render() {
-    const { description, filterBy, groupBy, reportPathsType, t, tabs, title, query } = this.props;
+    const { description, filterBy, groupBy, query, t, tabs, tagReportPathsType, title } = this.props;
 
     const filterByAccount = query && query.filter ? query.filter.account : undefined;
     const groupByOrg = this.getGroupByOrg();
@@ -105,7 +106,7 @@ class BreakdownHeaderBase extends React.Component<BreakdownHeaderProps> {
                 <Link to={this.buildDetailsLink()}>
                   {t('breakdown.back_to_details', {
                     groupBy: groupByKey,
-                    value: reportPathsType,
+                    value: tagReportPathsType,
                   })}
                 </Link>
               </li>
@@ -119,7 +120,7 @@ class BreakdownHeaderBase extends React.Component<BreakdownHeaderProps> {
             {tabs}
             <div style={styles.tag}>
               {Boolean(showTags) && (
-                <TagLink filterBy={filterBy} groupBy={groupByKey} id="tags" reportPathsType={reportPathsType} />
+                <TagLink filterBy={filterBy} groupBy={groupByKey} id="tags" tagReportPathsType={tagReportPathsType} />
               )}
             </div>
           </div>

--- a/src/pages/details/components/dataToolbar/dataToolbar.tsx
+++ b/src/pages/details/components/dataToolbar/dataToolbar.tsx
@@ -27,6 +27,7 @@ import { FilterIcon } from '@patternfly/react-icons/dist/js/icons/filter-icon';
 import { SearchIcon } from '@patternfly/react-icons/dist/js/icons/search-icon';
 import { orgUnitIdKey, orgUnitNameKey, Query, tagKey, tagPrefix } from 'api/queries/query';
 import { Report } from 'api/reports/report';
+import { Tag } from 'api/tags/tag';
 import { cloneDeep } from 'lodash';
 import { uniq, uniqBy } from 'lodash';
 import React from 'react';
@@ -55,7 +56,7 @@ interface DataToolbarOwnProps {
   orgReport?: Report; // Report containing AWS organizational unit data
   pagination?: React.ReactNode; // Optional pagination controls to display in toolbar
   query?: Query; // Query containing filter_by params used to restore state upon page refresh
-  tagReport?: Report; // Report containing tag key and value data
+  tagReport?: Tag; // Data containing tag key and value data
   selectedItems?: ComputedReportItem[];
   showExport?: boolean; // Show export icon
 }
@@ -611,7 +612,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
     if (hasTagKeys) {
       const keepData = tagReport.data.map(
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        ({ type, ...keepProps }) => keepProps
+        ({ type, ...keepProps }: any) => keepProps
       );
       data = uniqBy(keepData, 'key');
     } else {
@@ -619,8 +620,8 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
     }
 
     if (data.length > 0) {
-      options = data.map(tag => {
-        const key = hasTagKeys ? tag.key : tag;
+      options = data.map(item => {
+        const key = hasTagKeys ? item.key : item;
         return {
           key,
           name: key, // tag keys not localized

--- a/src/pages/details/components/groupBy/groupByTag.tsx
+++ b/src/pages/details/components/groupBy/groupByTag.tsx
@@ -1,6 +1,6 @@
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import { parseQuery, Query, tagPrefix } from 'api/queries/query';
-import { Report } from 'api/reports/report';
+import { Tag } from 'api/tags/tag';
 import { uniq, uniqBy } from 'lodash';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
@@ -15,7 +15,7 @@ interface GroupByTagOwnProps {
     label: string;
     value: string;
   }[];
-  report: Report;
+  tagReport: Tag;
 }
 
 interface GroupByTagState {
@@ -52,15 +52,15 @@ class GroupByTagBase extends React.Component<GroupByTagProps> {
   }
 
   private getGroupByItems = () => {
-    const { report } = this.props;
+    const { tagReport } = this.props;
 
-    if (!(report && report.data)) {
+    if (!(tagReport && tagReport.data)) {
       return [];
     }
 
     // If the key_only param is used, we have an array of strings
     let hasTagKeys = false;
-    for (const item of report.data) {
+    for (const item of tagReport.data) {
       if (item.hasOwnProperty('key')) {
         hasTagKeys = true;
         break;
@@ -70,18 +70,18 @@ class GroupByTagBase extends React.Component<GroupByTagProps> {
     // Workaround for https://github.com/project-koku/koku/issues/1797
     let data = [];
     if (hasTagKeys) {
-      const keepData = report.data.map(
+      const keepData = tagReport.data.map(
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         ({ type, ...keepProps }: any) => keepProps
       );
       data = uniqBy(keepData, 'key');
     } else {
-      data = uniq(report.data);
+      data = uniq(tagReport.data);
     }
 
-    return data.map(tag => {
-      const tagKey = hasTagKeys ? tag.key : tag;
-      return <SelectOption key={tag.key} value={tagKey} />;
+    return data.map(item => {
+      const tagKey = hasTagKeys ? item.key : item;
+      return <SelectOption key={item.key} value={tagKey} />;
     });
   };
 

--- a/src/pages/details/components/tag/tag.tsx
+++ b/src/pages/details/components/tag/tag.tsx
@@ -1,11 +1,10 @@
 import { getQuery, parseQuery, Query } from 'api/queries/query';
-import { Report } from 'api/reports/report';
-import { ReportPathsType, ReportType } from 'api/reports/report';
+import { Tag, TagPathsType, TagType } from 'api/tags/tag';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { reportActions, reportSelectors } from 'store/reports';
+import { tagActions, tagSelectors } from 'store/tags';
 import { getTestProps, testIds } from 'testIds';
 
 import { styles } from './tag.styles';
@@ -15,7 +14,7 @@ interface TagOwnProps {
   filterBy: string | number;
   groupBy: string;
   id?: string;
-  reportPathsType: ReportPathsType;
+  tagReportPathsType: TagPathsType;
 }
 
 interface TagState {
@@ -25,17 +24,17 @@ interface TagState {
 
 interface TagStateProps {
   queryString?: string;
-  report?: Report;
-  reportFetchStatus?: FetchStatus;
+  tagReport?: Tag;
+  tagReportFetchStatus?: FetchStatus;
 }
 
 interface TagDispatchProps {
-  fetchReport?: typeof reportActions.fetchReport;
+  fetchTag?: typeof tagActions.fetchTag;
 }
 
 type TagProps = TagOwnProps & TagStateProps & TagDispatchProps & WithTranslation;
 
-const reportType = ReportType.tag;
+const tagReportType = TagType.tag;
 
 class TagBase extends React.Component<TagProps> {
   protected defaultState: TagState = {
@@ -51,14 +50,14 @@ class TagBase extends React.Component<TagProps> {
   }
 
   public componentDidMount() {
-    const { fetchReport, queryString, reportPathsType } = this.props;
-    fetchReport(reportPathsType, reportType, queryString);
+    const { fetchTag, queryString, tagReportPathsType } = this.props;
+    fetchTag(tagReportPathsType, tagReportType, queryString);
   }
 
   public componentDidUpdate(prevProps: TagProps) {
-    const { fetchReport, queryString, reportPathsType } = this.props;
+    const { fetchTag, queryString, tagReportPathsType } = this.props;
     if (prevProps.queryString !== queryString) {
-      fetchReport(reportPathsType, reportType, queryString);
+      fetchTag(tagReportPathsType, tagReportType, queryString);
     }
   }
 
@@ -73,7 +72,7 @@ class TagBase extends React.Component<TagProps> {
   };
 
   public render() {
-    const { filterBy, groupBy, id, report, reportPathsType, t } = this.props;
+    const { filterBy, groupBy, id, tagReport, tagReportPathsType, t } = this.props;
     const { isOpen, showAll } = this.state;
 
     let charCount = 0;
@@ -81,11 +80,11 @@ class TagBase extends React.Component<TagProps> {
     const someTags = [];
     const allTags = [];
 
-    if (report) {
-      for (const tag of report.data) {
-        for (const val of tag.values) {
+    if (tagReport) {
+      for (const item of tagReport.data) {
+        for (const val of item.values) {
           const prefix = someTags.length > 0 ? ', ' : '';
-          const tagString = `${prefix}${(tag as any).key}: ${val}`;
+          const tagString = `${prefix}${(item as any).key}: ${val}`;
           if (showAll) {
             someTags.push(tagString);
           } else if (charCount <= maxChars) {
@@ -101,14 +100,14 @@ class TagBase extends React.Component<TagProps> {
             }
           }
           charCount += tagString.length;
-          allTags.push(`${(tag as any).key}: ${val}`);
+          allTags.push(`${(item as any).key}: ${val}`);
         }
       }
     }
 
     return (
       <div style={styles.tagsContainer} id={id}>
-        {Boolean(someTags) && someTags.map((tag, tagIndex) => <span key={tagIndex}>{tag}</span>)}
+        {Boolean(someTags) && someTags.map((val, tagIndex) => <span key={tagIndex}>{val}</span>)}
         {Boolean(someTags.length < allTags.length) && (
           <a {...getTestProps(testIds.details.tag_lnk)} href="#/" onClick={this.handleOpen}>
             {t('details.more_tags', {
@@ -121,7 +120,7 @@ class TagBase extends React.Component<TagProps> {
           groupBy={groupBy}
           isOpen={isOpen}
           onClose={this.handleClose}
-          reportPathsType={reportPathsType}
+          tagReportPathsType={tagReportPathsType}
         />
       </div>
     );
@@ -129,7 +128,7 @@ class TagBase extends React.Component<TagProps> {
 }
 
 const mapStateToProps = createMapStateToProps<TagOwnProps, TagStateProps>(
-  (state, { filterBy, groupBy, reportPathsType }) => {
+  (state, { filterBy, groupBy, tagReportPathsType }) => {
     const queryFromRoute = parseQuery<Query>(location.search);
     const queryString = getQuery({
       filter: {
@@ -142,19 +141,24 @@ const mapStateToProps = createMapStateToProps<TagOwnProps, TagStateProps>(
         }),
       },
     });
-    const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-    const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+    const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
+    const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(
+      state,
+      tagReportPathsType,
+      tagReportType,
+      queryString
+    );
     return {
       filterBy,
       queryString,
-      report,
-      reportFetchStatus,
+      tagReport,
+      tagReportFetchStatus,
     };
   }
 );
 
 const mapDispatchToProps: TagDispatchProps = {
-  fetchReport: reportActions.fetchReport,
+  fetchTag: tagActions.fetchTag,
 };
 
 const Tag = withTranslation()(connect(mapStateToProps, mapDispatchToProps)(TagBase));

--- a/src/pages/details/components/tag/tagLink.tsx
+++ b/src/pages/details/components/tag/tagLink.tsx
@@ -1,12 +1,11 @@
 import { TagIcon } from '@patternfly/react-icons/dist/js/icons/tag-icon';
 import { getQuery, parseQuery, Query } from 'api/queries/query';
-import { ReportPathsType, ReportType } from 'api/reports/report';
-import { Report } from 'api/reports/report';
+import { Tag, TagPathsType, TagType } from 'api/tags/tag';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { reportActions, reportSelectors } from 'store/reports';
+import { tagActions, tagSelectors } from 'store/tags';
 import { getTestProps, testIds } from 'testIds';
 
 import { styles } from './tag.styles';
@@ -16,7 +15,7 @@ interface TagLinkOwnProps {
   filterBy: string | number;
   groupBy: string;
   id?: string;
-  reportPathsType: ReportPathsType;
+  tagReportPathsType: TagPathsType;
 }
 
 interface TagLinkState {
@@ -25,17 +24,17 @@ interface TagLinkState {
 
 interface TagLinkStateProps {
   queryString?: string;
-  report?: Report;
-  reportFetchStatus?: FetchStatus;
+  tagReport?: Tag;
+  tagReportFetchStatus?: FetchStatus;
 }
 
 interface TagLinkDispatchProps {
-  fetchReport?: typeof reportActions.fetchReport;
+  fetchTag?: typeof tagActions.fetchTag;
 }
 
 type TagLinkProps = TagLinkOwnProps & TagLinkStateProps & TagLinkDispatchProps & WithTranslation;
 
-const reportType = ReportType.tag;
+const tagReportType = TagType.tag;
 
 class TagLinkBase extends React.Component<TagLinkProps> {
   protected defaultState: TagLinkState = {
@@ -50,14 +49,14 @@ class TagLinkBase extends React.Component<TagLinkProps> {
   }
 
   public componentDidMount() {
-    const { fetchReport, queryString, reportPathsType } = this.props;
-    fetchReport(reportPathsType, reportType, queryString);
+    const { fetchTag, queryString, tagReportPathsType } = this.props;
+    fetchTag(tagReportPathsType, tagReportType, queryString);
   }
 
   public componentDidUpdate(prevProps: TagLinkProps) {
-    const { fetchReport, queryString, reportPathsType } = this.props;
+    const { fetchTag, queryString, tagReportPathsType } = this.props;
     if (prevProps.queryString !== queryString) {
-      fetchReport(reportPathsType, reportType, queryString);
+      fetchTag(tagReportPathsType, tagReportType, queryString);
     }
   }
 
@@ -72,15 +71,15 @@ class TagLinkBase extends React.Component<TagLinkProps> {
   };
 
   public render() {
-    const { filterBy, groupBy, id, report, reportPathsType } = this.props;
+    const { filterBy, groupBy, id, tagReport, tagReportPathsType } = this.props;
     const { isOpen } = this.state;
 
     let count = 0;
 
-    if (report) {
-      for (const tag of report.data) {
-        if (tag.values) {
-          count += tag.values.length;
+    if (tagReport) {
+      for (const item of tagReport.data) {
+        if (item.values) {
+          count += item.values.length;
         }
       }
     }
@@ -100,7 +99,7 @@ class TagLinkBase extends React.Component<TagLinkProps> {
           groupBy={groupBy}
           isOpen={isOpen}
           onClose={this.handleClose}
-          reportPathsType={reportPathsType}
+          tagReportPathsType={tagReportPathsType}
         />
       </div>
     );
@@ -108,7 +107,7 @@ class TagLinkBase extends React.Component<TagLinkProps> {
 }
 
 const mapStateToProps = createMapStateToProps<TagLinkOwnProps, TagLinkStateProps>(
-  (state, { filterBy, groupBy, reportPathsType }) => {
+  (state, { filterBy, groupBy, tagReportPathsType }) => {
     const queryFromRoute = parseQuery<Query>(location.search);
     const queryString = getQuery({
       filter: {
@@ -121,19 +120,24 @@ const mapStateToProps = createMapStateToProps<TagLinkOwnProps, TagLinkStateProps
         }),
       },
     });
-    const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-    const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+    const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
+    const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(
+      state,
+      tagReportPathsType,
+      tagReportType,
+      queryString
+    );
     return {
       filterBy,
       queryString,
-      report,
-      reportFetchStatus,
+      tagReport,
+      tagReportFetchStatus,
     };
   }
 );
 
 const mapDispatchToProps: TagLinkDispatchProps = {
-  fetchReport: reportActions.fetchReport,
+  fetchTag: tagActions.fetchTag,
 };
 
 const TagLink = withTranslation()(connect(mapStateToProps, mapDispatchToProps)(TagLinkBase));

--- a/src/pages/details/components/tag/tagModal.tsx
+++ b/src/pages/details/components/tag/tagModal.tsx
@@ -1,11 +1,11 @@
 import { Modal } from '@patternfly/react-core';
 import { getQuery, parseQuery, Query } from 'api/queries/query';
-import { Report, ReportPathsType, ReportType } from 'api/reports/report';
+import { Tag, TagPathsType, TagType } from 'api/tags/tag';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { reportActions, reportSelectors } from 'store/reports';
+import { tagActions, tagSelectors } from 'store/tags';
 
 import { TagView } from './tagView';
 
@@ -14,22 +14,22 @@ interface TagModalOwnProps {
   groupBy: string;
   isOpen: boolean;
   onClose(isOpen: boolean);
-  reportPathsType: ReportPathsType;
+  tagReportPathsType: TagPathsType;
 }
 
 interface TagModalStateProps {
   queryString?: string;
-  report?: Report;
-  reportFetchStatus?: FetchStatus;
+  tagReport?: Tag;
+  tagReportFetchStatus?: FetchStatus;
 }
 
 interface TagModalDispatchProps {
-  fetchReport?: typeof reportActions.fetchReport;
+  fetchTag?: typeof tagActions.fetchTag;
 }
 
 type TagModalProps = TagModalOwnProps & TagModalStateProps & TagModalDispatchProps & WithTranslation;
 
-const reportType = ReportType.tag;
+const tagReportType = TagType.tag;
 
 class TagModalBase extends React.Component<TagModalProps> {
   constructor(props: TagModalProps) {
@@ -38,14 +38,14 @@ class TagModalBase extends React.Component<TagModalProps> {
   }
 
   public componentDidMount() {
-    const { fetchReport, queryString, reportPathsType } = this.props;
-    fetchReport(reportPathsType, reportType, queryString);
+    const { fetchTag, queryString, tagReportPathsType } = this.props;
+    fetchTag(tagReportPathsType, tagReportType, queryString);
   }
 
   public componentDidUpdate(prevProps: TagModalProps) {
-    const { fetchReport, queryString, reportPathsType } = this.props;
+    const { fetchTag, queryString, tagReportPathsType } = this.props;
     if (prevProps.queryString !== queryString) {
-      fetchReport(reportPathsType, reportType, queryString);
+      fetchTag(tagReportPathsType, tagReportType, queryString);
     }
   }
 
@@ -55,13 +55,13 @@ class TagModalBase extends React.Component<TagModalProps> {
   }
 
   private getTagValueCount = () => {
-    const { report } = this.props;
+    const { tagReport } = this.props;
     let count = 0;
 
-    if (report) {
-      for (const tag of report.data) {
-        if (tag.values) {
-          count += tag.values.length;
+    if (tagReport) {
+      for (const item of tagReport.data) {
+        if (item.values) {
+          count += item.values.length;
         }
       }
     }
@@ -73,7 +73,7 @@ class TagModalBase extends React.Component<TagModalProps> {
   };
 
   public render() {
-    const { filterBy, groupBy, isOpen, report, t } = this.props;
+    const { filterBy, groupBy, isOpen, tagReport, t } = this.props;
 
     return (
       <Modal
@@ -84,14 +84,14 @@ class TagModalBase extends React.Component<TagModalProps> {
         })}
         width={'50%'}
       >
-        <TagView filterBy={filterBy} groupBy={groupBy} report={report} />
+        <TagView filterBy={filterBy} groupBy={groupBy} tagReport={tagReport} />
       </Modal>
     );
   }
 }
 
 const mapStateToProps = createMapStateToProps<TagModalOwnProps, TagModalStateProps>(
-  (state, { filterBy, groupBy, reportPathsType }) => {
+  (state, { filterBy, groupBy, tagReportPathsType }) => {
     const queryFromRoute = parseQuery<Query>(location.search);
     const queryString = getQuery({
       filter: {
@@ -104,18 +104,23 @@ const mapStateToProps = createMapStateToProps<TagModalOwnProps, TagModalStatePro
         }),
       },
     });
-    const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-    const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+    const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
+    const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(
+      state,
+      tagReportPathsType,
+      tagReportType,
+      queryString
+    );
     return {
       queryString,
-      report,
-      reportFetchStatus,
+      tagReport,
+      tagReportFetchStatus,
     };
   }
 );
 
 const mapDispatchToProps: TagModalDispatchProps = {
-  fetchReport: reportActions.fetchReport,
+  fetchTag: tagActions.fetchTag,
 };
 
 const TagModal = withTranslation()(connect(mapStateToProps, mapDispatchToProps)(TagModalBase));

--- a/src/pages/details/components/tag/tagView.tsx
+++ b/src/pages/details/components/tag/tagView.tsx
@@ -1,5 +1,5 @@
 import { DataList, DataListCell, DataListItem, DataListItemCells, DataListItemRow } from '@patternfly/react-core';
-import { Report } from 'api/reports/report';
+import { Tag } from 'api/tags/tag';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -9,27 +9,27 @@ import { styles } from './tag.styles';
 interface TagViewOwnProps {
   filterBy: string | number;
   groupBy: string;
-  report?: Report;
+  tagReport?: Tag;
 }
 
 type TagViewProps = TagViewOwnProps & WithTranslation;
 
 class TagViewBase extends React.Component<TagViewProps> {
   private getDataListItems = () => {
-    const { report } = this.props;
+    const { tagReport } = this.props;
     const result = [];
 
-    if (report) {
-      for (const tag of report.data) {
-        for (const val of tag.values) {
-          const id = `${(tag as any).key}:${val}`;
+    if (tagReport) {
+      for (const item of tagReport.data) {
+        for (const val of item.values) {
+          const id = `${(item as any).key}:${val}`;
           result.push(
             <DataListItem aria-labelledby={id} key={`${id}-item`}>
               <DataListItemRow>
                 <DataListItemCells
                   dataListCells={[
                     <DataListCell key={`${id}-cell1`}>
-                      <span id={id}>{(tag as any).key}</span>
+                      <span id={id}>{(item as any).key}</span>
                     </DataListCell>,
                     <DataListCell key={`${id}-cell2`}>{val}</DataListCell>,
                   ]}

--- a/src/pages/details/gcpBreakdown/gcpBreakdown.tsx
+++ b/src/pages/details/gcpBreakdown/gcpBreakdown.tsx
@@ -1,6 +1,7 @@
 import { GcpQuery, getQuery, parseQuery } from 'api/queries/gcpQuery';
 import { breakdownDescKey, breakdownTitleKey, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
+import { TagPathsType } from 'api/tags/tag';
 import { AxiosError } from 'axios';
 import BreakdownBase from 'pages/details/components/breakdown/breakdownBase';
 import { getGroupById, getGroupByValue } from 'pages/details/components/utils/groupBy';
@@ -77,6 +78,7 @@ const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, GcpBreakdown
     reportFetchStatus,
     reportType,
     reportPathsType,
+    tagReportPathsType: TagPathsType.gcp,
     title: query[breakdownTitleKey] ? query[breakdownTitleKey] : filterBy,
   };
 });

--- a/src/pages/details/gcpDetails/detailsHeader.tsx
+++ b/src/pages/details/gcpDetails/detailsHeader.tsx
@@ -4,6 +4,7 @@ import { GcpQuery, getQuery } from 'api/queries/gcpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { GcpReport } from 'api/reports/gcpReports';
 import { ReportPathsType } from 'api/reports/report';
+import { TagPathsType } from 'api/tags/tag';
 import { AxiosError } from 'axios';
 import { GroupBy } from 'pages/details/components/groupBy/groupBy';
 import React from 'react';
@@ -51,6 +52,7 @@ const groupByOptions: {
 ];
 
 const reportPathsType = ReportPathsType.gcp;
+const tagReportPathsType = TagPathsType.gcp;
 
 class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
   public render() {
@@ -74,6 +76,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             options={groupByOptions}
             reportPathsType={reportPathsType}
             showTags
+            tagReportPathsType={tagReportPathsType}
           />
         </div>
         {Boolean(showContent) && (

--- a/src/pages/details/gcpDetails/detailsToolbar.tsx
+++ b/src/pages/details/gcpDetails/detailsToolbar.tsx
@@ -1,13 +1,13 @@
 import { ToolbarChipGroup } from '@patternfly/react-core';
 import { GcpQuery, getQuery } from 'api/queries/gcpQuery';
 import { tagKey } from 'api/queries/query';
-import { Report, ReportPathsType, ReportType } from 'api/reports/report';
+import { Tag, TagPathsType, TagType } from 'api/tags/tag';
 import { DataToolbar } from 'pages/details/components/dataToolbar/dataToolbar';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { reportActions, reportSelectors } from 'store/reports';
+import { tagActions, tagSelectors } from 'store/tags';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { isEqual } from 'utils/equal';
 
@@ -30,12 +30,12 @@ interface DetailsToolbarOwnProps {
 }
 
 interface DetailsToolbarStateProps {
-  tagReport?: Report;
+  tagReport?: Tag;
   tagReportFetchStatus?: FetchStatus;
 }
 
 interface DetailsToolbarDispatchProps {
-  fetchReport?: typeof reportActions.fetchReport;
+  fetchTag?: typeof tagActions.fetchTag;
 }
 
 interface DetailsToolbarState {
@@ -47,25 +47,25 @@ type DetailsToolbarProps = DetailsToolbarOwnProps &
   DetailsToolbarDispatchProps &
   WithTranslation;
 
-const tagReportType = ReportType.tag;
-const reportPathsType = ReportPathsType.gcp;
+const tagReportType = TagType.tag;
+const tagReportPathsType = TagPathsType.gcp;
 
 export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   protected defaultState: DetailsToolbarState = {};
   public state: DetailsToolbarState = { ...this.defaultState };
 
   public componentDidMount() {
-    const { fetchReport, queryString } = this.props;
-    fetchReport(reportPathsType, tagReportType, queryString);
+    const { fetchTag, queryString } = this.props;
+    fetchTag(tagReportPathsType, tagReportType, queryString);
     this.setState({
       categoryOptions: this.getCategoryOptions(),
     });
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps) {
-    const { fetchReport, query, queryString, tagReport } = this.props;
+    const { fetchTag, query, queryString, tagReport } = this.props;
     if (query && !isEqual(query, prevProps.query)) {
-      fetchReport(reportPathsType, tagReportType, queryString);
+      fetchTag(tagReportPathsType, tagReportType, queryString);
     }
     if (!isEqual(tagReport, prevProps.tagReport)) {
       this.setState({
@@ -138,13 +138,8 @@ const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToo
     // key_only: true
   });
 
-  const tagReport = reportSelectors.selectReport(state, reportPathsType, tagReportType, queryString);
-  const tagReportFetchStatus = reportSelectors.selectReportFetchStatus(
-    state,
-    reportPathsType,
-    tagReportType,
-    queryString
-  );
+  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
+  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);
   return {
     queryString,
     tagReport,
@@ -153,7 +148,7 @@ const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToo
 });
 
 const mapDispatchToProps: DetailsToolbarDispatchProps = {
-  fetchReport: reportActions.fetchReport,
+  fetchTag: tagActions.fetchTag,
 };
 
 const DetailsToolbar = withTranslation()(connect(mapStateToProps, mapDispatchToProps)(DetailsToolbarBase));

--- a/src/pages/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/pages/details/ocpBreakdown/ocpBreakdown.tsx
@@ -1,6 +1,7 @@
 import { getQuery, OcpQuery, parseQuery } from 'api/queries/ocpQuery';
 import { Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
+import { TagPathsType } from 'api/tags/tag';
 import { AxiosError } from 'axios';
 import BreakdownBase from 'pages/details/components/breakdown/breakdownBase';
 import { getGroupById, getGroupByValue } from 'pages/details/components/utils/groupBy';
@@ -61,6 +62,7 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
     reportFetchStatus,
     reportType,
     reportPathsType,
+    tagReportPathsType: TagPathsType.ocp,
     title: filterBy,
   };
 });

--- a/src/pages/details/ocpDetails/detailsHeader.tsx
+++ b/src/pages/details/ocpDetails/detailsHeader.tsx
@@ -5,6 +5,7 @@ import { getQuery, OcpQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { OcpReport } from 'api/reports/ocpReports';
 import { ReportPathsType } from 'api/reports/report';
+import { TagPathsType } from 'api/tags/tag';
 import { AxiosError } from 'axios';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import { GroupBy } from 'pages/details/components/groupBy/groupBy';
@@ -55,6 +56,7 @@ const groupByOptions: {
 ];
 
 const reportPathsType = ReportPathsType.ocp;
+const tagReportPathsType = TagPathsType.ocp;
 
 class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
   protected defaultState: DetailsHeaderState = {};
@@ -100,6 +102,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             options={groupByOptions}
             reportPathsType={reportPathsType}
             showTags
+            tagReportPathsType={tagReportPathsType}
           />
         </div>
         {Boolean(showContent) && (

--- a/src/pages/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpDetails/detailsToolbar.tsx
@@ -1,14 +1,14 @@
 import { ToolbarChipGroup } from '@patternfly/react-core';
 import { getQuery, OcpQuery } from 'api/queries/ocpQuery';
 import { tagKey } from 'api/queries/query';
-import { OcpReport } from 'api/reports/ocpReports';
-import { ReportPathsType, ReportType } from 'api/reports/report';
+import { OcpTag } from 'api/tags/ocpTags';
+import { TagPathsType, TagType } from 'api/tags/tag';
 import { DataToolbar } from 'pages/details/components/dataToolbar/dataToolbar';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { reportActions, reportSelectors } from 'store/reports';
+import { tagActions, tagSelectors } from 'store/tags';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { isEqual } from 'utils/equal';
 
@@ -25,17 +25,16 @@ interface DetailsToolbarOwnProps {
   pagination?: React.ReactNode;
   query?: OcpQuery;
   queryString?: string;
-  report?: OcpReport;
   selectedItems?: ComputedReportItem[];
 }
 
 interface DetailsToolbarStateProps {
-  report?: OcpReport;
-  reportFetchStatus?: FetchStatus;
+  tagReport?: OcpTag;
+  tagReportFetchStatus?: FetchStatus;
 }
 
 interface DetailsToolbarDispatchProps {
-  fetchReport?: typeof reportActions.fetchReport;
+  fetchTag?: typeof tagActions.fetchTag;
 }
 
 interface DetailsToolbarState {
@@ -47,27 +46,27 @@ type DetailsToolbarProps = DetailsToolbarOwnProps &
   DetailsToolbarDispatchProps &
   WithTranslation;
 
-const reportType = ReportType.tag;
-const reportPathsType = ReportPathsType.ocp;
+const tagReportType = TagType.tag;
+const tagReportPathsType = TagPathsType.ocp;
 
 export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   protected defaultState: DetailsToolbarState = {};
   public state: DetailsToolbarState = { ...this.defaultState };
 
   public componentDidMount() {
-    const { fetchReport, queryString } = this.props;
-    fetchReport(reportPathsType, reportType, queryString);
+    const { fetchTag, queryString } = this.props;
+    fetchTag(tagReportPathsType, tagReportType, queryString);
     this.setState({
       categoryOptions: this.getCategoryOptions(),
     });
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps) {
-    const { fetchReport, query, queryString, report } = this.props;
+    const { fetchTag, query, queryString, tagReport } = this.props;
     if (query && !isEqual(query, prevProps.query)) {
-      fetchReport(reportPathsType, reportType, queryString);
+      fetchTag(tagReportPathsType, tagReportType, queryString);
     }
-    if (!isEqual(report, prevProps.report)) {
+    if (!isEqual(tagReport, prevProps.tagReport)) {
       this.setState({
         categoryOptions: this.getCategoryOptions(),
       });
@@ -75,7 +74,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   }
 
   private getCategoryOptions = (): ToolbarChipGroup[] => {
-    const { report, t } = this.props;
+    const { tagReport, t } = this.props;
 
     const options = [
       { name: t('filter_by.values.cluster'), key: 'cluster' },
@@ -84,7 +83,9 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       { name: t('filter_by.values.tag'), key: tagKey },
     ];
 
-    return report && report.data && report.data.length ? options : options.filter(option => option.key !== tagKey);
+    return tagReport && tagReport.data && tagReport.data.length
+      ? options
+      : options.filter(option => option.key !== tagKey);
   };
 
   public render() {
@@ -136,17 +137,17 @@ const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToo
     },
     // key_only: true
   });
-  const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
+  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);
   return {
     queryString,
-    reportFetchStatus,
-    report,
+    tagReport,
+    tagReportFetchStatus,
   };
 });
 
 const mapDispatchToProps: DetailsToolbarDispatchProps = {
-  fetchReport: reportActions.fetchReport,
+  fetchTag: tagActions.fetchTag,
 };
 
 const DetailsToolbar = withTranslation()(connect(mapStateToProps, mapDispatchToProps)(DetailsToolbarBase));

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -26,6 +26,7 @@ import { ocpHistoricalDataReducer, ocpHistoricalDataStateKey } from 'store/histo
 import { priceListReducer, priceListStateKey } from 'store/priceList';
 import { reportReducer, reportStateKey } from 'store/reports';
 import { sourcesReducer, sourcesStateKey } from 'store/sourceSettings';
+import { tagReducer, tagStateKey } from 'store/tags';
 import { StateType } from 'typesafe-actions';
 
 import { metricsReducer, metricsStateKey } from './metrics';
@@ -44,10 +45,12 @@ export const rootReducer = combineReducers({
   [azureCostOverviewStateKey]: azureCostOverviewReducer,
   [azureDashboardStateKey]: azureDashboardReducer,
   [azureHistoricalDataStateKey]: azureHistoricalDataReducer,
+  [costModelsStateKey]: costModelsReducer,
   [exportStateKey]: exportReducer,
   [gcpCostOverviewStateKey]: gcpCostOverviewReducer,
   [gcpDashboardStateKey]: gcpDashboardReducer,
   [gcpHistoricalDataStateKey]: gcpHistoricalDataReducer,
+  [metricsStateKey]: metricsReducer,
   [ocpCostOverviewStateKey]: ocpCostOverviewReducer,
   [ocpDashboardStateKey]: ocpDashboardReducer,
   [ocpCloudDashboardStateKey]: ocpCloudDashboardReducer,
@@ -57,12 +60,11 @@ export const rootReducer = combineReducers({
   [ocpUsageDashboardStateKey]: ocpUsageDashboardReducer,
   [priceListStateKey]: priceListReducer,
   [providersStateKey]: providersReducer,
+  [rbacStateKey]: rbacReducer,
   [reportStateKey]: reportReducer,
   [forecastStateKey]: forecastReducer,
   [sourcesStateKey]: sourcesReducer,
-  [costModelsStateKey]: costModelsReducer,
+  [tagStateKey]: tagReducer,
   [uiStateKey]: uiReducer,
-  [metricsStateKey]: metricsReducer,
-  [rbacStateKey]: rbacReducer,
   notifications,
 });

--- a/src/store/tags/__snapshots__/tag.test.ts.snap
+++ b/src/store/tags/__snapshots__/tag.test.ts.snap
@@ -1,0 +1,20 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`default state 1`] = `
+Object {
+  "byId": Map {},
+  "errors": Map {},
+  "fetchStatus": Map {},
+}
+`;
+
+exports[`fetch tag report success 1`] = `
+Object {
+  "data": Array [],
+  "timeRequested": 12345,
+  "total": Object {
+    "units": "USD",
+    "value": 100,
+  },
+}
+`;

--- a/src/store/tags/index.ts
+++ b/src/store/tags/index.ts
@@ -1,0 +1,6 @@
+import * as tagActions from './tagActions';
+import { tagStateKey } from './tagCommon';
+import { CachedTag, TagAction, tagReducer, TagState } from './tagReducer';
+import * as tagSelectors from './tagSelectors';
+
+export { TagAction, CachedTag, tagActions, tagReducer, tagSelectors, TagState, tagStateKey };

--- a/src/store/tags/tag.test.ts
+++ b/src/store/tags/tag.test.ts
@@ -1,0 +1,86 @@
+jest.mock('api/tags/tagUtils');
+
+import { Tag, TagPathsType, TagType } from 'api/tags/tag';
+import { runTag } from 'api/tags/tagUtils';
+import { FetchStatus } from 'store/common';
+import { createMockStoreCreator } from 'store/mockStore';
+import { wait } from 'testUtils';
+
+import * as actions from './tagActions';
+import { tagStateKey } from './tagCommon';
+import { tagReducer } from './tagReducer';
+import * as selectors from './tagSelectors';
+
+const createTagsStore = createMockStoreCreator({
+  [tagStateKey]: tagReducer,
+});
+
+const runTagMock = runTag as jest.Mock;
+
+const mockTagReport: Tag = {
+  data: [],
+  total: {
+    value: 100,
+    units: 'USD',
+  },
+} as any;
+
+const query = 'query';
+const tagReportType = TagType.tag;
+const tagReportPathsType = TagPathsType.aws;
+
+runTagMock.mockResolvedValue({ data: mockTagReport });
+global.Date.now = jest.fn(() => 12345);
+
+test('default state', () => {
+  const store = createTagsStore();
+  expect(selectors.selectTagState(store.getState())).toMatchSnapshot();
+});
+
+test('fetch tag report success', async () => {
+  const store = createTagsStore();
+  store.dispatch(actions.fetchTag(tagReportPathsType, tagReportType, query));
+  expect(runTagMock).toBeCalled();
+  expect(selectors.selectTagFetchStatus(store.getState(), tagReportPathsType, tagReportType, query)).toBe(
+    FetchStatus.inProgress
+  );
+  await wait();
+  const finishedState = store.getState();
+  expect(selectors.selectTag(finishedState, tagReportPathsType, tagReportType, query)).toMatchSnapshot();
+  expect(selectors.selectTagFetchStatus(finishedState, tagReportPathsType, tagReportType, query)).toBe(
+    FetchStatus.complete
+  );
+  expect(selectors.selectTagError(finishedState, tagReportPathsType, tagReportType, query)).toBe(null);
+});
+
+test('fetch tag report failure', async () => {
+  const store = createTagsStore();
+  const error = Symbol('tag error');
+  runTagMock.mockRejectedValueOnce(error);
+  store.dispatch(actions.fetchTag(tagReportPathsType, tagReportType, query));
+  expect(runTag).toBeCalled();
+  expect(selectors.selectTagFetchStatus(store.getState(), tagReportPathsType, tagReportType, query)).toBe(
+    FetchStatus.inProgress
+  );
+  await wait();
+  const finishedState = store.getState();
+  expect(selectors.selectTagFetchStatus(finishedState, tagReportPathsType, tagReportType, query)).toBe(
+    FetchStatus.complete
+  );
+  expect(selectors.selectTagError(finishedState, tagReportPathsType, tagReportType, query)).toBe(error);
+});
+
+test('does not fetch tag report if the request is in progress', () => {
+  const store = createTagsStore();
+  store.dispatch(actions.fetchTag(tagReportPathsType, tagReportType, query));
+  store.dispatch(actions.fetchTag(tagReportPathsType, tagReportType, query));
+  expect(runTag).toHaveBeenCalledTimes(1);
+});
+
+test('tag report is not refetched if it has not expired', async () => {
+  const store = createTagsStore();
+  store.dispatch(actions.fetchTag(tagReportPathsType, tagReportType, query));
+  await wait();
+  store.dispatch(actions.fetchTag(tagReportPathsType, tagReportType, query));
+  expect(runTag).toHaveBeenCalledTimes(1);
+});

--- a/src/store/tags/tagActions.ts
+++ b/src/store/tags/tagActions.ts
@@ -1,0 +1,62 @@
+import { Tag, TagPathsType, TagType } from 'api/tags/tag';
+import { runTag } from 'api/tags/tagUtils';
+import { AxiosError } from 'axios';
+import { ThunkAction } from 'redux-thunk';
+import { FetchStatus } from 'store/common';
+import { RootState } from 'store/rootReducer';
+import { createStandardAction } from 'typesafe-actions';
+
+import { getTagId } from './tagCommon';
+import { selectTag, selectTagFetchStatus } from './tagSelectors';
+
+const expirationMS = 30 * 60 * 1000; // 30 minutes
+
+interface TagActionMeta {
+  tagId: string;
+}
+
+export const fetchTagRequest = createStandardAction('tag/request')<TagActionMeta>();
+export const fetchTagSuccess = createStandardAction('tag/success')<Tag, TagActionMeta>();
+export const fetchTagFailure = createStandardAction('tag/failure')<AxiosError, TagActionMeta>();
+
+export function fetchTag(
+  tagPathsType: TagPathsType,
+  tagType: TagType,
+  query: string
+): ThunkAction<void, RootState, void, any> {
+  return (dispatch, getState) => {
+    if (!isTagExpired(getState(), tagPathsType, tagType, query)) {
+      return;
+    }
+
+    const meta: TagActionMeta = {
+      tagId: getTagId(tagPathsType, tagType, query),
+    };
+
+    dispatch(fetchTagRequest(meta));
+    runTag(tagPathsType, tagType, query)
+      .then(res => {
+        // See https://github.com/project-koku/koku-ui/pull/580
+        // const repsonseData = dropCurrentMonthData(res, query);
+        dispatch(fetchTagSuccess(res.data, meta));
+      })
+      .catch(err => {
+        dispatch(fetchTagFailure(err, meta));
+      });
+  };
+}
+
+function isTagExpired(state: RootState, tagPathsType: TagPathsType, tagType: TagType, query: string) {
+  const tagReport = selectTag(state, tagPathsType, tagType, query);
+  const fetchStatus = selectTagFetchStatus(state, tagPathsType, tagType, query);
+  if (fetchStatus === FetchStatus.inProgress) {
+    return false;
+  }
+
+  if (!tagReport) {
+    return true;
+  }
+
+  const now = Date.now();
+  return now > tagReport.timeRequested + expirationMS;
+}

--- a/src/store/tags/tagCommon.ts
+++ b/src/store/tags/tagCommon.ts
@@ -1,0 +1,7 @@
+import { TagPathsType, TagType } from 'api/tags/tag';
+
+export const tagStateKey = 'tag';
+
+export function getTagId(tagPathsType: TagPathsType, tagType: TagType, query: string) {
+  return `${tagPathsType}--${tagType}--${query}`;
+}

--- a/src/store/tags/tagReducer.ts
+++ b/src/store/tags/tagReducer.ts
@@ -1,0 +1,54 @@
+import { Tag } from 'api/tags/tag';
+import { AxiosError } from 'axios';
+import { FetchStatus } from 'store/common';
+import { ActionType, getType } from 'typesafe-actions';
+
+import { fetchTagFailure, fetchTagRequest, fetchTagSuccess } from './tagActions';
+
+export interface CachedTag extends Tag {
+  timeRequested: number;
+}
+
+export type TagState = Readonly<{
+  byId: Map<string, CachedTag>;
+  fetchStatus: Map<string, FetchStatus>;
+  errors: Map<string, AxiosError>;
+}>;
+
+const defaultState: TagState = {
+  byId: new Map(),
+  fetchStatus: new Map(),
+  errors: new Map(),
+};
+
+export type TagAction = ActionType<typeof fetchTagFailure | typeof fetchTagRequest | typeof fetchTagSuccess>;
+
+export function tagReducer(state = defaultState, action: TagAction): TagState {
+  switch (action.type) {
+    case getType(fetchTagRequest):
+      return {
+        ...state,
+        fetchStatus: new Map(state.fetchStatus).set(action.payload.tagId, FetchStatus.inProgress),
+      };
+
+    case getType(fetchTagSuccess):
+      return {
+        ...state,
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.tagId, FetchStatus.complete),
+        byId: new Map(state.byId).set(action.meta.tagId, {
+          ...action.payload,
+          timeRequested: Date.now(),
+        }),
+        errors: new Map(state.errors).set(action.meta.tagId, null),
+      };
+
+    case getType(fetchTagFailure):
+      return {
+        ...state,
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.tagId, FetchStatus.complete),
+        errors: new Map(state.errors).set(action.meta.tagId, action.payload),
+      };
+    default:
+      return state;
+  }
+}

--- a/src/store/tags/tagSelectors.ts
+++ b/src/store/tags/tagSelectors.ts
@@ -1,0 +1,15 @@
+import { TagPathsType, TagType } from 'api/tags/tag';
+import { RootState } from 'store/rootReducer';
+
+import { getTagId, tagStateKey } from './tagCommon';
+
+export const selectTagState = (state: RootState) => state[tagStateKey];
+
+export const selectTag = (state: RootState, tagPathsType: TagPathsType, tagType: TagType, query: string) =>
+  selectTagState(state).byId.get(getTagId(tagPathsType, tagType, query));
+
+export const selectTagFetchStatus = (state: RootState, tagPathsType: TagPathsType, tagType: TagType, query: string) =>
+  selectTagState(state).fetchStatus.get(getTagId(tagPathsType, tagType, query));
+
+export const selectTagError = (state: RootState, tagPathsType: TagPathsType, tagType: TagType, query: string) =>
+  selectTagState(state).errors.get(getTagId(tagPathsType, tagType, query));


### PR DESCRIPTION
Want to move tags out of `Report` to its own `Tag` type.

We had added tag properties to `Report` type, but it would be cleaner if the tags API used its own `Tags` type. The tags API returns a unique data structure, compared with the `Report` type.

No visual changes. The UI should continue to function normally

https://issues.redhat.com/browse/COST-766

The `Tag` type mimics this API data structure
<img width="199" alt="Screen Shot 2020-11-24 at 5 17 47 PM" src="https://user-images.githubusercontent.com/17481322/100157708-fff2fd80-2e78-11eb-8b86-9902c65598e2.png">
