### PR TITLE
No data state

### DIFF
--- a/src/api/providers.ts
+++ b/src/api/providers.ts
@@ -32,15 +32,16 @@ export interface ProviderCostModel {
 
 export interface Provider {
   active?: boolean;
-  uuid?: string;
-  name?: string;
-  type?: string;
   authentication?: ProviderAuthentication;
   billing_source?: ProviderBillingSource;
-  customer?: ProviderCustomer;
   created_by?: ProviderCreatedBy;
   created_timestamp?: Date;
   cost_models?: ProviderCostModel[];
+  current_month_data?: boolean;
+  customer?: ProviderCustomer;
+  name?: string;
+  type?: string;
+  uuid?: string;
 }
 
 export interface Providers {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -741,6 +741,11 @@
   },
   "no_data_for_date": "No data available for {{startDate}} $t(months_abbr.{{month}})",
   "no_data_for_date_plural": "No data available for {{startDate}}-{{endDate}} $t(months_abbr.{{month}})",
+  "no_data_state": {
+    "desc": "We have detected a source, but we are not done processing the incoming data. The time to process could take up to 24 hours. Try refreshing the page at a later time.",
+    "refresh": "Refresh this page",
+    "title": "Still processing the data"
+  },
   "no_match_found_state": {
     "desc": "Sorry, no source with the given filter was found.",
     "title": "No match found"

--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -8,6 +8,7 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import { AxiosError } from 'axios';
 import { ExportModal } from 'pages/details/components/export/exportModal';
 import Loading from 'pages/state/loading';
+import NoData from 'pages/state/noData';
 import NoProviders from 'pages/state/noProviders';
 import NotAvailable from 'pages/state/notAvailable';
 import React from 'react';
@@ -405,6 +406,22 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     history.replace(filteredQuery);
   };
 
+  // Ensure at least one source provider has data available
+  private hasCurrentMonthData = () => {
+    const { providers } = this.props;
+    let result = false;
+
+    if (providers && providers.data) {
+      for (const provider of providers.data) {
+        if (provider.current_month_data) {
+          result = true;
+          break;
+        }
+      }
+    }
+    return result;
+  };
+
   private updateReport = () => {
     const { query, location, fetchReport, history, queryString } = this.props;
     if (!location.search) {
@@ -439,6 +456,9 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 
       if (noProviders) {
         return <NoProviders providerType={ProviderType.aws} title={title} />;
+      }
+      if (!this.hasCurrentMonthData()) {
+        return <NoData title={title} />;
       }
     }
     return (

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -20,6 +20,7 @@ import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedAzureReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 
+import NoData from '../../state/noData';
 import { styles } from './azureDetails.styles';
 import { DetailsHeader } from './detailsHeader';
 import { DetailsTable } from './detailsTable';
@@ -398,6 +399,22 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     history.replace(filteredQuery);
   };
 
+  // Ensure at least one source provider has data available
+  private hasCurrentMonthData = () => {
+    const { providers } = this.props;
+    let result = false;
+
+    if (providers && providers.data) {
+      for (const provider of providers.data) {
+        if (provider.current_month_data) {
+          result = true;
+          break;
+        }
+      }
+    }
+    return result;
+  };
+
   private updateReport = () => {
     const { query, location, fetchReport, history, queryString } = this.props;
     if (!location.search) {
@@ -432,6 +449,9 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
 
       if (noProviders) {
         return <NoProviders providerType={ProviderType.azure} title={title} />;
+      }
+      if (!this.hasCurrentMonthData()) {
+        return <NoData title={title} />;
       }
     }
     return (

--- a/src/pages/details/components/breakdown/breakdownBase.tsx
+++ b/src/pages/details/components/breakdown/breakdownBase.tsx
@@ -13,6 +13,7 @@ import { RouteComponentProps } from 'react-router';
 import { FetchStatus } from 'store/common';
 import { reportActions } from 'store/reports';
 
+import NoData from '../../../state/noData';
 import { styles } from './breakdown.styles';
 import { BreakdownHeader } from './breakdownHeader';
 
@@ -180,6 +181,22 @@ class BreakdownBase extends React.Component<BreakdownProps> {
     }
   };
 
+  // Ensure at least one source provider has data available
+  private hasCurrentMonthData = () => {
+    const { providers } = this.props;
+    let result = false;
+
+    if (providers && providers.data) {
+      for (const provider of providers.data) {
+        if (provider.current_month_data) {
+          result = true;
+          break;
+        }
+      }
+    }
+    return result;
+  };
+
   private updateReport = () => {
     const { location, fetchReport, queryString, reportPathsType, reportType } = this.props;
     if (location.search) {
@@ -218,6 +235,9 @@ class BreakdownBase extends React.Component<BreakdownProps> {
 
       if (noProviders) {
         return <NoProviders providerType={providerType} title={emptyStateTitle} />;
+      }
+      if (!this.hasCurrentMonthData()) {
+        return <NoData title={title} />;
       }
     }
     return (

--- a/src/pages/details/gcpDetails/gcpDetails.tsx
+++ b/src/pages/details/gcpDetails/gcpDetails.tsx
@@ -20,6 +20,7 @@ import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedGcpReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 
+import NoData from '../../state/noData';
 import { DetailsHeader } from './detailsHeader';
 import { DetailsTable } from './detailsTable';
 import { DetailsToolbar } from './detailsToolbar';
@@ -394,6 +395,22 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
     history.replace(filteredQuery);
   };
 
+  // Ensure at least one source provider has data available
+  private hasCurrentMonthData = () => {
+    const { providers } = this.props;
+    let result = false;
+
+    if (providers && providers.data) {
+      for (const provider of providers.data) {
+        if (provider.current_month_data) {
+          result = true;
+          break;
+        }
+      }
+    }
+    return result;
+  };
+
   private updateReport = () => {
     const { query, location, fetchReport, history, queryString } = this.props;
     if (!location.search) {
@@ -428,6 +445,9 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
 
       if (noProviders) {
         return <NoProviders providerType={ProviderType.gcp} title={title} />;
+      }
+      if (!this.hasCurrentMonthData()) {
+        return <NoData title={title} />;
       }
     }
     return (

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -20,6 +20,7 @@ import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedOcpReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 
+import NoData from '../../state/noData';
 import { DetailsHeader } from './detailsHeader';
 import { DetailsTable } from './detailsTable';
 import { DetailsToolbar } from './detailsToolbar';
@@ -395,6 +396,22 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     history.replace(filteredQuery);
   };
 
+  // Ensure at least one source provider has data available
+  private hasCurrentMonthData = () => {
+    const { providers } = this.props;
+    let result = false;
+
+    if (providers && providers.data) {
+      for (const provider of providers.data) {
+        if (provider.current_month_data) {
+          result = true;
+          break;
+        }
+      }
+    }
+    return result;
+  };
+
   private updateReport = () => {
     const { query, location, fetchReport, history, queryString } = this.props;
     if (!location.search) {
@@ -429,6 +446,9 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
       if (noProviders) {
         return <NoProviders providerType={ProviderType.ocp} title={title} />;
+      }
+      if (!this.hasCurrentMonthData()) {
+        return <NoData title={title} />;
       }
     }
     return (

--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -32,6 +32,7 @@ import {
 } from 'store/providers';
 import { allUserAccessQuery, userAccessSelectors } from 'store/userAccess';
 
+import NoData from '../state/noData/noData';
 import { styles } from './overview.styles';
 import { Perspective } from './perspective';
 
@@ -314,9 +315,26 @@ class OverviewBase extends React.Component<OverviewProps> {
     });
   };
 
+  // Ensure at least one source provider has data available
+  private hasCurrentMonthData = (providers: Providers) => {
+    let result = false;
+
+    if (providers && providers.data) {
+      for (const provider of providers.data) {
+        if (provider.current_month_data) {
+          result = true;
+          break;
+        }
+      }
+    }
+    return result;
+  };
+
   private getTabItem = (tab: OverviewTab, index: number) => {
+    const { awsProviders, azureProviders, gcpProviders, ocpProviders } = this.props;
     const { activeTabKey, currentInfrastructurePerspective, currentOcpPerspective } = this.state;
     const emptyTab = <></>; // Lazily load tabs
+    const noData = <NoData showReload={false} />;
 
     if (activeTabKey !== index) {
       return emptyTab;
@@ -324,29 +342,29 @@ class OverviewBase extends React.Component<OverviewProps> {
     const currentTab = getIdKeyForTab(tab);
     if (currentTab === OverviewTab.infrastructure) {
       if (currentInfrastructurePerspective === InfrastructurePerspective.allCloud) {
-        return <OcpCloudDashboard />;
+        return this.hasCurrentMonthData(ocpProviders) ? <OcpCloudDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.aws) {
-        return <AwsDashboard />;
+        return this.hasCurrentMonthData(awsProviders) ? <AwsDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.awsFiltered) {
-        return <AwsCloudDashboard />;
+        return this.hasCurrentMonthData(awsProviders) ? <AwsCloudDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.gcp) {
-        return <GcpDashboard />;
+        return this.hasCurrentMonthData(gcpProviders) ? <GcpDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.azure) {
-        return <AzureDashboard />;
+        return this.hasCurrentMonthData(azureProviders) ? <AzureDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.azureCloud) {
-        return <AzureCloudDashboard />;
+        return this.hasCurrentMonthData(azureProviders) ? <AzureCloudDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.ocpUsage) {
-        return <OcpUsageDashboard />;
+        return this.hasCurrentMonthData(ocpProviders) ? <OcpUsageDashboard /> : noData;
       } else {
-        return <OcpCloudDashboard />; // default
+        return this.hasCurrentMonthData(ocpProviders) ? <OcpCloudDashboard /> : noData; // default
       }
     } else if (currentTab === OverviewTab.ocp) {
       if (currentOcpPerspective === OcpPerspective.all) {
-        return <OcpDashboard />;
+        return this.hasCurrentMonthData(ocpProviders) ? <OcpDashboard /> : noData;
       } else if (currentOcpPerspective === OcpPerspective.supplementary) {
-        return <OcpSupplementaryDashboard />;
+        return this.hasCurrentMonthData(ocpProviders) ? <OcpSupplementaryDashboard /> : noData;
       } else {
-        return <OcpDashboard />; // default
+        return this.hasCurrentMonthData(ocpProviders) ? <OcpDashboard /> : noData; // default
       }
     } else {
       return emptyTab;
@@ -398,8 +416,8 @@ class OverviewBase extends React.Component<OverviewProps> {
     const data = (userAccess.data as any).find(d => d.type === UserAccessType.aws);
     const isUserAccessAllowed = data && data.access;
 
+    // providers API returns empty data array for no sources
     return (
-      // API returns empty data array for no sources
       isUserAccessAllowed &&
       awsProviders !== undefined &&
       awsProviders.meta !== undefined &&
@@ -413,8 +431,8 @@ class OverviewBase extends React.Component<OverviewProps> {
     const data = (userAccess.data as any).find(d => d.type === UserAccessType.azure);
     const isUserAccessAllowed = data && data.access;
 
+    // providers API returns empty data array for no sources
     return (
-      // API returns empty data array for no sources
       isUserAccessAllowed &&
       azureProviders !== undefined &&
       azureProviders.meta !== undefined &&
@@ -428,8 +446,8 @@ class OverviewBase extends React.Component<OverviewProps> {
     const data = (userAccess.data as any).find(d => d.type === UserAccessType.gcp);
     const isUserAccessAllowed = data && data.access;
 
+    // providers API returns empty data array for no sources
     return (
-      // API returns empty data array for no sources
       isUserAccessAllowed &&
       gcpProviders !== undefined &&
       gcpProviders.meta !== undefined &&
@@ -443,8 +461,8 @@ class OverviewBase extends React.Component<OverviewProps> {
     const data = (userAccess.data as any).find(d => d.type === UserAccessType.ocp);
     const isUserAccessAllowed = data && data.access;
 
+    // providers API returns empty data array for no sources
     return (
-      // API returns empty data array for no sources
       isUserAccessAllowed &&
       ocpProviders !== undefined &&
       ocpProviders.meta !== undefined &&

--- a/src/pages/state/noData/index.ts
+++ b/src/pages/state/noData/index.ts
@@ -1,0 +1,3 @@
+import NoData from './noData';
+
+export default NoData;

--- a/src/pages/state/noData/noData.tsx
+++ b/src/pages/state/noData/noData.tsx
@@ -1,0 +1,30 @@
+import { Main } from '@redhat-cloud-services/frontend-components/components/Main';
+import { PageHeader, PageHeaderTitle } from '@redhat-cloud-services/frontend-components/components/PageHeader';
+import React from 'react';
+import { RouteComponentProps, withRouter } from 'react-router';
+
+import { NoDataState } from './noDataState';
+
+interface NoDataOwnProps {
+  showReload?: boolean;
+  title?: string;
+}
+
+type NoDataProps = NoDataOwnProps & RouteComponentProps<void>;
+
+const NoData = ({ showReload, title }: NoDataProps) => {
+  return (
+    <>
+      {title && (
+        <PageHeader>
+          <PageHeaderTitle title={title} />
+        </PageHeader>
+      )}
+      <Main>
+        <NoDataState showReload={showReload} />
+      </Main>
+    </>
+  );
+};
+
+export default withRouter(NoData);

--- a/src/pages/state/noData/noDataState.tsx
+++ b/src/pages/state/noData/noDataState.tsx
@@ -1,0 +1,36 @@
+import { Button, EmptyState, EmptyStateBody, EmptyStateIcon, EmptyStateVariant, Title } from '@patternfly/react-core';
+import { FileInvoiceDollarIcon } from '@patternfly/react-icons/dist/js/icons/file-invoice-dollar-icon';
+import React from 'react';
+import { WithTranslation, withTranslation } from 'react-i18next';
+import { RouteComponentProps, withRouter } from 'react-router';
+
+interface NoDataStateOwnProps {
+  showReload?: boolean;
+}
+
+type NoDataStateProps = NoDataStateOwnProps & WithTranslation & RouteComponentProps<void>;
+
+class NoDataStateBase extends React.Component<NoDataStateProps> {
+  public render() {
+    const { showReload = true, t } = this.props;
+
+    return (
+      <EmptyState variant={EmptyStateVariant.large} className="pf-m-redhat-font">
+        <EmptyStateIcon icon={FileInvoiceDollarIcon} />
+        <Title headingLevel="h5" size="lg">
+          {t('no_data_state.title')}
+        </Title>
+        <EmptyStateBody>{t('no_data_state.desc')}</EmptyStateBody>
+        {showReload && (
+          <Button variant="primary" onClick={() => window.location.reload()}>
+            {t('no_data_state.refresh')}
+          </Button>
+        )}
+      </EmptyState>
+    );
+  }
+}
+
+const NoDataState = withRouter(withTranslation()(NoDataStateBase));
+
+export { NoDataState };


### PR DESCRIPTION
This adds a no data state to help indicate that a source provider has been created, but we're still processing their data. This makes use of the new `current_month_data` flag now available from the sources API response.

https://issues.redhat.com/browse/COST-914

**Details pages**
<img width="1483" alt="details no data state" src="https://user-images.githubusercontent.com/17481322/106155680-f161e480-614e-11eb-8882-0e879efae463.png">

**Overview tabs**
<img width="1484" alt="overview no data state" src="https://user-images.githubusercontent.com/17481322/106155705-f6269880-614e-11eb-8265-c619f7fa3846.png">
