### PR TITLE
gcp need to order by 'account' not 'account_alias'

### DIFF
--- a/src/pages/details/gcpDetails/detailsTable.tsx
+++ b/src/pages/details/gcpDetails/detailsTable.tsx
@@ -119,7 +119,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         ]
       : [
           {
-            orderBy: groupById === 'account' ? 'account_alias' : groupById,
+            orderBy: groupById,
             title: t('gcp_details.name_column_title', { groupBy: groupById }),
             transforms: [sortable],
           },


### PR DESCRIPTION
Closes: https://issues.redhat.com/browse/COST-956

URL change - "order_by[account_alias]" to "order_by[account]" : 
`https://ci.foo.redhat.com:1337/api/cost-management/v1/reports/gcp/costs/?delta=cost&filter[limit]=10&filter[offset]=0&filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&group_by[account]=*&order_by[account]=desc`


![Screen Shot 2021-02-03 at 8 34 30 AM](https://user-images.githubusercontent.com/57504257/106755448-257c5000-65fc-11eb-8cf9-2ba0426b7f76.png)

![Screen Shot 2021-02-03 at 8 34 41 AM](https://user-images.githubusercontent.com/57504257/106755457-27deaa00-65fc-11eb-9b68-146ba28399d5.png)
