### PR TITLE
Enable forecast for all users

### DIFF
--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -72,23 +72,10 @@ type DashboardWidgetProps = DashboardWidgetOwnProps &
   DashboardWidgetDispatchProps &
   WithTranslation;
 
-// Todo: Temporary check until forecast feature is ready for prod
-const isForecastAuthorized = async () => {
-  const _insights = (window as any).insights;
-
-  if (_insights && _insights.chrome && _insights.chrome.auth && _insights.chrome.auth.getUser) {
-    const user = await _insights.chrome.auth.getUser();
-    const username = user.identity.user.username;
-    return username === 'cost-demo' || username === 'insights-qa' || username === 'cost-management';
-  }
-  return false;
-};
-
 class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   public state = {
     activeTabKey: 0,
     currentComparison: Comparison.cumulative,
-    forecastAuthorized: false,
   };
 
   public componentDidMount() {
@@ -101,12 +88,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
       fetchReports(widgetId);
     }
     if (trend.computedForecastItem !== undefined) {
-      isForecastAuthorized().then(val => {
-        if (val && fetchForecasts) {
-          fetchForecasts(widgetId);
-        }
-        this.setState({ forecastAuthorized: val });
-      });
+      fetchForecasts(widgetId);
     }
   }
 
@@ -161,7 +143,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   // This chart displays cumulative and daily cost compared to infrastructure cost
   private getDailyCostChart = (containerHeight: number, height: number, adjustContainerHeight: boolean = false) => {
     const { currentReport, previousReport, trend } = this.props;
-    const { currentComparison, forecastAuthorized } = this.state;
+    const { currentComparison } = this.state;
 
     const computedReportItem = trend.computedReportItem; // cost, supplementary cost, etc.
     const computedReportItemValue = trend.computedReportItemValue; // infrastructure usage cost
@@ -211,7 +193,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
           height={height}
           previousCostData={previousCostData}
           previousInfrastructureCostData={previousInfrastructureData}
-          showForecast={trend.computedForecastItem !== undefined && forecastAuthorized}
+          showForecast={trend.computedForecastItem !== undefined}
         />
       </>
     );
@@ -225,7 +207,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     showSupplementaryLabel: boolean = false
   ) => {
     const { currentReport, details, previousReport, trend } = this.props;
-    const { currentComparison, forecastAuthorized } = this.state;
+    const { currentComparison } = this.state;
 
     const units = this.getUnits();
     const computedReportItem = trend.computedReportItem; // cost, supplementary cost, etc.
@@ -255,7 +237,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
           formatDatumOptions={trend.formatOptions}
           height={height}
           previousData={previousData}
-          showForecast={trend.computedForecastItem !== undefined && forecastAuthorized}
+          showForecast={trend.computedForecastItem !== undefined}
           showSupplementaryLabel={showSupplementaryLabel}
           showUsageLegendLabel={details.showUsageLegendLabel}
           units={units}
@@ -369,7 +351,6 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     showSupplementaryLabel: boolean = false
   ) => {
     const { currentReport, details, previousReport, t, trend } = this.props;
-    const { forecastAuthorized } = this.state;
 
     const units = this.getUnits();
     const title = t(trend.titleKey, { units: t(`units.${units}`) });
@@ -400,7 +381,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         formatDatumOptions={trend.formatOptions}
         height={height}
         previousData={previousData}
-        showForecast={trend.computedForecastItem !== undefined && forecastAuthorized}
+        showForecast={trend.computedForecastItem !== undefined}
         showSupplementaryLabel={showSupplementaryLabel}
         showUsageLegendLabel={details.showUsageLegendLabel}
         title={title}


### PR DESCRIPTION
The forecast is currently limited to the cost-demo, insights-qa, and cost-management users. We would like to remove this requirement, but waiting on final testing from QA.

https://issues.redhat.com/browse/COST-947