### PR TITLE
Move common functions to detailsUtils

### DIFF
--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -6,6 +6,7 @@ import { orgUnitIdKey, tagPrefix } from 'api/queries/query';
 import { AwsReport } from 'api/reports/awsReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { AxiosError } from 'axios';
+import { addQueryFilter, getGroupByTagKey, removeQueryFilter } from 'pages/details/common/detailsUtils';
 import { ExportModal } from 'pages/details/components/export/exportModal';
 import Loading from 'pages/state/loading';
 import NoData from 'pages/state/noData';
@@ -118,7 +119,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     const { query, report } = this.props;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByTagKey = this.getGroupByTagKey();
+    const groupByTagKey = getGroupByTagKey(query);
 
     return getUnsortedComputedReportItems({
       report,
@@ -131,7 +132,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     const { query, report } = this.props;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByTagKey = this.getGroupByTagKey();
+    const groupByTagKey = getGroupByTagKey(query);
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
     return (
@@ -145,20 +146,6 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
         reportPathsType={reportPathsType}
       />
     );
-  };
-
-  private getGroupByTagKey = () => {
-    const { query } = this.props;
-    let groupByTag;
-
-    for (const groupBy of Object.keys(query.group_by)) {
-      const index = groupBy.indexOf(tagPrefix);
-      if (index !== -1) {
-        groupByTag = groupBy.substring(index + tagPrefix.length) as any;
-        break;
-      }
-    }
-    return groupByTag;
   };
 
   private getPagination = (isBottom: boolean = false) => {
@@ -207,7 +194,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     const { isAllSelected, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByTagKey = this.getGroupByTagKey();
+    const groupByTagKey = getGroupByTagKey(query);
 
     return (
       <DetailsTable
@@ -228,7 +215,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     const { isAllSelected, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByTagKey = this.getGroupByTagKey();
+    const groupByTagKey = getGroupByTagKey(query);
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
     return (
@@ -274,57 +261,16 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 
   private handleFilterAdded = (filterType: string, filterValue: string) => {
     const { history, query } = this.props;
-    const newQuery = { ...JSON.parse(JSON.stringify(query)) };
 
-    // Filter by * won't generate a new request if group_by * already exists
-    if (filterValue === '*' && newQuery.group_by[filterType] === '*') {
-      return;
-    }
-
-    if (newQuery.filter_by[filterType]) {
-      let found = false;
-      const filters = newQuery.filter_by[filterType];
-      if (!Array.isArray(filters)) {
-        found = filterValue === newQuery.filter_by[filterType];
-      } else {
-        for (const filter of filters) {
-          if (filter === filterValue) {
-            found = true;
-            break;
-          }
-        }
-      }
-      if (!found) {
-        newQuery.filter_by[filterType] = [newQuery.filter_by[filterType], filterValue];
-      }
-    } else {
-      newQuery.filter_by[filterType] = [filterValue];
-    }
-    const filteredQuery = this.getRouteForQuery(newQuery, true);
-    history.replace(filteredQuery);
+    const filteredQuery = addQueryFilter(query, filterType, filterValue);
+    history.replace(this.getRouteForQuery(filteredQuery, true));
   };
 
   private handleFilterRemoved = (filterType: string, filterValue: string) => {
     const { history, query } = this.props;
-    const newQuery = { ...JSON.parse(JSON.stringify(query)) };
 
-    if (filterType === null) {
-      newQuery.filter_by = undefined; // Clear all
-    } else if (filterValue === null) {
-      newQuery.filter_by[filterType] = undefined; // Clear all values
-    } else if (Array.isArray(newQuery.filter_by[filterType])) {
-      const index = newQuery.filter_by[filterType].indexOf(filterValue);
-      if (index > -1) {
-        newQuery.filter_by[filterType] = [
-          ...query.filter_by[filterType].slice(0, index),
-          ...query.filter_by[filterType].slice(index + 1),
-        ];
-      }
-    } else {
-      newQuery.filter_by[filterType] = undefined;
-    }
-    const filteredQuery = this.getRouteForQuery(newQuery, true);
-    history.replace(filteredQuery);
+    const filteredQuery = removeQueryFilter(query, filterType, filterValue);
+    history.replace(this.getRouteForQuery(filteredQuery, true));
   };
 
   private handleGroupByClick = groupBy => {

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -2,10 +2,11 @@ import { Pagination, PaginationVariant } from '@patternfly/react-core';
 import { Providers, ProviderType } from 'api/providers';
 import { AzureQuery, getQuery, getQueryRoute, parseQuery } from 'api/queries/azureQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { tagKey, tagPrefix } from 'api/queries/query';
+import { tagPrefix } from 'api/queries/query';
 import { AzureReport } from 'api/reports/azureReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { AxiosError } from 'axios';
+import { addQueryFilter, getGroupByTagKey, removeQueryFilter } from 'pages/details/common/detailsUtils';
 import { ExportModal } from 'pages/details/components/export/exportModal';
 import Loading from 'pages/state/loading';
 import NoProviders from 'pages/state/noProviders';
@@ -118,7 +119,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     const { query, report } = this.props;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByTagKey = this.getGroupByTagKey();
+    const groupByTagKey = getGroupByTagKey(query);
 
     return getUnsortedComputedReportItems({
       report,
@@ -131,7 +132,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     const { query, report } = this.props;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByTagKey = this.getGroupByTagKey();
+    const groupByTagKey = getGroupByTagKey(query);
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
     return (
@@ -145,20 +146,6 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
         reportPathsType={reportPathsType}
       />
     );
-  };
-
-  private getGroupByTagKey = () => {
-    const { query } = this.props;
-    let groupByTag;
-
-    for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf(tagPrefix);
-      if (tagIndex !== -1) {
-        groupByTag = groupBy.substring(tagIndex + tagPrefix.length) as any;
-        break;
-      }
-    }
-    return groupByTag;
   };
 
   private getPagination = (isBottom: boolean = false) => {
@@ -207,7 +194,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     const { isAllSelected, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByTagKey = this.getGroupByTagKey();
+    const groupByTagKey = getGroupByTagKey(query);
 
     return (
       <DetailsTable
@@ -228,7 +215,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     const { isAllSelected, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByTagKey = this.getGroupByTagKey();
+    const groupByTagKey = getGroupByTagKey(query);
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
     return (
@@ -274,60 +261,16 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
 
   private handleFilterAdded = (filterType: string, filterValue: string) => {
     const { history, query } = this.props;
-    const newQuery = { ...JSON.parse(JSON.stringify(query)) };
 
-    const groupByTagKey = this.getGroupByTagKey();
-    const newFilterType = filterType === tagKey ? `${tagPrefix}${groupByTagKey}` : filterType;
-
-    // Filter by * won't generate a new request if group_by * already exists
-    if (filterValue === '*' && newQuery.group_by[newFilterType] === '*') {
-      return;
-    }
-
-    if (newQuery.filter_by[newFilterType]) {
-      let found = false;
-      const filters = newQuery.filter_by[newFilterType];
-      if (!Array.isArray(filters)) {
-        found = filterValue === newQuery.filter_by[newFilterType];
-      } else {
-        for (const filter of filters) {
-          if (filter === filterValue) {
-            found = true;
-            break;
-          }
-        }
-      }
-      if (!found) {
-        newQuery.filter_by[newFilterType] = [newQuery.filter_by[newFilterType], filterValue];
-      }
-    } else {
-      newQuery.filter_by[filterType] = [filterValue];
-    }
-    const filteredQuery = this.getRouteForQuery(newQuery, true);
-    history.replace(filteredQuery);
+    const filteredQuery = addQueryFilter(query, filterType, filterValue);
+    history.replace(this.getRouteForQuery(filteredQuery, true));
   };
 
   private handleFilterRemoved = (filterType: string, filterValue: string) => {
     const { history, query } = this.props;
-    const newQuery = { ...JSON.parse(JSON.stringify(query)) };
 
-    if (filterType === null) {
-      newQuery.filter_by = undefined; // Clear all
-    } else if (filterValue === null) {
-      newQuery.filter_by[filterType] = undefined; // Clear all values
-    } else if (Array.isArray(newQuery.filter_by[filterType])) {
-      const index = newQuery.filter_by[filterType].indexOf(filterValue);
-      if (index > -1) {
-        newQuery.filter_by[filterType] = [
-          ...query.filter_by[filterType].slice(0, index),
-          ...query.filter_by[filterType].slice(index + 1),
-        ];
-      }
-    } else {
-      newQuery.filter_by[filterType] = undefined;
-    }
-    const filteredQuery = this.getRouteForQuery(newQuery, true);
-    history.replace(filteredQuery);
+    const filteredQuery = removeQueryFilter(query, filterType, filterValue);
+    history.replace(this.getRouteForQuery(filteredQuery, true));
   };
 
   private handleGroupByClick = groupBy => {

--- a/src/pages/details/common/detailsUtils.ts
+++ b/src/pages/details/common/detailsUtils.ts
@@ -1,0 +1,65 @@
+import { Query, tagPrefix } from 'api/queries/query';
+
+export const getGroupByTagKey = (query: Query) => {
+  let groupByTagKey;
+
+  for (const groupBy of Object.keys(query.group_by)) {
+    const tagIndex = groupBy.indexOf(tagPrefix);
+    if (tagIndex !== -1) {
+      groupByTagKey = groupBy.substring(tagIndex + tagPrefix.length) as any;
+      break;
+    }
+  }
+  return groupByTagKey;
+};
+
+export const addQueryFilter = (query: Query, filterType: string, filterValue: string) => {
+  const newQuery = { ...JSON.parse(JSON.stringify(query)) };
+
+  // Filter by * won't generate a new request if group_by * already exists
+  if (filterValue === '*' && newQuery.group_by[filterType] === '*') {
+    return;
+  }
+
+  if (newQuery.filter_by[filterType]) {
+    let found = false;
+    const filters = newQuery.filter_by[filterType];
+    if (!Array.isArray(filters)) {
+      found = filterValue === newQuery.filter_by[filterType];
+    } else {
+      for (const filter of filters) {
+        if (filter === filterValue) {
+          found = true;
+          break;
+        }
+      }
+    }
+    if (!found) {
+      newQuery.filter_by[filterType] = [newQuery.filter_by[filterType], filterValue];
+    }
+  } else {
+    newQuery.filter_by[filterType] = [filterValue];
+  }
+  return newQuery;
+};
+
+export const removeQueryFilter = (query: Query, filterType: string, filterValue: string) => {
+  const newQuery = { ...JSON.parse(JSON.stringify(query)) };
+
+  if (filterType === null) {
+    newQuery.filter_by = undefined; // Clear all
+  } else if (filterValue === null) {
+    newQuery.filter_by[filterType] = undefined; // Clear all values
+  } else if (Array.isArray(newQuery.filter_by[filterType])) {
+    const index = newQuery.filter_by[filterType].indexOf(filterValue);
+    if (index > -1) {
+      newQuery.filter_by[filterType] = [
+        ...query.filter_by[filterType].slice(0, index),
+        ...query.filter_by[filterType].slice(index + 1),
+      ];
+    }
+  } else {
+    newQuery.filter_by[filterType] = undefined;
+  }
+  return newQuery;
+};

--- a/src/pages/details/gcpDetails/gcpDetails.tsx
+++ b/src/pages/details/gcpDetails/gcpDetails.tsx
@@ -6,6 +6,7 @@ import { tagPrefix } from 'api/queries/query';
 import { GcpReport } from 'api/reports/gcpReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { AxiosError } from 'axios';
+import { addQueryFilter, getGroupByTagKey, removeQueryFilter } from 'pages/details/common/detailsUtils';
 import { ExportModal } from 'pages/details/components/export/exportModal';
 import Loading from 'pages/state/loading';
 import NoProviders from 'pages/state/noProviders';
@@ -118,7 +119,7 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
     const { query, report } = this.props;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByTagKey = this.getGroupByTagKey();
+    const groupByTagKey = getGroupByTagKey(query);
 
     return getUnsortedComputedReportItems({
       report,
@@ -131,7 +132,7 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
     const { query, report } = this.props;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByTagKey = this.getGroupByTagKey();
+    const groupByTagKey = getGroupByTagKey(query);
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
     return (
@@ -145,20 +146,6 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
         reportPathsType={reportPathsType}
       />
     );
-  };
-
-  private getGroupByTagKey = () => {
-    const { query } = this.props;
-    let groupByTag;
-
-    for (const groupBy of Object.keys(query.group_by)) {
-      const index = groupBy.indexOf(tagPrefix);
-      if (index !== -1) {
-        groupByTag = groupBy.substring(index + tagPrefix.length) as any;
-        break;
-      }
-    }
-    return groupByTag;
   };
 
   private getPagination = (isBottom: boolean = false) => {
@@ -206,7 +193,7 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
     const { query, report, reportFetchStatus } = this.props;
     const { isAllSelected, selectedItems } = this.state;
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByTagKey = this.getGroupByTagKey();
+    const groupByTagKey = getGroupByTagKey(query);
 
     return (
       <DetailsTable
@@ -227,7 +214,7 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
     const { isAllSelected, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByTagKey = this.getGroupByTagKey();
+    const groupByTagKey = getGroupByTagKey(query);
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
     return (
@@ -273,57 +260,16 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
 
   private handleFilterAdded = (filterType: string, filterValue: string) => {
     const { history, query } = this.props;
-    const newQuery = { ...JSON.parse(JSON.stringify(query)) };
 
-    // Filter by * won't generate a new request if group_by * already exists
-    if (filterValue === '*' && newQuery.group_by[filterType] === '*') {
-      return;
-    }
-
-    if (newQuery.filter_by[filterType]) {
-      let found = false;
-      const filters = newQuery.filter_by[filterType];
-      if (!Array.isArray(filters)) {
-        found = filterValue === newQuery.filter_by[filterType];
-      } else {
-        for (const filter of filters) {
-          if (filter === filterValue) {
-            found = true;
-            break;
-          }
-        }
-      }
-      if (!found) {
-        newQuery.filter_by[filterType] = [newQuery.filter_by[filterType], filterValue];
-      }
-    } else {
-      newQuery.filter_by[filterType] = [filterValue];
-    }
-    const filteredQuery = this.getRouteForQuery(newQuery, true);
-    history.replace(filteredQuery);
+    const filteredQuery = addQueryFilter(query, filterType, filterValue);
+    history.replace(this.getRouteForQuery(filteredQuery, true));
   };
 
   private handleFilterRemoved = (filterType: string, filterValue: string) => {
     const { history, query } = this.props;
-    const newQuery = { ...JSON.parse(JSON.stringify(query)) };
 
-    if (filterType === null) {
-      newQuery.filter_by = undefined; // Clear all
-    } else if (filterValue === null) {
-      newQuery.filter_by[filterType] = undefined; // Clear all values
-    } else if (Array.isArray(newQuery.filter_by[filterType])) {
-      const index = newQuery.filter_by[filterType].indexOf(filterValue);
-      if (index > -1) {
-        newQuery.filter_by[filterType] = [
-          ...query.filter_by[filterType].slice(0, index),
-          ...query.filter_by[filterType].slice(index + 1),
-        ];
-      }
-    } else {
-      newQuery.filter_by[filterType] = undefined;
-    }
-    const filteredQuery = this.getRouteForQuery(newQuery, true);
-    history.replace(filteredQuery);
+    const filteredQuery = removeQueryFilter(query, filterType, filterValue);
+    history.replace(this.getRouteForQuery(filteredQuery, true));
   };
 
   private handleGroupByClick = groupBy => {

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -6,6 +6,7 @@ import { tagPrefix } from 'api/queries/query';
 import { OcpReport } from 'api/reports/ocpReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { AxiosError } from 'axios';
+import { addQueryFilter, getGroupByTagKey, removeQueryFilter } from 'pages/details/common/detailsUtils';
 import { ExportModal } from 'pages/details/components/export/exportModal';
 import Loading from 'pages/state/loading';
 import NoProviders from 'pages/state/noProviders';
@@ -118,7 +119,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     const { query, report } = this.props;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByTagKey = this.getGroupByTagKey();
+    const groupByTagKey = getGroupByTagKey(query);
 
     return getUnsortedComputedReportItems({
       report,
@@ -131,7 +132,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     const { query, report } = this.props;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByTagKey = this.getGroupByTagKey();
+    const groupByTagKey = getGroupByTagKey(query);
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
     return (
@@ -145,20 +146,6 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
         reportPathsType={reportPathsType}
       />
     );
-  };
-
-  private getGroupByTagKey = () => {
-    const { query } = this.props;
-    let groupByTagKey;
-
-    for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf(tagPrefix);
-      if (tagIndex !== -1) {
-        groupByTagKey = groupBy.substring(tagIndex + tagPrefix.length) as any;
-        break;
-      }
-    }
-    return groupByTagKey;
   };
 
   private getPagination = (isBottom: boolean = false) => {
@@ -207,7 +194,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     const { isAllSelected, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByTagKey = this.getGroupByTagKey();
+    const groupByTagKey = getGroupByTagKey(query);
 
     return (
       <DetailsTable
@@ -228,7 +215,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     const { isAllSelected, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByTagKey = this.getGroupByTagKey();
+    const groupByTagKey = getGroupByTagKey(query);
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
     return (
@@ -274,57 +261,16 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
   private handleFilterAdded = (filterType: string, filterValue: string) => {
     const { history, query } = this.props;
-    const newQuery = { ...JSON.parse(JSON.stringify(query)) };
 
-    // Filter by * won't generate a new request if group_by * already exists
-    if (filterValue === '*' && newQuery.group_by[filterType] === '*') {
-      return;
-    }
-
-    if (newQuery.filter_by[filterType]) {
-      let found = false;
-      const filters = newQuery.filter_by[filterType];
-      if (!Array.isArray(filters)) {
-        found = filterValue === newQuery.filter_by[filterType];
-      } else {
-        for (const filter of filters) {
-          if (filter === filterValue) {
-            found = true;
-            break;
-          }
-        }
-      }
-      if (!found) {
-        newQuery.filter_by[filterType] = [newQuery.filter_by[filterType], filterValue];
-      }
-    } else {
-      newQuery.filter_by[filterType] = [filterValue];
-    }
-    const filteredQuery = this.getRouteForQuery(newQuery, true);
-    history.replace(filteredQuery);
+    const filteredQuery = addQueryFilter(query, filterType, filterValue);
+    history.replace(this.getRouteForQuery(filteredQuery, true));
   };
 
   private handleFilterRemoved = (filterType: string, filterValue: string) => {
     const { history, query } = this.props;
-    const newQuery = { ...JSON.parse(JSON.stringify(query)) };
 
-    if (filterType === null) {
-      newQuery.filter_by = undefined; // Clear all
-    } else if (filterValue === null) {
-      newQuery.filter_by[filterType] = undefined; // Clear all values
-    } else if (Array.isArray(newQuery.filter_by[filterType])) {
-      const index = newQuery.filter_by[filterType].indexOf(filterValue);
-      if (index > -1) {
-        newQuery.filter_by[filterType] = [
-          ...query.filter_by[filterType].slice(0, index),
-          ...query.filter_by[filterType].slice(index + 1),
-        ];
-      }
-    } else {
-      newQuery.filter_by[filterType] = undefined;
-    }
-    const filteredQuery = this.getRouteForQuery(newQuery, true);
-    history.replace(filteredQuery);
+    const filteredQuery = removeQueryFilter(query, filterType, filterValue);
+    history.replace(this.getRouteForQuery(filteredQuery, true));
   };
 
   private handleGroupByClick = groupBy => {


### PR DESCRIPTION
The details pages have a couple common functions; for example, `handleFilterAdded`, `handleFilterRemoved`, etc. I'd like to move some of this dup code to a new file, named `detailsUtils`.

https://issues.redhat.com/browse/COST-949