### PR TITLE
fix(costmodels): delete i18n keys for metrics/measurements

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -165,19 +165,6 @@
   },
   "cost_management": "Cost Management",
   "cost_models": {
-    "CPU": "CPU",
-    "Cluster": "Cluster",
-    "Currency": "Price ({{units}})",
-    "GB-hours": "GB-hours",
-    "GB-month": "GB-month",
-    "Infrastructure": "Infrastructure",
-    "Memory": "Memory",
-    "Node": "Node",
-    "Persistent volume claims": "Persistent volume claims",
-    "Request": "Request ({{units}})",
-    "Storage": "Storage",
-    "Supplementary": "Supplementary",
-    "Usage": "Usage ({{units}})",
     "add_rate_form": {
       "calculation_type": "Calculation type",
       "default_label": "Default",
@@ -198,8 +185,6 @@
       "tag_key": "Filter by tag",
       "tag_value": "Tag value"
     },
-    "core-hours": "core-hours",
-    "for_every": "${{rate}} per {{units}}",
     "infra_cost_switch": "Use this rate to calculate infrastructure cost",
     "infra_no": "No",
     "infra_yes": "Yes",
@@ -938,12 +923,7 @@
       "measurement": "Measurement",
       "measurement_placeholder": "Filter by measurements",
       "metric": "Metric",
-      "metric_placeholder": "Filter by metrics",
-      "options": {
-        "Currency": "Price",
-        "Request": "Request",
-        "Usage": "Usage"
-      }
+      "metric_placeholder": "Filter by metrics"
     },
     "sources": {
       "assign_sources": "Assign source",

--- a/src/pages/costModels/components/rateTable.tsx
+++ b/src/pages/costModels/components/rateTable.tsx
@@ -48,9 +48,7 @@ export const RateTable: React.SFC<RateTableProps> = ({ t, tiers, actions, isComp
         cells: [
           tier.description || '',
           tier.metric.label_metric,
-          t(`cost_models.${tier.metric.label_measurement}`, {
-            units: tier.metric.label_measurement_unit,
-          }),
+          `${tier.metric.label_measurement} (${tier.metric.label_measurement_unit})`,
           tier.cost_type,
           {
             title:

--- a/src/pages/costModels/costModelsDetails/components/priceListTable.tsx
+++ b/src/pages/costModels/costModelsDetails/components/priceListTable.tsx
@@ -75,13 +75,13 @@ class PriceListTable extends React.Component<Props, State> {
   public render() {
     const { t, fetchStatus, fetchError, isDialogOpen, metricsHash, isWritePermission } = this.props;
     const metricOpts = Object.keys(metricsHash).map(m => ({
-      label: t(`cost_models.${m}`),
+      label: m,
       value: m,
     }));
     const measurementOpts = metricOpts.reduce((acc, curr) => {
       const measurs = Object.keys(metricsHash[curr.value])
         .filter(m => !acc.map(i => i.value).includes(m))
-        .map(m => ({ label: t(`toolbar.pricelist.options.${m}`), value: m }));
+        .map(m => ({ label: m, value: m }));
       return [...acc, ...measurs];
     }, []);
 

--- a/src/pages/costModels/createCostModelWizard/priceListTable.tsx
+++ b/src/pages/costModels/createCostModelWizard/priceListTable.tsx
@@ -68,13 +68,13 @@ class PriceListTable extends React.Component<Props, State> {
   public render() {
     const { metricsHash, t, addRateAction, deleteRateAction, items } = this.props;
     const metricOpts = Object.keys(metricsHash).map(m => ({
-      label: t(`cost_models.${m}`),
+      label: m,
       value: m,
     }));
     const measurementOpts = metricOpts.reduce((acc, curr) => {
       const measurs = Object.keys(metricsHash[curr.value])
         .filter(m => !acc.map(i => i.value).includes(m))
-        .map(m => ({ label: t(`toolbar.pricelist.options.${m}`), value: m }));
+        .map(m => ({ label: m, value: m }));
       return [...acc, ...measurs];
     }, []);
     return (


### PR DESCRIPTION
closes COST 756
remove unnecessary i18n keys and removing them from toolbars and tables in cost models.