### PR TITLE
Daily chart for "All OpenShift cost" overview

### DIFF
--- a/src/components/charts/common/chartUtils.ts
+++ b/src/components/charts/common/chartUtils.ts
@@ -223,10 +223,6 @@ export function fillChartDatums(datums: ChartDatum[], type: ChartType = ChartTyp
   if (!datums || datums.length === 0) {
     return result;
   }
-  // Todo: Omit null values to extrapolate data?
-  // if (type === ChartType.daily) {
-  //   return datums;
-  // }
   const firstDate = new Date(datums[0].key + 'T00:00:00');
   const lastDate = new Date(datums[datums.length - 1].key + 'T00:00:00');
 
@@ -246,11 +242,9 @@ export function fillChartDatums(datums: ChartDatum[], type: ChartType = ChartTyp
       });
     }
     if (chartDatum) {
-      // Todo: Omit null values to extrapolate data?
-      //
-      // Although we want to show when there is missing data, charts won't extrapolate (connect the dots) if we return null
-      // here for missing daily values. If there is only data for the first and last day of the month; for example, a chart
-      // would draw a line between the two points by default. However, showing "no data" is more obvious there was a problem.
+      // Note: We want to identify missing data, but charts won't extrapolate (connect data points) if we return null here
+      // for missing daily values. For example, if there is only data for the first and last day of the month, charts would
+      // typically draw a line between two points by default. However, showing "no data" is more obvious there was a problem.
       if (type === ChartType.daily) {
         prevChartDatum = {
           key: id,

--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -562,8 +562,13 @@ class CostChart extends React.Component<CostChartProps, State> {
     const { cursorVoronoiContainer, series, width } = this.state;
 
     const domain = this.getDomain();
-    const endDate = this.getEndDate();
-    const midDate = Math.floor(endDate / 2);
+    const lastDate = this.getEndDate();
+
+    const half = Math.floor(lastDate / 2);
+    const _1stDay = 1;
+    const _2ndDay = _1stDay + Math.floor(half / 2);
+    const _3rdDay = _1stDay + half;
+    const _4thDay = lastDate - Math.floor(half / 2);
 
     // Clone original container. See https://issues.redhat.com/browse/COST-762
     const container = cursorVoronoiContainer
@@ -602,7 +607,7 @@ class CostChart extends React.Component<CostChartProps, State> {
                 series.map((s, index) => {
                   return this.getChart(s, index);
                 })}
-              <ChartAxis style={chartStyles.xAxis} tickValues={[1, midDate, endDate]} />
+              <ChartAxis style={chartStyles.xAxis} tickValues={[_1stDay, _2ndDay, _3rdDay, _4thDay, lastDate]} />
               <ChartAxis dependentAxis style={chartStyles.yAxis} />
             </Chart>
           </div>

--- a/src/components/charts/dailyCostChart/dailyCostChart.styles.ts
+++ b/src/components/charts/dailyCostChart/dailyCostChart.styles.ts
@@ -1,0 +1,78 @@
+import { chart_color_black_200 } from '@patternfly/react-tokens/dist/js/chart_color_black_200';
+import { chart_color_blue_100 } from '@patternfly/react-tokens/dist/js/chart_color_blue_100';
+import { chart_color_blue_200 } from '@patternfly/react-tokens/dist/js/chart_color_blue_200';
+import { chart_color_blue_300 } from '@patternfly/react-tokens/dist/js/chart_color_blue_300';
+import { chart_color_blue_400 } from '@patternfly/react-tokens/dist/js/chart_color_blue_400';
+import { chart_color_blue_500 } from '@patternfly/react-tokens/dist/js/chart_color_blue_500';
+import { chart_color_green_100 } from '@patternfly/react-tokens/dist/js/chart_color_green_100';
+import { chart_color_green_200 } from '@patternfly/react-tokens/dist/js/chart_color_green_200';
+import { chart_color_green_300 } from '@patternfly/react-tokens/dist/js/chart_color_green_300';
+import { chart_color_green_400 } from '@patternfly/react-tokens/dist/js/chart_color_green_400';
+import { chart_color_green_500 } from '@patternfly/react-tokens/dist/js/chart_color_green_500';
+import { chart_color_orange_300 } from '@patternfly/react-tokens/dist/js/chart_color_orange_300';
+
+export const chartStyles = {
+  // See: https://github.com/project-koku/koku-ui/issues/241
+  currentColorScale: [
+    chart_color_green_400.value,
+    chart_color_green_300.value,
+    chart_color_green_200.value,
+    chart_color_green_100.value,
+    chart_color_green_500.value,
+  ],
+  currentInfrastructureColorScale: [
+    chart_color_blue_400.value,
+    chart_color_blue_300.value,
+    chart_color_blue_200.value,
+    chart_color_blue_100.value,
+    chart_color_blue_500.value,
+  ],
+  currentInfrastructureCostData: {
+    strokeDasharray: '3,3',
+  },
+  forecastConeData: {
+    fill: chart_color_orange_300.value,
+    strokeWidth: 0,
+  },
+  forecastConeDataColorScale: [chart_color_orange_300.value],
+  forecastData: {
+    fill: chart_color_green_200.value,
+  },
+  forecastDataColorScale: [chart_color_green_200.value],
+  forecastInfrastructureConeData: {
+    fill: chart_color_orange_300.value,
+    strokeWidth: 0,
+  },
+  forecastInfrastructureConeDataColorScale: [chart_color_orange_300.value],
+  forecastInfrastructureDataColorScale: [chart_color_blue_200.value],
+  previousInfrastructureCostData: {
+    strokeDasharray: '3,3',
+  },
+  // See: https://github.com/project-koku/koku-ui/issues/241
+  previousColorScale: [chart_color_black_200.value, chart_color_black_200.value],
+  yAxis: {
+    axisLabel: {
+      padding: 15,
+    },
+    grid: {
+      stroke: 'none',
+    },
+    ticks: {
+      stroke: 'none',
+    },
+    tickLabels: {
+      fontSize: 0,
+    },
+  },
+  xAxis: {
+    axisLabel: {
+      padding: 40,
+    },
+    grid: {
+      stroke: 'none',
+    },
+    ticks: {
+      stroke: 'none',
+    },
+  },
+};

--- a/src/components/charts/dailyCostChart/index.ts
+++ b/src/components/charts/dailyCostChart/index.ts
@@ -1,0 +1,1 @@
+export { DailyCostChart, DailyCostChartProps } from './dailyCostChart';

--- a/src/components/reports/reportSummary/index.ts
+++ b/src/components/reports/reportSummary/index.ts
@@ -4,5 +4,6 @@ export { ReportSummaryDetails } from './reportSummaryDetails';
 export { ReportSummaryItem } from './reportSummaryItem';
 export { ReportSummaryItems } from './reportSummaryItems';
 export { ReportSummaryCost } from './reportSummaryCost';
+export { ReportSummaryDailyCost } from './reportSummaryDailyCost';
 export { ReportSummaryTrend } from './reportSummaryTrend';
 export { ReportSummaryUsage } from './reportSummaryUsage';

--- a/src/components/reports/reportSummary/reportSummaryDailyCost.scss
+++ b/src/components/reports/reportSummary/reportSummaryDailyCost.scss
@@ -1,0 +1,5 @@
+@import url("~@patternfly/patternfly/base/patternfly-variables.css");
+
+.chart {
+  margin-bottom: var(--pf-global--spacer--sm);
+}

--- a/src/components/reports/reportSummary/reportSummaryDailyCost.tsx
+++ b/src/components/reports/reportSummary/reportSummaryDailyCost.tsx
@@ -1,0 +1,12 @@
+import './reportSummaryDailyCost.scss';
+
+import { DailyCostChart, DailyCostChartProps } from 'components/charts/dailyCostChart';
+import React from 'react';
+
+const ReportSummaryDailyCost: React.SFC<DailyCostChartProps> = props => (
+  <div className="chart">
+    <DailyCostChart {...props} />
+  </div>
+);
+
+export { ReportSummaryDailyCost };

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -795,6 +795,7 @@
     "cpu_title": "CPU usage and requests",
     "cpu_trend_title": "Daily usage and requests comparison ({{units}})",
     "cumulative_cost_label": "Cumulative cost",
+    "daily_cost_trend_title": "All OpenShift daily cost comparison ({{units}})",
     "memory_title": "Memory usage and requests",
     "memory_trend_title": "Daily usage and requests comparison ({{units}})",
     "requests_label": "Requests",

--- a/src/pages/dashboard/components/chartComparison.tsx
+++ b/src/pages/dashboard/components/chartComparison.tsx
@@ -1,0 +1,86 @@
+import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
+import React from 'react';
+import { WithTranslation, withTranslation } from 'react-i18next';
+
+interface ChartComparisonOwnProps {
+  currentItem?: string;
+  onItemClicked(value: string);
+  options?: {
+    label: string;
+    value: string;
+  }[];
+}
+
+interface ChartComparisonState {
+  isChartComparisonOpen: boolean;
+}
+
+type ChartComparisonProps = ChartComparisonOwnProps & WithTranslation;
+
+class ChartComparisonBase extends React.Component<ChartComparisonProps> {
+  protected defaultState: ChartComparisonState = {
+    isChartComparisonOpen: false,
+  };
+  public state: ChartComparisonState = { ...this.defaultState };
+
+  private getDropDownItems = () => {
+    const { options, t } = this.props;
+
+    return options.map(option => (
+      <DropdownItem component="button" key={option.value} onClick={() => this.handleClick(option.value)}>
+        {t(option.label)}
+      </DropdownItem>
+    ));
+  };
+
+  private getCurrentLabel = () => {
+    const { currentItem, options, t } = this.props;
+
+    let label = '';
+    for (const option of options) {
+      if (currentItem === option.value) {
+        label = t(option.label);
+        break;
+      }
+    }
+    return label;
+  };
+
+  public handleClick = value => {
+    const { onItemClicked } = this.props;
+    if (onItemClicked) {
+      onItemClicked(value);
+    }
+  };
+
+  private handleSelect = () => {
+    this.setState({
+      isChartComparisonOpen: !this.state.isChartComparisonOpen,
+    });
+  };
+
+  private handleToggle = isChartComparisonOpen => {
+    this.setState({
+      isChartComparisonOpen,
+    });
+  };
+
+  public render() {
+    // const { t } = this.props;
+    const { isChartComparisonOpen } = this.state;
+    const dropdownItems = this.getDropDownItems();
+
+    return (
+      <Dropdown
+        onSelect={this.handleSelect}
+        toggle={<DropdownToggle onToggle={this.handleToggle}>{this.getCurrentLabel()}</DropdownToggle>}
+        isOpen={isChartComparisonOpen}
+        dropdownItems={dropdownItems}
+      />
+    );
+  }
+}
+
+const ChartComparison = withTranslation()(ChartComparisonBase);
+
+export { ChartComparison };

--- a/src/pages/dashboard/components/dashboardWidget.styles.ts
+++ b/src/pages/dashboard/components/dashboardWidget.styles.ts
@@ -1,4 +1,5 @@
 import global_spacer_2xl from '@patternfly/react-tokens/dist/js/global_spacer_2xl';
+import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
 import global_spacer_xl from '@patternfly/react-tokens/dist/js/global_spacer_xl';
 import React from 'react';
 
@@ -11,6 +12,9 @@ export const chartStyles = {
 };
 
 export const styles = {
+  cumulative: {
+    marginBottom: global_spacer_md.value,
+  },
   tabs: {
     marginTop: global_spacer_2xl.value,
   },

--- a/src/pages/dashboard/components/dashboardWidget.styles.ts
+++ b/src/pages/dashboard/components/dashboardWidget.styles.ts
@@ -12,7 +12,7 @@ export const chartStyles = {
 };
 
 export const styles = {
-  cumulative: {
+  comparison: {
     marginBottom: global_spacer_md.value,
   },
   tabs: {

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -196,7 +196,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     const ReportSummaryComponent = daily ? ReportSummaryDailyCost : ReportSummaryCost;
     return (
       <>
-        <div style={styles.cumulative}>{this.getChartComparison()}</div>
+        <div style={styles.comparison}>{this.getChartComparison()}</div>
         <ReportSummaryComponent
           adjustContainerHeight={adjustContainerHeight}
           containerHeight={containerHeight}

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -3,6 +3,7 @@ import { Forecast } from 'api/forecasts/forecast';
 import { getQuery } from 'api/queries/awsQuery';
 import { Report } from 'api/reports/report';
 import {
+  ChartType,
   ComputedReportItemType,
   transformForecast,
   transformForecastCone,
@@ -12,6 +13,7 @@ import {
   ReportSummary,
   ReportSummaryAlt,
   ReportSummaryCost,
+  ReportSummaryDailyCost,
   ReportSummaryDetails,
   ReportSummaryItem,
   ReportSummaryItems,
@@ -29,7 +31,14 @@ import { Link } from 'react-router-dom';
 import { DashboardChartType, DashboardWidget } from 'store/dashboard/common/dashboardCommon';
 import { formatValue, unitLookupKey } from 'utils/formatValue';
 
+import { ChartComparison } from './chartComparison';
 import { chartStyles, styles } from './dashboardWidget.styles';
+
+// eslint-disable-next-line no-shadow
+const enum Comparison {
+  cumulative = 'cumulative',
+  daily = 'daily',
+}
 
 interface DashboardWidgetOwnProps {
   chartAltHeight?: number;
@@ -77,6 +86,7 @@ const isForecastAuthorized = async () => {
 class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   public state = {
     activeTabKey: 0,
+    currentComparison: Comparison.cumulative,
     forecastAuthorized: false,
   };
 
@@ -125,75 +135,95 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     }
   };
 
-  // This chart displays cost and infrastructure cost
-  private getCostChart = (containerHeight: number, height: number, adjustContainerHeight: boolean = false) => {
-    const { currentReport, previousReport, t, trend } = this.props;
-    const { forecastAuthorized } = this.state;
+  private getChartComparison = () => {
+    const { t, trend } = this.props;
+    const { currentComparison } = this.state;
 
     const units = this.getUnits();
-    const title = t(trend.titleKey, { units: t(`units.${units}`) });
+    const cumulativeTitle = t(trend.titleKey, { units: t(`units.${units}`) });
+    const dailyTitle = t(trend.dailyTitleKey, { units: t(`units.${units}`) });
+
+    const options = [
+      { label: dailyTitle, value: Comparison.daily },
+      { label: cumulativeTitle, value: Comparison.cumulative },
+    ];
+
+    return (
+      <ChartComparison
+        currentItem={currentComparison || options[0].value}
+        onItemClicked={this.handleComparisonClick}
+        options={options}
+      />
+    );
+  };
+
+  // This chart displays cost and infrastructure cost
+  private getCostChart = (containerHeight: number, height: number, adjustContainerHeight: boolean = false) => {
+    const { currentReport, previousReport, trend } = this.props;
+    const { currentComparison, forecastAuthorized } = this.state;
+
     const computedReportItem = trend.computedReportItem; // cost, supplementary cost, etc.
     const computedReportItemValue = trend.computedReportItemValue; // infrastructure usage cost
+
+    // Todo: Add cumulative / daily prop
+    const daily = currentComparison === Comparison.daily;
+    const type = daily ? ChartType.daily : trend.type;
 
     // Infrastructure data
     const currentInfrastructureData = transformReport(
       currentReport,
-      trend.type,
+      type,
       'date',
       'infrastructure',
       computedReportItemValue
     );
     const previousInfrastructureData = transformReport(
       previousReport,
-      trend.type,
+      type,
       'date',
       'infrastructure',
       computedReportItemValue
     );
 
     // Cost data
-    const currentCostData = transformReport(
-      currentReport,
-      trend.type,
-      'date',
-      computedReportItem,
-      computedReportItemValue
-    );
-    const previousCostData = transformReport(
-      previousReport,
-      trend.type,
-      'date',
-      computedReportItem,
-      computedReportItemValue
-    );
+    const currentCostData = transformReport(currentReport, type, 'date', computedReportItem, computedReportItemValue);
+    const previousCostData = transformReport(previousReport, type, 'date', computedReportItem, computedReportItemValue);
 
     // Forecast data
     const forecastData = this.getForecastData(currentReport, trend.computedForecastItem);
     const forecastInfrastructureData = this.getForecastData(currentReport, trend.computedForecastInfrastructureItem);
 
+    const ReportSummaryComponent = daily ? ReportSummaryDailyCost : ReportSummaryCost;
     return (
-      <ReportSummaryCost
-        adjustContainerHeight={adjustContainerHeight}
-        containerHeight={containerHeight}
-        currentCostData={currentCostData}
-        currentInfrastructureCostData={currentInfrastructureData}
-        forecastConeData={forecastData.forecastConeData}
-        forecastData={forecastData.forecastData}
-        forecastInfrastructureConeData={forecastInfrastructureData.forecastConeData}
-        forecastInfrastructureData={forecastInfrastructureData.forecastData}
-        formatDatumValue={formatValue}
-        formatDatumOptions={trend.formatOptions}
-        height={height}
-        previousCostData={previousCostData}
-        previousInfrastructureCostData={previousInfrastructureData}
-        showForecast={trend.computedForecastItem !== undefined && forecastAuthorized}
-        title={title}
-      />
+      <>
+        <div style={styles.cumulative}>{this.getChartComparison()}</div>
+        <ReportSummaryComponent
+          adjustContainerHeight={adjustContainerHeight}
+          containerHeight={containerHeight}
+          currentCostData={currentCostData}
+          currentInfrastructureCostData={currentInfrastructureData}
+          forecastConeData={forecastData.forecastConeData}
+          forecastData={forecastData.forecastData}
+          forecastInfrastructureConeData={forecastInfrastructureData.forecastConeData}
+          forecastInfrastructureData={forecastInfrastructureData.forecastData}
+          formatDatumValue={formatValue}
+          formatDatumOptions={trend.formatOptions}
+          height={height}
+          previousCostData={previousCostData}
+          previousInfrastructureCostData={previousInfrastructureData}
+          showForecast={trend.computedForecastItem !== undefined && forecastAuthorized}
+        />
+      </>
     );
   };
 
   private getForecastData = (report: Report, computedForecastItem: string = 'cost') => {
     const { forecast, trend } = this.props;
+    const { currentComparison } = this.state;
+
+    // Todo: Add cumulative / daily prop
+    const daily = currentComparison === Comparison.daily;
+    const type = daily ? ChartType.daily : trend.type;
 
     let forecastData;
     let forecastConeData;
@@ -223,61 +253,63 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
             const forecastDate = new Date(item.date);
             const forecastMonth = forecastDate.getMonth() + 1;
 
-            // Ensure month match. AWS forecast currently starts with "2020-12-04", but ends on "2021-01-01"
+            // Ensure month match. AWS forecast may begin with "2020-12-04", but ends on "2021-01-01"
             if (forecastDate > lastReportedDate && lastReportedMonth === forecastMonth) {
               newForecast.data.push(item);
             }
           }
         }
 
-        // Show continuous line from current report to forecast
-        newForecast.data.unshift({
-          date: lastReported,
-          values: [
-            {
-              date: lastReported,
-              cost: {
-                confidence_max: {
-                  value: 0,
+        // For cumulative data, show continuous line from current report to forecast
+        if (type === ChartType.rolling) {
+          newForecast.data.unshift({
+            date: lastReported,
+            values: [
+              {
+                date: lastReported,
+                cost: {
+                  confidence_max: {
+                    value: 0,
+                  },
+                  confidence_min: {
+                    value: 0,
+                  },
+                  total: {
+                    value: total,
+                    units: 'USD',
+                  },
                 },
-                confidence_min: {
-                  value: 0,
+                infrastructure: {
+                  confidence_max: {
+                    value: 0,
+                  },
+                  confidence_min: {
+                    value: 0,
+                  },
+                  total: {
+                    value: total,
+                    units: 'USD',
+                  },
                 },
-                total: {
-                  value: total,
-                  units: 'USD',
+                supplementary: {
+                  confidence_max: {
+                    value: 0,
+                  },
+                  confidence_min: {
+                    value: 0,
+                  },
+                  total: {
+                    value: total,
+                    units: 'USD',
+                  },
                 },
               },
-              infrastructure: {
-                confidence_max: {
-                  value: 0,
-                },
-                confidence_min: {
-                  value: 0,
-                },
-                total: {
-                  value: total,
-                  units: 'USD',
-                },
-              },
-              supplementary: {
-                confidence_max: {
-                  value: 0,
-                },
-                confidence_min: {
-                  value: 0,
-                },
-                total: {
-                  value: total,
-                  units: 'USD',
-                },
-              },
-            },
-          ],
-        });
+            ],
+          });
+        }
       }
-      forecastData = transformForecast(newForecast, trend.type, computedForecastItem);
-      forecastConeData = transformForecastCone(newForecast, trend.type, computedForecastItem);
+      forecastData = transformForecast(newForecast, type, computedForecastItem);
+      forecastConeData = transformForecastCone(newForecast, type, computedForecastItem);
     }
     return { forecastData, forecastConeData };
   };
@@ -583,6 +615,10 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         {Boolean(availableTabs) && <div style={styles.tabs}>{this.getTabs()}</div>}
       </ReportSummary>
     );
+  };
+
+  private handleComparisonClick = (value: string) => {
+    this.setState({ currentComparison: value });
   };
 
   private handleInsightsNavClick = () => {

--- a/src/store/dashboard/common/dashboardCommon.ts
+++ b/src/store/dashboard/common/dashboardCommon.ts
@@ -58,6 +58,7 @@ export interface DashboardWidget<T> {
     computedForecastInfrastructureItem?: string; // The computed forecast infrastructure item to use in charts.
     computedReportItem: string; // The computed report item to use in charts, summary, etc.
     computedReportItemValue: string; // The computed report value (e.g., raw, markup, total, or usage)
+    dailyTitleKey?: string;
     titleKey: string;
     type: number;
     formatOptions: ValueFormatOptions;

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -38,6 +38,7 @@ export const costSummaryWidget: OcpDashboardWidget = {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
+    dailyTitleKey: 'ocp_dashboard.daily_cost_trend_title',
     titleKey: 'ocp_dashboard.cost_trend_title',
     type: ChartType.rolling,
   },


### PR DESCRIPTION
Created a daily cost comparison for the "All OpenShift cost" overview page. The cumulative cost chart is sown by default, with a dropdown to select the daily cost chart.

Unfortunately, the fake (nise) data were using for the cost-demo user doesn't produce a pretty chart. The high cost values scale the chart so that it's difficult to view the infrastructure cost and forecast values without hiding other data. 

Scaling issues are nothing new, but wanted to explain why the mock looks different. I expect the chart to look closer to the mock with real data from prod.

https://issues.redhat.com/browse/COST-834


![chrome-capture (1)](https://user-images.githubusercontent.com/17481322/103704895-1613d380-4f78-11eb-81b8-47f15d0d26f0.gif)
