### PR TITLE
percentages were showing 'NaN' for value in…

### DIFF
--- a/src/pages/details/awsDetails/detailsTable.tsx
+++ b/src/pages/details/awsDetails/detailsTable.tsx
@@ -370,13 +370,17 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       report && report.meta && report.meta.total && report.meta.total.cost && report.meta.total.cost.total
         ? report.meta.total.cost.total.value
         : 0;
+    const percentValue =
+      cost === 0
+        ? cost.toFixed(2)
+        : ((item.cost.total.value / cost) * 100).toFixed(2);
 
     return (
       <>
         {formatCurrency(item.cost.total.value)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
-            value: ((item.cost.total.value / cost) * 100).toFixed(2),
+            value: percentValue,
           })}
         </div>
       </>

--- a/src/pages/details/awsDetails/detailsTable.tsx
+++ b/src/pages/details/awsDetails/detailsTable.tsx
@@ -370,10 +370,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       report && report.meta && report.meta.total && report.meta.total.cost && report.meta.total.cost.total
         ? report.meta.total.cost.total.value
         : 0;
-    const percentValue =
-      cost === 0
-        ? cost.toFixed(2)
-        : ((item.cost.total.value / cost) * 100).toFixed(2);
+    const percentValue = cost === 0 ? cost.toFixed(2) : ((item.cost.total.value / cost) * 100).toFixed(2);
 
     return (
       <>

--- a/src/pages/details/azureDetails/detailsTable.tsx
+++ b/src/pages/details/azureDetails/detailsTable.tsx
@@ -303,10 +303,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       report && report.meta && report.meta.total && report.meta.total.cost && report.meta.total.cost.total
         ? report.meta.total.cost.total.value
         : 0;
-    const percentValue =
-      cost === 0
-        ? cost.toFixed(2)
-        : ((item.cost.total.value / cost) * 100).toFixed(2);
+    const percentValue = cost === 0 ? cost.toFixed(2) : ((item.cost.total.value / cost) * 100).toFixed(2);
 
     return (
       <>

--- a/src/pages/details/azureDetails/detailsTable.tsx
+++ b/src/pages/details/azureDetails/detailsTable.tsx
@@ -303,13 +303,17 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       report && report.meta && report.meta.total && report.meta.total.cost && report.meta.total.cost.total
         ? report.meta.total.cost.total.value
         : 0;
+    const percentValue =
+      cost === 0
+        ? cost.toFixed(2)
+        : ((item.cost.total.value / cost) * 100).toFixed(2);
 
     return (
       <>
         {formatCurrency(item.cost.total.value)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
-            value: ((item.cost.total.value / cost) * 100).toFixed(2),
+            value: percentValue,
           })}
         </div>
       </>

--- a/src/pages/details/gcpDetails/detailsTable.tsx
+++ b/src/pages/details/gcpDetails/detailsTable.tsx
@@ -303,10 +303,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       report && report.meta && report.meta.total && report.meta.total.cost && report.meta.total.cost.total
         ? report.meta.total.cost.total.value
         : 0;
-    const percentValue =
-      cost === 0
-        ? cost.toFixed(2)
-        : ((item.cost.total.value / cost) * 100).toFixed(2);
+    const percentValue = cost === 0 ? cost.toFixed(2) : ((item.cost.total.value / cost) * 100).toFixed(2);
 
     return (
       <>

--- a/src/pages/details/gcpDetails/detailsTable.tsx
+++ b/src/pages/details/gcpDetails/detailsTable.tsx
@@ -303,13 +303,17 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       report && report.meta && report.meta.total && report.meta.total.cost && report.meta.total.cost.total
         ? report.meta.total.cost.total.value
         : 0;
+    const percentValue =
+      cost === 0
+        ? cost.toFixed(2)
+        : ((item.cost.total.value / cost) * 100).toFixed(2);
 
     return (
       <>
         {formatCurrency(item.cost.total.value)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
-            value: ((item.cost.total.value / cost) * 100).toFixed(2),
+            value: percentValue,
           })}
         </div>
       </>

--- a/src/pages/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/details/ocpDetails/detailsTable.tsx
@@ -387,13 +387,16 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       report && report.meta && report.meta.total && report.meta.total.cost && report.meta.total.cost.total
         ? report.meta.total.cost.total.value
         : 0;
-
+    const percentValue =
+      cost === 0
+        ? cost.toFixed(2)
+        : ((item.cost.total.value / cost) * 100).toFixed(2);
     return (
       <>
         {formatCurrency(item.cost.total.value)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
-            value: ((item.cost.total.value / cost) * 100).toFixed(2),
+            value: percentValue,
           })}
         </div>
       </>

--- a/src/pages/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/details/ocpDetails/detailsTable.tsx
@@ -258,13 +258,16 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       report.meta.total.supplementary.total
         ? report.meta.total.supplementary.total.value
         : 0;
-
+    const percentValue =
+      total === 0
+        ? total.toFixed(2)
+        : ((item.supplementary.total.value / total) * 100).toFixed(2);
     return (
       <>
         {formatCurrency(item.supplementary.total.value)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
-            value: ((item.supplementary.total.value / total) * 100).toFixed(2),
+            value: percentValue,
           })}
         </div>
       </>
@@ -296,13 +299,16 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       report.meta.total.infrastructure.total.value
         ? report.meta.total.infrastructure.total.value
         : 0;
-
+    const percentValue =
+      total === 0
+        ? total.toFixed(2)
+        : ((item.infrastructure.total.value / total) * 100).toFixed(2);
     return (
       <>
         {formatCurrency(item.infrastructure.total.value)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {t('percent_of_cost', {
-            value: ((item.infrastructure.total.value / total) * 100).toFixed(2),
+            value: percentValue,
           })}
         </div>
       </>

--- a/src/pages/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/details/ocpDetails/detailsTable.tsx
@@ -258,10 +258,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       report.meta.total.supplementary.total
         ? report.meta.total.supplementary.total.value
         : 0;
-    const percentValue =
-      total === 0
-        ? total.toFixed(2)
-        : ((item.supplementary.total.value / total) * 100).toFixed(2);
+    const percentValue = total === 0 ? total.toFixed(2) : ((item.supplementary.total.value / total) * 100).toFixed(2);
     return (
       <>
         {formatCurrency(item.supplementary.total.value)}
@@ -299,10 +296,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       report.meta.total.infrastructure.total.value
         ? report.meta.total.infrastructure.total.value
         : 0;
-    const percentValue =
-      total === 0
-        ? total.toFixed(2)
-        : ((item.infrastructure.total.value / total) * 100).toFixed(2);
+    const percentValue = total === 0 ? total.toFixed(2) : ((item.infrastructure.total.value / total) * 100).toFixed(2);
     return (
       <>
         {formatCurrency(item.infrastructure.total.value)}
@@ -387,10 +381,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       report && report.meta && report.meta.total && report.meta.total.cost && report.meta.total.cost.total
         ? report.meta.total.cost.total.value
         : 0;
-    const percentValue =
-      cost === 0
-        ? cost.toFixed(2)
-        : ((item.cost.total.value / cost) * 100).toFixed(2);
+    const percentValue = cost === 0 ? cost.toFixed(2) : ((item.cost.total.value / cost) * 100).toFixed(2);
     return (
       <>
         {formatCurrency(item.cost.total.value)}


### PR DESCRIPTION
Charts were showing NaN for `% of cost` when the item value was $0.00. This is when filtering by Tag.
the cause was dividing by zero.

### **BEFORE FIX**

![Screen Shot 2020-12-01 at 2 58 15 PM](https://user-images.githubusercontent.com/57504257/100808018-60e27e80-3401-11eb-895a-3b66c63381e1.png)

![Screen Shot 2020-12-01 at 3 10 03 PM](https://user-images.githubusercontent.com/57504257/100808020-6213ab80-3401-11eb-8379-0205195c4b73.png)

### **AFTER FIX:**

![Screen Shot 2020-12-01 at 5 25 02 PM](https://user-images.githubusercontent.com/57504257/100804146-583a7a00-33fa-11eb-8a2b-e0c9976aaf06.png)

![Screen Shot 2020-12-01 at 5 23 21 PM](https://user-images.githubusercontent.com/57504257/100804009-19a4bf80-33fa-11eb-93cd-bd9102ced201.png)

