### PR TITLE
Bottom pagination controls to not be compact

### DIFF
--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -443,18 +443,20 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     return (
       <div style={styles.awsDetails}>
         <DetailsHeader groupBy={groupById} onGroupByClicked={this.handleGroupByClick} report={report} />
-        {reportFetchStatus === FetchStatus.inProgress ? (
-          <Loading />
-        ) : (
-          <div style={styles.content}>
-            {this.getToolbar(computedItems)}
-            {this.getExportModal(computedItems)}
-            <div style={styles.tableContainer}>{this.getTable()}</div>
-            <div style={styles.paginationContainer}>
-              <div style={styles.pagination}>{this.getPagination(true)}</div>
-            </div>
-          </div>
-        )}
+        <div style={styles.content}>
+          {this.getToolbar(computedItems)}
+          {this.getExportModal(computedItems)}
+          {reportFetchStatus === FetchStatus.inProgress ? (
+            <Loading />
+          ) : (
+            <>
+              <div style={styles.tableContainer}>{this.getTable()}</div>
+              <div style={styles.paginationContainer}>
+                <div style={styles.pagination}>{this.getPagination(true)}</div>
+              </div>
+            </>
+          )}
+        </div>
       </div>
     );
   }

--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -176,7 +176,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 
     return (
       <Pagination
-        isCompact
+        isCompact={!isBottom}
         itemCount={count}
         onPerPageSelect={this.handlePerPageSelect}
         onSetPage={this.handleSetPage}

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -436,18 +436,20 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     return (
       <div style={styles.azureDetails}>
         <DetailsHeader groupBy={groupById} onGroupByClicked={this.handleGroupByClick} report={report} />
-        {reportFetchStatus === FetchStatus.inProgress ? (
-          <Loading />
-        ) : (
-          <div style={styles.content}>
-            {this.getToolbar(computedItems)}
-            {this.getExportModal(computedItems)}
-            <div style={styles.tableContainer}>{this.getTable()}</div>
-            <div style={styles.paginationContainer}>
-              <div style={styles.pagination}>{this.getPagination(true)}</div>
-            </div>
-          </div>
-        )}
+        <div style={styles.content}>
+          {this.getToolbar(computedItems)}
+          {this.getExportModal(computedItems)}
+          {reportFetchStatus === FetchStatus.inProgress ? (
+            <Loading />
+          ) : (
+            <>
+              <div style={styles.tableContainer}>{this.getTable()}</div>
+              <div style={styles.paginationContainer}>
+                <div style={styles.pagination}>{this.getPagination(true)}</div>
+              </div>
+            </>
+          )}
+        </div>
       </div>
     );
   }

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -176,7 +176,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
 
     return (
       <Pagination
-        isCompact
+        isCompact={!isBottom}
         itemCount={count}
         onPerPageSelect={this.handlePerPageSelect}
         onSetPage={this.handleSetPage}

--- a/src/pages/details/gcpDetails/gcpDetails.tsx
+++ b/src/pages/details/gcpDetails/gcpDetails.tsx
@@ -176,7 +176,7 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
 
     return (
       <Pagination
-        isCompact
+        isCompact={!isBottom}
         itemCount={count}
         onPerPageSelect={this.handlePerPageSelect}
         onSetPage={this.handleSetPage}

--- a/src/pages/details/gcpDetails/gcpDetails.tsx
+++ b/src/pages/details/gcpDetails/gcpDetails.tsx
@@ -432,18 +432,20 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
     return (
       <div style={styles.gcpDetails}>
         <DetailsHeader groupBy={groupById} onGroupByClicked={this.handleGroupByClick} report={report} />
-        {reportFetchStatus === FetchStatus.inProgress ? (
-          <Loading />
-        ) : (
-          <div style={styles.content}>
-            {this.getToolbar(computedItems)}
-            {this.getExportModal(computedItems)}
-            <div style={styles.tableContainer}>{this.getTable()}</div>
-            <div style={styles.paginationContainer}>
-              <div style={styles.pagination}>{this.getPagination(true)}</div>
-            </div>
-          </div>
-        )}
+        <div style={styles.content}>
+          {this.getToolbar(computedItems)}
+          {this.getExportModal(computedItems)}
+          {reportFetchStatus === FetchStatus.inProgress ? (
+            <Loading />
+          ) : (
+            <>
+              <div style={styles.tableContainer}>{this.getTable()}</div>
+              <div style={styles.paginationContainer}>
+                <div style={styles.pagination}>{this.getPagination(true)}</div>
+              </div>
+            </>
+          )}
+        </div>
       </div>
     );
   }

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -433,18 +433,20 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     return (
       <div style={styles.ocpDetails}>
         <DetailsHeader groupBy={groupById} onGroupByClicked={this.handleGroupByClick} report={report} />
-        {reportFetchStatus === FetchStatus.inProgress ? (
-          <Loading />
-        ) : (
-          <div style={styles.content}>
-            {this.getToolbar(computedItems)}
-            {this.getExportModal(computedItems)}
-            <div style={styles.tableContainer}>{this.getTable()}</div>
-            <div style={styles.paginationContainer}>
-              <div style={styles.pagination}>{this.getPagination(true)}</div>
-            </div>
-          </div>
-        )}
+        <div style={styles.content}>
+          {this.getToolbar(computedItems)}
+          {this.getExportModal(computedItems)}
+          {reportFetchStatus === FetchStatus.inProgress ? (
+            <Loading />
+          ) : (
+            <>
+              <div style={styles.tableContainer}>{this.getTable()}</div>
+              <div style={styles.paginationContainer}>
+                <div style={styles.pagination}>{this.getPagination(true)}</div>
+              </div>
+            </>
+          )}
+        </div>
       </div>
     );
   }

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -176,7 +176,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
     return (
       <Pagination
-        isCompact
+        isCompact={!isBottom}
         itemCount={count}
         onPerPageSelect={this.handlePerPageSelect}
         onSetPage={this.handleSetPage}


### PR DESCRIPTION
Currently, the details pages for compact pagination controls at the top and bottom of each table. We don't want the controls at the bottom to be compact, only the top.

Also moved the loading icon to table body in order to help avoid some page flashing.

https://issues.redhat.com/browse/COST-913

<img width="1905" alt="Screen Shot 2021-01-27 at 9 05 28 AM" src="https://user-images.githubusercontent.com/17481322/106002888-a1681c80-607f-11eb-986b-2e988a03258a.png">
