### PR TITLE
OpenShift infrastructure forecast

### DIFF
--- a/src/api/forecasts/forecast.ts
+++ b/src/api/forecasts/forecast.ts
@@ -43,6 +43,7 @@ export interface Forecast {
 // eslint-disable-next-line no-shadow
 export const enum ForecastType {
   cost = 'cost',
+  infrastructure = 'infrastructure',
   supplementary = 'supplementary',
 }
 

--- a/src/api/forecasts/ocpForecast.ts
+++ b/src/api/forecasts/ocpForecast.ts
@@ -4,6 +4,7 @@ import { Forecast, ForecastType } from './forecast';
 
 export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
   [ForecastType.cost]: 'forecasts/openshift/costs/',
+  [ForecastType.infrastructure]: 'forecasts/openshift/costs/',
   [ForecastType.supplementary]: 'forecasts/openshift/costs/',
 };
 

--- a/src/components/charts/common/chartUtils.ts
+++ b/src/components/charts/common/chartUtils.ts
@@ -362,6 +362,22 @@ export function getMaxValue(datums: ChartDatum[]) {
   return max;
 }
 
+export function getMaxMinValues(datums: ChartDatum[]) {
+  let max = 0;
+  let min = 0;
+  if (datums && datums.length) {
+    datums.forEach(datum => {
+      if (datum.y > max) {
+        max = datum.y;
+      }
+      if ((min === 0 || datum.y < min) && datum.y !== null) {
+        min = datum.y;
+      }
+    });
+  }
+  return { max, min };
+}
+
 export function getTooltipContent(formatValue) {
   return function labelFormatter(value: number, unit: string = null, options: FormatOptions = {}) {
     const lookup = unitLookupKey(unit);

--- a/src/components/charts/costChart/costChart.styles.ts
+++ b/src/components/charts/costChart/costChart.styles.ts
@@ -1,4 +1,9 @@
 import { chart_color_black_200 } from '@patternfly/react-tokens/dist/js/chart_color_black_200';
+import { chart_color_blue_100 } from '@patternfly/react-tokens/dist/js/chart_color_blue_100';
+import { chart_color_blue_200 } from '@patternfly/react-tokens/dist/js/chart_color_blue_200';
+import { chart_color_blue_300 } from '@patternfly/react-tokens/dist/js/chart_color_blue_300';
+import { chart_color_blue_400 } from '@patternfly/react-tokens/dist/js/chart_color_blue_400';
+import { chart_color_blue_500 } from '@patternfly/react-tokens/dist/js/chart_color_blue_500';
 import { chart_color_green_100 } from '@patternfly/react-tokens/dist/js/chart_color_green_100';
 import { chart_color_green_200 } from '@patternfly/react-tokens/dist/js/chart_color_green_200';
 import { chart_color_green_300 } from '@patternfly/react-tokens/dist/js/chart_color_green_300';
@@ -17,19 +22,35 @@ export const chartStyles = {
   currentCostData: {
     fill: 'none',
   },
+  currentInfrastructureColorScale: [
+    chart_color_blue_400.value,
+    chart_color_blue_300.value,
+    chart_color_blue_200.value,
+    chart_color_blue_100.value,
+    chart_color_blue_500.value,
+  ],
   currentInfrastructureCostData: {
     fill: 'none',
     strokeDasharray: '3,3',
-  },
-  forecastColorScale: [chart_color_green_200.value],
-  forecastConeColorScale: [chart_color_green_100.value],
-  forecastData: {
-    fill: 'none',
   },
   forecastConeData: {
     fill: chart_color_green_100.value,
     strokeWidth: 0,
   },
+  forecastConeDataColorScale: [chart_color_green_100.value],
+  forecastData: {
+    fill: 'none',
+  },
+  forecastDataColorScale: [chart_color_green_200.value],
+  forecastInfrastructureConeData: {
+    fill: chart_color_blue_100.value,
+    strokeWidth: 0,
+  },
+  forecastInfrastructureConeDataColorScale: [chart_color_blue_100.value],
+  forecastInfrastructureData: {
+    fill: 'none',
+  },
+  forecastInfrastructureDataColorScale: [chart_color_blue_200.value],
   previousCostData: {
     fill: 'none',
   },

--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -12,7 +12,12 @@ import {
 } from '@patternfly/react-charts';
 import { Title } from '@patternfly/react-core';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import { getCostRangeString, getDateRange, getMaxValue, getTooltipContent } from 'components/charts/common/chartUtils';
+import {
+  getCostRangeString,
+  getDateRange,
+  getMaxMinValues,
+  getTooltipContent,
+} from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
 import React from 'react';
@@ -350,19 +355,29 @@ class CostChart extends React.Component<CostChartProps, State> {
 
     const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
     let maxValue = 0;
+    let minValue = 0;
 
     if (series) {
       series.forEach((s: any, index) => {
         if (!this.isSeriesHidden(index) && s.data && s.data.length !== 0) {
-          const max = getMaxValue(s.data);
+          const { max, min } = getMaxMinValues(s.data);
           maxValue = Math.max(maxValue, max);
+          if (minValue === 0) {
+            minValue = min;
+          } else {
+            minValue = Math.min(minValue, min);
+          }
         }
       });
     }
 
-    const max = maxValue > 0 ? Math.ceil(maxValue + maxValue * 0.1) : 0;
+    const threshold = maxValue * 0.1;
+    const max = maxValue > 0 ? Math.ceil(maxValue + threshold) : 0;
+    const _min = minValue > 0 ? Math.max(0, Math.floor(minValue - threshold)) : 0;
+    const min = _min > 0 ? _min : 0;
+
     if (max > 0) {
-      domain.y = [0, max];
+      domain.y = [min, max];
     }
     return domain;
   }

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -12,7 +12,7 @@ import {
 } from '@patternfly/react-charts';
 import { Title } from '@patternfly/react-core';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import { getCostRangeString, getMaxValue, getTooltipContent } from 'components/charts/common/chartUtils';
+import { getCostRangeString, getMaxMinValues, getTooltipContent } from 'components/charts/common/chartUtils';
 import { getDateRange } from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
@@ -233,19 +233,29 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
 
     const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
     let maxValue = 0;
+    let minValue = 0;
 
     if (series) {
       series.forEach((s: any, index) => {
         if (!this.isSeriesHidden(index) && s.data && s.data.length !== 0) {
-          const max = getMaxValue(s.data);
+          const { max, min } = getMaxMinValues(s.data);
           maxValue = Math.max(maxValue, max);
+          if (minValue === 0) {
+            minValue = min;
+          } else {
+            minValue = Math.min(minValue, min);
+          }
         }
       });
     }
 
-    const max = maxValue > 0 ? Math.ceil(maxValue + maxValue * 0.1) : 0;
+    const threshold = maxValue * 0.1;
+    const max = maxValue > 0 ? Math.ceil(maxValue + threshold) : 0;
+    const _min = minValue > 0 ? Math.max(0, Math.floor(minValue - threshold)) : 0;
+    const min = _min > 0 ? _min : 0;
+
     if (max > 0) {
-      domain.y = [0, max];
+      domain.y = [min, max];
     }
     return domain;
   }

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -12,7 +12,12 @@ import {
 } from '@patternfly/react-charts';
 import { Title } from '@patternfly/react-core';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import { getCostRangeString, getDateRange, getMaxValue, getTooltipContent } from 'components/charts/common/chartUtils';
+import {
+  getCostRangeString,
+  getDateRange,
+  getMaxMinValues,
+  getTooltipContent,
+} from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
 import React from 'react';
@@ -183,19 +188,29 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
 
     const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
     let maxValue = 0;
+    let minValue = 0;
 
     if (series) {
       series.forEach((s: any, index) => {
         if (!this.isSeriesHidden(index) && s.data && s.data.length !== 0) {
-          const max = getMaxValue(s.data);
+          const { max, min } = getMaxMinValues(s.data);
           maxValue = Math.max(maxValue, max);
+          if (minValue === 0) {
+            minValue = min;
+          } else {
+            minValue = Math.min(minValue, min);
+          }
         }
       });
     }
 
-    const max = maxValue > 0 ? Math.ceil(maxValue + maxValue * 0.1) : 0;
+    const threshold = maxValue * 0.1;
+    const max = maxValue > 0 ? Math.ceil(maxValue + threshold) : 0;
+    const _min = minValue > 0 ? Math.max(0, Math.floor(minValue - threshold)) : 0;
+    const min = _min > 0 ? _min : 0;
+
     if (max > 0) {
-      domain.y = [0, max];
+      domain.y = [min, max];
     }
     return domain;
   }

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -12,7 +12,7 @@ import {
 } from '@patternfly/react-charts';
 import { Title } from '@patternfly/react-core';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import { getDateRange, getMaxValue } from 'components/charts/common/chartUtils';
+import { getDateRange, getMaxMinValues } from 'components/charts/common/chartUtils';
 import { getTooltipContent, getUsageRangeString } from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
@@ -277,19 +277,29 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
 
     const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
     let maxValue = 0;
+    let minValue = 0;
 
     if (series) {
       series.forEach((s: any, index) => {
         if (!this.isSeriesHidden(index) && s.data && s.data.length !== 0) {
-          const max = getMaxValue(s.data);
+          const { max, min } = getMaxMinValues(s.data);
           maxValue = Math.max(maxValue, max);
+          if (minValue === 0) {
+            minValue = min;
+          } else {
+            minValue = Math.min(minValue, min);
+          }
         }
       });
     }
 
-    const max = maxValue > 0 ? Math.ceil(maxValue + maxValue * 0.1) : 0;
+    const threshold = maxValue * 0.1;
+    const max = maxValue > 0 ? Math.ceil(maxValue + threshold) : 0;
+    const _min = minValue > 0 ? Math.max(0, Math.floor(minValue - threshold)) : 0;
+    const min = _min > 0 ? _min : 0;
+
     if (max > 0) {
-      domain.y = [0, max];
+      domain.y = [min, max];
     }
     return domain;
   }

--- a/src/components/charts/trendChart/trendChart.styles.ts
+++ b/src/components/charts/trendChart/trendChart.styles.ts
@@ -17,15 +17,15 @@ export const chartStyles = {
   currentMonthData: {
     fill: 'none',
   },
-  forecastColorScale: [chart_color_green_200.value],
-  forecastConeColorScale: [chart_color_green_100.value],
-  forecastData: {
-    fill: 'none',
-  },
   forecastConeData: {
     fill: chart_color_green_100.value,
     strokeWidth: 0,
   },
+  forecastConeDataColorScale: [chart_color_green_100.value],
+  forecastData: {
+    fill: 'none',
+  },
+  forecastDataColorScale: [chart_color_green_200.value],
   itemsPerRow: 4,
   // See: https://github.com/project-koku/koku-ui/issues/241
   previousColorScale: [chart_color_black_200.value, chart_color_black_200.value],

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -12,7 +12,12 @@ import {
 } from '@patternfly/react-charts';
 import { Title } from '@patternfly/react-core';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import { getCostRangeString, getDateRange, getMaxValue, getTooltipContent } from 'components/charts/common/chartUtils';
+import {
+  getCostRangeString,
+  getDateRange,
+  getMaxMinValues,
+  getTooltipContent,
+} from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
 import React from 'react';
@@ -257,19 +262,29 @@ class TrendChart extends React.Component<TrendChartProps, State> {
 
     const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
     let maxValue = 0;
+    let minValue = 0;
 
     if (series) {
       series.forEach((s: any, index) => {
         if (!this.isSeriesHidden(index) && s.data && s.data.length !== 0) {
-          const max = getMaxValue(s.data);
+          const { max, min } = getMaxMinValues(s.data);
           maxValue = Math.max(maxValue, max);
+          if (minValue === 0) {
+            minValue = min;
+          } else {
+            minValue = Math.min(minValue, min);
+          }
         }
       });
     }
 
-    const max = maxValue > 0 ? Math.ceil(maxValue + maxValue * 0.1) : 0;
+    const threshold = maxValue * 0.1;
+    const max = maxValue > 0 ? Math.ceil(maxValue + threshold) : 0;
+    const _min = minValue > 0 ? Math.max(0, Math.floor(minValue - threshold)) : 0;
+    const min = _min > 0 ? _min : 0;
+
     if (max > 0) {
-      domain.y = [0, max];
+      domain.y = [min, max];
     }
     return domain;
   }

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -172,7 +172,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         legendItem: {
           name: getCostRangeString(forecastData, 'chart.cost_forecast_legend_label', false, false),
           symbol: {
-            fill: chartStyles.forecastColorScale[0],
+            fill: chartStyles.forecastDataColorScale[0],
             type: 'minus',
           },
           tooltip: getCostRangeString(forecastData, 'chart.cost_forecast_legend_tooltip', false, false),
@@ -180,7 +180,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         style: {
           data: {
             ...chartStyles.forecastData,
-            stroke: chartStyles.forecastColorScale[0],
+            stroke: chartStyles.forecastDataColorScale[0],
           },
         },
       });
@@ -190,7 +190,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         legendItem: {
           name: getCostRangeString(forecastConeData, 'chart.cost_forecast_cone_legend_label', false, false),
           symbol: {
-            fill: chartStyles.forecastConeColorScale[0],
+            fill: chartStyles.forecastConeDataColorScale[0],
             type: 'triangleUp',
           },
           tooltip: getCostRangeString(forecastConeData, 'chart.cost_forecast_cone_legend_tooltip', false, false),
@@ -198,7 +198,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         style: {
           data: {
             ...chartStyles.forecastConeData,
-            stroke: chartStyles.forecastConeColorScale[0],
+            stroke: chartStyles.forecastConeDataColorScale[0],
           },
         },
       });
@@ -318,16 +318,26 @@ class TrendChart extends React.Component<TrendChartProps, State> {
 
   // Hide each data series individually
   private handleLegendClick = props => {
-    // Todo: Leave one legend item visible at all times?
-    // const { hiddenSeries, series } = this.state;
-    // const leaveVisible = hiddenSeries.size === series.length - 1;
-    // if (leaveVisible && !this.isSeriesHidden(props.index)) {
-    //   return;
-    // }
-    if (!this.state.hiddenSeries.delete(props.index)) {
-      this.state.hiddenSeries.add(props.index);
+    const { hiddenSeries, series } = this.state;
+
+    // Toggle forecast confidence
+    const childName = series[props.index].childName;
+    if (childName.indexOf('forecast') !== -1) {
+      let index;
+      for (let i = 0; i < series.length; i++) {
+        if (series[i].childName === `${childName}Cone`) {
+          index = i;
+          break;
+        }
+      }
+      if (index !== undefined && !hiddenSeries.delete(index)) {
+        hiddenSeries.add(index);
+      }
     }
-    this.setState({ hiddenSeries: new Set(this.state.hiddenSeries) });
+    if (!hiddenSeries.delete(props.index)) {
+      hiddenSeries.add(props.index);
+    }
+    this.setState({ hiddenSeries: new Set(hiddenSeries) });
   };
 
   // Returns true if at least one data series is available
@@ -404,8 +414,9 @@ class TrendChart extends React.Component<TrendChartProps, State> {
           ...getInteractiveLegendItemStyles(hiddenSeries.has(index)), // hidden styles
         };
       });
-      return result;
+      return tooltip ? result : result.filter(d => d.childName.indexOf('Cone') === -1);
     }
+    return undefined;
   };
 
   public render() {

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -12,7 +12,12 @@ import {
 } from '@patternfly/react-charts';
 import { Title } from '@patternfly/react-core';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import { getDateRange, getMaxValue, getTooltipContent, getUsageRangeString } from 'components/charts/common/chartUtils';
+import {
+  getDateRange,
+  getMaxMinValues,
+  getTooltipContent,
+  getUsageRangeString,
+} from 'components/charts/common/chartUtils';
 import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
 import React from 'react';
@@ -214,19 +219,29 @@ class UsageChart extends React.Component<UsageChartProps, State> {
 
     const domain: { x: DomainTuple; y?: DomainTuple } = { x: [1, 31] };
     let maxValue = 0;
+    let minValue = 0;
 
     if (series) {
       series.forEach((s: any, index) => {
         if (!this.isSeriesHidden(index) && s.data && s.data.length !== 0) {
-          const max = getMaxValue(s.data);
+          const { max, min } = getMaxMinValues(s.data);
           maxValue = Math.max(maxValue, max);
+          if (minValue === 0) {
+            minValue = min;
+          } else {
+            minValue = Math.min(minValue, min);
+          }
         }
       });
     }
 
-    const max = maxValue > 0 ? Math.ceil(maxValue + maxValue * 0.1) : 0;
+    const threshold = maxValue * 0.1;
+    const max = maxValue > 0 ? Math.ceil(maxValue + threshold) : 0;
+    const _min = minValue > 0 ? Math.max(0, Math.floor(minValue - threshold)) : 0;
+    const min = _min > 0 ? _min : 0;
+
     if (max > 0) {
-      domain.y = [0, max];
+      domain.y = [min, max];
     }
     return domain;
   }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -132,6 +132,7 @@
     "usage_cost_title": "Usage cost"
   },
   "chart": {
+    "cos_infrastructuret_forecast_legend_label_plural": "Infrastructure forecast ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
     "cost_forecast_cone_legend_label": "Cost confidence ({{startDate}} $t(months_abbr.{{month}}))",
     "cost_forecast_cone_legend_label_plural": "Cost confidence ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
     "cost_forecast_cone_legend_tooltip": "Cost confidence ($t(months_abbr.{{month}}))",
@@ -139,6 +140,12 @@
     "cost_forecast_legend_label": "Cost forecast ({{startDate}} $t(months_abbr.{{month}}))",
     "cost_forecast_legend_label_plural": "Cost forecast ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
     "cost_forecast_legend_tooltip": "Cost forecast ($t(months_abbr.{{month}}))",
+    "cost_infrastructure_forecast_cone_legend_label": "Infrastructure confidence ({{startDate}} $t(months_abbr.{{month}}))",
+    "cost_infrastructure_forecast_cone_legend_label_plural": "Infrastructure confidence ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
+    "cost_infrastructure_forecast_cone_legend_tooltip": "Infrastructure confidence ($t(months_abbr.{{month}}))",
+    "cost_infrastructure_forecast_cone_tooltip": "{{value0}} - {{value1}}",
+    "cost_infrastructure_forecast_legend_label": "Infrastructure forecast ({{startDate}} $t(months_abbr.{{month}}))",
+    "cost_infrastructure_forecast_legend_tooltip": "Infrastructure forecast ($t(months_abbr.{{month}}))",
     "cost_infrastructure_legend_label": "Infrastructure cost ({{startDate}} $t(months_abbr.{{month}}))",
     "cost_infrastructure_legend_label_plural": "Infrastructure cost ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
     "cost_infrastructure_legend_tooltip": "Infrastructure cost ($t(months_abbr.{{month}}))",

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -168,7 +168,8 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     );
 
     // Forecast data
-    const { forecastData, forecastConeData } = this.getForecastData();
+    const forecastData = this.getForecastData(currentReport, trend.computedForecastItem);
+    const forecastInfrastructureData = this.getForecastData(currentReport, trend.computedForecastInfrastructureItem);
 
     return (
       <ReportSummaryCost
@@ -176,8 +177,10 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         containerHeight={containerHeight}
         currentCostData={currentCostData}
         currentInfrastructureCostData={currentInfrastructureData}
-        forecastData={forecastData}
-        forecastConeData={forecastConeData}
+        forecastConeData={forecastData.forecastConeData}
+        forecastData={forecastData.forecastData}
+        forecastInfrastructureConeData={forecastInfrastructureData.forecastConeData}
+        forecastInfrastructureData={forecastInfrastructureData.forecastData}
         formatDatumValue={formatValue}
         formatDatumOptions={trend.formatOptions}
         height={height}
@@ -189,10 +192,9 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     );
   };
 
-  private getForecastData = () => {
-    const { currentReport, forecast, trend } = this.props;
+  private getForecastData = (report: Report, computedForecastItem: string = 'cost') => {
+    const { forecast, trend } = this.props;
 
-    const computedForecastItem = trend.computedForecastItem;
     let forecastData;
     let forecastConeData;
 
@@ -201,14 +203,14 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
       if (newForecast) {
         newForecast.data = [];
       }
-      if (forecast && currentReport && currentReport.data) {
+      if (forecast && report && report.data) {
         const total =
-          currentReport.meta && currentReport.meta.total && currentReport.meta.total.cost
-            ? currentReport.meta.total.cost.total.value
+          report.meta && report.meta.total && report.meta.total[computedForecastItem]
+            ? report.meta.total[computedForecastItem].total.value
             : 0;
 
         // Find last currentData date with values
-        const reportedValues = currentReport.data.filter(val => val.values.length);
+        const reportedValues = report.data.filter(val => val.values.length);
         const lastReported = reportedValues[reportedValues.length - 1]
           ? reportedValues[reportedValues.length - 1].date
           : undefined;
@@ -306,7 +308,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     );
 
     // Forecast data
-    const { forecastData, forecastConeData } = this.getForecastData();
+    const { forecastData, forecastConeData } = this.getForecastData(currentReport, trend.computedForecastItem);
 
     return (
       <ReportSummaryTrend

--- a/src/store/dashboard/common/dashboardCommon.ts
+++ b/src/store/dashboard/common/dashboardCommon.ts
@@ -55,6 +55,7 @@ export interface DashboardWidget<T> {
   };
   trend: {
     computedForecastItem?: string; // The computed forecast item to use in charts.
+    computedForecastInfrastructureItem?: string; // The computed forecast infrastructure item to use in charts.
     computedReportItem: string; // The computed report item to use in charts, summary, etc.
     computedReportItemValue: string; // The computed report value (e.g., raw, markup, total, or usage)
     titleKey: string;

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -34,6 +34,7 @@ export const costSummaryWidget: OcpDashboardWidget = {
   },
   trend: {
     computedForecastItem: ComputedForecastItemType.cost,
+    computedForecastInfrastructureItem: ComputedForecastItemType.infrastructure,
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},


### PR DESCRIPTION
Added the infrastructure forecast to the OpenShift overview page. For clarity, we changed the infrastructure color from green to blue.

Note that the forecast confidence is still shown in the chart, but it has been omitted from the legend items. This was done because the legend is becoming too crowded.

When you hover over the legend item, it highlights just the forecast line. However, when you click on the legend item, it hides both the forecast line and forecast confidence cone.

The tooltip still shows both forecast and confidence, but the confidence cone appears as the last item in the list. The tooltip and legend items must appear in the same order so the indexes match exactly for on-hover events.

https://issues.redhat.com/browse/COST-817

![chrome-capture 2 14 38 PM](https://user-images.githubusercontent.com/17481322/102267345-c2b5e480-3ee7-11eb-92d3-d84dbe2b6599.gif)
