### PR TITLE
Fetch forecast data for dev & QA only

### DIFF
--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -85,13 +85,13 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     if (availableTabs) {
       updateTab(id, availableTabs[0]);
     }
-    if (fetchForecasts) {
-      fetchForecasts(widgetId);
-    }
     if (fetchReports) {
       fetchReports(widgetId);
     }
     isForecastAuthorized().then(val => {
+      if (val && fetchForecasts) {
+        fetchForecasts(widgetId);
+      }
       this.setState({ forecastAuthorized: val });
     });
   }


### PR DESCRIPTION
This ensures forecast APIs are called only for the cost-demo and insights-qa users. That is, until the forecast feature is fully tested and ready for production.

https://issues.redhat.com/browse/COST-806