### PR TITLE
fix(costmodels): show measurement units in the select options

### DIFF
--- a/src/pages/costModels/components/rateForm/rateForm.tsx
+++ b/src/pages/costModels/components/rateForm/rateForm.tsx
@@ -114,8 +114,8 @@ export const RateForm: React.FunctionComponent<RateFormProps> = ({ metricsHash, 
                 },
                 ...measurementOptions.map(opt => {
                   return {
+                    label: `${opt} (${metricsHash[metric][opt].label_measurement_unit})`,
                     value: opt,
-                    label: opt,
                     isDisabled: false,
                   };
                 }),


### PR DESCRIPTION
Closes COST 769

Before

![image](https://user-images.githubusercontent.com/2453279/100353514-479f9380-2ff7-11eb-80a9-f2c941e25d89.png)

Now

![image](https://user-images.githubusercontent.com/2453279/100353428-28086b00-2ff7-11eb-8369-b3849ff5fc10.png)
