### PR TITLE
Last forecast date not shown

### DIFF
--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -219,13 +219,13 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         if (forecast && forecast.data) {
           const lastReportedDate = new Date(lastReported);
           const lastReportedMonth = lastReportedDate.getMonth() + 1;
-          for (let i = 0; i < forecast.data.length - 1; i++) {
-            const forecastDate = new Date(forecast.data[i].date);
+          for (const item of forecast.data) {
+            const forecastDate = new Date(item.date);
             const forecastMonth = forecastDate.getMonth() + 1;
 
             // Ensure month match. AWS forecast currently starts with "2020-12-04", but ends on "2021-01-01"
             if (forecastDate > lastReportedDate && lastReportedMonth === forecastMonth) {
-              newForecast.data.push(forecast.data[i]);
+              newForecast.data.push(item);
             }
           }
         }


### PR DESCRIPTION
The last forecast date is not shown. It currently stops on 12/30; although, we have data for 12/31.

https://issues.redhat.com/browse/COST-844

<img width="1878" alt="Screen Shot 2020-12-21 at 11 34 55 AM" src="https://user-images.githubusercontent.com/17481322/102799459-91726400-4380-11eb-8260-ef295c473422.png">
