### PR TITLE
Empty providers state for breakdown pages

### DIFF
--- a/src/pages/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/pages/details/awsBreakdown/awsBreakdown.tsx
@@ -1,4 +1,6 @@
+import { ProviderType } from 'api/providers';
 import { AwsQuery, getQuery, parseQuery } from 'api/queries/awsQuery';
+import { getProvidersQuery } from 'api/queries/providersQuery';
 import { breakdownDescKey, breakdownTitleKey, orgUnitIdKey, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import { TagPathsType } from 'api/tags/tag';
@@ -10,6 +12,7 @@ import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { paths } from 'routes';
 import { createMapStateToProps, FetchStatus } from 'store/common';
+import { awsProvidersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 
 import { CostOverview } from './costOverview';
@@ -45,6 +48,7 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
   const filterBy = getGroupByValue(query);
   const groupBy = getGroupById(query);
   const groupByOrg = query && query.group_by && query.group_by[orgUnitIdKey] ? query.group_by[orgUnitIdKey] : undefined;
+
   const newQuery: Query = {
     filter: {
       time_scope_units: 'month',
@@ -59,19 +63,31 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
       ...(groupBy && { [groupBy]: filterBy }),
     },
   };
-
   const queryString = getQuery(newQuery);
+
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+
+  const providersQueryString = getProvidersQuery(awsProvidersQuery);
+  const providers = providersSelectors.selectProviders(state, ProviderType.aws, providersQueryString);
+  const providersFetchStatus = providersSelectors.selectProvidersFetchStatus(
+    state,
+    ProviderType.aws,
+    providersQueryString
+  );
 
   return {
     costOverviewComponent: <CostOverview filterBy={filterBy} groupBy={groupBy} query={query} report={report} />,
     description: query[breakdownDescKey],
     detailsURL,
+    emptyStateTitle: props.t('navigation.aws_details'),
     filterBy,
     groupBy,
     historicalDataComponent: <HistoricalData filterBy={filterBy} groupBy={groupBy} query={query} />,
+    providers,
+    providersFetchStatus,
+    providerType: ProviderType.aws,
     query,
     queryString,
     report,

--- a/src/pages/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/pages/details/azureBreakdown/azureBreakdown.tsx
@@ -1,4 +1,6 @@
+import { ProviderType } from 'api/providers';
 import { getQuery, OcpQuery, parseQuery } from 'api/queries/ocpQuery';
+import { getProvidersQuery } from 'api/queries/providersQuery';
 import { Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import { TagPathsType } from 'api/tags/tag';
@@ -10,6 +12,7 @@ import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { paths } from 'routes';
 import { createMapStateToProps, FetchStatus } from 'store/common';
+import { azureProvidersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 
 import { CostOverview } from './costOverview';
@@ -43,18 +46,31 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateP
   const queryFromRoute = parseQuery<OcpQuery>(location.search);
   const query = queryFromRoute;
   const queryString = getQuery(query);
+  const filterBy = getGroupByValue(query);
+  const groupBy = getGroupById(query);
+
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
-  const filterBy = getGroupByValue(query);
-  const groupBy = getGroupById(query);
+
+  const providersQueryString = getProvidersQuery(azureProvidersQuery);
+  const providers = providersSelectors.selectProviders(state, ProviderType.azure, providersQueryString);
+  const providersFetchStatus = providersSelectors.selectProvidersFetchStatus(
+    state,
+    ProviderType.azure,
+    providersQueryString
+  );
 
   return {
     costOverviewComponent: <CostOverview filterBy={filterBy} groupBy={groupBy} report={report} />,
     detailsURL,
+    emptyStateTitle: props.t('navigation.azure_details'),
     filterBy,
     groupBy,
     historicalDataComponent: <HistoricalData filterBy={filterBy} groupBy={groupBy} />,
+    providers,
+    providersFetchStatus,
+    providerType: ProviderType.azure,
     query,
     queryString,
     report,

--- a/src/pages/details/gcpBreakdown/gcpBreakdown.tsx
+++ b/src/pages/details/gcpBreakdown/gcpBreakdown.tsx
@@ -1,4 +1,6 @@
+import { ProviderType } from 'api/providers';
 import { GcpQuery, getQuery, parseQuery } from 'api/queries/gcpQuery';
+import { getProvidersQuery } from 'api/queries/providersQuery';
 import { breakdownDescKey, breakdownTitleKey, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import { TagPathsType } from 'api/tags/tag';
@@ -10,6 +12,7 @@ import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { paths } from 'routes';
 import { createMapStateToProps, FetchStatus } from 'store/common';
+import { gcpProvidersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 
 import { CostOverview } from './costOverview';
@@ -58,19 +61,31 @@ const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, GcpBreakdown
       ...(groupBy && { [groupBy]: filterBy }),
     },
   };
-
   const queryString = getQuery(newQuery);
+
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+
+  const providersQueryString = getProvidersQuery(gcpProvidersQuery);
+  const providers = providersSelectors.selectProviders(state, ProviderType.gcp, providersQueryString);
+  const providersFetchStatus = providersSelectors.selectProvidersFetchStatus(
+    state,
+    ProviderType.gcp,
+    providersQueryString
+  );
 
   return {
     costOverviewComponent: <CostOverview filterBy={filterBy} groupBy={groupBy} query={query} report={report} />,
     description: query[breakdownDescKey],
     detailsURL,
+    emptyStateTitle: props.t('navigation.gcp_details'),
     filterBy,
     groupBy,
     historicalDataComponent: <HistoricalData filterBy={filterBy} groupBy={groupBy} query={query} />,
+    providers,
+    providersFetchStatus,
+    providerType: ProviderType.gcp,
     query,
     queryString,
     report,

--- a/src/pages/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/pages/details/ocpBreakdown/ocpBreakdown.tsx
@@ -1,4 +1,6 @@
+import { ProviderType } from 'api/providers';
 import { getQuery, OcpQuery, parseQuery } from 'api/queries/ocpQuery';
+import { getProvidersQuery } from 'api/queries/providersQuery';
 import { Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import { TagPathsType } from 'api/tags/tag';
@@ -10,6 +12,7 @@ import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
 import { paths } from 'routes';
 import { createMapStateToProps, FetchStatus } from 'store/common';
+import { ocpProvidersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 
 import { CostOverview } from './costOverview';
@@ -43,18 +46,31 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
   const queryFromRoute = parseQuery<OcpQuery>(location.search);
   const query = queryFromRoute;
   const queryString = getQuery(query);
+  const filterBy = getGroupByValue(query);
+  const groupBy = getGroupById(query);
+
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
-  const filterBy = getGroupByValue(query);
-  const groupBy = getGroupById(query);
+
+  const providersQueryString = getProvidersQuery(ocpProvidersQuery);
+  const providers = providersSelectors.selectProviders(state, ProviderType.ocp, providersQueryString);
+  const providersFetchStatus = providersSelectors.selectProvidersFetchStatus(
+    state,
+    ProviderType.ocp,
+    providersQueryString
+  );
 
   return {
     costOverviewComponent: <CostOverview filterBy={filterBy} groupBy={groupBy} report={report} />,
     detailsURL,
+    emptyStateTitle: props.t('navigation.ocp_details'),
     filterBy,
     groupBy,
     historicalDataComponent: <HistoricalData filterBy={filterBy} groupBy={groupBy} />,
+    providers,
+    providersFetchStatus,
+    providerType: ProviderType.ocp,
     query,
     queryString,
     report,


### PR DESCRIPTION
Similar to the details pages, this adds empty providers and error states for the breakdown pages.

https://issues.redhat.com/browse/COST-944

<img width="1578" alt="Screen Shot 2021-01-28 at 1 15 05 AM" src="https://user-images.githubusercontent.com/17481322/106098997-fc455680-6107-11eb-8e85-b5b025094e83.png">

<img width="1578" alt="Screen Shot 2021-01-28 at 1 16 19 AM" src="https://user-images.githubusercontent.com/17481322/106099016-00717400-6108-11eb-83d8-44241c368ff8.png">
