### PR TITLE
Initialize perspective menu

### DIFF
--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -144,6 +144,10 @@ class OverviewBase extends React.Component<OverviewProps> {
     if (!userAccess && userAccessFetchStatus !== FetchStatus.inProgress) {
       this.fetchUserAccess();
     }
+    this.setState({
+      currentInfrastructurePerspective: this.getDefaultInfrastructurePerspective(),
+      currentOcpPerspective: this.getDefaultOcpPerspective(),
+    });
   }
 
   public componentDidUpdate(prevProps: OverviewProps) {


### PR DESCRIPTION
Need to initialize the perspective menu in the overiew's `componentDidMount` function. This will ensure the menu is reset properly when navigating between pages.

https://issues.redhat.com/browse/COST-933