### PR TITLE
Create GitHub workflow

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,0 +1,59 @@
+# Run this workflow for PRs only. Travis is required to push via insights-frontend-builder-common scripts
+
+name: Pull request
+on:
+  pull_request:
+    branches: [ master, ci-stable, prod-beta, prod-stable, qa-beta, qa-stable ]
+env:
+  BRANCH: ${{ github.base_ref }}
+
+jobs:
+  build:
+    name: koku-ui build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Setup Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Set Node.js packages yarn cache directory
+        id: yarn-cache-dir
+        run: echo ::set-output name=CACHE_DIR::$(yarn cache dir)
+      - name: Node.js yarn cache
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.yarn-cache-dir.outputs.CACHE_DIR }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn
+      - name: Node.js modules cache
+        uses: actions/cache@v2
+        id: modules-cache
+        with:
+          path: ${{ github.workspace }}/node_modules
+          key: ${{ runner.os }}-${{ matrix.node-version }}-modules-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.node-version }}-modules
+      - name: Install Node.js packages
+        if: ${{ steps.modules-cache.outputs.cache-hit != 'true' }}
+        run: yarn --frozen-lockfile
+      - name: Check manifest
+        if: ${{ success() }}
+        run: ${{ github.workspace }}/.travis/check_manifest.sh
+      - name: Lint
+        if: ${{ success() }}
+        run: yarn lint
+      - name: Test
+        if: ${{ success() }}
+        run: yarn test --coverage --maxWorkers=4
+      - name: Build
+        if: ${{ success() }}
+        run: yarn build
+      - name: Code coverage
+        if: ${{ success() }}
+        uses: codecov/codecov-action@v1


### PR DESCRIPTION
Travis has become unbearably slow, waiting for queued PRs to build. Thus, I've created a Github workflow for PRs only.

Note that the `insights-frontend-builder-common` release scripts still require Travis in order to push to the ci-stable branch. Therefore, Travis is still used for pushes.

This mimics what Subscription Watch is doing with Github workflows. Although, I'm open to ideas about what to do with those release scripts?

This build only takes 4 minutes, compared to being queued for several hours.

**Workflow output**
<img width="1127" alt="Screen Shot 2020-12-02 at 11 35 08 PM" src="https://user-images.githubusercontent.com/17481322/100964676-25c27700-34f7-11eb-9fcc-3bad1318e8ff.png">
