### PR TITLE
Unable to assign a source to a cost model via the UI

### DIFF
--- a/src/pages/costModels/costModelsDetails/addSourceWizard.tsx
+++ b/src/pages/costModels/costModelsDetails/addSourceWizard.tsx
@@ -151,7 +151,7 @@ export default connect(
       isLoadingSources: sourcesSelectors.status(state) === FetchStatus.inProgress,
       isUpdateInProgress: costModelsSelectors.updateProcessing(state),
       updateApiError: costModelsSelectors.updateError(state),
-      fetchingSourcesError: sourcesSelectors.error(state) ? parseApiError(sourcesSelectors.error(state)) : '',
+      fetchingSourcesError: sourcesSelectors.error(state) ? parseApiError(sourcesSelectors.error(state)) : null,
     };
   }),
   {


### PR DESCRIPTION
The problem is that the button is disabled via testing `fetchingSourcesError` for null, while the value is assigned an empty string.

https://issues.redhat.com/browse/COST-841

<img width="1748" alt="Screen Shot 2020-12-18 at 10 33 12 AM" src="https://user-images.githubusercontent.com/17481322/102632131-a0f17300-411c-11eb-8a59-cdeb15cc814a.png">
