### PR TITLE
Forecast params

### DIFF
--- a/src/components/charts/common/chartUtils.ts
+++ b/src/components/charts/common/chartUtils.ts
@@ -119,7 +119,7 @@ export function transformForecastCone(
       ];
     }, []);
   }
-  return padComputedReportItems(result);
+  return result;
 }
 
 export function transformReport(
@@ -329,6 +329,22 @@ export function getMaxValue(datums: ChartDatum[]) {
     });
   }
   return max;
+}
+
+export function getMaxMinValues(datums: ChartDatum[]) {
+  let max = 0;
+  let min = 0;
+  if (datums && datums.length) {
+    datums.forEach(datum => {
+      if (datum.y > max) {
+        max = datum.y;
+      }
+      if ((min === 0 || datum.y < min) && datum.y !== null) {
+        min = datum.y;
+      }
+    });
+  }
+  return { max, min };
 }
 
 export function getTooltipContent(formatValue) {

--- a/src/components/charts/common/chartUtils.ts
+++ b/src/components/charts/common/chartUtils.ts
@@ -217,7 +217,7 @@ export function createReportDatum<T extends ComputedReportItem>(
   };
 }
 
-// This pads computed report items with null datum objects, representing missing data at the begining and end of the
+// This pads computed report items with null datum objects, representing missing data at the beginning and end of the
 // data series. The remaining data is left as is to allow for extrapolation. This allows us to display a "no data"
 // message in the tooltip, which helps distinguish between zero values and when there is no data available.
 export function padComputedReportItems(datums: ChartDatum[]): ChartDatum[] {

--- a/src/components/charts/common/chartUtils.ts
+++ b/src/components/charts/common/chartUtils.ts
@@ -119,7 +119,7 @@ export function transformForecastCone(
       ];
     }, []);
   }
-  return result;
+  return padComputedReportItems(result);
 }
 
 export function transformReport(

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -12,7 +12,7 @@ import {
 } from '@patternfly/react-charts';
 import { Title } from '@patternfly/react-core';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import { getCostRangeString, getMaxValue, getTooltipContent } from 'components/charts/common/chartUtils';
+import { getCostRangeString, getMaxMinValues, getTooltipContent } from 'components/charts/common/chartUtils';
 import { getDateRange } from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
@@ -235,23 +235,32 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
   };
 
   private getDomain() {
-    const {
-      currentCostData,
-      currentInfrastructureCostData,
-      previousCostData,
-      previousInfrastructureCostData,
-    } = this.props;
-    const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
+    const { series } = this.state;
 
-    const maxCurrentLimit = currentCostData ? getMaxValue(currentCostData) : 0;
-    const maxCurrentRequest = currentInfrastructureCostData ? getMaxValue(currentInfrastructureCostData) : 0;
-    const maxPreviousLimit = previousCostData ? getMaxValue(previousCostData) : 0;
-    const maxPreviousRequest = previousInfrastructureCostData ? getMaxValue(previousInfrastructureCostData) : 0;
-    const maxValue = Math.max(maxCurrentLimit, maxCurrentRequest, maxPreviousLimit, maxPreviousRequest);
+    const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
+    let maxValue = 0;
+    let minValue = 0;
+
+    if (series) {
+      series.forEach((s: any, index) => {
+        if (!this.isSeriesHidden(index) && s.data && s.data.length !== 0) {
+          const { max, min } = getMaxMinValues(s.data);
+          maxValue = Math.max(maxValue, max);
+          if (minValue === 0) {
+            minValue = min;
+          } else {
+            minValue = Math.min(minValue, min);
+          }
+        }
+      });
+    }
+
     const max = maxValue > 0 ? Math.ceil(maxValue + maxValue * 0.1) : 0;
+    const minY = Math.floor(minValue - minValue * 0.1);
+    const min = minY > 0 ? minY : 0;
 
     if (max > 0) {
-      domain.y = [0, max];
+      domain.y = [min, max];
     }
     return domain;
   }

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -12,8 +12,8 @@ import {
 } from '@patternfly/react-charts';
 import { Title } from '@patternfly/react-core';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import { getDateRange } from 'components/charts/common/chartUtils';
-import { getMaxValue, getTooltipContent, getUsageRangeString } from 'components/charts/common/chartUtils';
+import { getDateRange, getMaxMinValues } from 'components/charts/common/chartUtils';
+import { getTooltipContent, getUsageRangeString } from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
 import React from 'react';
@@ -279,34 +279,32 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
   };
 
   private getDomain() {
-    const {
-      currentRequestData,
-      currentUsageData,
-      currentLimitData,
-      previousLimitData,
-      previousRequestData,
-      previousUsageData,
-    } = this.props;
-    const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
+    const { series } = this.state;
 
-    const maxCurrentLimit = currentLimitData ? getMaxValue(currentLimitData) : 0;
-    const maxCurrentRequest = currentRequestData ? getMaxValue(currentRequestData) : 0;
-    const maxCurrentUsage = currentUsageData ? getMaxValue(currentUsageData) : 0;
-    const maxPreviousLimit = previousLimitData ? getMaxValue(previousLimitData) : 0;
-    const maxPreviousRequest = previousRequestData ? getMaxValue(previousRequestData) : 0;
-    const maxPreviousUsage = previousUsageData ? getMaxValue(previousUsageData) : 0;
-    const maxValue = Math.max(
-      maxCurrentLimit,
-      maxCurrentRequest,
-      maxCurrentUsage,
-      maxPreviousLimit,
-      maxPreviousRequest,
-      maxPreviousUsage
-    );
+    const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
+    let maxValue = 0;
+    let minValue = 0;
+
+    if (series) {
+      series.forEach((s: any, index) => {
+        if (!this.isSeriesHidden(index) && s.data && s.data.length !== 0) {
+          const { max, min } = getMaxMinValues(s.data);
+          maxValue = Math.max(maxValue, max);
+          if (minValue === 0) {
+            minValue = min;
+          } else {
+            minValue = Math.min(minValue, min);
+          }
+        }
+      });
+    }
+
     const max = maxValue > 0 ? Math.ceil(maxValue + maxValue * 0.1) : 0;
+    const minY = Math.floor(minValue - minValue * 0.1);
+    const min = minY > 0 ? minY : 0;
 
     if (max > 0) {
-      domain.y = [0, max];
+      domain.y = [min, max];
     }
     return domain;
   }

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -12,7 +12,12 @@ import {
 } from '@patternfly/react-charts';
 import { Title } from '@patternfly/react-core';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import { getCostRangeString, getDateRange, getMaxValue, getTooltipContent } from 'components/charts/common/chartUtils';
+import {
+  getCostRangeString,
+  getDateRange,
+  getMaxMinValues,
+  getTooltipContent,
+} from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
 import React from 'react';
@@ -261,18 +266,32 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   };
 
   private getDomain() {
-    const { currentData, forecastData, forecastConeData, previousData } = this.props;
-    const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
+    const { series } = this.state;
 
-    const maxCurrent = currentData ? getMaxValue(currentData) : 0;
-    const maxForecast = forecastData ? getMaxValue(forecastData) : 0;
-    const maxForecastCone = forecastConeData ? getMaxValue(forecastConeData) : 0;
-    const maxPrevious = previousData ? getMaxValue(previousData) : 0;
-    const maxValue = Math.max(maxCurrent, maxForecast, maxForecastCone, maxPrevious);
+    const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
+    let maxValue = 0;
+    let minValue = 0;
+
+    if (series) {
+      series.forEach((s: any, index) => {
+        if (!this.isSeriesHidden(index) && s.data && s.data.length !== 0) {
+          const { max, min } = getMaxMinValues(s.data);
+          maxValue = Math.max(maxValue, max);
+          if (minValue === 0) {
+            minValue = min;
+          } else {
+            minValue = Math.min(minValue, min);
+          }
+        }
+      });
+    }
+
     const max = maxValue > 0 ? Math.ceil(maxValue + maxValue * 0.1) : 0;
+    const minY = Math.floor(minValue - minValue * 0.1);
+    const min = minY > 0 ? minY : 0;
 
     if (max > 0) {
-      domain.y = [0, max];
+      domain.y = [min, max];
     }
     return domain;
   }

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -12,7 +12,12 @@ import {
 } from '@patternfly/react-charts';
 import { Title } from '@patternfly/react-core';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import { getDateRange, getMaxValue, getTooltipContent, getUsageRangeString } from 'components/charts/common/chartUtils';
+import {
+  getDateRange,
+  getMaxMinValues,
+  getTooltipContent,
+  getUsageRangeString,
+} from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
 import React from 'react';
@@ -216,18 +221,32 @@ class UsageChart extends React.Component<UsageChartProps, State> {
   };
 
   private getDomain() {
-    const { currentRequestData, currentUsageData, previousRequestData, previousUsageData } = this.props;
-    const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
+    const { series } = this.state;
 
-    const maxCurrentRequest = currentRequestData ? getMaxValue(currentRequestData) : 0;
-    const maxCurrentUsage = currentUsageData ? getMaxValue(currentUsageData) : 0;
-    const maxPreviousRequest = previousRequestData ? getMaxValue(previousRequestData) : 0;
-    const maxPreviousUsage = previousUsageData ? getMaxValue(previousUsageData) : 0;
-    const maxValue = Math.max(maxCurrentRequest, maxCurrentUsage, maxPreviousRequest, maxPreviousUsage);
+    const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
+    let maxValue = 0;
+    let minValue = 0;
+
+    if (series) {
+      series.forEach((s: any, index) => {
+        if (!this.isSeriesHidden(index) && s.data && s.data.length !== 0) {
+          const { max, min } = getMaxMinValues(s.data);
+          maxValue = Math.max(maxValue, max);
+          if (minValue === 0) {
+            minValue = min;
+          } else {
+            minValue = Math.min(minValue, min);
+          }
+        }
+      });
+    }
+
     const max = maxValue > 0 ? Math.ceil(maxValue + maxValue * 0.1) : 0;
+    const minY = Math.floor(minValue - minValue * 0.1);
+    const min = minY > 0 ? minY : 0;
 
     if (max > 0) {
-      domain.y = [0, max];
+      domain.y = [min, max];
     }
     return domain;
   }

--- a/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
@@ -34,12 +34,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       time_scope_value: -2,
     }),
     current: getQueryForWidget(filter),
-    forecast: getQueryForWidget(
-      {
-        time_scope_value: -2,
-      },
-      { limit: 31 }
-    ),
+    forecast: getQueryForWidget({}, { limit: 31 }),
     tabs: getQueryForWidgetTabs(widget, {
       ...tabsFilter,
       resolution: 'monthly',

--- a/src/store/dashboard/azureDashboard/azureDashboardSelectors.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardSelectors.ts
@@ -34,12 +34,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       time_scope_value: -2,
     }),
     current: getQueryForWidget(filter),
-    forecast: getQueryForWidget(
-      {
-        time_scope_value: -2,
-      },
-      { limit: 31 }
-    ),
+    forecast: getQueryForWidget({}, { limit: 31 }),
     tabs: getQueryForWidgetTabs(widget, {
       ...tabsFilter,
       resolution: 'monthly',

--- a/src/store/dashboard/ocpDashboard/ocpDashboardSelectors.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardSelectors.ts
@@ -34,12 +34,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       time_scope_value: -2,
     }),
     current: getQueryForWidget(defaultFilter),
-    forecast: getQueryForWidget(
-      {
-        time_scope_value: -2,
-      },
-      { limit: 31 }
-    ),
+    forecast: getQueryForWidget({}, { limit: 31 }),
     tabs: getQueryForWidgetTabs(widget, {
       ...tabsFilter,
       resolution: 'monthly',


### PR DESCRIPTION
Refactored the chart forecast a bit for:

1. Forecast API removed the `filter[time_scope_value]` parameter
2. Scale charts dynamically when a data series is hidden / shown
3. Purne erroneous data outside forecast date range

![chrome-capture](https://user-images.githubusercontent.com/17481322/101222804-97660680-3658-11eb-91e0-48bdc115d309.gif)
