### PR TITLE
Ocp details page percentages should be based on total cost

### DIFF
--- a/src/pages/costModels/components/rateForm/useRateForm.test.tsx
+++ b/src/pages/costModels/components/rateForm/useRateForm.test.tsx
@@ -1,5 +1,3 @@
-import React from 'react';
-
 import { rateFormReducer } from './useRateForm';
 import { initialRateFormData } from './utils';
 

--- a/src/pages/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/details/ocpDetails/detailsTable.tsx
@@ -250,15 +250,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
   private getSupplementaryCost = (item: ComputedReportItem, index: number) => {
     const { report, t } = this.props;
-    const total =
-      report &&
-      report.meta &&
-      report.meta.total &&
-      report.meta.total.supplementary &&
-      report.meta.total.supplementary.total
-        ? report.meta.total.supplementary.total.value
+    const cost =
+      report && report.meta && report.meta.total && report.meta.total.cost && report.meta.total.cost.total
+        ? report.meta.total.cost.total.value
         : 0;
-    const percentValue = total === 0 ? total.toFixed(2) : ((item.supplementary.total.value / total) * 100).toFixed(2);
+    const percentValue = cost === 0 ? cost.toFixed(2) : ((item.supplementary.total.value / cost) * 100).toFixed(2);
     return (
       <>
         {formatCurrency(item.supplementary.total.value)}
@@ -287,16 +283,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
   private getInfrastructureCost = (item: ComputedReportItem, index: number) => {
     const { report, t } = this.props;
-    const total =
-      report &&
-      report.meta &&
-      report.meta.total &&
-      report.meta.total.infrastructure &&
-      report.meta.total.infrastructure.total &&
-      report.meta.total.infrastructure.total.value
-        ? report.meta.total.infrastructure.total.value
+    const cost =
+      report && report.meta && report.meta.total && report.meta.total.cost && report.meta.total.cost.total
+        ? report.meta.total.cost.total.value
         : 0;
-    const percentValue = total === 0 ? total.toFixed(2) : ((item.infrastructure.total.value / total) * 100).toFixed(2);
+    const percentValue = cost === 0 ? cost.toFixed(2) : ((item.infrastructure.total.value / cost) * 100).toFixed(2);
     return (
       <>
         {formatCurrency(item.infrastructure.total.value)}


### PR DESCRIPTION
OpenShift supplemental and infrastructure cost percentages, shown via the details table, should be based of of the total cost. Currently, the cost percentages are based on total supplemental cost and total infrastructure cost.

Also fixed a lint issue with cost models test.

https://issues.redhat.com/browse/COST-778

<img width="1879" alt="Screen Shot 2020-12-02 at 12 29 32 PM" src="https://user-images.githubusercontent.com/17481322/100908904-0ea16c00-349a-11eb-80fe-d831fa12d817.png">
