### PR TITLE
Incorrect display of graph labels

### DIFF
--- a/src/components/charts/common/chartUtils.ts
+++ b/src/components/charts/common/chartUtils.ts
@@ -82,7 +82,7 @@ export function transformForecast(
       return [...acc, createForecastDatum(prevValue + d[forecastItem][forecastItemValue].value, d)];
     }, []);
   }
-  return result;
+  return padComputedReportItems(result);
 }
 
 export function transformForecastCone(
@@ -119,7 +119,7 @@ export function transformForecastCone(
       ];
     }, []);
   }
-  return result;
+  return padComputedReportItems(result);
 }
 
 export function transformReport(

--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -35,6 +35,7 @@ interface CostChartProps {
   padding?: any;
   previousInfrastructureCostData?: any;
   previousCostData?: any;
+  showForecast?: boolean; // Show forecast legend regardless if data is available
   title?: string;
 }
 
@@ -109,6 +110,7 @@ class CostChart extends React.Component<CostChartProps, State> {
       forecastConeData,
       previousInfrastructureCostData,
       previousCostData,
+      showForecast,
     } = this.props;
 
     const costKey = 'chart.cost_legend_label';
@@ -193,7 +195,7 @@ class CostChart extends React.Component<CostChartProps, State> {
       },
     ];
 
-    if (forecastData && forecastData.length) {
+    if (showForecast || (forecastData && forecastData.length)) {
       series.push({
         childName: 'forecast',
         data: forecastData,
@@ -213,7 +215,7 @@ class CostChart extends React.Component<CostChartProps, State> {
         },
       });
     }
-    if (forecastConeData && forecastConeData.length) {
+    if (showForecast || (forecastConeData && forecastConeData.length)) {
       series.push({
         childName: 'forecastCone',
         data: forecastConeData,
@@ -353,14 +355,14 @@ class CostChart extends React.Component<CostChartProps, State> {
   }
 
   private getLegend = () => {
-    const { forecastData, legendItemsPerRow } = this.props;
+    const { forecastData, legendItemsPerRow, showForecast } = this.props;
     const { width } = this.state;
 
     // Todo: use PF legendAllowWrap feature
     const itemsPerRow = legendItemsPerRow
       ? legendItemsPerRow
-      : width > (forecastData && forecastData.length ? 650 : 450)
-      ? chartStyles.itemsPerRow - (forecastData && forecastData.length ? 0 : 1)
+      : width > (showForecast || (forecastData && forecastData.length) ? 650 : 450)
+      ? chartStyles.itemsPerRow - (showForecast || (forecastData && forecastData.length) ? 0 : 1)
       : 1;
 
     return <ChartLegend height={25} gutter={20} itemsPerRow={itemsPerRow} name="legend" responsive={false} />;
@@ -466,6 +468,7 @@ class CostChart extends React.Component<CostChartProps, State> {
         right: 8,
         top: 8,
       },
+      showForecast,
       title,
     } = this.props;
     const { series, width } = this.state;
@@ -475,9 +478,9 @@ class CostChart extends React.Component<CostChartProps, State> {
     const midDate = Math.floor(endDate / 2);
 
     const adjustedContainerHeight = adjustContainerHeight
-      ? width > (forecastData && forecastData.length ? 650 : 450)
+      ? width > (showForecast || (forecastData && forecastData.length) ? 650 : 450)
         ? containerHeight
-        : containerHeight + (forecastData && forecastData.length ? 125 : 75)
+        : containerHeight + (showForecast || (forecastData && forecastData.length) ? 125 : 75)
       : containerHeight;
 
     return (

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -33,6 +33,7 @@ interface TrendChartProps {
   formatDatumValue: ValueFormatter;
   formatDatumOptions?: FormatOptions;
   padding?: any;
+  showForecast?: boolean; // Show forecast legend regardless if data is available
   showSupplementaryLabel?: boolean; // Show supplementary cost labels
   showUsageLegendLabel?: boolean; // The cost legend label is shown by default
   title?: string;
@@ -105,6 +106,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
       forecastData,
       forecastConeData,
       previousData,
+      showForecast,
       showSupplementaryLabel = false,
       showUsageLegendLabel = false,
     } = this.props;
@@ -162,7 +164,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
       },
     ];
 
-    if (forecastData && forecastData.length) {
+    if (showForecast || (forecastData && forecastData.length)) {
       series.push({
         childName: 'forecast',
         data: forecastData,
@@ -182,7 +184,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         },
       });
     }
-    if (forecastConeData && forecastConeData.length) {
+    if (showForecast || (forecastConeData && forecastConeData.length)) {
       series.push({
         childName: 'forecastCone',
         data: forecastConeData,

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -163,6 +163,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         height={height}
         previousCostData={previousCostData}
         previousInfrastructureCostData={previousInfrastructureData}
+        showForecast={trend.computedForecastItem !== undefined}
         title={title}
       />
     );
@@ -260,6 +261,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         formatDatumOptions={trend.formatOptions}
         height={height}
         previousData={previousData}
+        showForecast={trend.computedForecastItem !== undefined}
         showSupplementaryLabel={showSupplementaryLabel}
         showUsageLegendLabel={details.showUsageLegendLabel}
         title={title}

--- a/src/store/dashboard/awsDashboard/awsDashboardCommon.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardCommon.ts
@@ -40,9 +40,10 @@ export function getGroupByForTab(widget: AwsDashboardWidget): AwsQuery['group_by
   }
 }
 
-export function getQueryForWidget(filter: AwsFilters = awsDashboardDefaultFilters) {
+export function getQueryForWidget(filter: AwsFilters = awsDashboardDefaultFilters, props?) {
   const query: AwsQuery = {
     filter,
+    ...(props ? props : {}),
   };
   return getQuery(query);
 }

--- a/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
@@ -34,10 +34,12 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       time_scope_value: -2,
     }),
     current: getQueryForWidget(filter),
-    forecast: getQueryForWidget({
-      limit: 31,
-      time_scope_value: -2,
-    }),
+    forecast: getQueryForWidget(
+      {
+        time_scope_value: -2,
+      },
+      { limit: 31 }
+    ),
     tabs: getQueryForWidgetTabs(widget, {
       ...tabsFilter,
       resolution: 'monthly',

--- a/src/store/dashboard/azureDashboard/azureDashboardCommon.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardCommon.ts
@@ -40,9 +40,10 @@ export function getGroupByForTab(widget: AzureDashboardWidget): AzureQuery['grou
   }
 }
 
-export function getQueryForWidget(filter: AzureFilters = azureDashboardDefaultFilters) {
+export function getQueryForWidget(filter: AzureFilters = azureDashboardDefaultFilters, props?) {
   const query: AzureQuery = {
     filter,
+    ...(props ? props : {}),
   };
   return getQuery(query);
 }

--- a/src/store/dashboard/azureDashboard/azureDashboardSelectors.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardSelectors.ts
@@ -34,10 +34,12 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       time_scope_value: -2,
     }),
     current: getQueryForWidget(filter),
-    forecast: getQueryForWidget({
-      limit: 31,
-      time_scope_value: -2,
-    }),
+    forecast: getQueryForWidget(
+      {
+        time_scope_value: -2,
+      },
+      { limit: 31 }
+    ),
     tabs: getQueryForWidgetTabs(widget, {
       ...tabsFilter,
       resolution: 'monthly',

--- a/src/store/dashboard/ocpDashboard/ocpDashboardCommon.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardCommon.ts
@@ -35,9 +35,10 @@ export function getGroupByForTab(tab: OcpDashboardTab): OcpQuery['group_by'] {
   }
 }
 
-export function getQueryForWidget(filter: OcpFilters = ocpDashboardDefaultFilters) {
+export function getQueryForWidget(filter: OcpFilters = ocpDashboardDefaultFilters, props?) {
   const query: OcpQuery = {
     filter,
+    ...(props ? props : {}),
   };
   return getQuery(query);
 }

--- a/src/store/dashboard/ocpDashboard/ocpDashboardSelectors.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardSelectors.ts
@@ -34,10 +34,12 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       time_scope_value: -2,
     }),
     current: getQueryForWidget(defaultFilter),
-    forecast: getQueryForWidget({
-      limit: 31,
-      time_scope_value: -2,
-    }),
+    forecast: getQueryForWidget(
+      {
+        time_scope_value: -2,
+      },
+      { limit: 31 }
+    ),
     tabs: getQueryForWidgetTabs(widget, {
       ...tabsFilter,
       resolution: 'monthly',


### PR DESCRIPTION
Added padding to chart forecast data. This will ensure tooltips will be displayed even if all other data is hidden via the chart legend.

https://issues.redhat.com/browse/COST-762

<img width="1669" alt="Screen Shot 2020-11-30 at 3 31 32 PM" src="https://user-images.githubusercontent.com/17481322/100661432-75e7e080-3321-11eb-8ec3-73a8239cc883.png">
