### PR TITLE
Wrong tooltip label/value for cost forecast

### DIFF
--- a/src/components/charts/costChart/costChart.styles.ts
+++ b/src/components/charts/costChart/costChart.styles.ts
@@ -30,7 +30,6 @@ export const chartStyles = {
     fill: chart_color_green_100.value,
     strokeWidth: 0,
   },
-  itemsPerRow: 3,
   previousCostData: {
     fill: 'none',
   },

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -309,15 +309,13 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     const { legendItemsPerRow } = this.props;
     const { series, width } = this.state;
 
-    const itemsPerRow = legendItemsPerRow ? legendItemsPerRow : width > 700 ? chartStyles.itemsPerRow : 2;
-
     // Todo: use PF legendAllowWrap feature
     return (
       <ChartLegend
         data={this.getLegendData(series)}
         gutter={20}
         height={25}
-        itemsPerRow={itemsPerRow}
+        itemsPerRow={legendItemsPerRow}
         name="legend"
         orientation={width > 150 ? 'horizontal' : 'vertical'}
       />
@@ -388,6 +386,21 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     return result as any;
   };
 
+  private getAdjustedContainerHeight = () => {
+    const { adjustContainerHeight, forecastData, height, containerHeight = height, showForecast } = this.props;
+    const { width } = this.state;
+
+    let adjustedContainerHeight = containerHeight;
+    if (adjustContainerHeight) {
+      if (showForecast || (forecastData && forecastData.length)) {
+        if (width < 700) {
+          adjustedContainerHeight += 25;
+        }
+      }
+    }
+    return adjustedContainerHeight;
+  };
+
   // Returns onMouseOver, onMouseOut, and onClick events for the interactive legend
   private getEvents = () => {
     const result = getInteractiveLegendEvents({
@@ -417,9 +430,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
 
   public render() {
     const {
-      adjustContainerHeight,
       height,
-      containerHeight = height,
       padding = {
         bottom: 50,
         left: 8,
@@ -434,12 +445,6 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     const endDate = this.getEndDate();
     const midDate = Math.floor(endDate / 2);
 
-    const adjustedContainerHeight = adjustContainerHeight
-      ? width > 700
-        ? containerHeight
-        : containerHeight + 20
-      : containerHeight;
-
     // Clone original container. See https://issues.redhat.com/browse/COST-762
     const container = cursorVoronoiContainer
       ? React.cloneElement(cursorVoronoiContainer, {
@@ -451,13 +456,14 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         <Title headingLevel="h3" size="md">
           {title}
         </Title>
-        <div className="chartOverride" ref={this.containerRef} style={{ height: adjustedContainerHeight }}>
+        <div className="chartOverride" ref={this.containerRef} style={{ height: this.getAdjustedContainerHeight() }}>
           <div style={{ height, width }}>
             <Chart
               containerComponent={container}
               domain={domain}
               events={this.getEvents()}
               height={height}
+              legendAllowWrap
               legendComponent={this.getLegend()}
               legendData={this.getLegendData(series)}
               legendPosition="bottom-left"

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -312,6 +312,19 @@ class UsageChart extends React.Component<UsageChartProps, State> {
     return hiddenSeries.has(index);
   };
 
+  private getAdjustedContainerHeight = () => {
+    const { adjustContainerHeight, height, containerHeight = height } = this.props;
+    const { width } = this.state;
+
+    let adjustedContainerHeight = containerHeight;
+    if (adjustContainerHeight) {
+      if (width < 480) {
+        adjustedContainerHeight += 20;
+      }
+    }
+    return adjustedContainerHeight;
+  };
+
   // Returns groups of chart names associated with each data series
   private getChartNames = () => {
     const { series } = this.state;
@@ -354,9 +367,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
 
   public render() {
     const {
-      adjustContainerHeight,
       height,
-      containerHeight = height,
       padding = {
         bottom: 75,
         left: 8,
@@ -371,12 +382,6 @@ class UsageChart extends React.Component<UsageChartProps, State> {
     const endDate = this.getEndDate();
     const midDate = Math.floor(endDate / 2);
 
-    const adjustedContainerHeight = adjustContainerHeight
-      ? width > 480
-        ? containerHeight
-        : containerHeight + 20
-      : containerHeight;
-
     // Clone original container. See https://issues.redhat.com/browse/COST-762
     const container = cursorVoronoiContainer
       ? React.cloneElement(cursorVoronoiContainer, {
@@ -388,7 +393,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
         <Title headingLevel="h3" size="md">
           {title}
         </Title>
-        <div className="chartOverride" ref={this.containerRef} style={{ height: adjustedContainerHeight }}>
+        <div className="chartOverride" ref={this.containerRef} style={{ height: this.getAdjustedContainerHeight() }}>
           <div style={{ height, width }}>
             <Chart
               containerComponent={container}

--- a/src/components/reports/reportSummary/reportSummaryDetails.tsx
+++ b/src/components/reports/reportSummary/reportSummaryDetails.tsx
@@ -1,7 +1,7 @@
 import './reportSummaryDetails.scss';
 
 import { Tooltip } from '@patternfly/react-core';
-import { Report } from 'api/reports/report';
+import { Report, ReportType } from 'api/reports/report';
 import { ComputedReportItemType } from 'components/charts/common/chartUtils';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import React from 'react';
@@ -19,6 +19,7 @@ interface ReportSummaryDetailsProps extends WithTranslation {
   report: Report;
   requestFormatOptions?: FormatOptions;
   requestLabel?: string;
+  reportType?: ReportType;
   showTooltip?: boolean;
   showUnits?: boolean;
   showUsageFirst?: boolean;
@@ -37,6 +38,7 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
   report,
   requestFormatOptions,
   requestLabel,
+  reportType,
   showTooltip = false,
   showUnits = false,
   showUsageFirst = false,
@@ -181,19 +183,19 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
   };
 
   if (chartType === DashboardChartType.cost || chartType === DashboardChartType.supplementary) {
-    return <>{getCostLayout(true)}</>;
+    return <>{getCostLayout(reportType === ReportType.cost)}</>;
   } else if (chartType === DashboardChartType.trend) {
     if (showUsageFirst) {
       return (
         <>
           {getUsageLayout()}
-          {getCostLayout()}
+          {getCostLayout(reportType === ReportType.cost)}
         </>
       );
     }
     return (
       <>
-        {getCostLayout()}
+        {getCostLayout(reportType === ReportType.cost)}
         {getUsageLayout()}
       </>
     );

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -313,7 +313,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   };
 
   private getDetails = () => {
-    const { chartType, currentReport, details, trend } = this.props;
+    const { chartType, currentReport, details, reportType, trend } = this.props;
     const computedReportItem = trend.computedReportItem || 'cost';
     const computedReportItemValue = trend.computedReportItemValue || 'total';
     const units = this.getUnits();
@@ -327,6 +327,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         formatOptions={details.formatOptions}
         formatValue={formatValue}
         report={currentReport}
+        reportType={reportType}
         requestLabel={this.getDetailsLabel(details.requestKey, units)}
         showTooltip={details.showTooltip}
         showUnits={details.showUnits}


### PR DESCRIPTION
The chart tooltip legend may show the wrong label for infrastructure data. The legend labels appear to be swapped (e.g., the value expected for "Infrastructure cost" is labeled "Cost foreccast".

This is due to reordering legend items in order to wrap items when there is not enough room. However, we can now use PatternFly's `legendAllowWrap` feature to do that for us.

**Correct tooltip labels**
<img width="1243" alt="Screen Shot 2020-12-08 at 12 00 45 PM" src="https://user-images.githubusercontent.com/17481322/101516119-1a36dc00-394d-11eb-8349-66e7e4548af2.png">

**Example of legend item responsiveness**
![chrome-capture (1)](https://user-images.githubusercontent.com/17481322/101515954-e8257a00-394c-11eb-85a7-cac2f32b8cf9.gif)
