### PR TITLE
Interactive legends to store chart container via state

### DIFF
--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -272,7 +272,7 @@ class CostChart extends React.Component<CostChartProps, State> {
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={this.isDataAvailable(series) ? this.getTooltipLabel : undefined}
+        labels={this.getTooltipLabel}
         labelComponent={
           <ChartLegendTooltip
             legendData={this.getLegendData(series, true)}
@@ -397,9 +397,9 @@ class CostChart extends React.Component<CostChartProps, State> {
   };
 
   // Returns true if at least one data series is available
-  private isDataAvailable = (series: CostChartSeries[]) => {
-    // API data may not be available (e.g., on 1st of month)
-    const unavailable = [];
+  private isDataAvailable = () => {
+    const { series } = this.state;
+    const unavailable = []; // API data may not be available (e.g., on 1st of month)
 
     if (series) {
       series.forEach((s: any, index) => {
@@ -493,6 +493,12 @@ class CostChart extends React.Component<CostChartProps, State> {
         : containerHeight + (showForecast || (forecastData && forecastData.length) ? 125 : 75)
       : containerHeight;
 
+    // Clone original container. See https://issues.redhat.com/browse/COST-762
+    const container = cursorVoronoiContainer
+      ? React.cloneElement(cursorVoronoiContainer, {
+          disable: !this.isDataAvailable(),
+        })
+      : undefined;
     return (
       <>
         <Title headingLevel="h3" size="md">
@@ -501,7 +507,7 @@ class CostChart extends React.Component<CostChartProps, State> {
         <div className="chartOverride" ref={this.containerRef} style={{ height: adjustedContainerHeight }}>
           <div style={{ height, width }}>
             <Chart
-              containerComponent={cursorVoronoiContainer}
+              containerComponent={container}
               domain={domain}
               events={this.getEvents()}
               height={height}

--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -58,6 +58,7 @@ interface CostChartSeries {
 }
 
 interface State {
+  cursorVoronoiContainer?: any;
   hiddenSeries: Set<number>;
   series?: CostChartSeries[];
   width: number;
@@ -235,7 +236,8 @@ class CostChart extends React.Component<CostChartProps, State> {
         },
       });
     }
-    this.setState({ series });
+    const cursorVoronoiContainer = this.getCursorVoronoiContainer(series);
+    this.setState({ cursorVoronoiContainer, series });
   };
 
   private handleNavToggle = () => {
@@ -263,17 +265,17 @@ class CostChart extends React.Component<CostChartProps, State> {
   };
 
   // Returns CursorVoronoiContainer component
-  private getContainer = () => {
+  private getCursorVoronoiContainer = (series: CostChartSeries[]) => {
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
 
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={this.isDataAvailable() ? this.getTooltipLabel : undefined}
+        labels={this.isDataAvailable(series) ? this.getTooltipLabel : undefined}
         labelComponent={
           <ChartLegendTooltip
-            legendData={this.getLegendData(true)}
+            legendData={this.getLegendData(series, true)}
             title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
           />
         }
@@ -356,7 +358,7 @@ class CostChart extends React.Component<CostChartProps, State> {
 
   private getLegend = () => {
     const { forecastData, legendItemsPerRow, showForecast } = this.props;
-    const { width } = this.state;
+    const { series, width } = this.state;
 
     // Todo: use PF legendAllowWrap feature
     const itemsPerRow = legendItemsPerRow
@@ -365,7 +367,16 @@ class CostChart extends React.Component<CostChartProps, State> {
       ? chartStyles.itemsPerRow - (showForecast || (forecastData && forecastData.length) ? 0 : 1)
       : 1;
 
-    return <ChartLegend height={25} gutter={20} itemsPerRow={itemsPerRow} name="legend" responsive={false} />;
+    return (
+      <ChartLegend
+        data={this.getLegendData(series)}
+        height={25}
+        gutter={20}
+        itemsPerRow={itemsPerRow}
+        name="legend"
+        responsive={false}
+      />
+    );
   };
 
   private getTooltipLabel = ({ datum }) => {
@@ -386,11 +397,10 @@ class CostChart extends React.Component<CostChartProps, State> {
   };
 
   // Returns true if at least one data series is available
-  private isDataAvailable = () => {
-    const { series } = this.state;
-
+  private isDataAvailable = (series: CostChartSeries[]) => {
     // API data may not be available (e.g., on 1st of month)
     const unavailable = [];
+
     if (series) {
       series.forEach((s: any, index) => {
         if (this.isSeriesHidden(index) || (s.data && s.data.length === 0)) {
@@ -432,8 +442,8 @@ class CostChart extends React.Component<CostChartProps, State> {
   };
 
   // Returns legend data styled per hiddenSeries
-  private getLegendData = (tooltip: boolean = false) => {
-    const { hiddenSeries, series, width } = this.state;
+  private getLegendData = (series: CostChartSeries[], tooltip: boolean = false) => {
+    const { hiddenSeries, width } = this.state;
     if (series) {
       // Reorder forecast legend item
       if (series.length > 4 && series[4].childName === 'forecast' && width > 650) {
@@ -471,7 +481,7 @@ class CostChart extends React.Component<CostChartProps, State> {
       showForecast,
       title,
     } = this.props;
-    const { series, width } = this.state;
+    const { cursorVoronoiContainer, series, width } = this.state;
 
     const domain = this.getDomain();
     const endDate = this.getEndDate();
@@ -491,12 +501,12 @@ class CostChart extends React.Component<CostChartProps, State> {
         <div className="chartOverride" ref={this.containerRef} style={{ height: adjustedContainerHeight }}>
           <div style={{ height, width }}>
             <Chart
-              containerComponent={this.getContainer()}
+              containerComponent={cursorVoronoiContainer}
               domain={domain}
               events={this.getEvents()}
               height={height}
               legendComponent={this.getLegend()}
-              legendData={this.getLegendData()}
+              legendData={this.getLegendData(series)}
               legendPosition="bottom-left"
               padding={padding}
               theme={ChartTheme}

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -215,7 +215,7 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={this.isDataAvailable(series) ? this.getTooltipLabel : undefined}
+        labels={this.getTooltipLabel}
         labelComponent={
           <ChartLegendTooltip
             legendData={this.getLegendData(series, true)}
@@ -296,9 +296,9 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
   };
 
   // Returns true if at least one data series is available
-  private isDataAvailable = (series: HistoricalCostChartSeries[]) => {
-    // API data may not be available (e.g., on 1st of month)
-    const unavailable = [];
+  private isDataAvailable = () => {
+    const { series } = this.state;
+    const unavailable = []; // API data may not be available (e.g., on 1st of month)
 
     if (series) {
       series.forEach((s: any, index) => {
@@ -383,7 +383,12 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
         : containerHeight
       : containerHeight;
 
-    const theme = ChartTheme;
+    // Clone original container. See https://issues.redhat.com/browse/COST-762
+    const container = cursorVoronoiContainer
+      ? React.cloneElement(cursorVoronoiContainer, {
+          disable: !this.isDataAvailable(),
+        })
+      : undefined;
     return (
       <div className="chartOverride" ref={this.containerRef}>
         <Title headingLevel="h2" style={styles.title} size="xl">
@@ -392,7 +397,7 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
         <div style={{ ...styles.chart, height: adjustedContainerHeight }}>
           <div style={{ height, width }}>
             <Chart
-              containerComponent={cursorVoronoiContainer}
+              containerComponent={container}
               domain={domain}
               events={this.getEvents()}
               height={height}
@@ -400,7 +405,7 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
               legendData={this.getLegendData(series)}
               legendPosition="bottom"
               padding={padding}
-              theme={theme}
+              theme={ChartTheme}
               width={width}
             >
               {series &&

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -165,7 +165,7 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={this.isDataAvailable(series) ? this.getTooltipLabel : undefined}
+        labels={this.getTooltipLabel}
         labelComponent={
           <ChartLegendTooltip
             legendData={this.getLegendData(series, true)}
@@ -239,9 +239,9 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
   };
 
   // Returns true if at least one data series is available
-  private isDataAvailable = (series: HistoricalTrendChartSeries[]) => {
-    // API data may not be available (e.g., on 1st of month)
-    const unavailable = [];
+  private isDataAvailable = () => {
+    const { series } = this.state;
+    const unavailable = []; // API data may not be available (e.g., on 1st of month)
 
     if (series) {
       series.forEach((s: any, index) => {
@@ -319,6 +319,12 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
     const endDate = this.getEndDate();
     const midDate = Math.floor(endDate / 2);
 
+    // Clone original container. See https://issues.redhat.com/browse/COST-762
+    const container = cursorVoronoiContainer
+      ? React.cloneElement(cursorVoronoiContainer, {
+          disable: !this.isDataAvailable(),
+        })
+      : undefined;
     return (
       <div className="chartOverride" ref={this.containerRef}>
         <Title headingLevel="h2" style={styles.title} size="xl">
@@ -327,7 +333,7 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
         <div style={{ ...styles.chart, height: containerHeight }}>
           <div style={{ height, width }}>
             <Chart
-              containerComponent={cursorVoronoiContainer}
+              containerComponent={container}
               domain={domain}
               events={this.getEvents()}
               height={height}

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -259,7 +259,7 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={this.isDataAvailable(series) ? this.getTooltipLabel : undefined}
+        labels={this.getTooltipLabel}
         labelComponent={
           <ChartLegendTooltip
             legendData={this.getLegendData(series, true)}
@@ -350,9 +350,9 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
   };
 
   // Returns true if at least one data series is available
-  private isDataAvailable = (series: HistoricalUsageChartSeries[]) => {
-    // API data may not be available (e.g., on 1st of month)
-    const unavailable = [];
+  private isDataAvailable = () => {
+    const { series } = this.state;
+    const unavailable = []; // API data may not be available (e.g., on 1st of month)
 
     if (series) {
       series.forEach((s: any, index) => {
@@ -437,6 +437,12 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
         : containerHeight
       : containerHeight;
 
+    // Clone original container. See https://issues.redhat.com/browse/COST-762
+    const container = cursorVoronoiContainer
+      ? React.cloneElement(cursorVoronoiContainer, {
+          disable: !this.isDataAvailable(),
+        })
+      : undefined;
     return (
       <div className="chartOverride" ref={this.containerRef}>
         <Title headingLevel="h2" style={styles.title} size="xl">
@@ -445,7 +451,7 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
         <div style={{ ...styles.chart, height: adjustedContainerHeight }}>
           <div style={{ height, width }}>
             <Chart
-              containerComponent={cursorVoronoiContainer}
+              containerComponent={container}
               domain={domain}
               events={this.getEvents()}
               height={height}

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -59,6 +59,7 @@ interface HistoricalUsageChartSeries {
 }
 
 interface State {
+  cursorVoronoiContainer?: any;
   hiddenSeries: Set<number>;
   series?: HistoricalUsageChartSeries[];
   width: number;
@@ -117,118 +118,118 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
 
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
-    this.setState({
-      series: [
-        {
-          childName: 'previousUsage',
-          data: previousUsageData,
-          legendItem: {
-            name: getUsageRangeString(previousUsageData, usageKey, true, true, 1),
-            symbol: {
-              fill: chartStyles.previousColorScale[0],
-              type: 'minus',
-            },
-            tooltip: getUsageRangeString(previousUsageData, usageTooltipKey, false, false, 1),
+    const series: HistoricalUsageChartSeries[] = [
+      {
+        childName: 'previousUsage',
+        data: previousUsageData,
+        legendItem: {
+          name: getUsageRangeString(previousUsageData, usageKey, true, true, 1),
+          symbol: {
+            fill: chartStyles.previousColorScale[0],
+            type: 'minus',
           },
-          style: {
-            data: {
-              ...chartStyles.previousUsageData,
-              stroke: chartStyles.previousColorScale[0],
-            },
+          tooltip: getUsageRangeString(previousUsageData, usageTooltipKey, false, false, 1),
+        },
+        style: {
+          data: {
+            ...chartStyles.previousUsageData,
+            stroke: chartStyles.previousColorScale[0],
           },
         },
-        {
-          childName: 'currentUsage',
-          data: currentUsageData,
-          legendItem: {
-            name: getUsageRangeString(currentUsageData, usageKey, true, false),
-            symbol: {
-              fill: chartStyles.currentColorScale[0],
-              type: 'minus',
-            },
-            tooltip: getUsageRangeString(currentUsageData, usageTooltipKey, false, false),
+      },
+      {
+        childName: 'currentUsage',
+        data: currentUsageData,
+        legendItem: {
+          name: getUsageRangeString(currentUsageData, usageKey, true, false),
+          symbol: {
+            fill: chartStyles.currentColorScale[0],
+            type: 'minus',
           },
-          style: {
-            data: {
-              ...chartStyles.currentUsageData,
-              stroke: chartStyles.currentColorScale[0],
-            },
+          tooltip: getUsageRangeString(currentUsageData, usageTooltipKey, false, false),
+        },
+        style: {
+          data: {
+            ...chartStyles.currentUsageData,
+            stroke: chartStyles.currentColorScale[0],
           },
         },
-        {
-          childName: 'previousRequest',
-          data: previousRequestData,
-          legendItem: {
-            name: getUsageRangeString(previousRequestData, requestKey, true, true, 1),
-            symbol: {
-              fill: chartStyles.previousColorScale[1],
-              type: 'dash',
-            },
-            tooltip: getUsageRangeString(previousRequestData, requestTooltipKey, false, false, 1),
+      },
+      {
+        childName: 'previousRequest',
+        data: previousRequestData,
+        legendItem: {
+          name: getUsageRangeString(previousRequestData, requestKey, true, true, 1),
+          symbol: {
+            fill: chartStyles.previousColorScale[1],
+            type: 'dash',
           },
-          style: {
-            data: {
-              ...chartStyles.previousRequestData,
-              stroke: chartStyles.previousColorScale[1],
-            },
+          tooltip: getUsageRangeString(previousRequestData, requestTooltipKey, false, false, 1),
+        },
+        style: {
+          data: {
+            ...chartStyles.previousRequestData,
+            stroke: chartStyles.previousColorScale[1],
           },
         },
-        {
-          childName: 'currentRequest',
-          data: currentRequestData,
-          legendItem: {
-            name: getUsageRangeString(currentRequestData, requestKey, true, false),
-            symbol: {
-              fill: chartStyles.currentColorScale[1],
-              type: 'dash',
-            },
-            tooltip: getUsageRangeString(currentRequestData, requestTooltipKey, false, false),
+      },
+      {
+        childName: 'currentRequest',
+        data: currentRequestData,
+        legendItem: {
+          name: getUsageRangeString(currentRequestData, requestKey, true, false),
+          symbol: {
+            fill: chartStyles.currentColorScale[1],
+            type: 'dash',
           },
-          style: {
-            data: {
-              ...chartStyles.currentRequestData,
-              stroke: chartStyles.currentColorScale[1],
-            },
+          tooltip: getUsageRangeString(currentRequestData, requestTooltipKey, false, false),
+        },
+        style: {
+          data: {
+            ...chartStyles.currentRequestData,
+            stroke: chartStyles.currentColorScale[1],
           },
         },
-        {
-          childName: 'previousLimit',
-          data: previousLimitData,
-          legendItem: {
-            name: getUsageRangeString(previousLimitData, limitKey, true, true, 1),
-            symbol: {
-              fill: chartStyles.previousColorScale[2],
-              type: 'minus',
-            },
-            tooltip: getUsageRangeString(previousLimitData, limitTooltipKey, false, false, 1),
+      },
+      {
+        childName: 'previousLimit',
+        data: previousLimitData,
+        legendItem: {
+          name: getUsageRangeString(previousLimitData, limitKey, true, true, 1),
+          symbol: {
+            fill: chartStyles.previousColorScale[2],
+            type: 'minus',
           },
-          style: {
-            data: {
-              ...chartStyles.previousLimitData,
-              stroke: chartStyles.previousColorScale[2],
-            },
+          tooltip: getUsageRangeString(previousLimitData, limitTooltipKey, false, false, 1),
+        },
+        style: {
+          data: {
+            ...chartStyles.previousLimitData,
+            stroke: chartStyles.previousColorScale[2],
           },
         },
-        {
-          childName: 'currentLimit',
-          data: currentLimitData,
-          legendItem: {
-            name: getUsageRangeString(currentLimitData, limitKey, true, false),
-            symbol: {
-              fill: chartStyles.currentColorScale[2],
-              type: 'minus',
-            },
-            tooltip: getUsageRangeString(currentLimitData, limitTooltipKey, false, false),
+      },
+      {
+        childName: 'currentLimit',
+        data: currentLimitData,
+        legendItem: {
+          name: getUsageRangeString(currentLimitData, limitKey, true, false),
+          symbol: {
+            fill: chartStyles.currentColorScale[2],
+            type: 'minus',
           },
-          style: {
-            data: {
-              ...chartStyles.currentLimitData,
-              stroke: chartStyles.currentColorScale[2],
-            },
+          tooltip: getUsageRangeString(currentLimitData, limitTooltipKey, false, false),
+        },
+        style: {
+          data: {
+            ...chartStyles.currentLimitData,
+            stroke: chartStyles.currentColorScale[2],
           },
         },
-      ],
-    });
+      },
+    ];
+    const cursorVoronoiContainer = this.getCursorVoronoiContainer(series);
+    this.setState({ cursorVoronoiContainer, series });
   };
 
   private handleResize = () => {
@@ -251,17 +252,17 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
   };
 
   // Returns CursorVoronoiContainer component
-  private getContainer = () => {
+  private getCursorVoronoiContainer = (series: HistoricalUsageChartSeries[]) => {
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
 
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={this.isDataAvailable() ? this.getTooltipLabel : undefined}
+        labels={this.isDataAvailable(series) ? this.getTooltipLabel : undefined}
         labelComponent={
           <ChartLegendTooltip
-            legendData={this.getLegendData(true)}
+            legendData={this.getLegendData(series, true)}
             title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
           />
         }
@@ -324,10 +325,12 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
 
   private getLegend = () => {
     const { legendItemsPerRow } = this.props;
-    const { width } = this.state;
+    const { series, width } = this.state;
     const itemsPerRow = legendItemsPerRow ? legendItemsPerRow : width > 900 ? chartStyles.itemsPerRow : 2;
 
-    return <ChartLegend data={this.getLegendData()} height={25} gutter={20} itemsPerRow={itemsPerRow} name="legend" />;
+    return (
+      <ChartLegend data={this.getLegendData(series)} height={25} gutter={20} itemsPerRow={itemsPerRow} name="legend" />
+    );
   };
 
   private getTooltipLabel = ({ datum }) => {
@@ -347,11 +350,10 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
   };
 
   // Returns true if at least one data series is available
-  private isDataAvailable = () => {
-    const { series } = this.state;
-
+  private isDataAvailable = (series: HistoricalUsageChartSeries[]) => {
     // API data may not be available (e.g., on 1st of month)
     const unavailable = [];
+
     if (series) {
       series.forEach((s: any, index) => {
         if (this.isSeriesHidden(index) || (s.data && s.data.length === 0)) {
@@ -393,8 +395,8 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
   };
 
   // Returns legend data styled per hiddenSeries
-  private getLegendData = (tooltip: boolean = false) => {
-    const { hiddenSeries, series } = this.state;
+  private getLegendData = (series: HistoricalUsageChartSeries[], tooltip: boolean = false) => {
+    const { hiddenSeries } = this.state;
     if (series) {
       const result = series.map((s, index) => {
         return {
@@ -423,7 +425,7 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
       xAxisLabel,
       yAxisLabel,
     } = this.props;
-    const { series, width } = this.state;
+    const { cursorVoronoiContainer, series, width } = this.state;
 
     const domain = this.getDomain();
     const endDate = this.getEndDate();
@@ -443,12 +445,12 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
         <div style={{ ...styles.chart, height: adjustedContainerHeight }}>
           <div style={{ height, width }}>
             <Chart
-              containerComponent={this.getContainer()}
+              containerComponent={cursorVoronoiContainer}
               domain={domain}
               events={this.getEvents()}
               height={height}
               legendComponent={this.getLegend()}
-              legendData={this.getLegendData()}
+              legendData={this.getLegendData(series)}
               legendPosition="bottom"
               padding={padding}
               theme={ChartTheme}

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -58,6 +58,7 @@ interface TrendChartSeries {
 }
 
 interface State {
+  cursorVoronoiContainer?: any;
   hiddenSeries: Set<number>;
   series?: TrendChartSeries[];
   width: number;
@@ -204,7 +205,8 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         },
       });
     }
-    this.setState({ series });
+    const cursorVoronoiContainer = this.getCursorVoronoiContainer(series);
+    this.setState({ cursorVoronoiContainer, series });
   };
 
   private handleNavToggle = () => {
@@ -232,17 +234,17 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   };
 
   // Returns CursorVoronoiContainer component
-  private getContainer = () => {
+  private getCursorVoronoiContainer = (series: TrendChartSeries[]) => {
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
 
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={this.isDataAvailable() ? this.getTooltipLabel : undefined}
+        labels={this.isDataAvailable(series) ? this.getTooltipLabel : undefined}
         labelComponent={
           <ChartLegendTooltip
-            legendData={this.getLegendData(true)}
+            legendData={this.getLegendData(series, true)}
             title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
           />
         }
@@ -286,14 +288,14 @@ class TrendChart extends React.Component<TrendChartProps, State> {
 
   private getLegend = () => {
     const { legendItemsPerRow } = this.props;
-    const { width } = this.state;
+    const { series, width } = this.state;
 
     const itemsPerRow = legendItemsPerRow ? legendItemsPerRow : width > 700 ? chartStyles.itemsPerRow : 2;
 
     // Todo: use PF legendAllowWrap feature
     return (
       <ChartLegend
-        data={this.getLegendData()}
+        data={this.getLegendData(series)}
         gutter={20}
         height={25}
         itemsPerRow={itemsPerRow}
@@ -333,11 +335,10 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   };
 
   // Returns true if at least one data series is available
-  private isDataAvailable = () => {
-    const { series } = this.state;
-
+  private isDataAvailable = (series: TrendChartSeries[]) => {
     // API data may not be available (e.g., on 1st of month)
     const unavailable = [];
+
     if (series) {
       series.forEach((s: any, index) => {
         if (this.isSeriesHidden(index) || (s.data && s.data.length === 0)) {
@@ -380,8 +381,8 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   };
 
   // Returns legend data styled per hiddenSeries
-  private getLegendData = (tooltip: boolean = false) => {
-    const { hiddenSeries, series } = this.state;
+  private getLegendData = (series: TrendChartSeries[], tooltip: boolean = false) => {
+    const { hiddenSeries } = this.state;
     if (series) {
       const result = series.map((s, index) => {
         return {
@@ -408,7 +409,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
       },
       title,
     } = this.props;
-    const { series, width } = this.state;
+    const { cursorVoronoiContainer, series, width } = this.state;
 
     const domain = this.getDomain();
     const endDate = this.getEndDate();
@@ -428,12 +429,12 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         <div className="chartOverride" ref={this.containerRef} style={{ height: adjustedContainerHeight }}>
           <div style={{ height, width }}>
             <Chart
-              containerComponent={this.getContainer()}
+              containerComponent={cursorVoronoiContainer}
               domain={domain}
               events={this.getEvents()}
               height={height}
               legendComponent={this.getLegend()}
-              legendData={this.getLegendData()}
+              legendData={this.getLegendData(series)}
               legendPosition="bottom-left"
               padding={padding}
               theme={ChartTheme}

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -241,7 +241,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={this.isDataAvailable(series) ? this.getTooltipLabel : undefined}
+        labels={this.getTooltipLabel}
         labelComponent={
           <ChartLegendTooltip
             legendData={this.getLegendData(series, true)}
@@ -335,9 +335,9 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   };
 
   // Returns true if at least one data series is available
-  private isDataAvailable = (series: TrendChartSeries[]) => {
-    // API data may not be available (e.g., on 1st of month)
-    const unavailable = [];
+  private isDataAvailable = () => {
+    const { series } = this.state;
+    const unavailable = []; // API data may not be available (e.g., on 1st of month)
 
     if (series) {
       series.forEach((s: any, index) => {
@@ -421,6 +421,12 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         : containerHeight + 20
       : containerHeight;
 
+    // Clone original container. See https://issues.redhat.com/browse/COST-762
+    const container = cursorVoronoiContainer
+      ? React.cloneElement(cursorVoronoiContainer, {
+          disable: !this.isDataAvailable(),
+        })
+      : undefined;
     return (
       <>
         <Title headingLevel="h3" size="md">
@@ -429,7 +435,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         <div className="chartOverride" ref={this.containerRef} style={{ height: adjustedContainerHeight }}>
           <div style={{ height, width }}>
             <Chart
-              containerComponent={cursorVoronoiContainer}
+              containerComponent={container}
               domain={domain}
               events={this.getEvents()}
               height={height}

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -54,6 +54,7 @@ interface UsageChartSeries {
 }
 
 interface State {
+  cursorVoronoiContainer?: any;
   hiddenSeries: Set<number>;
   series?: UsageChartSeries[];
   width: number;
@@ -106,62 +107,62 @@ class UsageChart extends React.Component<UsageChartProps, State> {
 
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
-    this.setState({
-      series: [
-        {
-          childName: 'previousUsage',
-          data: previousUsageData,
-          legendItem: {
-            name: getUsageRangeString(previousUsageData, usageKey, true, true, 1),
-            symbol: {
-              fill: chartStyles.legendColorScale[0],
-              type: 'minus',
-            },
-            tooltip: getUsageRangeString(previousUsageData, usageTooltipKey, false, false, 1),
+    const series: UsageChartSeries[] = [
+      {
+        childName: 'previousUsage',
+        data: previousUsageData,
+        legendItem: {
+          name: getUsageRangeString(previousUsageData, usageKey, true, true, 1),
+          symbol: {
+            fill: chartStyles.legendColorScale[0],
+            type: 'minus',
           },
-          style: chartStyles.previousUsageData,
+          tooltip: getUsageRangeString(previousUsageData, usageTooltipKey, false, false, 1),
         },
-        {
-          childName: 'currentUsage',
-          data: currentUsageData,
-          legendItem: {
-            name: getUsageRangeString(currentUsageData, usageKey, true, false),
-            symbol: {
-              fill: chartStyles.legendColorScale[1],
-              type: 'minus',
-            },
-            tooltip: getUsageRangeString(currentUsageData, usageTooltipKey, false, false),
+        style: chartStyles.previousUsageData,
+      },
+      {
+        childName: 'currentUsage',
+        data: currentUsageData,
+        legendItem: {
+          name: getUsageRangeString(currentUsageData, usageKey, true, false),
+          symbol: {
+            fill: chartStyles.legendColorScale[1],
+            type: 'minus',
           },
-          style: chartStyles.currentUsageData,
+          tooltip: getUsageRangeString(currentUsageData, usageTooltipKey, false, false),
         },
-        {
-          childName: 'previousRequest',
-          data: previousRequestData,
-          legendItem: {
-            name: getUsageRangeString(previousRequestData, requestKey, true, true, 1),
-            symbol: {
-              fill: chartStyles.legendColorScale[2],
-              type: 'dash',
-            },
-            tooltip: getUsageRangeString(previousRequestData, requestTooltipKey, false, false, 1),
+        style: chartStyles.currentUsageData,
+      },
+      {
+        childName: 'previousRequest',
+        data: previousRequestData,
+        legendItem: {
+          name: getUsageRangeString(previousRequestData, requestKey, true, true, 1),
+          symbol: {
+            fill: chartStyles.legendColorScale[2],
+            type: 'dash',
           },
-          style: chartStyles.previousRequestData,
+          tooltip: getUsageRangeString(previousRequestData, requestTooltipKey, false, false, 1),
         },
-        {
-          childName: 'currentRequest',
-          data: currentRequestData,
-          legendItem: {
-            name: getUsageRangeString(currentRequestData, requestKey, true, false),
-            symbol: {
-              fill: chartStyles.legendColorScale[3],
-              type: 'dash',
-            },
-            tooltip: getUsageRangeString(currentRequestData, requestTooltipKey, false, false),
+        style: chartStyles.previousRequestData,
+      },
+      {
+        childName: 'currentRequest',
+        data: currentRequestData,
+        legendItem: {
+          name: getUsageRangeString(currentRequestData, requestKey, true, false),
+          symbol: {
+            fill: chartStyles.legendColorScale[3],
+            type: 'dash',
           },
-          style: chartStyles.currentRequestData,
+          tooltip: getUsageRangeString(currentRequestData, requestTooltipKey, false, false),
         },
-      ],
-    });
+        style: chartStyles.currentRequestData,
+      },
+    ];
+    const cursorVoronoiContainer = this.getCursorVoronoiContainer(series);
+    this.setState({ cursorVoronoiContainer, series });
   };
 
   private handleNavToggle = () => {
@@ -188,17 +189,17 @@ class UsageChart extends React.Component<UsageChartProps, State> {
   };
 
   // Returns CursorVoronoiContainer component
-  private getContainer = () => {
+  private getCursorVoronoiContainer = (series: UsageChartSeries[]) => {
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
 
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={this.isDataAvailable() ? this.getTooltipLabel : undefined}
+        labels={this.isDataAvailable(series) ? this.getTooltipLabel : undefined}
         labelComponent={
           <ChartLegendTooltip
-            legendData={this.getLegendData(true)}
+            legendData={this.getLegendData(series, true)}
             title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
           />
         }
@@ -245,12 +246,14 @@ class UsageChart extends React.Component<UsageChartProps, State> {
 
   private getLegend = () => {
     const { legendItemsPerRow } = this.props;
-    const { width } = this.state;
+    const { series, width } = this.state;
 
     // Todo: use PF legendAllowWrap feature
     const itemsPerRow = legendItemsPerRow ? legendItemsPerRow : width > 300 ? chartStyles.itemsPerRow : 1;
 
-    return <ChartLegend data={this.getLegendData()} height={25} gutter={20} itemsPerRow={itemsPerRow} name="legend" />;
+    return (
+      <ChartLegend data={this.getLegendData(series)} height={25} gutter={20} itemsPerRow={itemsPerRow} name="legend" />
+    );
   };
 
   private getTooltipLabel = ({ datum }) => {
@@ -270,11 +273,10 @@ class UsageChart extends React.Component<UsageChartProps, State> {
   };
 
   // Returns true if at least one data series is available
-  private isDataAvailable = () => {
-    const { series } = this.state;
-
+  private isDataAvailable = (series: UsageChartSeries[]) => {
     // API data may not be available (e.g., on 1st of month)
     const unavailable = [];
+
     if (series) {
       series.forEach((s: any, index) => {
         if (this.isSeriesHidden(index) || (s.data && s.data.length === 0)) {
@@ -316,8 +318,8 @@ class UsageChart extends React.Component<UsageChartProps, State> {
   };
 
   // Returns legend data styled per hiddenSeries
-  private getLegendData = (tooltip: boolean = false) => {
-    const { hiddenSeries, series } = this.state;
+  private getLegendData = (series: UsageChartSeries[], tooltip: boolean = false) => {
+    const { hiddenSeries } = this.state;
     if (series) {
       const result = series.map((s, index) => {
         return {
@@ -344,7 +346,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
       },
       title,
     } = this.props;
-    const { series, width } = this.state;
+    const { cursorVoronoiContainer, series, width } = this.state;
 
     const domain = this.getDomain();
     const endDate = this.getEndDate();
@@ -364,12 +366,12 @@ class UsageChart extends React.Component<UsageChartProps, State> {
         <div className="chartOverride" ref={this.containerRef} style={{ height: adjustedContainerHeight }}>
           <div style={{ height, width }}>
             <Chart
-              containerComponent={this.getContainer()}
+              containerComponent={cursorVoronoiContainer}
               domain={domain}
               events={this.getEvents()}
               height={height}
               legendComponent={this.getLegend()}
-              legendData={this.getLegendData()}
+              legendData={this.getLegendData(series)}
               legendPosition="bottom-left"
               padding={padding}
               theme={ChartTheme}

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -196,7 +196,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={this.isDataAvailable(series) ? this.getTooltipLabel : undefined}
+        labels={this.getTooltipLabel}
         labelComponent={
           <ChartLegendTooltip
             legendData={this.getLegendData(series, true)}
@@ -273,9 +273,9 @@ class UsageChart extends React.Component<UsageChartProps, State> {
   };
 
   // Returns true if at least one data series is available
-  private isDataAvailable = (series: UsageChartSeries[]) => {
-    // API data may not be available (e.g., on 1st of month)
-    const unavailable = [];
+  private isDataAvailable = () => {
+    const { series } = this.state;
+    const unavailable = []; // API data may not be available (e.g., on 1st of month)
 
     if (series) {
       series.forEach((s: any, index) => {
@@ -358,6 +358,12 @@ class UsageChart extends React.Component<UsageChartProps, State> {
         : containerHeight + 20
       : containerHeight;
 
+    // Clone original container. See https://issues.redhat.com/browse/COST-762
+    const container = cursorVoronoiContainer
+      ? React.cloneElement(cursorVoronoiContainer, {
+          disable: !this.isDataAvailable(),
+        })
+      : undefined;
     return (
       <>
         <Title headingLevel="h3" size="md">
@@ -366,7 +372,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
         <div className="chartOverride" ref={this.containerRef} style={{ height: adjustedContainerHeight }}>
           <div style={{ height, width }}>
             <Chart
-              containerComponent={cursorVoronoiContainer}
+              containerComponent={container}
               domain={domain}
               events={this.getEvents()}
               height={height}


### PR DESCRIPTION
Refactored interactive legends to store chart container via state.

It appears if the chart container is recreated from scratch, each time the chart is redrawn, onMouseOver events are lost. If we store the container via state, then tooltips continue to be displayed properly after a data series is hidden / shown via the interactive legend.

https://issues.redhat.com/browse/COST-762

**Before**
![chrome-capture](https://user-images.githubusercontent.com/17481322/100830071-d6b20e80-3430-11eb-9fc6-0d650b660be8.gif)

**After**
![chrome-capture](https://user-images.githubusercontent.com/17481322/100820011-5634e300-341b-11eb-9143-9046db472bc0.gif)
