### PR TITLE
Enable forecast feature for dev & QA only

### DIFF
--- a/src/components/charts/common/chartUtils.ts
+++ b/src/components/charts/common/chartUtils.ts
@@ -331,22 +331,6 @@ export function getMaxValue(datums: ChartDatum[]) {
   return max;
 }
 
-export function getMaxMinValues(datums: ChartDatum[]) {
-  let max = 0;
-  let min = 0;
-  if (datums && datums.length) {
-    datums.forEach(datum => {
-      if (datum.y > max) {
-        max = datum.y;
-      }
-      if ((min === 0 || datum.y < min) && datum.y !== null) {
-        min = datum.y;
-      }
-    });
-  }
-  return { max, min };
-}
-
 export function getTooltipContent(formatValue) {
   return function labelFormatter(value: number, unit: string = null, options: FormatOptions = {}) {
     const lookup = unitLookupKey(unit);

--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -12,12 +12,7 @@ import {
 } from '@patternfly/react-charts';
 import { Title } from '@patternfly/react-core';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import {
-  getCostRangeString,
-  getDateRange,
-  getMaxMinValues,
-  getTooltipContent,
-} from 'components/charts/common/chartUtils';
+import { getCostRangeString, getDateRange, getMaxValue, getTooltipContent } from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
 import React from 'react';
@@ -200,7 +195,8 @@ class CostChart extends React.Component<CostChartProps, State> {
         },
       },
     ];
-    if (showForecast || (forecastData && forecastData.length)) {
+
+    if (showForecast) {
       series.push({
         childName: 'forecast',
         data: forecastData,
@@ -219,8 +215,6 @@ class CostChart extends React.Component<CostChartProps, State> {
           },
         },
       });
-    }
-    if (showForecast || (forecastConeData && forecastConeData.length)) {
       series.push({
         childName: 'forecastCone',
         data: forecastConeData,
@@ -300,28 +294,19 @@ class CostChart extends React.Component<CostChartProps, State> {
 
     const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
     let maxValue = 0;
-    let minValue = 0;
 
     if (series) {
       series.forEach((s: any, index) => {
         if (!this.isSeriesHidden(index) && s.data && s.data.length !== 0) {
-          const { max, min } = getMaxMinValues(s.data);
+          const max = getMaxValue(s.data);
           maxValue = Math.max(maxValue, max);
-          if (minValue === 0) {
-            minValue = min;
-          } else {
-            minValue = Math.min(minValue, min);
-          }
         }
       });
     }
 
     const max = maxValue > 0 ? Math.ceil(maxValue + maxValue * 0.1) : 0;
-    const minY = Math.floor(minValue - minValue * 0.1);
-    const min = minY > 0 ? minY : 0;
-
     if (max > 0) {
-      domain.y = [min, max];
+      domain.y = [0, max];
     }
     return domain;
   }
@@ -367,13 +352,15 @@ class CostChart extends React.Component<CostChartProps, State> {
   private getTooltipLabel = ({ datum }) => {
     const { formatDatumValue, formatDatumOptions } = this.props;
     const formatter = getTooltipContent(formatDatumValue);
-    const dy = datum.y !== null ? formatter(datum.y, datum.units, formatDatumOptions) : undefined;
-    const dy0 = datum.y0 && datum.y0 !== null ? formatter(datum.y0, datum.units, formatDatumOptions) : undefined;
+    const dy =
+      datum.y !== undefined && datum.y !== null ? formatter(datum.y, datum.units, formatDatumOptions) : undefined;
+    const dy0 =
+      datum.y0 !== undefined && datum.y0 !== null ? formatter(datum.y0, datum.units, formatDatumOptions) : undefined;
 
-    if (dy && dy0) {
+    if (dy !== undefined && dy0 !== undefined) {
       return i18next.t('chart.cost_forecast_cone_tooltip', { value0: dy0, value1: dy });
     }
-    return dy ? dy : i18next.t('chart.no_data');
+    return dy !== undefined ? dy : i18next.t('chart.no_data');
   };
 
   // Interactive legend
@@ -421,12 +408,12 @@ class CostChart extends React.Component<CostChartProps, State> {
   };
 
   private getAdjustedContainerHeight = () => {
-    const { adjustContainerHeight, forecastData, height, containerHeight = height, showForecast } = this.props;
+    const { adjustContainerHeight, height, containerHeight = height, showForecast } = this.props;
     const { width } = this.state;
 
     let adjustedContainerHeight = containerHeight;
     if (adjustContainerHeight) {
-      if (showForecast || (forecastData && forecastData.length)) {
+      if (showForecast) {
         if (width > 650 && width < 1130) {
           adjustedContainerHeight += 25;
         } else if (width > 450 && width < 650) {
@@ -495,6 +482,12 @@ class CostChart extends React.Component<CostChartProps, State> {
     const container = cursorVoronoiContainer
       ? React.cloneElement(cursorVoronoiContainer, {
           disable: !this.isDataAvailable(),
+          labelComponent: (
+            <ChartLegendTooltip
+              legendData={this.getLegendData(series, true)}
+              title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
+            />
+          ),
         })
       : undefined;
     return (

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -12,7 +12,7 @@ import {
 } from '@patternfly/react-charts';
 import { Title } from '@patternfly/react-core';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import { getCostRangeString, getMaxMinValues, getTooltipContent } from 'components/charts/common/chartUtils';
+import { getCostRangeString, getMaxValue, getTooltipContent } from 'components/charts/common/chartUtils';
 import { getDateRange } from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
@@ -239,28 +239,19 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
 
     const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
     let maxValue = 0;
-    let minValue = 0;
 
     if (series) {
       series.forEach((s: any, index) => {
         if (!this.isSeriesHidden(index) && s.data && s.data.length !== 0) {
-          const { max, min } = getMaxMinValues(s.data);
+          const max = getMaxValue(s.data);
           maxValue = Math.max(maxValue, max);
-          if (minValue === 0) {
-            minValue = min;
-          } else {
-            minValue = Math.min(minValue, min);
-          }
         }
       });
     }
 
     const max = maxValue > 0 ? Math.ceil(maxValue + maxValue * 0.1) : 0;
-    const minY = Math.floor(minValue - minValue * 0.1);
-    const min = minY > 0 ? minY : 0;
-
     if (max > 0) {
-      domain.y = [min, max];
+      domain.y = [0, max];
     }
     return domain;
   }
@@ -291,7 +282,9 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
   private getTooltipLabel = ({ datum }) => {
     const { formatDatumValue, formatDatumOptions } = this.props;
     const formatter = getTooltipContent(formatDatumValue);
-    return datum.y !== null ? formatter(datum.y, datum.units, formatDatumOptions) : i18next.t('chart.no_data');
+    return datum.y !== undefined && datum.y !== null
+      ? formatter(datum.y, datum.units, formatDatumOptions)
+      : i18next.t('chart.no_data');
   };
 
   // Interactive legend

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -12,12 +12,7 @@ import {
 } from '@patternfly/react-charts';
 import { Title } from '@patternfly/react-core';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import {
-  getCostRangeString,
-  getDateRange,
-  getMaxMinValues,
-  getTooltipContent,
-} from 'components/charts/common/chartUtils';
+import { getCostRangeString, getDateRange, getMaxValue, getTooltipContent } from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
 import React from 'react';
@@ -194,28 +189,19 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
 
     const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
     let maxValue = 0;
-    let minValue = 0;
 
     if (series) {
       series.forEach((s: any, index) => {
         if (!this.isSeriesHidden(index) && s.data && s.data.length !== 0) {
-          const { max, min } = getMaxMinValues(s.data);
+          const max = getMaxValue(s.data);
           maxValue = Math.max(maxValue, max);
-          if (minValue === 0) {
-            minValue = min;
-          } else {
-            minValue = Math.min(minValue, min);
-          }
         }
       });
     }
 
     const max = maxValue > 0 ? Math.ceil(maxValue + maxValue * 0.1) : 0;
-    const minY = Math.floor(minValue - minValue * 0.1);
-    const min = minY > 0 ? minY : 0;
-
     if (max > 0) {
-      domain.y = [min, max];
+      domain.y = [0, max];
     }
     return domain;
   }
@@ -246,7 +232,9 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
   private getTooltipLabel = ({ datum }) => {
     const { formatDatumValue, formatDatumOptions, units } = this.props;
     const formatter = getTooltipContent(formatDatumValue);
-    return datum.y !== null ? formatter(datum.y, units || datum.units, formatDatumOptions) : i18next.t('chart.no_data');
+    return datum.y !== undefined && datum.y !== null
+      ? formatter(datum.y, units || datum.units, formatDatumOptions)
+      : i18next.t('chart.no_data');
   };
 
   // Interactive legend

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -12,7 +12,7 @@ import {
 } from '@patternfly/react-charts';
 import { Title } from '@patternfly/react-core';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import { getDateRange, getMaxMinValues } from 'components/charts/common/chartUtils';
+import { getDateRange, getMaxValue } from 'components/charts/common/chartUtils';
 import { getTooltipContent, getUsageRangeString } from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
@@ -283,28 +283,19 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
 
     const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
     let maxValue = 0;
-    let minValue = 0;
 
     if (series) {
       series.forEach((s: any, index) => {
         if (!this.isSeriesHidden(index) && s.data && s.data.length !== 0) {
-          const { max, min } = getMaxMinValues(s.data);
+          const max = getMaxValue(s.data);
           maxValue = Math.max(maxValue, max);
-          if (minValue === 0) {
-            minValue = min;
-          } else {
-            minValue = Math.min(minValue, min);
-          }
         }
       });
     }
 
     const max = maxValue > 0 ? Math.ceil(maxValue + maxValue * 0.1) : 0;
-    const minY = Math.floor(minValue - minValue * 0.1);
-    const min = minY > 0 ? minY : 0;
-
     if (max > 0) {
-      domain.y = [min, max];
+      domain.y = [0, max];
     }
     return domain;
   }
@@ -334,7 +325,9 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
   private getTooltipLabel = ({ datum }) => {
     const { formatDatumValue, formatDatumOptions } = this.props;
     const formatter = getTooltipContent(formatDatumValue);
-    return datum.y !== null ? formatter(datum.y, datum.units, formatDatumOptions) : i18next.t('chart.no_data');
+    return datum.y !== undefined && datum.y !== null
+      ? formatter(datum.y, datum.units, formatDatumOptions)
+      : i18next.t('chart.no_data');
   };
 
   // Interactive legend

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -12,12 +12,7 @@ import {
 } from '@patternfly/react-charts';
 import { Title } from '@patternfly/react-core';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import {
-  getDateRange,
-  getMaxMinValues,
-  getTooltipContent,
-  getUsageRangeString,
-} from 'components/charts/common/chartUtils';
+import { getDateRange, getMaxValue, getTooltipContent, getUsageRangeString } from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
 import React from 'react';
@@ -225,28 +220,19 @@ class UsageChart extends React.Component<UsageChartProps, State> {
 
     const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
     let maxValue = 0;
-    let minValue = 0;
 
     if (series) {
       series.forEach((s: any, index) => {
         if (!this.isSeriesHidden(index) && s.data && s.data.length !== 0) {
-          const { max, min } = getMaxMinValues(s.data);
+          const max = getMaxValue(s.data);
           maxValue = Math.max(maxValue, max);
-          if (minValue === 0) {
-            minValue = min;
-          } else {
-            minValue = Math.min(minValue, min);
-          }
         }
       });
     }
 
     const max = maxValue > 0 ? Math.ceil(maxValue + maxValue * 0.1) : 0;
-    const minY = Math.floor(minValue - minValue * 0.1);
-    const min = minY > 0 ? minY : 0;
-
     if (max > 0) {
-      domain.y = [min, max];
+      domain.y = [0, max];
     }
     return domain;
   }
@@ -278,7 +264,9 @@ class UsageChart extends React.Component<UsageChartProps, State> {
   private getTooltipLabel = ({ datum }) => {
     const { formatDatumValue, formatDatumOptions } = this.props;
     const formatter = getTooltipContent(formatDatumValue);
-    return datum.y !== null ? formatter(datum.y, datum.units, formatDatumOptions) : i18next.t('chart.no_data');
+    return datum.y !== undefined && datum.y !== null
+      ? formatter(datum.y, datum.units, formatDatumOptions)
+      : i18next.t('chart.no_data');
   };
 
   // Interactive legend


### PR DESCRIPTION
The forecast feature should only be enabled for dev and QA users; `cost-demo` and `insights-qa`. This is a temporary change until the forecast APIs have been fully tested and ready for production.

Also set charts min y domain back to zero.