### PR TITLE
Sync chart tooltips

### DIFF
--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -234,7 +234,7 @@ class CostChart extends React.Component<CostChartProps, State> {
         },
       });
     }
-    const cursorVoronoiContainer = this.getCursorVoronoiContainer(series);
+    const cursorVoronoiContainer = this.getCursorVoronoiContainer();
     this.setState({ cursorVoronoiContainer, series });
   };
 
@@ -263,7 +263,7 @@ class CostChart extends React.Component<CostChartProps, State> {
   };
 
   // Returns CursorVoronoiContainer component
-  private getCursorVoronoiContainer = (series: CostChartSeries[]) => {
+  private getCursorVoronoiContainer = () => {
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
 
@@ -271,12 +271,6 @@ class CostChart extends React.Component<CostChartProps, State> {
       <CursorVoronoiContainer
         cursorDimension="x"
         labels={this.getTooltipLabel}
-        labelComponent={
-          <ChartLegendTooltip
-            legendData={this.getLegendData(series, true)}
-            title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
-          />
-        }
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{
@@ -344,9 +338,7 @@ class CostChart extends React.Component<CostChartProps, State> {
   }
 
   private getLegend = () => {
-    const { series } = this.state;
-
-    return <ChartLegend data={this.getLegendData(series)} height={25} gutter={20} name="legend" responsive={false} />;
+    return <ChartLegend data={this.getLegendData()} height={25} gutter={20} name="legend" responsive={false} />;
   };
 
   private getTooltipLabel = ({ datum }) => {
@@ -444,8 +436,9 @@ class CostChart extends React.Component<CostChartProps, State> {
   };
 
   // Returns legend data styled per hiddenSeries
-  private getLegendData = (series: CostChartSeries[], tooltip: boolean = false) => {
-    const { hiddenSeries } = this.state;
+  private getLegendData = (tooltip: boolean = false) => {
+    const { hiddenSeries, series } = this.state;
+
     if (series) {
       const result = series.map((s, index) => {
         const data = {
@@ -484,12 +477,13 @@ class CostChart extends React.Component<CostChartProps, State> {
           disable: !this.isDataAvailable(),
           labelComponent: (
             <ChartLegendTooltip
-              legendData={this.getLegendData(series, true)}
+              legendData={this.getLegendData(true)}
               title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
             />
           ),
         })
       : undefined;
+
     return (
       <>
         <Title headingLevel="h3" size="md">
@@ -504,7 +498,7 @@ class CostChart extends React.Component<CostChartProps, State> {
               height={height}
               legendAllowWrap
               legendComponent={this.getLegend()}
-              legendData={this.getLegendData(series)}
+              legendData={this.getLegendData()}
               legendPosition="bottom-left"
               padding={padding}
               theme={ChartTheme}

--- a/src/components/charts/historicalCostChart/__snapshots__/historicalCostChart.test.tsx.snap
+++ b/src/components/charts/historicalCostChart/__snapshots__/historicalCostChart.test.tsx.snap
@@ -1,48 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`reports are formatted to datums: current month cost data 1`] = `
-Array [
-  Object {
-    "key": "12-15-17",
-    "units": null,
-    "x": 15,
-    "y": 0,
-  },
-]
-`;
+exports[`reports are formatted to datums: current month cost data 1`] = `Array []`;
 
-exports[`reports are formatted to datums: current month infrastructure cost data 1`] = `
-Array [
-  Object {
-    "key": "1-15-18",
-    "units": null,
-    "x": 15,
-    "y": 0,
-  },
-]
-`;
+exports[`reports are formatted to datums: current month infrastructure cost data 1`] = `Array []`;
 
-exports[`reports are formatted to datums: previous month cost data 1`] = `
-Array [
-  Object {
-    "key": "12-15-17",
-    "units": null,
-    "x": 15,
-    "y": 0,
-  },
-]
-`;
+exports[`reports are formatted to datums: previous month cost data 1`] = `Array []`;
 
-exports[`reports are formatted to datums: previous month infrastructure cost data 1`] = `
-Array [
-  Object {
-    "key": "1-15-18",
-    "units": null,
-    "x": 15,
-    "y": 0,
-  },
-]
-`;
+exports[`reports are formatted to datums: previous month infrastructure cost data 1`] = `Array []`;
 
 exports[`trend is a daily value: current month data 1`] = `
 Array [

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -184,7 +184,7 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
         },
       },
     ];
-    const cursorVoronoiContainer = this.getCursorVoronoiContainer(series);
+    const cursorVoronoiContainer = this.getCursorVoronoiContainer();
     this.setState({ cursorVoronoiContainer, series });
   };
 
@@ -208,7 +208,7 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
   };
 
   // Returns CursorVoronoiContainer component
-  private getCursorVoronoiContainer = (series: HistoricalCostChartSeries[]) => {
+  private getCursorVoronoiContainer = () => {
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
 
@@ -216,12 +216,6 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
       <CursorVoronoiContainer
         cursorDimension="x"
         labels={this.getTooltipLabel}
-        labelComponent={
-          <ChartLegendTooltip
-            legendData={this.getLegendData(series, true)}
-            title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
-          />
-        }
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{
@@ -270,13 +264,11 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
 
   private getLegend = () => {
     const { legendItemsPerRow } = this.props;
-    const { series, width } = this.state;
+    const { width } = this.state;
 
     const itemsPerRow = legendItemsPerRow ? legendItemsPerRow : width > 700 ? chartStyles.itemsPerRow : 2;
 
-    return (
-      <ChartLegend data={this.getLegendData(series)} height={25} gutter={20} itemsPerRow={itemsPerRow} name="legend" />
-    );
+    return <ChartLegend data={this.getLegendData()} height={25} gutter={20} itemsPerRow={itemsPerRow} name="legend" />;
   };
 
   private getTooltipLabel = ({ datum }) => {
@@ -343,8 +335,9 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
   };
 
   // Returns legend data styled per hiddenSeries
-  private getLegendData = (series: HistoricalCostChartSeries[], tooltip: boolean = false) => {
-    const { hiddenSeries } = this.state;
+  private getLegendData = (tooltip: boolean = false) => {
+    const { hiddenSeries, series } = this.state;
+
     if (series) {
       const result = series.map((s, index) => {
         return {
@@ -389,8 +382,15 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
     const container = cursorVoronoiContainer
       ? React.cloneElement(cursorVoronoiContainer, {
           disable: !this.isDataAvailable(),
+          labelComponent: (
+            <ChartLegendTooltip
+              legendData={this.getLegendData(true)}
+              title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
+            />
+          ),
         })
       : undefined;
+
     return (
       <div className="chartOverride" ref={this.containerRef}>
         <Title headingLevel="h2" style={styles.title} size="xl">
@@ -404,7 +404,7 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
               events={this.getEvents()}
               height={height}
               legendComponent={this.getLegend()}
-              legendData={this.getLegendData(series)}
+              legendData={this.getLegendData()}
               legendPosition="bottom"
               padding={padding}
               theme={ChartTheme}

--- a/src/components/charts/historicalTrendChart/__snapshots__/historicalTrendChart.test.tsx.snap
+++ b/src/components/charts/historicalTrendChart/__snapshots__/historicalTrendChart.test.tsx.snap
@@ -1,57 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`reports are formatted to datums: current month data 1`] = `
-Array [
-  Object {
-    "key": "1-15-18",
-    "units": null,
-    "x": 15,
-    "y": 0,
-  },
-]
-`;
+exports[`reports are formatted to datums: current month data 1`] = `Array []`;
 
-exports[`reports are formatted to datums: previous month data 1`] = `
-Array [
-  Object {
-    "key": "12-15-17",
-    "units": null,
-    "x": 15,
-    "y": 0,
-  },
-]
-`;
+exports[`reports are formatted to datums: previous month data 1`] = `Array []`;
 
-exports[`trend is a daily value: current month data 1`] = `
-Array [
-  Object {
-    "key": "1-15-18",
-    "units": null,
-    "x": 15,
-    "y": 0,
-  },
-  Object {
-    "key": "1-16-18",
-    "units": null,
-    "x": 16,
-    "y": 0,
-  },
-]
-`;
+exports[`trend is a daily value: current month data 1`] = `Array []`;
 
-exports[`trend is a running total: current month data 1`] = `
-Array [
-  Object {
-    "key": "1-15-18",
-    "units": null,
-    "x": 15,
-    "y": 0,
-  },
-  Object {
-    "key": "1-16-18",
-    "units": null,
-    "x": 16,
-    "y": 0,
-  },
-]
-`;
+exports[`trend is a running total: current month data 1`] = `Array []`;

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -134,7 +134,7 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
         },
       },
     ];
-    const cursorVoronoiContainer = this.getCursorVoronoiContainer(series);
+    const cursorVoronoiContainer = this.getCursorVoronoiContainer();
     this.setState({ cursorVoronoiContainer, series });
   };
 
@@ -158,7 +158,7 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
   };
 
   // Returns CursorVoronoiContainer component
-  private getCursorVoronoiContainer = (series: HistoricalTrendChartSeries[]) => {
+  private getCursorVoronoiContainer = () => {
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
 
@@ -166,12 +166,6 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
       <CursorVoronoiContainer
         cursorDimension="x"
         labels={this.getTooltipLabel}
-        labelComponent={
-          <ChartLegendTooltip
-            legendData={this.getLegendData(series, true)}
-            title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
-          />
-        }
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{
@@ -216,16 +210,9 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
 
   private getLegend = () => {
     const { legendItemsPerRow } = this.props;
-    const { series } = this.state;
 
     return (
-      <ChartLegend
-        data={this.getLegendData(series)}
-        height={25}
-        gutter={20}
-        itemsPerRow={legendItemsPerRow}
-        name="legend"
-      />
+      <ChartLegend data={this.getLegendData()} height={25} gutter={20} itemsPerRow={legendItemsPerRow} name="legend" />
     );
   };
 
@@ -293,8 +280,9 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
   };
 
   // Returns legend data styled per hiddenSeries
-  private getLegendData = (series: HistoricalTrendChartSeries[], tooltip: boolean = false) => {
-    const { hiddenSeries } = this.state;
+  private getLegendData = (tooltip: boolean = false) => {
+    const { hiddenSeries, series } = this.state;
+
     if (series) {
       const result = series.map((s, index) => {
         return {
@@ -332,8 +320,15 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
     const container = cursorVoronoiContainer
       ? React.cloneElement(cursorVoronoiContainer, {
           disable: !this.isDataAvailable(),
+          labelComponent: (
+            <ChartLegendTooltip
+              legendData={this.getLegendData(true)}
+              title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
+            />
+          ),
         })
       : undefined;
+
     return (
       <div className="chartOverride" ref={this.containerRef}>
         <Title headingLevel="h2" style={styles.title} size="xl">
@@ -347,7 +342,7 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
               events={this.getEvents()}
               height={height}
               legendComponent={this.getLegend()}
-              legendData={this.getLegendData(series)}
+              legendData={this.getLegendData()}
               legendPosition="bottom"
               padding={padding}
               theme={ChartTheme}

--- a/src/components/charts/historicalUsageChart/__snapshots__/historicalUsageChart.test.tsx.snap
+++ b/src/components/charts/historicalUsageChart/__snapshots__/historicalUsageChart.test.tsx.snap
@@ -1,48 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`reports are formatted to datums: current month request data 1`] = `
-Array [
-  Object {
-    "key": "1-15-18",
-    "units": "unit",
-    "x": 15,
-    "y": 1,
-  },
-]
-`;
+exports[`reports are formatted to datums: current month request data 1`] = `Array []`;
 
-exports[`reports are formatted to datums: current month usage data 1`] = `
-Array [
-  Object {
-    "key": "12-15-17",
-    "units": "unit",
-    "x": 15,
-    "y": 1,
-  },
-]
-`;
+exports[`reports are formatted to datums: current month usage data 1`] = `Array []`;
 
-exports[`reports are formatted to datums: previous month request data 1`] = `
-Array [
-  Object {
-    "key": "1-15-18",
-    "units": "Core-Hours",
-    "x": 15,
-    "y": 0,
-  },
-]
-`;
+exports[`reports are formatted to datums: previous month request data 1`] = `Array []`;
 
-exports[`reports are formatted to datums: previous month usage data 1`] = `
-Array [
-  Object {
-    "key": "12-15-17",
-    "units": "Core-Hours",
-    "x": 15,
-    "y": 0,
-  },
-]
-`;
+exports[`reports are formatted to datums: previous month usage data 1`] = `Array []`;
 
 exports[`trend is a daily value: current month data 1`] = `
 Array [

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -228,7 +228,7 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
         },
       },
     ];
-    const cursorVoronoiContainer = this.getCursorVoronoiContainer(series);
+    const cursorVoronoiContainer = this.getCursorVoronoiContainer();
     this.setState({ cursorVoronoiContainer, series });
   };
 
@@ -252,7 +252,7 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
   };
 
   // Returns CursorVoronoiContainer component
-  private getCursorVoronoiContainer = (series: HistoricalUsageChartSeries[]) => {
+  private getCursorVoronoiContainer = () => {
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
 
@@ -260,12 +260,6 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
       <CursorVoronoiContainer
         cursorDimension="x"
         labels={this.getTooltipLabel}
-        labelComponent={
-          <ChartLegendTooltip
-            legendData={this.getLegendData(series, true)}
-            title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
-          />
-        }
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{
@@ -314,12 +308,10 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
 
   private getLegend = () => {
     const { legendItemsPerRow } = this.props;
-    const { series, width } = this.state;
+    const { width } = this.state;
     const itemsPerRow = legendItemsPerRow ? legendItemsPerRow : width > 900 ? chartStyles.itemsPerRow : 2;
 
-    return (
-      <ChartLegend data={this.getLegendData(series)} height={25} gutter={20} itemsPerRow={itemsPerRow} name="legend" />
-    );
+    return <ChartLegend data={this.getLegendData()} height={25} gutter={20} itemsPerRow={itemsPerRow} name="legend" />;
   };
 
   private getTooltipLabel = ({ datum }) => {
@@ -386,8 +378,9 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
   };
 
   // Returns legend data styled per hiddenSeries
-  private getLegendData = (series: HistoricalUsageChartSeries[], tooltip: boolean = false) => {
-    const { hiddenSeries } = this.state;
+  private getLegendData = (tooltip: boolean = false) => {
+    const { hiddenSeries, series } = this.state;
+
     if (series) {
       const result = series.map((s, index) => {
         return {
@@ -432,8 +425,15 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
     const container = cursorVoronoiContainer
       ? React.cloneElement(cursorVoronoiContainer, {
           disable: !this.isDataAvailable(),
+          labelComponent: (
+            <ChartLegendTooltip
+              legendData={this.getLegendData(true)}
+              title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
+            />
+          ),
         })
       : undefined;
+
     return (
       <div className="chartOverride" ref={this.containerRef}>
         <Title headingLevel="h2" style={styles.title} size="xl">
@@ -447,7 +447,7 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
               events={this.getEvents()}
               height={height}
               legendComponent={this.getLegend()}
-              legendData={this.getLegendData(series)}
+              legendData={this.getLegendData()}
               legendPosition="bottom"
               padding={padding}
               theme={ChartTheme}

--- a/src/components/charts/trendChart/__snapshots__/trendChart.test.tsx.snap
+++ b/src/components/charts/trendChart/__snapshots__/trendChart.test.tsx.snap
@@ -1,57 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`reports are formatted to datums: current month data 1`] = `
-Array [
-  Object {
-    "key": "1-15-18",
-    "units": null,
-    "x": 15,
-    "y": 0,
-  },
-]
-`;
+exports[`reports are formatted to datums: current month data 1`] = `Array []`;
 
-exports[`reports are formatted to datums: previous month data 1`] = `
-Array [
-  Object {
-    "key": "12-15-17",
-    "units": null,
-    "x": 15,
-    "y": 0,
-  },
-]
-`;
+exports[`reports are formatted to datums: previous month data 1`] = `Array []`;
 
-exports[`trend is a daily value: current month data 1`] = `
-Array [
-  Object {
-    "key": "1-15-18",
-    "units": null,
-    "x": 15,
-    "y": 0,
-  },
-  Object {
-    "key": "1-16-18",
-    "units": null,
-    "x": 16,
-    "y": 0,
-  },
-]
-`;
+exports[`trend is a daily value: current month data 1`] = `Array []`;
 
-exports[`trend is a running total: current month data 1`] = `
-Array [
-  Object {
-    "key": "1-15-18",
-    "units": null,
-    "x": 15,
-    "y": 0,
-  },
-  Object {
-    "key": "1-16-18",
-    "units": null,
-    "x": 16,
-    "y": 0,
-  },
-]
-`;
+exports[`trend is a running total: current month data 1`] = `Array []`;

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -203,7 +203,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         },
       });
     }
-    const cursorVoronoiContainer = this.getCursorVoronoiContainer(series);
+    const cursorVoronoiContainer = this.getCursorVoronoiContainer();
     this.setState({ cursorVoronoiContainer, series });
   };
 
@@ -232,7 +232,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   };
 
   // Returns CursorVoronoiContainer component
-  private getCursorVoronoiContainer = (series: TrendChartSeries[]) => {
+  private getCursorVoronoiContainer = () => {
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
 
@@ -240,12 +240,6 @@ class TrendChart extends React.Component<TrendChartProps, State> {
       <CursorVoronoiContainer
         cursorDimension="x"
         labels={this.getTooltipLabel}
-        labelComponent={
-          <ChartLegendTooltip
-            legendData={this.getLegendData(series, true)}
-            title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
-          />
-        }
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{
@@ -291,12 +285,12 @@ class TrendChart extends React.Component<TrendChartProps, State> {
 
   private getLegend = () => {
     const { legendItemsPerRow } = this.props;
-    const { series, width } = this.state;
+    const { width } = this.state;
 
     // Todo: use PF legendAllowWrap feature
     return (
       <ChartLegend
-        data={this.getLegendData(series)}
+        data={this.getLegendData()}
         gutter={20}
         height={25}
         itemsPerRow={legendItemsPerRow}
@@ -398,8 +392,9 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   };
 
   // Returns legend data styled per hiddenSeries
-  private getLegendData = (series: TrendChartSeries[], tooltip: boolean = false) => {
-    const { hiddenSeries } = this.state;
+  private getLegendData = (tooltip: boolean = false) => {
+    const { hiddenSeries, series } = this.state;
+
     if (series) {
       const result = series.map((s, index) => {
         return {
@@ -434,8 +429,15 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     const container = cursorVoronoiContainer
       ? React.cloneElement(cursorVoronoiContainer, {
           disable: !this.isDataAvailable(),
+          labelComponent: (
+            <ChartLegendTooltip
+              legendData={this.getLegendData(true)}
+              title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
+            />
+          ),
         })
       : undefined;
+
     return (
       <>
         <Title headingLevel="h3" size="md">
@@ -450,7 +452,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
               height={height}
               legendAllowWrap
               legendComponent={this.getLegend()}
-              legendData={this.getLegendData(series)}
+              legendData={this.getLegendData()}
               legendPosition="bottom-left"
               padding={padding}
               theme={ChartTheme}

--- a/src/components/charts/usageChart/__snapshots__/usageChart.test.tsx.snap
+++ b/src/components/charts/usageChart/__snapshots__/usageChart.test.tsx.snap
@@ -1,48 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`reports are formatted to datums: current month request data 1`] = `
-Array [
-  Object {
-    "key": "1-15-18",
-    "units": undefined,
-    "x": 15,
-    "y": 0,
-  },
-]
-`;
+exports[`reports are formatted to datums: current month request data 1`] = `Array []`;
 
-exports[`reports are formatted to datums: current month usage data 1`] = `
-Array [
-  Object {
-    "key": "12-15-17",
-    "units": undefined,
-    "x": 15,
-    "y": 0,
-  },
-]
-`;
+exports[`reports are formatted to datums: current month usage data 1`] = `Array []`;
 
-exports[`reports are formatted to datums: previous month request data 1`] = `
-Array [
-  Object {
-    "key": "1-15-18",
-    "units": "Core-Hours",
-    "x": 15,
-    "y": 0,
-  },
-]
-`;
+exports[`reports are formatted to datums: previous month request data 1`] = `Array []`;
 
-exports[`reports are formatted to datums: previous month usage data 1`] = `
-Array [
-  Object {
-    "key": "12-15-17",
-    "units": "Core-Hours",
-    "x": 15,
-    "y": 0,
-  },
-]
-`;
+exports[`reports are formatted to datums: previous month usage data 1`] = `Array []`;
 
 exports[`trend is a daily value: current month data 1`] = `
 Array [

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -161,7 +161,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
         style: chartStyles.currentRequestData,
       },
     ];
-    const cursorVoronoiContainer = this.getCursorVoronoiContainer(series);
+    const cursorVoronoiContainer = this.getCursorVoronoiContainer();
     this.setState({ cursorVoronoiContainer, series });
   };
 
@@ -189,7 +189,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
   };
 
   // Returns CursorVoronoiContainer component
-  private getCursorVoronoiContainer = (series: UsageChartSeries[]) => {
+  private getCursorVoronoiContainer = () => {
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
 
@@ -197,12 +197,6 @@ class UsageChart extends React.Component<UsageChartProps, State> {
       <CursorVoronoiContainer
         cursorDimension="x"
         labels={this.getTooltipLabel}
-        labelComponent={
-          <ChartLegendTooltip
-            legendData={this.getLegendData(series, true)}
-            title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
-          />
-        }
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{
@@ -251,14 +245,12 @@ class UsageChart extends React.Component<UsageChartProps, State> {
 
   private getLegend = () => {
     const { legendItemsPerRow } = this.props;
-    const { series, width } = this.state;
+    const { width } = this.state;
 
     // Todo: use PF legendAllowWrap feature
     const itemsPerRow = legendItemsPerRow ? legendItemsPerRow : width > 300 ? chartStyles.itemsPerRow : 1;
 
-    return (
-      <ChartLegend data={this.getLegendData(series)} height={25} gutter={20} itemsPerRow={itemsPerRow} name="legend" />
-    );
+    return <ChartLegend data={this.getLegendData()} height={25} gutter={20} itemsPerRow={itemsPerRow} name="legend" />;
   };
 
   private getTooltipLabel = ({ datum }) => {
@@ -338,8 +330,9 @@ class UsageChart extends React.Component<UsageChartProps, State> {
   };
 
   // Returns legend data styled per hiddenSeries
-  private getLegendData = (series: UsageChartSeries[], tooltip: boolean = false) => {
-    const { hiddenSeries } = this.state;
+  private getLegendData = (tooltip: boolean = false) => {
+    const { hiddenSeries, series } = this.state;
+
     if (series) {
       const result = series.map((s, index) => {
         return {
@@ -374,8 +367,15 @@ class UsageChart extends React.Component<UsageChartProps, State> {
     const container = cursorVoronoiContainer
       ? React.cloneElement(cursorVoronoiContainer, {
           disable: !this.isDataAvailable(),
+          labelComponent: (
+            <ChartLegendTooltip
+              legendData={this.getLegendData(true)}
+              title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
+            />
+          ),
         })
       : undefined;
+
     return (
       <>
         <Title headingLevel="h3" size="md">
@@ -389,7 +389,7 @@ class UsageChart extends React.Component<UsageChartProps, State> {
               events={this.getEvents()}
               height={height}
               legendComponent={this.getLegend()}
-              legendData={this.getLegendData(series)}
+              legendData={this.getLegendData()}
               legendPosition="bottom-left"
               padding={padding}
               theme={ChartTheme}


### PR DESCRIPTION
This ensures chart tooltips are updated properly when a data series is hidden / shown. Although the container view is stored in state, the tooltip legend data still needs to be updated upon each render.

https://issues.redhat.com/browse/COST-806