### PR TITLE
fix(costmodels): hide the enter-by-tag switch on cluster metric

### DIFF
--- a/src/pages/costModels/components/addPriceList.test.tsx
+++ b/src/pages/costModels/components/addPriceList.test.tsx
@@ -42,6 +42,16 @@ const metricsHash = {
       default_cost_type: 'Supplementary',
     },
   },
+  Cluster: {
+    Currency: {
+      source_type: 'Openshift Container Platform',
+      metric: 'cluster_cost_per_month',
+      label_metric: 'Cluster',
+      label_measurement: 'Currency',
+      label_measurement_unit: 'pvc-months',
+      default_cost_type: 'Infrastructure',
+    },
+  },
 };
 
 const qr = {
@@ -220,5 +230,13 @@ describe('add-a-new-rate', () => {
 
     fireEvent.change(container.querySelector(qr.measurement), { target: { value: 'Request' } });
     expect(queryByText('cost_models.add_rate_form.duplicate')).toBeTruthy();
+  });
+  test('hide "enter tag rates" switch on Cluster metric', () => {
+    const submit = jest.fn();
+    const cancel = jest.fn();
+    const { container, queryAllByLabelText } = render(<RenderFormDataUI submit={submit} cancel={cancel} />);
+    fireEvent.change(container.querySelector(qr.metric), { target: { value: 'Cluster' } });
+    fireEvent.change(container.querySelector(qr.measurement), { target: { value: 'Currency' } });
+    expect(queryAllByLabelText(qr.switch)).toHaveLength(0);
   });
 });

--- a/src/pages/costModels/components/rateForm/rateForm.tsx
+++ b/src/pages/costModels/components/rateForm/rateForm.tsx
@@ -148,12 +148,14 @@ export const RateForm: React.FunctionComponent<RateFormProps> = ({ metricsHash, 
                 onChange={() => setCalculation('Supplementary')}
               />
             </FormGroup>
-            <Switch
-              aria-label="Enter rate by tag"
-              label={t('cost_models.add_rate_form.rate_switch')}
-              isChecked={rateKind === 'tagging'}
-              onChange={toggleTaggingRate}
-            />
+            {metric !== 'Cluster' ? (
+              <Switch
+                aria-label="Enter rate by tag"
+                label={t('cost_models.add_rate_form.rate_switch')}
+                isChecked={rateKind === 'tagging'}
+                onChange={toggleTaggingRate}
+              />
+            ) : null}
           </>
           {rateKind === 'regular' ? (
             <RateInputBase

--- a/src/pages/costModels/components/rateForm/useRateForm.tsx
+++ b/src/pages/costModels/components/rateForm/useRateForm.tsx
@@ -59,6 +59,7 @@ function rateFormReducer(state = initialRateFormData, action: Actions) {
         errors,
         step,
         calculation: action.defaultCalculation,
+        rateKind: action.value === 'Cluster' ? 'regular' : state.rateKind,
       };
       const cur = OtherTierFromRateForm(newState);
       const duplicate = newState.otherTiers.find(val => isDuplicateTagRate(OtherTierFromRate(val), cur));


### PR DESCRIPTION
closed COST 782

![image](https://user-images.githubusercontent.com/2453279/100856350-fcbcca80-3493-11eb-954c-46236379050c.png)
