### PR TITLE
Bar chart remains muted with interactive legend

### DIFF
--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -436,7 +436,12 @@ class CostChart extends React.Component<CostChartProps, State> {
 
   // Hide each data series individually
   private handleLegendClick = props => {
-    const { hiddenSeries, series } = this.state;
+    const { series } = this.state;
+
+    const hiddenSeries = new Set(this.state.hiddenSeries);
+    if (!hiddenSeries.delete(props.index)) {
+      hiddenSeries.add(props.index);
+    }
 
     // Toggle forecast confidence
     const childName = series[props.index].childName;
@@ -452,11 +457,7 @@ class CostChart extends React.Component<CostChartProps, State> {
         hiddenSeries.add(index);
       }
     }
-
-    if (!hiddenSeries.delete(props.index)) {
-      hiddenSeries.add(props.index);
-    }
-    this.setState({ hiddenSeries: new Set(this.state.hiddenSeries) });
+    this.setState({ hiddenSeries });
   };
 
   // Returns true if at least one data series is available
@@ -500,9 +501,9 @@ class CostChart extends React.Component<CostChartProps, State> {
     let adjustedContainerHeight = containerHeight;
     if (adjustContainerHeight) {
       if (showForecast) {
-        if (width > 650 && width < 1130) {
+        if (width > 675 && width < 1175) {
           adjustedContainerHeight += 25;
-        } else if (width > 450 && width < 650) {
+        } else if (width > 450 && width < 675) {
           adjustedContainerHeight += 50;
         } else if (width <= 450) {
           adjustedContainerHeight += 75;

--- a/src/components/charts/dailyTrendChart/dailyTrendChart.tsx
+++ b/src/components/charts/dailyTrendChart/dailyTrendChart.tsx
@@ -380,7 +380,12 @@ class DailyTrendChart extends React.Component<DailyTrendChartProps, State> {
 
   // Hide each data series individually
   private handleLegendClick = props => {
-    const { hiddenSeries, series } = this.state;
+    const { series } = this.state;
+
+    const hiddenSeries = new Set(this.state.hiddenSeries);
+    if (!hiddenSeries.delete(props.index)) {
+      hiddenSeries.add(props.index);
+    }
 
     // Toggle forecast confidence
     const childName = series[props.index].childName;
@@ -396,10 +401,7 @@ class DailyTrendChart extends React.Component<DailyTrendChartProps, State> {
         hiddenSeries.add(index);
       }
     }
-    if (!hiddenSeries.delete(props.index)) {
-      hiddenSeries.add(props.index);
-    }
-    this.setState({ hiddenSeries: new Set(hiddenSeries) });
+    this.setState({ hiddenSeries });
   };
 
   // Returns true if at least one data series is available

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -293,10 +293,11 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
 
   // Hide each data series individually
   private handleLegendClick = props => {
-    if (!this.state.hiddenSeries.delete(props.index)) {
-      this.state.hiddenSeries.add(props.index);
+    const hiddenSeries = new Set(this.state.hiddenSeries);
+    if (!hiddenSeries.delete(props.index)) {
+      hiddenSeries.add(props.index);
     }
-    this.setState({ hiddenSeries: new Set(this.state.hiddenSeries) });
+    this.setState({ hiddenSeries });
   };
 
   // Returns true if at least one data series is available

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -243,10 +243,11 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
 
   // Hide each data series individually
   private handleLegendClick = props => {
-    if (!this.state.hiddenSeries.delete(props.index)) {
-      this.state.hiddenSeries.add(props.index);
+    const hiddenSeries = new Set(this.state.hiddenSeries);
+    if (!hiddenSeries.delete(props.index)) {
+      hiddenSeries.add(props.index);
     }
-    this.setState({ hiddenSeries: new Set(this.state.hiddenSeries) });
+    this.setState({ hiddenSeries });
   };
 
   // Returns true if at least one data series is available

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -336,10 +336,11 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
 
   // Hide each data series individually
   private handleLegendClick = props => {
-    if (!this.state.hiddenSeries.delete(props.index)) {
-      this.state.hiddenSeries.add(props.index);
+    const hiddenSeries = new Set(this.state.hiddenSeries);
+    if (!hiddenSeries.delete(props.index)) {
+      hiddenSeries.add(props.index);
     }
-    this.setState({ hiddenSeries: new Set(this.state.hiddenSeries) });
+    this.setState({ hiddenSeries });
   };
 
   // Returns true if at least one data series is available

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -333,7 +333,12 @@ class TrendChart extends React.Component<TrendChartProps, State> {
 
   // Hide each data series individually
   private handleLegendClick = props => {
-    const { hiddenSeries, series } = this.state;
+    const { series } = this.state;
+
+    const hiddenSeries = new Set(this.state.hiddenSeries);
+    if (!hiddenSeries.delete(props.index)) {
+      hiddenSeries.add(props.index);
+    }
 
     // Toggle forecast confidence
     const childName = series[props.index].childName;
@@ -349,10 +354,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
         hiddenSeries.add(index);
       }
     }
-    if (!hiddenSeries.delete(props.index)) {
-      hiddenSeries.add(props.index);
-    }
-    this.setState({ hiddenSeries: new Set(hiddenSeries) });
+    this.setState({ hiddenSeries });
   };
 
   // Returns true if at least one data series is available

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -280,10 +280,11 @@ class UsageChart extends React.Component<UsageChartProps, State> {
 
   // Hide each data series individually
   private handleLegendClick = props => {
-    if (!this.state.hiddenSeries.delete(props.index)) {
-      this.state.hiddenSeries.add(props.index);
+    const hiddenSeries = new Set(this.state.hiddenSeries);
+    if (!hiddenSeries.delete(props.index)) {
+      hiddenSeries.add(props.index);
     }
-    this.setState({ hiddenSeries: new Set(this.state.hiddenSeries) });
+    this.setState({ hiddenSeries });
   };
 
   // Returns true if at least one data series is available


### PR DESCRIPTION
When hovering over an interactive legend item, all other datasets in the chart are muted (i.e., an opacity is applied to make them look slightly grayed out). When the cursor moves away from the legend item, the muted styles are removed. This works fine with line and area charts, but there is a problem with bar charts. It's more of an edge case, but under certain conditions, bars may remain muted.

https://issues.redhat.com/browse/COST-924

![capture-good](https://user-images.githubusercontent.com/17481322/105927714-8ad7ac00-6012-11eb-9823-1544c505ea74.gif)
