### PR TITLE
Historical Cost Explorer

### DIFF
--- a/src/api/userAccess.ts
+++ b/src/api/userAccess.ts
@@ -19,6 +19,7 @@ export const enum UserAccessType {
   aws = 'aws',
   azure = 'azure',
   cost_model = 'cost_model',
+  explorer = 'explorer',
   gcp = 'gcp',
   ocp = 'ocp',
 }

--- a/src/components/async/permissionsComponent/permissions.tsx
+++ b/src/components/async/permissionsComponent/permissions.tsx
@@ -51,9 +51,18 @@ class PermissionsBase extends React.Component<PermissionsProps> {
       return false;
     }
 
+    // Todo: Remove override when API is available
+    if (userAccess && userAccess.data) {
+      userAccess.data.push({
+        type: 'explorer',
+        access: true,
+      });
+    }
+
     const aws = userAccess.data.find(d => d.type === UserAccessType.aws);
     const azure = userAccess.data.find(d => d.type === UserAccessType.azure);
     const costModel = userAccess.data.find(d => d.type === UserAccessType.cost_model);
+    const explorer = userAccess.data.find(d => d.type === UserAccessType.explorer);
     const gcp = userAccess.data.find(d => d.type === UserAccessType.gcp);
     const ocp = userAccess.data.find(d => d.type === UserAccessType.ocp);
 
@@ -78,6 +87,8 @@ class PermissionsBase extends React.Component<PermissionsProps> {
         return azure && azure.access;
       case paths.costModels:
         return costModel && costModel.access;
+      case paths.explorer:
+        return explorer && explorer.access;
       case paths.gcpDetails:
       case paths.gcpDetailsBreakdown:
         return gcp && gcp.access;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -471,6 +471,13 @@
     "unexpected_desc": "We encountered an unexpected error. Contact your administrator.",
     "unexpected_title": "Oops!"
   },
+  "explorer": {
+    "daily_column_title": "{{date}}-$t(months_abbr.{{month}})",
+    "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
+    "name_column_title": "Names",
+    "tag_column_title": "Tag names",
+    "total_cost": "Total cost"
+  },
   "export": {
     "aggregate_type": "Select aggregate type",
     "all": "All",
@@ -718,6 +725,7 @@
     "azure_details": "Microsoft Azure details",
     "azure_details_breakdown": "Microsoft Azure Details Breakdown",
     "cost_models": "Cost models",
+    "explorer": "Historical Cost Explorer",
     "gcp_details": "Google Cloud Platform Details",
     "gcp_details_breakdown": "Google Cloud Platform Details Breakdown",
     "ocp_details": "OpenShift Details",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -475,6 +475,7 @@
     "daily_column_title": "{{date}}-$t(months_abbr.{{month}})",
     "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "name_column_title": "Names",
+    "no_data": "no data",
     "tag_column_title": "Tag names",
     "total_cost": "Total cost"
   },

--- a/src/pages/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/details/awsDetails/detailsToolbar.tsx
@@ -140,7 +140,9 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         pagination={pagination}
         query={query}
         selectedItems={selectedItems}
+        showBulkSelect
         showExport
+        showFilter
         tagReport={tagReport}
       />
     );

--- a/src/pages/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/details/azureDetails/detailsToolbar.tsx
@@ -128,7 +128,9 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         pagination={pagination}
         query={query}
         selectedItems={selectedItems}
+        showBulkSelect
         showExport
+        showFilter
         tagReport={tagReport}
       />
     );

--- a/src/pages/details/components/dataToolbar/dataToolbar.tsx
+++ b/src/pages/details/components/dataToolbar/dataToolbar.tsx
@@ -46,19 +46,23 @@ interface DataToolbarOwnProps {
   groupBy?: string; // Sync category selection with groupBy value
   isAllSelected?: boolean;
   isBulkSelectDisabled?: boolean;
+  isDisabled?: boolean;
   isExportDisabled?: boolean; // Show export icon as disabled
   itemsPerPage?: number;
   itemsTotal?: number;
-  onBulkSelected(action: string);
-  onExportClicked();
-  onFilterAdded(filterType: string, filterValue: string);
-  onFilterRemoved(filterType: string, filterValue?: string);
+  onBulkSelected?: (action: string) => void;
+  onExportClicked?: () => void;
+  onFilterAdded?: (filterType: string, filterValue: string) => void;
+  onFilterRemoved?: (filterType: string, filterValue?: string) => void;
   orgReport?: Org; // Report containing AWS organizational unit data
   pagination?: React.ReactNode; // Optional pagination controls to display in toolbar
   query?: Query; // Query containing filter_by params used to restore state upon page refresh
   tagReport?: Tag; // Data containing tag key and value data
   selectedItems?: ComputedReportItem[];
+  showBulkSelect?: boolean; // Show bulk select
   showExport?: boolean; // Show export icon
+  showFilter?: boolean; // Show export icon
+  style?: React.CSSProperties;
 }
 
 interface DataToolbarState {
@@ -210,7 +214,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
   // Bulk select
 
   public getBulkSelect = () => {
-    const { isAllSelected, isBulkSelectDisabled = false, itemsPerPage, itemsTotal, selectedItems, t } = this.props;
+    const { isAllSelected, isBulkSelectDisabled, isDisabled, itemsPerPage, itemsTotal, selectedItems, t } = this.props;
     const { isBulkSelectOpen } = this.state;
 
     const numSelected = isAllSelected ? itemsTotal : selectedItems ? selectedItems.length : 0;
@@ -239,7 +243,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
         position={DropdownPosition.left}
         toggle={
           <DropdownToggle
-            isDisabled={isBulkSelectDisabled}
+            isDisabled={isDisabled || isBulkSelectDisabled}
             splitButtonItems={[
               <DropdownToggleCheckbox
                 id="bulk-select"
@@ -285,7 +289,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
   // Category dropdown
 
   public getCategoryDropdown() {
-    const { categoryOptions } = this.props;
+    const { categoryOptions, isDisabled } = this.props;
     const { isCategoryDropdownOpen } = this.state;
 
     if (!categoryOptions) {
@@ -297,7 +301,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
           onSelect={this.onCategorySelect}
           position={DropdownPosition.left}
           toggle={
-            <DropdownToggle onToggle={this.onCategoryToggle} style={{ width: '100%' }}>
+            <DropdownToggle isDisabled={isDisabled} onToggle={this.onCategoryToggle} style={{ width: '100%' }}>
               <FilterIcon /> {this.getCurrentCategoryOption().name}
             </DropdownToggle>
           }
@@ -354,7 +358,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
   // Category input
 
   public getCategoryInput = categoryOption => {
-    const { t } = this.props;
+    const { isDisabled, t } = this.props;
     const { currentCategory, filters, categoryInput } = this.state;
 
     return (
@@ -367,6 +371,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
       >
         <InputGroup>
           <TextInput
+            isDisabled={isDisabled}
             name={`${categoryOption.key}-input`}
             id={`${categoryOption.key}-input`}
             type="search"
@@ -377,6 +382,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
             onKeyDown={evt => this.onCategoryInput(evt, categoryOption.key)}
           />
           <Button
+            isDisabled={isDisabled}
             variant={ButtonVariant.control}
             aria-label={t(`filter_by.${categoryOption.key}.button_aria_label`)}
             onClick={evt => this.onCategoryInput(evt, categoryOption.key)}
@@ -429,7 +435,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
   // Org unit select
 
   public getOrgUnitSelect = () => {
-    const { t } = this.props;
+    const { isDisabled, t } = this.props;
     const { currentCategory, filters, isOrgUnitSelectExpanded } = this.state;
 
     const options: GroupByOrgOption[] = this.getOrgUnitOptions().map(option => ({
@@ -467,6 +473,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
         showToolbarItem={currentCategory === orgUnitIdKey}
       >
         <Select
+          isDisabled={isDisabled}
           className="selectOverride"
           variant={SelectVariant.checkbox}
           aria-label={t('filter_by.org_unit.aria_label')}
@@ -560,7 +567,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
   // Tag key select
 
   public getTagKeySelect = () => {
-    const { t } = this.props;
+    const { isDisabled, t } = this.props;
     const { currentCategory, currentTagKey, isTagKeySelectExpanded } = this.state;
 
     if (currentCategory !== tagKey) {
@@ -574,6 +581,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
     return (
       <ToolbarItem>
         <Select
+          isDisabled={isDisabled}
           variant={SelectVariant.typeahead}
           aria-label={t('filter_by.tag_key.aria_label')}
           onClear={this.onTagKeyClear}
@@ -654,7 +662,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
   // Tag value select
 
   public getTagValueSelect = tagKeyOption => {
-    const { t } = this.props;
+    const { isDisabled, t } = this.props;
     const { currentCategory, currentTagKey, filters, isTagValueSelectExpanded, tagKeyValueInput } = this.state;
 
     const selectOptions = this.getTagValueOptions().map(selectOption => {
@@ -671,6 +679,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
       >
         {selectOptions.length < tagKeyValueLimit ? (
           <Select
+            isDisabled={isDisabled}
             variant={SelectVariant.checkbox}
             aria-label={t('filter_by.tag_value.aria_label')}
             onToggle={this.onTagValueToggle}
@@ -684,6 +693,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
         ) : (
           <InputGroup>
             <TextInput
+              isDisabled={isDisabled}
               name="tagkeyvalue-input"
               id="tagkeyvalue-input"
               type="search"
@@ -694,6 +704,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
               onKeyDown={evt => this.onTagValueInput(evt)}
             />
             <Button
+              isDisabled={isDisabled}
               variant={ButtonVariant.control}
               aria-label={t('filter_by.tag_value.button_aria_label')}
               onClick={evt => this.onTagValueInput(evt)}
@@ -800,11 +811,15 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
   // Export button
 
   public getExportButton = () => {
-    const { isExportDisabled } = this.props;
+    const { isDisabled, isExportDisabled } = this.props;
 
     return (
       <ToolbarItem>
-        <Button isDisabled={isExportDisabled} onClick={this.handleExportClicked} variant={ButtonVariant.plain}>
+        <Button
+          isDisabled={isDisabled || isExportDisabled}
+          onClick={this.handleExportClicked}
+          variant={ButtonVariant.plain}
+        >
           <ExportIcon />
         </Button>
       </ToolbarItem>
@@ -816,26 +831,28 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
   };
 
   public render() {
-    const { categoryOptions, pagination, showExport } = this.props;
+    const { categoryOptions, pagination, showBulkSelect, showExport, showFilter, style } = this.props;
     const options = categoryOptions ? categoryOptions : this.getDefaultCategoryOptions();
 
     // Todo: clearAllFilters workaround https://github.com/patternfly/patternfly-react/issues/4222
     return (
-      <div style={styles.toolbarContainer}>
+      <div style={style ? style : styles.toolbarContainer}>
         <Toolbar id="details-toolbar" clearAllFilters={this.onDelete as any} collapseListedFiltersBreakpoint="xl">
           <ToolbarContent>
             <ToolbarToggleGroup breakpoint="xl" toggleIcon={<FilterIcon />}>
-              <ToolbarItem variant="bulk-select">{this.getBulkSelect()}</ToolbarItem>
-              <ToolbarGroup variant="filter-group">
-                {this.getCategoryDropdown()}
-                {this.getTagKeySelect()}
-                {this.getTagKeyOptions().map(option => this.getTagValueSelect(option))}
-                {this.getOrgUnitSelect()}
-                {options &&
-                  options
-                    .filter(option => option.key !== tagKey && option.key !== orgUnitIdKey)
-                    .map(option => this.getCategoryInput(option))}
-              </ToolbarGroup>
+              {showBulkSelect && <ToolbarItem variant="bulk-select">{this.getBulkSelect()}</ToolbarItem>}
+              {showFilter && (
+                <ToolbarGroup variant="filter-group">
+                  {this.getCategoryDropdown()}
+                  {this.getTagKeySelect()}
+                  {this.getTagKeyOptions().map(option => this.getTagValueSelect(option))}
+                  {this.getOrgUnitSelect()}
+                  {options &&
+                    options
+                      .filter(option => option.key !== tagKey && option.key !== orgUnitIdKey)
+                      .map(option => this.getCategoryInput(option))}
+                </ToolbarGroup>
+              )}
               {Boolean(showExport) && <ToolbarGroup>{this.getExportButton()}</ToolbarGroup>}
             </ToolbarToggleGroup>
             <ToolbarItem alignment={{ default: 'alignRight' }} variant="pagination">

--- a/src/pages/details/gcpDetails/detailsToolbar.tsx
+++ b/src/pages/details/gcpDetails/detailsToolbar.tsx
@@ -124,7 +124,9 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         pagination={pagination}
         query={query}
         selectedItems={selectedItems}
+        showBulkSelect
         showExport
+        showFilter
         tagReport={tagReport}
       />
     );

--- a/src/pages/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/details/ocpDetails/detailsToolbar.tsx
@@ -121,7 +121,9 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         pagination={pagination}
         query={query}
         selectedItems={selectedItems}
+        showBulkSelect
         showExport
+        showFilter
         tagReport={tagReport}
       />
     );

--- a/src/pages/explorer/explorer.styles.ts
+++ b/src/pages/explorer/explorer.styles.ts
@@ -1,0 +1,25 @@
+import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
+import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
+import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
+
+export const styles = {
+  content: {
+    paddingBottom: global_spacer_lg.value,
+    paddingTop: global_spacer_lg.value,
+  },
+  explorer: {
+    minHeight: '100%',
+  },
+  paginationContainer: {
+    marginLeft: global_spacer_lg.value,
+    marginRight: global_spacer_lg.value,
+  },
+  pagination: {
+    backgroundColor: global_BackgroundColor_light_100.value,
+    padding: global_spacer_md.value,
+  },
+  tableContainer: {
+    marginLeft: global_spacer_lg.value,
+    marginRight: global_spacer_lg.value,
+  },
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/explorer/explorer.tsx
+++ b/src/pages/explorer/explorer.tsx
@@ -1,0 +1,488 @@
+import { Pagination, PaginationVariant } from '@patternfly/react-core';
+import { Providers, ProviderType } from 'api/providers';
+import { AwsQuery, getQuery, getQueryRoute, parseQuery } from 'api/queries/awsQuery';
+import { getProvidersQuery } from 'api/queries/providersQuery';
+import { orgUnitIdKey, tagPrefix } from 'api/queries/query';
+import { AwsReport } from 'api/reports/awsReports';
+import { ReportPathsType, ReportType } from 'api/reports/report';
+import { AxiosError } from 'axios';
+import { addQueryFilter, getGroupByTagKey, removeQueryFilter } from 'pages/details/common/detailsUtils';
+import { ExportModal } from 'pages/details/components/export/exportModal';
+import Loading from 'pages/state/loading';
+import NoData from 'pages/state/noData';
+import NoProviders from 'pages/state/noProviders';
+import NotAvailable from 'pages/state/notAvailable';
+import React from 'react';
+import { WithTranslation, withTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
+import { RouteComponentProps } from 'react-router';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { awsProvidersQuery, providersSelectors } from 'store/providers';
+import { reportActions, reportSelectors } from 'store/reports';
+import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedAwsReportItems';
+import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
+
+import { styles } from './explorer.styles';
+import { ExplorerHeader } from './explorerHeader';
+import { ExplorerTable } from './explorerTable';
+import { ExplorerToolbar } from './explorerToolbar';
+
+interface AwsExplorerStateProps {
+  providers: Providers;
+  providersFetchStatus: FetchStatus;
+  query: AwsQuery;
+  queryString: string;
+  report: AwsReport;
+  reportError: AxiosError;
+  reportFetchStatus: FetchStatus;
+}
+
+interface AwsExplorerDispatchProps {
+  fetchReport: typeof reportActions.fetchReport;
+}
+
+interface AwsExplorerState {
+  columns: any[];
+  isAllSelected: boolean;
+  isExportModalOpen: boolean;
+  rows: any[];
+  selectedItems: ComputedReportItem[];
+}
+
+type AwsExplorerOwnProps = RouteComponentProps<void> & WithTranslation;
+
+type AwsExplorerProps = AwsExplorerStateProps & AwsExplorerOwnProps & AwsExplorerDispatchProps;
+
+const baseQuery: AwsQuery = {
+  delta: 'cost',
+  filter: {
+    limit: 10,
+    offset: 0,
+    resolution: 'daily',
+    time_scope_units: 'month',
+    time_scope_value: -1,
+  },
+  filter_by: {},
+  group_by: {
+    account: '*',
+  },
+  order_by: {
+    cost: 'desc',
+  },
+};
+
+const reportType = ReportType.cost;
+const reportPathsType = ReportPathsType.aws;
+
+class Explorer extends React.Component<AwsExplorerProps> {
+  protected defaultState: AwsExplorerState = {
+    columns: [],
+    isAllSelected: false,
+    isExportModalOpen: false,
+    rows: [],
+    selectedItems: [],
+  };
+  public state: AwsExplorerState = { ...this.defaultState };
+
+  constructor(stateProps, dispatchProps) {
+    super(stateProps, dispatchProps);
+    this.handleBulkSelected = this.handleBulkSelected.bind(this);
+    this.handleExportModalClose = this.handleExportModalClose.bind(this);
+    this.handleExportModalOpen = this.handleExportModalOpen.bind(this);
+    this.handleFilterAdded = this.handleFilterAdded.bind(this);
+    this.handleFilterRemoved = this.handleFilterRemoved.bind(this);
+    this.handlePerPageSelect = this.handlePerPageSelect.bind(this);
+    this.handleSelected = this.handleSelected.bind(this);
+    this.handleSetPage = this.handleSetPage.bind(this);
+    this.handleSort = this.handleSort.bind(this);
+  }
+
+  public componentDidMount() {
+    this.updateReport();
+  }
+
+  public componentDidUpdate(prevProps: AwsExplorerProps, prevState: AwsExplorerState) {
+    const { location, report, reportError, queryString } = this.props;
+    const { selectedItems } = this.state;
+
+    const newQuery = prevProps.queryString !== queryString;
+    const noReport = !report && !reportError;
+    const noLocation = !location.search;
+    const newItems = prevState.selectedItems !== selectedItems;
+
+    if (newQuery || noReport || noLocation || newItems) {
+      this.updateReport();
+    }
+  }
+
+  private getComputedItems = () => {
+    const { query, report } = this.props;
+
+    const groupById = getIdKeyForGroupBy(query.group_by);
+    const groupByTagKey = getGroupByTagKey(query);
+
+    return getUnsortedComputedReportItems({
+      report,
+      idKey: (groupByTagKey as any) || groupById,
+    });
+  };
+
+  private getExportModal = (computedItems: ComputedReportItem[]) => {
+    const { isAllSelected, isExportModalOpen, selectedItems } = this.state;
+    const { query, report } = this.props;
+
+    const groupById = getIdKeyForGroupBy(query.group_by);
+    const groupByTagKey = getGroupByTagKey(query);
+    const itemsTotal = report && report.meta ? report.meta.count : 0;
+
+    return (
+      <ExportModal
+        isAllItems={(isAllSelected || selectedItems.length === itemsTotal) && computedItems.length > 0}
+        groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
+        isOpen={isExportModalOpen}
+        items={selectedItems}
+        onClose={this.handleExportModalClose}
+        query={query}
+        reportPathsType={reportPathsType}
+      />
+    );
+  };
+
+  private getPagination = (isBottom: boolean = false) => {
+    const { report } = this.props;
+
+    const count = report && report.meta ? report.meta.count : 0;
+    const limit =
+      report && report.meta && report.meta.filter && report.meta.filter.limit
+        ? report.meta.filter.limit
+        : baseQuery.filter.limit;
+    const offset =
+      report && report.meta && report.meta.filter && report.meta.filter.offset
+        ? report.meta.filter.offset
+        : baseQuery.filter.offset;
+    const page = offset / limit + 1;
+
+    return (
+      <Pagination
+        isCompact={!isBottom}
+        itemCount={count}
+        onPerPageSelect={this.handlePerPageSelect}
+        onSetPage={this.handleSetPage}
+        page={page}
+        perPage={limit}
+        variant={isBottom ? PaginationVariant.bottom : PaginationVariant.top}
+        widgetId="`pagination${isBottom ? '-bottom' : ''}`"
+      />
+    );
+  };
+
+  private getRouteForQuery(query: AwsQuery, reset: boolean = false) {
+    const { history } = this.props;
+
+    // Reset pagination
+    if (reset) {
+      query.filter = {
+        ...query.filter,
+        offset: baseQuery.filter.offset,
+      };
+    }
+    return `${history.location.pathname}?${getQueryRoute(query)}`;
+  }
+
+  private getTable = () => {
+    const { query, report, reportFetchStatus } = this.props;
+    const { isAllSelected, selectedItems } = this.state;
+
+    const groupById = getIdKeyForGroupBy(query.group_by);
+    const groupByTagKey = getGroupByTagKey(query);
+
+    return (
+      <ExplorerTable
+        groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
+        isAllSelected={isAllSelected}
+        isLoading={reportFetchStatus === FetchStatus.inProgress}
+        onSelected={this.handleSelected}
+        onSort={this.handleSort}
+        query={query}
+        report={report}
+        selectedItems={selectedItems}
+      />
+    );
+  };
+
+  private getToolbar = (computedItems: ComputedReportItem[]) => {
+    const { query, report } = this.props;
+    const { isAllSelected, selectedItems } = this.state;
+
+    const groupById = getIdKeyForGroupBy(query.group_by);
+    const groupByTagKey = getGroupByTagKey(query);
+    const itemsTotal = report && report.meta ? report.meta.count : 0;
+
+    return (
+      <ExplorerToolbar
+        groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
+        isAllSelected={isAllSelected}
+        isExportDisabled={computedItems.length === 0 || (!isAllSelected && selectedItems.length === 0)}
+        itemsPerPage={computedItems.length}
+        itemsTotal={itemsTotal}
+        onBulkSelected={this.handleBulkSelected}
+        onExportClicked={this.handleExportModalOpen}
+        onFilterAdded={this.handleFilterAdded}
+        onFilterRemoved={this.handleFilterRemoved}
+        pagination={this.getPagination()}
+        query={query}
+        selectedItems={selectedItems}
+      />
+    );
+  };
+
+  private handleBulkSelected = (action: string) => {
+    const { isAllSelected } = this.state;
+
+    if (action === 'none') {
+      this.setState({ isAllSelected: false, selectedItems: [] });
+    } else if (action === 'page') {
+      this.setState({
+        isAllSelected: false,
+        selectedItems: this.getComputedItems(),
+      });
+    } else if (action === 'all') {
+      this.setState({ isAllSelected: !isAllSelected, selectedItems: [] });
+    }
+  };
+
+  public handleExportModalClose = (isOpen: boolean) => {
+    this.setState({ isExportModalOpen: isOpen });
+  };
+
+  public handleExportModalOpen = () => {
+    this.setState({ isExportModalOpen: true });
+  };
+
+  private handleFilterAdded = (filterType: string, filterValue: string) => {
+    const { history, query } = this.props;
+
+    const filteredQuery = addQueryFilter(query, filterType, filterValue);
+    history.replace(this.getRouteForQuery(filteredQuery, true));
+  };
+
+  private handleFilterRemoved = (filterType: string, filterValue: string) => {
+    const { history, query } = this.props;
+
+    const filteredQuery = removeQueryFilter(query, filterType, filterValue);
+    history.replace(this.getRouteForQuery(filteredQuery, true));
+  };
+
+  private handleGroupByClick = groupBy => {
+    const { history, query } = this.props;
+
+    let groupByKey = groupBy;
+    let value = '*';
+
+    // Check for for org units
+    const index = groupBy.indexOf(orgUnitIdKey);
+    if (index !== -1) {
+      groupByKey = orgUnitIdKey.substring(0, orgUnitIdKey.length);
+      value = groupBy.slice(orgUnitIdKey.length);
+    }
+
+    const newQuery = {
+      ...JSON.parse(JSON.stringify(query)),
+      filter_by: undefined,
+      group_by: {
+        [groupByKey]: value,
+      },
+      order_by: { cost: 'desc' },
+    };
+    history.replace(this.getRouteForQuery(newQuery, true));
+    this.setState({ isAllSelected: false, selectedItems: [] });
+  };
+
+  private handlePerPageSelect = (_event, perPage) => {
+    const { history, query } = this.props;
+    const newQuery = { ...JSON.parse(JSON.stringify(query)) };
+    newQuery.filter = {
+      ...query.filter,
+      limit: perPage,
+    };
+    const filteredQuery = this.getRouteForQuery(newQuery, true);
+    history.replace(filteredQuery);
+  };
+
+  private handleSelected = (items: ComputedReportItem[], isSelected: boolean = false) => {
+    const { isAllSelected, selectedItems } = this.state;
+
+    let newItems = [...(isAllSelected ? this.getComputedItems() : selectedItems)];
+    if (items && items.length > 0) {
+      if (isSelected) {
+        items.map(item => newItems.push(item));
+      } else {
+        items.map(item => {
+          newItems = newItems.filter(val => val.id !== item.id);
+        });
+      }
+    }
+    this.setState({ isAllSelected: false, selectedItems: newItems });
+  };
+
+  private handleSetPage = (event, pageNumber) => {
+    const { history, query, report } = this.props;
+
+    const limit =
+      report && report.meta && report.meta.filter && report.meta.filter.limit
+        ? report.meta.filter.limit
+        : baseQuery.filter.limit;
+    const offset = pageNumber * limit - limit;
+
+    const newQuery = { ...JSON.parse(JSON.stringify(query)) };
+    newQuery.filter = {
+      ...query.filter,
+      offset,
+    };
+    const filteredQuery = this.getRouteForQuery(newQuery);
+    history.replace(filteredQuery);
+  };
+
+  private handleSort = (sortType: string, isSortAscending: boolean) => {
+    const { history, query } = this.props;
+    const newQuery = { ...JSON.parse(JSON.stringify(query)) };
+    newQuery.order_by = {};
+    newQuery.order_by[sortType] = isSortAscending ? 'asc' : 'desc';
+    const filteredQuery = this.getRouteForQuery(newQuery);
+    history.replace(filteredQuery);
+  };
+
+  // Ensure at least one source provider has data available
+  private hasCurrentMonthData = () => {
+    const { providers } = this.props;
+    let result = false;
+
+    if (providers && providers.data) {
+      for (const provider of providers.data) {
+        if (provider.current_month_data) {
+          result = true;
+          break;
+        }
+      }
+    }
+    return result;
+  };
+
+  private updateReport = () => {
+    const { query, location, fetchReport, history, queryString } = this.props;
+    if (!location.search) {
+      history.replace(
+        this.getRouteForQuery({
+          filter_by: query ? query.filter_by : undefined,
+          group_by: query ? query.group_by : undefined,
+          order_by: { cost: 'desc' },
+        })
+      );
+    } else {
+      fetchReport(reportPathsType, reportType, queryString);
+    }
+  };
+
+  public render() {
+    const { providers, providersFetchStatus, query, report, reportError, reportFetchStatus, t } = this.props;
+
+    const groupById = getIdKeyForGroupBy(query.group_by);
+    const computedItems = this.getComputedItems();
+    const title = t('navigation.explorer');
+
+    // Note: Providers are fetched via the InactiveSources component used by all routes
+    if (reportError) {
+      return <NotAvailable title={title} />;
+    } else if (providersFetchStatus === FetchStatus.inProgress && reportFetchStatus === FetchStatus.inProgress) {
+      return <Loading title={title} />;
+    } else if (providersFetchStatus === FetchStatus.complete && reportFetchStatus === FetchStatus.complete) {
+      // API returns empy data array for no sources
+      const noProviders =
+        providers && providers.meta && providers.meta.count === 0 && providersFetchStatus === FetchStatus.complete;
+
+      if (noProviders) {
+        return <NoProviders providerType={ProviderType.aws} title={title} />;
+      }
+      if (!this.hasCurrentMonthData()) {
+        return <NoData title={title} />;
+      }
+    }
+    return (
+      <div style={styles.explorer}>
+        <ExplorerHeader groupBy={groupById} onGroupByClicked={this.handleGroupByClick} report={report} />
+        <div style={styles.content}>
+          {this.getToolbar(computedItems)}
+          {this.getExportModal(computedItems)}
+          {reportFetchStatus === FetchStatus.inProgress ? (
+            <Loading />
+          ) : (
+            <>
+              <div style={styles.tableContainer}>{this.getTable()}</div>
+              <div style={styles.paginationContainer}>
+                <div style={styles.pagination}>{this.getPagination(true)}</div>
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+    );
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<AwsExplorerOwnProps, AwsExplorerStateProps>((state, props) => {
+  const queryFromRoute = parseQuery<AwsQuery>(location.search);
+  const query = {
+    delta: 'cost',
+    filter: {
+      ...baseQuery.filter,
+      ...queryFromRoute.filter,
+    },
+    filter_by: queryFromRoute.filter_by || baseQuery.filter_by,
+    group_by: queryFromRoute.group_by || baseQuery.group_by,
+    order_by: queryFromRoute.order_by || baseQuery.order_by,
+  };
+  const queryString = getQuery(query);
+  const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
+  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
+  const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+
+  const providersQueryString = getProvidersQuery(awsProvidersQuery);
+  const providers = providersSelectors.selectProviders(state, ProviderType.aws, providersQueryString);
+  const providersFetchStatus = providersSelectors.selectProvidersFetchStatus(
+    state,
+    ProviderType.aws,
+    providersQueryString
+  );
+
+  return {
+    providers,
+    providersFetchStatus,
+    query,
+    queryString,
+    report,
+    reportError,
+    reportFetchStatus,
+
+    // Testing...
+    //
+    // providers: {
+    //   meta: {
+    //     count: 0,
+    //   },
+    // } as any,
+    // providersError: {
+    //   response: {
+    //     // status: 401
+    //     status: 500
+    //   }
+    // } as any,
+    // providersFetchStatus: FetchStatus.inProgress,
+  };
+});
+
+const mapDispatchToProps: AwsExplorerDispatchProps = {
+  fetchReport: reportActions.fetchReport,
+};
+
+export default withTranslation()(connect(mapStateToProps, mapDispatchToProps)(Explorer));

--- a/src/pages/explorer/explorer.tsx
+++ b/src/pages/explorer/explorer.tsx
@@ -211,26 +211,20 @@ class Explorer extends React.Component<AwsExplorerProps> {
   };
 
   private getToolbar = (computedItems: ComputedReportItem[]) => {
-    const { query, report } = this.props;
+    const { report } = this.props;
     const { isAllSelected, selectedItems } = this.state;
 
-    const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByTagKey = getGroupByTagKey(query);
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
     return (
       <ExplorerToolbar
-        groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isAllSelected={isAllSelected}
         isExportDisabled={computedItems.length === 0 || (!isAllSelected && selectedItems.length === 0)}
         itemsPerPage={computedItems.length}
         itemsTotal={itemsTotal}
         onBulkSelected={this.handleBulkSelected}
         onExportClicked={this.handleExportModalOpen}
-        onFilterAdded={this.handleFilterAdded}
-        onFilterRemoved={this.handleFilterRemoved}
         pagination={this.getPagination()}
-        query={query}
         selectedItems={selectedItems}
       />
     );
@@ -409,7 +403,14 @@ class Explorer extends React.Component<AwsExplorerProps> {
     }
     return (
       <div style={styles.explorer}>
-        <ExplorerHeader groupBy={groupById} onGroupByClicked={this.handleGroupByClick} report={report} />
+        <ExplorerHeader
+          groupBy={groupById}
+          onGroupByClicked={this.handleGroupByClick}
+          onFilterAdded={this.handleFilterAdded}
+          onFilterRemoved={this.handleFilterRemoved}
+          query={query}
+          report={report}
+        />
         <div style={styles.content}>
           {this.getToolbar(computedItems)}
           {this.getExportModal(computedItems)}

--- a/src/pages/explorer/explorerFilter.styles.ts
+++ b/src/pages/explorer/explorerFilter.styles.ts
@@ -1,0 +1,11 @@
+import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
+import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
+import React from 'react';
+
+export const styles = {
+  toolbarContainer: {
+    backgroundColor: global_BackgroundColor_light_100.value,
+    marginLeft: `-${global_spacer_md.value}`,
+    paddingTop: global_spacer_md.value,
+  },
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/explorer/explorerFilter.tsx
+++ b/src/pages/explorer/explorerFilter.tsx
@@ -1,0 +1,145 @@
+import { ToolbarChipGroup } from '@patternfly/react-core';
+import { Org, OrgPathsType, OrgType } from 'api/orgs/org';
+import { getQuery, orgUnitIdKey, Query, tagKey } from 'api/queries/query';
+import { Tag, TagPathsType, TagType } from 'api/tags/tag';
+import { DataToolbar } from 'pages/details/components/dataToolbar/dataToolbar';
+import React from 'react';
+import { WithTranslation, withTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { orgActions, orgSelectors } from 'store/orgs';
+import { tagActions, tagSelectors } from 'store/tags';
+import { isEqual } from 'utils/equal';
+
+import { styles } from './explorerFilter.styles';
+
+interface ExplorerFilterOwnProps {
+  groupBy: string;
+  isDisabled?: boolean;
+  onFilterAdded(filterType: string, filterValue: string);
+  onFilterRemoved(filterType: string, filterValue?: string);
+  pagination?: React.ReactNode;
+  query?: Query;
+  queryString?: string;
+}
+
+interface ExplorerFilterStateProps {
+  orgReport?: Org;
+  orgReportFetchStatus?: FetchStatus;
+  tagReport?: Tag;
+  tagReportFetchStatus?: FetchStatus;
+}
+
+interface ExplorerFilterDispatchProps {
+  fetchOrg?: typeof orgActions.fetchOrg;
+  fetchTag?: typeof tagActions.fetchTag;
+}
+
+interface ExplorerFilterState {
+  categoryOptions?: ToolbarChipGroup[];
+}
+
+type ExplorerFilterProps = ExplorerFilterOwnProps &
+  ExplorerFilterStateProps &
+  ExplorerFilterDispatchProps &
+  WithTranslation;
+
+const orgReportPathsType = OrgPathsType.aws;
+const orgReportType = OrgType.org;
+const tagReportPathsType = TagPathsType.aws;
+const tagReportType = TagType.tag;
+
+export class ExplorerFilterBase extends React.Component<ExplorerFilterProps> {
+  protected defaultState: ExplorerFilterState = {};
+  public state: ExplorerFilterState = { ...this.defaultState };
+
+  public componentDidMount() {
+    const { fetchOrg, fetchTag, queryString } = this.props;
+    fetchOrg(orgReportPathsType, orgReportType, queryString);
+    fetchTag(tagReportPathsType, tagReportType, queryString);
+    this.setState({
+      categoryOptions: this.getCategoryOptions(),
+    });
+  }
+
+  public componentDidUpdate(prevProps: ExplorerFilterProps) {
+    const { fetchOrg, fetchTag, orgReport, query, queryString, tagReport } = this.props;
+    if (query && !isEqual(query, prevProps.query)) {
+      fetchOrg(orgReportPathsType, orgReportType, queryString);
+      fetchTag(tagReportPathsType, tagReportType, queryString);
+    }
+    if (!isEqual(orgReport, prevProps.orgReport) || !isEqual(tagReport, prevProps.tagReport)) {
+      this.setState({
+        categoryOptions: this.getCategoryOptions(),
+      });
+    }
+  }
+
+  private getCategoryOptions = (): ToolbarChipGroup[] => {
+    const { orgReport, t, tagReport } = this.props;
+
+    const options = [
+      { name: t('filter_by.values.account'), key: 'account' },
+      { name: t('filter_by.values.service'), key: 'service' },
+      { name: t('filter_by.values.region'), key: 'region' },
+    ];
+    if (orgReport && orgReport.data && orgReport.data.length > 0) {
+      options.push({
+        name: t('filter_by.values.org_unit_id'),
+        key: orgUnitIdKey,
+      });
+    }
+    if (tagReport && tagReport.data && tagReport.data.length > 0) {
+      options.push({ name: t('filter_by.values.tag'), key: tagKey });
+    }
+    return options;
+  };
+
+  public render() {
+    const { groupBy, isDisabled, onFilterAdded, onFilterRemoved, orgReport, query, tagReport } = this.props;
+    const { categoryOptions } = this.state;
+
+    return (
+      <DataToolbar
+        categoryOptions={categoryOptions}
+        groupBy={groupBy}
+        isDisabled={isDisabled}
+        onFilterAdded={onFilterAdded}
+        onFilterRemoved={onFilterRemoved}
+        orgReport={orgReport}
+        query={query}
+        style={styles.toolbarContainer}
+        showFilter
+        tagReport={tagReport}
+      />
+    );
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<ExplorerFilterOwnProps, ExplorerFilterStateProps>((state, props) => {
+  // Omitting key_only to share a single request -- the toolbar needs key values
+  const queryString = getQuery({
+    // key_only: true
+  });
+  const orgReport = orgSelectors.selectOrg(state, orgReportPathsType, orgReportType, queryString);
+  const orgReportFetchStatus = orgSelectors.selectOrgFetchStatus(state, orgReportPathsType, orgReportType, queryString);
+  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
+  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);
+  return {
+    queryString,
+    orgReport,
+    orgReportFetchStatus,
+    tagReport,
+    tagReportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: ExplorerFilterDispatchProps = {
+  fetchOrg: orgActions.fetchOrg,
+  fetchTag: tagActions.fetchTag,
+};
+
+const ExplorerFilter = withTranslation()(connect(mapStateToProps, mapDispatchToProps)(ExplorerFilterBase));
+
+export { ExplorerFilter, ExplorerFilterProps };

--- a/src/pages/explorer/explorerHeader.styles.ts
+++ b/src/pages/explorer/explorerHeader.styles.ts
@@ -29,7 +29,10 @@ export const styles = {
   header: {
     display: 'flex',
     justifyContent: 'space-between',
-    padding: global_spacer_lg.var,
+    paddingBottom: global_spacer_sm.var,
+    paddingLeft: global_spacer_lg.var,
+    paddingRight: global_spacer_lg.var,
+    paddingTop: global_spacer_lg.var,
     backgroundColor: global_BackgroundColor_light_100.var,
   },
   title: {

--- a/src/pages/explorer/explorerHeader.styles.ts
+++ b/src/pages/explorer/explorerHeader.styles.ts
@@ -1,0 +1,38 @@
+import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
+import global_Color_100 from '@patternfly/react-tokens/dist/js/global_Color_100';
+import global_Color_200 from '@patternfly/react-tokens/dist/js/global_Color_200';
+import global_FontSize_sm from '@patternfly/react-tokens/dist/js/global_FontSize_sm';
+import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
+import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
+import global_spacer_sm from '@patternfly/react-tokens/dist/js/global_spacer_sm';
+import React from 'react';
+
+export const styles = {
+  cost: {
+    display: 'flex',
+    alignItems: 'center',
+  },
+  costLabel: {},
+  costValue: {
+    marginTop: 0,
+    marginBottom: 0,
+    marginRight: global_spacer_md.var,
+  },
+  costLabelUnit: {
+    fontSize: global_FontSize_sm.value,
+    color: global_Color_100.var,
+  },
+  costLabelDate: {
+    fontSize: global_FontSize_sm.value,
+    color: global_Color_200.var,
+  },
+  header: {
+    display: 'flex',
+    justifyContent: 'space-between',
+    padding: global_spacer_lg.var,
+    backgroundColor: global_BackgroundColor_light_100.var,
+  },
+  title: {
+    paddingBottom: global_spacer_sm.var,
+  },
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/explorer/explorerHeader.tsx
+++ b/src/pages/explorer/explorerHeader.tsx
@@ -1,0 +1,121 @@
+import { Title } from '@patternfly/react-core';
+import { OrgPathsType } from 'api/orgs/org';
+import { Providers, ProviderType } from 'api/providers';
+import { AwsQuery, getQuery } from 'api/queries/awsQuery';
+import { getProvidersQuery } from 'api/queries/providersQuery';
+import { AwsReport } from 'api/reports/awsReports';
+import { TagPathsType } from 'api/tags/tag';
+import { AxiosError } from 'axios';
+import { GroupBy } from 'pages/details/components/groupBy/groupBy';
+import React from 'react';
+import { WithTranslation, withTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { awsProvidersQuery, providersSelectors } from 'store/providers';
+import { ComputedAwsReportItemsParams, getIdKeyForGroupBy } from 'utils/computedReport/getComputedAwsReportItems';
+import { getSinceDateRangeString } from 'utils/dateRange';
+import { formatCurrency } from 'utils/formatValue';
+
+import { styles } from './explorerHeader.styles';
+
+interface ExplorerHeaderOwnProps {
+  groupBy?: string;
+  onGroupByClicked(value: string);
+  report: AwsReport;
+}
+
+interface ExplorerHeaderStateProps {
+  queryString?: string;
+  providers: Providers;
+  providersError: AxiosError;
+  providersFetchStatus: FetchStatus;
+}
+
+type ExplorerHeaderProps = ExplorerHeaderOwnProps & ExplorerHeaderStateProps & WithTranslation;
+
+const baseQuery: AwsQuery = {
+  delta: 'cost',
+  filter: {
+    time_scope_units: 'month',
+    time_scope_value: -1,
+    resolution: 'monthly',
+  },
+};
+
+const groupByOptions: {
+  label: string;
+  value: ComputedAwsReportItemsParams['idKey'];
+}[] = [
+  { label: 'account', value: 'account' },
+  { label: 'service', value: 'service' },
+  { label: 'region', value: 'region' },
+];
+
+const orgReportPathsType = OrgPathsType.aws;
+const tagReportPathsType = TagPathsType.aws;
+
+class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
+  public render() {
+    const { groupBy, onGroupByClicked, providers, providersError, report, t } = this.props;
+    const showContent = report && !providersError && providers && providers.meta && providers.meta.count > 0;
+
+    const hasCost =
+      report && report.meta && report.meta.total && report.meta.total.cost && report.meta.total.cost.total;
+
+    return (
+      <header style={styles.header}>
+        <div>
+          <Title headingLevel="h2" style={styles.title} size="2xl">
+            {t('navigation.explorer')}
+          </Title>
+          <GroupBy
+            getIdKeyForGroupBy={getIdKeyForGroupBy}
+            groupBy={groupBy}
+            isDisabled={!showContent}
+            onItemClicked={onGroupByClicked}
+            options={groupByOptions}
+            orgReportPathsType={orgReportPathsType}
+            showOrgs
+            showTags
+            tagReportPathsType={tagReportPathsType}
+          />
+        </div>
+        {Boolean(showContent) && (
+          <div style={styles.cost}>
+            <Title headingLevel="h2" style={styles.costValue} size="4xl">
+              {formatCurrency(hasCost ? report.meta.total.cost.total.value : 0)}
+            </Title>
+            <div style={styles.costLabel}>
+              <div style={styles.costLabelUnit}>{t('explorer.total_cost')}</div>
+              <div style={styles.costLabelDate}>{getSinceDateRangeString()}</div>
+            </div>
+          </div>
+        )}
+      </header>
+    );
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHeaderStateProps>((state, props) => {
+  const queryString = getQuery(baseQuery);
+  const providersQueryString = getProvidersQuery(awsProvidersQuery);
+  const providers = providersSelectors.selectProviders(state, ProviderType.aws, providersQueryString);
+  const providersError = providersSelectors.selectProvidersError(state, ProviderType.aws, providersQueryString);
+  const providersFetchStatus = providersSelectors.selectProvidersFetchStatus(
+    state,
+    ProviderType.aws,
+    providersQueryString
+  );
+
+  return {
+    providers,
+    providersError,
+    providersFetchStatus,
+    queryString,
+  };
+});
+
+const ExplorerHeader = withTranslation()(connect(mapStateToProps, {})(ExplorerHeaderBase));
+
+export { ExplorerHeader, ExplorerHeaderProps };

--- a/src/pages/explorer/explorerTable.scss
+++ b/src/pages/explorer/explorerTable.scss
@@ -1,0 +1,44 @@
+@import url("~@patternfly/patternfly/base/patternfly-variables.css");
+
+.monthOverMonthOverride {
+  div {
+    display: block;
+    margin-right: 0;
+    margin-bottom: var(--pf-global--spacer--xs);
+    &.iconOverride {
+      &.decrease {
+        color: var(--pf-global--success-color--100);
+      }
+      &.increase {
+        color: var(--pf-global--danger-color--100);
+      }
+      .fa-sort-up {}
+      .fa-sort-down {
+        margin-left: 10px;
+      }
+      .fa-sort-up::before {
+        color: var(--pf-global--danger-color--100);
+      }
+      .fa-sort-down::before {
+        color: var(--pf-global--success-color--100);
+      }
+      span {
+        margin-right: -17px !important;
+      }
+    }
+  }
+}
+
+.tableOverride {
+  &.pf-c-table {
+    thead th + th + th + th {
+      .pf-c-table__button {
+        margin-left: auto;
+      }
+      text-align: right;
+    }
+    tbody td + td + td + td {
+      text-align: right;
+    }
+  }
+}

--- a/src/pages/explorer/explorerTable.styles.ts
+++ b/src/pages/explorer/explorerTable.styles.ts
@@ -1,0 +1,27 @@
+import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
+import global_disabled_color_100 from '@patternfly/react-tokens/dist/js/global_disabled_color_100';
+import global_FontSize_xs from '@patternfly/react-tokens/dist/js/global_FontSize_xs';
+import global_spacer_3xl from '@patternfly/react-tokens/dist/js/global_spacer_3xl';
+import global_spacer_xs from '@patternfly/react-tokens/dist/js/global_spacer_xs';
+import React from 'react';
+
+export const styles = {
+  emptyState: {
+    backgroundColor: global_BackgroundColor_light_100.value,
+    display: 'flex',
+    justifyContent: 'center',
+    paddingTop: global_spacer_3xl.value,
+    height: '35vh',
+    width: '100%',
+  },
+  infoArrow: {
+    position: 'relative',
+  },
+  infoArrowDesc: {
+    bottom: global_spacer_xs.value,
+  },
+  infoDescription: {
+    color: global_disabled_color_100.value,
+    fontSize: global_FontSize_xs.value,
+  },
+} as { [className: string]: React.CSSProperties };

--- a/src/pages/explorer/explorerTable.tsx
+++ b/src/pages/explorer/explorerTable.tsx
@@ -1,27 +1,21 @@
-import './awsDetailsTable.scss';
+import './explorerTable.scss';
 
 import { Bullseye, EmptyState, EmptyStateBody, EmptyStateIcon, Spinner } from '@patternfly/react-core';
 import { CalculatorIcon } from '@patternfly/react-icons/dist/js/icons/calculator-icon';
 import { sortable, SortByDirection, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { AwsQuery, getQuery, getQueryRoute } from 'api/queries/awsQuery';
-import { breakdownDescKey, breakdownTitleKey, orgUnitIdKey, tagPrefix } from 'api/queries/query';
+import { AwsQuery, getQuery } from 'api/queries/awsQuery';
+import { orgUnitIdKey, tagPrefix } from 'api/queries/query';
 import { AwsReport } from 'api/reports/awsReports';
-import { ReportPathsType } from 'api/reports/report';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
-import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
-import { Actions } from 'pages/details/components/actions/actions';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
-import { Link } from 'react-router-dom';
-import { paths } from 'routes';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedAwsReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
-import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dateRange';
 import { formatCurrency } from 'utils/formatValue';
 
-import { styles } from './detailsTable.styles';
+import { styles } from './explorerTable.styles';
 
-interface DetailsTableOwnProps {
+interface ExplorerTableOwnProps {
   groupBy: string;
   isAllSelected?: boolean;
   isLoading?: boolean;
@@ -32,23 +26,21 @@ interface DetailsTableOwnProps {
   selectedItems?: ComputedReportItem[];
 }
 
-interface DetailsTableState {
+interface ExplorerTableState {
   columns?: any[];
   loadingRows?: any[];
   rows?: any[];
 }
 
-type DetailsTableProps = DetailsTableOwnProps & WithTranslation;
+type ExplorerTableProps = ExplorerTableOwnProps & WithTranslation;
 
-const reportPathsType = ReportPathsType.aws;
-
-class DetailsTableBase extends React.Component<DetailsTableProps> {
-  public state: DetailsTableState = {
+class ExplorerTableBase extends React.Component<ExplorerTableProps> {
+  public state: ExplorerTableState = {
     columns: [],
     rows: [],
   };
 
-  constructor(props: DetailsTableProps) {
+  constructor(props: ExplorerTableProps) {
     super(props);
     this.handleOnSelect = this.handleOnSelect.bind(this);
     this.handleOnSort = this.handleOnSort.bind(this);
@@ -58,7 +50,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     this.initDatum();
   }
 
-  public componentDidUpdate(prevProps: DetailsTableProps) {
+  public componentDidUpdate(prevProps: ExplorerTableProps) {
     const { query, report, selectedItems } = this.props;
     const currentReport = report && report.data ? JSON.stringify(report.data) : '';
     const previousReport = prevProps.report && prevProps.report.data ? JSON.stringify(prevProps.report.data) : '';
@@ -72,47 +64,6 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     }
   }
 
-  private buildCostLink = ({
-    description,
-    groupByOrg,
-    id,
-    orgUnitId,
-    title,
-    type,
-  }: {
-    description: string | number; // Used to display a description in the breakdown header
-    groupByOrg: string | number; // Used for group_by[org_unit_id]=<groupByOrg> param in the breakdown page
-    id: string | number; // group_by[account]=<id> param in the breakdown page
-    orgUnitId: string | number; // Used to navigate back to details page
-    title: string | number; // Used to display a title in the breakdown header
-    type: string; // account or organizational_unit
-  }) => {
-    const { groupBy, query } = this.props;
-    const newQuery = {
-      ...JSON.parse(JSON.stringify(query)),
-      ...(description && description !== title && { [breakdownDescKey]: description }),
-      ...(title && { [breakdownTitleKey]: title }),
-      ...(groupByOrg && orgUnitId && { [orgUnitIdKey]: orgUnitId }),
-      group_by: {
-        [groupBy]: id, // This may be overridden below
-      },
-    };
-    if (!newQuery.filter) {
-      newQuery.filter = {};
-    }
-    if (type === 'account') {
-      newQuery.filter.account = id;
-      newQuery.group_by = {
-        [orgUnitIdKey]: groupByOrg,
-      };
-    } else if (type === 'organizational_unit') {
-      newQuery.group_by = {
-        [orgUnitIdKey]: id,
-      };
-    }
-    return `${paths.awsDetailsBreakdown}?${getQueryRoute(newQuery)}`;
-  };
-
   private initDatum = () => {
     const { isAllSelected, query, report, selectedItems, t } = this.props;
     if (!query || !report) {
@@ -123,47 +74,27 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const groupByOrg = this.getGroupByOrg();
     const groupByTagKey = this.getGroupByTagKey();
 
-    const total = formatCurrency(
-      report && report.meta && report.meta.total && report.meta.total.cost && report.meta.total.cost.total
-        ? report.meta.total.cost.total.value
-        : 0
-    );
-
     const columns =
       groupByTagKey || groupByOrg
         ? [
             {
-              title: groupByOrg ? t('aws_details.name_column_title') : t('aws_details.tag_column_title'),
+              title: groupByOrg ? t('explorer.name_column_title') : t('explorer.tag_column_title'),
             },
             {
-              title: t('aws_details.change_column_title'),
+              title: t('explorer.daily_column_title'),
             },
-            {
-              orderBy: 'cost',
-              title: t('aws_details.cost_column_title', { total }),
-              transforms: [sortable],
-            },
-            {
-              title: '',
-            },
+            // Todo: add columns for daily data
           ]
         : [
             {
               orderBy: groupById === 'account' ? 'account_alias' : groupById,
-              title: t('aws_details.name_column_title', { groupBy: groupById }),
+              title: t('explorer.name_column_title', { groupBy: groupById }),
               transforms: [sortable],
             },
             {
-              title: t('aws_details.change_column_title'),
+              title: t('explorer.daily_column_title'),
             },
-            {
-              orderBy: 'cost',
-              title: t('aws_details.cost_column_title'),
-              transforms: [sortable],
-            },
-            {
-              title: '',
-            },
+            // Todo: add columns for daily data
           ];
 
     const rows = [];
@@ -174,28 +105,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
 
     computedItems.map((item, index) => {
       const label = item && item.label && item.label !== null ? item.label : '';
-      const monthOverMonth = this.getMonthOverMonthCost(item, index);
       const cost = this.getTotalCost(item, index);
-      const actions = this.getActions(item, index);
 
-      let name = (
-        <Link
-          to={this.buildCostLink({
-            description: item.id,
-            groupByOrg,
-            id: item.id,
-            orgUnitId: this.getGroupByOrg(),
-            title: item.label,
-            type: item.type,
-          })}
-        >
-          {label}
-        </Link>
-      );
-      if (label === `no-${groupById}` || label === `no-${groupByTagKey}`) {
-        name = label as any;
-      }
-
+      // Todo: Fix missing id -- see https://issues.redhat.com/browse/COST-955
       const id = item.id && item.id !== item.label ? <div style={styles.infoDescription}>{item.id}</div> : null;
 
       rows.push({
@@ -203,14 +115,12 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           {
             title: (
               <div>
-                {name}
+                {label}
                 {id}
               </div>
             ),
           },
-          { title: <div>{monthOverMonth}</div> },
           { title: <div>{cost}</div> },
-          { title: <div>{actions}</div> },
         ],
         item,
         selected: isAllSelected || (selectedItems && selectedItems.find(val => val.id === item.id) !== undefined),
@@ -243,14 +153,6 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     });
   };
 
-  private getActions = (item: ComputedReportItem, index: number, disabled: boolean = false) => {
-    const { groupBy, query } = this.props;
-
-    return (
-      <Actions groupBy={groupBy} isDisabled={disabled} item={item} query={query} reportPathsType={reportPathsType} />
-    );
-  };
-
   private getEmptyState = () => {
     const { query, t } = this.props;
 
@@ -262,7 +164,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <EmptyState>
         <EmptyStateIcon icon={CalculatorIcon} />
-        <EmptyStateBody>{t('aws_details.empty_state')}</EmptyStateBody>
+        <EmptyStateBody>{t('explorer.empty_state')}</EmptyStateBody>
       </EmptyState>
     );
   };
@@ -292,54 +194,6 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       }
     }
     return groupByTagKey;
-  };
-
-  private getMonthOverMonthCost = (item: ComputedReportItem, index: number) => {
-    const { t } = this.props;
-    const value = formatCurrency(Math.abs(item.cost.total.value - item.delta_value));
-    const percentage = item.delta_percent !== null ? Math.abs(item.delta_percent).toFixed(2) : 0;
-
-    const showPercentage = !(percentage === 0 || percentage === '0.00');
-    const showValue = item.delta_percent !== null; // Workaround for https://github.com/project-koku/koku/issues/1395
-
-    let iconOverride;
-    if (showPercentage) {
-      iconOverride = 'iconOverride';
-      if (item.delta_percent !== null && item.delta_value < 0) {
-        iconOverride += ' decrease';
-      }
-      if (item.delta_percent !== null && item.delta_value > 0) {
-        iconOverride += ' increase';
-      }
-    }
-
-    if (!showValue) {
-      return getNoDataForDateRangeString();
-    } else {
-      return (
-        <div className="monthOverMonthOverride">
-          <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-            {showPercentage ? t('percent', { value: percentage }) : <EmptyValueState />}
-            {Boolean(showPercentage && item.delta_percent !== null && item.delta_value > 0) && (
-              <span className="fa fa-sort-up" style={styles.infoArrow} key={`month-over-month-icon-${index}`} />
-            )}
-            {Boolean(showPercentage && item.delta_percent !== null && item.delta_value < 0) && (
-              <span
-                className="fa fa-sort-down"
-                style={{
-                  ...styles.infoArrow,
-                  ...styles.infoArrowDesc,
-                }}
-                key={`month-over-month-icon-${index}`}
-              />
-            )}
-          </div>
-          <div style={styles.infoDescription} key={`month-over-month-info-${index}`}>
-            {getForDateRangeString(value)}
-          </div>
-        </div>
-      );
-    }
   };
 
   public getSortBy = () => {
@@ -423,7 +277,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <>
         <Table
-          aria-label="details-table"
+          aria-label="explorer-table"
           canSelectAll={false}
           cells={columns}
           className="tableOverride"
@@ -442,6 +296,6 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   }
 }
 
-const DetailsTable = withTranslation()(DetailsTableBase);
+const ExplorerTable = withTranslation()(ExplorerTableBase);
 
-export { DetailsTable, DetailsTableProps };
+export { ExplorerTable, ExplorerTableProps };

--- a/src/pages/explorer/explorerToolbar.tsx
+++ b/src/pages/explorer/explorerToolbar.tsx
@@ -1,46 +1,29 @@
 import { ToolbarChipGroup } from '@patternfly/react-core';
-import { Org, OrgPathsType, OrgType } from 'api/orgs/org';
-import { AwsQuery, getQuery } from 'api/queries/awsQuery';
-import { orgUnitIdKey, tagKey } from 'api/queries/query';
-import { Tag, TagPathsType, TagType } from 'api/tags/tag';
 import { DataToolbar } from 'pages/details/components/dataToolbar/dataToolbar';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
-import { createMapStateToProps, FetchStatus } from 'store/common';
-import { orgActions, orgSelectors } from 'store/orgs';
-import { tagActions, tagSelectors } from 'store/tags';
+import { createMapStateToProps } from 'store/common';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
-import { isEqual } from 'utils/equal';
 
 interface ExplorerToolbarOwnProps {
   isAllSelected?: boolean;
   isBulkSelectDisabled?: boolean;
   isExportDisabled?: boolean;
-  items?: ComputedReportItem[];
   itemsPerPage?: number;
   itemsTotal?: number;
-  groupBy: string;
   onBulkSelected(action: string);
   onExportClicked();
-  onFilterAdded(filterType: string, filterValue: string);
-  onFilterRemoved(filterType: string, filterValue?: string);
   pagination?: React.ReactNode;
-  query?: AwsQuery;
-  queryString?: string;
   selectedItems?: ComputedReportItem[];
 }
 
 interface ExplorerToolbarStateProps {
-  orgReport?: Org;
-  orgReportFetchStatus?: FetchStatus;
-  tagReport?: Tag;
-  tagReportFetchStatus?: FetchStatus;
+  // TBD...
 }
 
 interface ExplorerToolbarDispatchProps {
-  fetchOrg?: typeof orgActions.fetchOrg;
-  fetchTag?: typeof tagActions.fetchTag;
+  // TBD...
 }
 
 interface ExplorerToolbarState {
@@ -52,60 +35,12 @@ type ExplorerToolbarProps = ExplorerToolbarOwnProps &
   ExplorerToolbarDispatchProps &
   WithTranslation;
 
-const orgReportPathsType = OrgPathsType.aws;
-const orgReportType = OrgType.org;
-const tagReportPathsType = TagPathsType.aws;
-const tagReportType = TagType.tag;
-
 export class ExplorerToolbarBase extends React.Component<ExplorerToolbarProps> {
   protected defaultState: ExplorerToolbarState = {};
   public state: ExplorerToolbarState = { ...this.defaultState };
 
-  public componentDidMount() {
-    const { fetchOrg, fetchTag, queryString } = this.props;
-    fetchOrg(orgReportPathsType, orgReportType, queryString);
-    fetchTag(tagReportPathsType, tagReportType, queryString);
-    this.setState({
-      categoryOptions: this.getCategoryOptions(),
-    });
-  }
-
-  public componentDidUpdate(prevProps: ExplorerToolbarProps) {
-    const { fetchOrg, fetchTag, orgReport, query, queryString, tagReport } = this.props;
-    if (query && !isEqual(query, prevProps.query)) {
-      fetchOrg(orgReportPathsType, orgReportType, queryString);
-      fetchTag(tagReportPathsType, tagReportType, queryString);
-    }
-    if (!isEqual(orgReport, prevProps.orgReport) || !isEqual(tagReport, prevProps.tagReport)) {
-      this.setState({
-        categoryOptions: this.getCategoryOptions(),
-      });
-    }
-  }
-
-  private getCategoryOptions = (): ToolbarChipGroup[] => {
-    const { orgReport, t, tagReport } = this.props;
-
-    const options = [
-      { name: t('filter_by.values.account'), key: 'account' },
-      { name: t('filter_by.values.service'), key: 'service' },
-      { name: t('filter_by.values.region'), key: 'region' },
-    ];
-    if (orgReport && orgReport.data && orgReport.data.length > 0) {
-      options.push({
-        name: t('filter_by.values.org_unit_id'),
-        key: orgUnitIdKey,
-      });
-    }
-    if (tagReport && tagReport.data && tagReport.data.length > 0) {
-      options.push({ name: t('filter_by.values.tag'), key: tagKey });
-    }
-    return options;
-  };
-
   public render() {
     const {
-      groupBy,
       isAllSelected,
       isBulkSelectDisabled,
       isExportDisabled,
@@ -113,20 +48,12 @@ export class ExplorerToolbarBase extends React.Component<ExplorerToolbarProps> {
       itemsTotal,
       onBulkSelected,
       onExportClicked,
-      onFilterAdded,
-      onFilterRemoved,
-      orgReport,
       pagination,
-      query,
       selectedItems,
-      tagReport,
     } = this.props;
-    const { categoryOptions } = this.state;
 
     return (
       <DataToolbar
-        categoryOptions={categoryOptions}
-        groupBy={groupBy}
         isAllSelected={isAllSelected}
         isBulkSelectDisabled={isBulkSelectDisabled}
         isExportDisabled={isExportDisabled}
@@ -134,14 +61,10 @@ export class ExplorerToolbarBase extends React.Component<ExplorerToolbarProps> {
         itemsTotal={itemsTotal}
         onBulkSelected={onBulkSelected}
         onExportClicked={onExportClicked}
-        onFilterAdded={onFilterAdded}
-        onFilterRemoved={onFilterRemoved}
-        orgReport={orgReport}
         pagination={pagination}
-        query={query}
         selectedItems={selectedItems}
+        showBulkSelect
         showExport
-        tagReport={tagReport}
       />
     );
   }
@@ -149,26 +72,11 @@ export class ExplorerToolbarBase extends React.Component<ExplorerToolbarProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<ExplorerToolbarOwnProps, ExplorerToolbarStateProps>((state, props) => {
-  // Omitting key_only to share a single request -- the toolbar needs key values
-  const queryString = getQuery({
-    // key_only: true
-  });
-  const orgReport = orgSelectors.selectOrg(state, orgReportPathsType, orgReportType, queryString);
-  const orgReportFetchStatus = orgSelectors.selectOrgFetchStatus(state, orgReportPathsType, orgReportType, queryString);
-  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
-  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);
-  return {
-    queryString,
-    orgReport,
-    orgReportFetchStatus,
-    tagReport,
-    tagReportFetchStatus,
-  };
+  return {};
 });
 
 const mapDispatchToProps: ExplorerToolbarDispatchProps = {
-  fetchOrg: orgActions.fetchOrg,
-  fetchTag: tagActions.fetchTag,
+  // TBD...
 };
 
 const ExplorerToolbar = withTranslation()(connect(mapStateToProps, mapDispatchToProps)(ExplorerToolbarBase));

--- a/src/pages/explorer/explorerToolbar.tsx
+++ b/src/pages/explorer/explorerToolbar.tsx
@@ -1,0 +1,176 @@
+import { ToolbarChipGroup } from '@patternfly/react-core';
+import { Org, OrgPathsType, OrgType } from 'api/orgs/org';
+import { AwsQuery, getQuery } from 'api/queries/awsQuery';
+import { orgUnitIdKey, tagKey } from 'api/queries/query';
+import { Tag, TagPathsType, TagType } from 'api/tags/tag';
+import { DataToolbar } from 'pages/details/components/dataToolbar/dataToolbar';
+import React from 'react';
+import { WithTranslation, withTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { orgActions, orgSelectors } from 'store/orgs';
+import { tagActions, tagSelectors } from 'store/tags';
+import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
+import { isEqual } from 'utils/equal';
+
+interface ExplorerToolbarOwnProps {
+  isAllSelected?: boolean;
+  isBulkSelectDisabled?: boolean;
+  isExportDisabled?: boolean;
+  items?: ComputedReportItem[];
+  itemsPerPage?: number;
+  itemsTotal?: number;
+  groupBy: string;
+  onBulkSelected(action: string);
+  onExportClicked();
+  onFilterAdded(filterType: string, filterValue: string);
+  onFilterRemoved(filterType: string, filterValue?: string);
+  pagination?: React.ReactNode;
+  query?: AwsQuery;
+  queryString?: string;
+  selectedItems?: ComputedReportItem[];
+}
+
+interface ExplorerToolbarStateProps {
+  orgReport?: Org;
+  orgReportFetchStatus?: FetchStatus;
+  tagReport?: Tag;
+  tagReportFetchStatus?: FetchStatus;
+}
+
+interface ExplorerToolbarDispatchProps {
+  fetchOrg?: typeof orgActions.fetchOrg;
+  fetchTag?: typeof tagActions.fetchTag;
+}
+
+interface ExplorerToolbarState {
+  categoryOptions?: ToolbarChipGroup[];
+}
+
+type ExplorerToolbarProps = ExplorerToolbarOwnProps &
+  ExplorerToolbarStateProps &
+  ExplorerToolbarDispatchProps &
+  WithTranslation;
+
+const orgReportPathsType = OrgPathsType.aws;
+const orgReportType = OrgType.org;
+const tagReportPathsType = TagPathsType.aws;
+const tagReportType = TagType.tag;
+
+export class ExplorerToolbarBase extends React.Component<ExplorerToolbarProps> {
+  protected defaultState: ExplorerToolbarState = {};
+  public state: ExplorerToolbarState = { ...this.defaultState };
+
+  public componentDidMount() {
+    const { fetchOrg, fetchTag, queryString } = this.props;
+    fetchOrg(orgReportPathsType, orgReportType, queryString);
+    fetchTag(tagReportPathsType, tagReportType, queryString);
+    this.setState({
+      categoryOptions: this.getCategoryOptions(),
+    });
+  }
+
+  public componentDidUpdate(prevProps: ExplorerToolbarProps) {
+    const { fetchOrg, fetchTag, orgReport, query, queryString, tagReport } = this.props;
+    if (query && !isEqual(query, prevProps.query)) {
+      fetchOrg(orgReportPathsType, orgReportType, queryString);
+      fetchTag(tagReportPathsType, tagReportType, queryString);
+    }
+    if (!isEqual(orgReport, prevProps.orgReport) || !isEqual(tagReport, prevProps.tagReport)) {
+      this.setState({
+        categoryOptions: this.getCategoryOptions(),
+      });
+    }
+  }
+
+  private getCategoryOptions = (): ToolbarChipGroup[] => {
+    const { orgReport, t, tagReport } = this.props;
+
+    const options = [
+      { name: t('filter_by.values.account'), key: 'account' },
+      { name: t('filter_by.values.service'), key: 'service' },
+      { name: t('filter_by.values.region'), key: 'region' },
+    ];
+    if (orgReport && orgReport.data && orgReport.data.length > 0) {
+      options.push({
+        name: t('filter_by.values.org_unit_id'),
+        key: orgUnitIdKey,
+      });
+    }
+    if (tagReport && tagReport.data && tagReport.data.length > 0) {
+      options.push({ name: t('filter_by.values.tag'), key: tagKey });
+    }
+    return options;
+  };
+
+  public render() {
+    const {
+      groupBy,
+      isAllSelected,
+      isBulkSelectDisabled,
+      isExportDisabled,
+      itemsPerPage,
+      itemsTotal,
+      onBulkSelected,
+      onExportClicked,
+      onFilterAdded,
+      onFilterRemoved,
+      orgReport,
+      pagination,
+      query,
+      selectedItems,
+      tagReport,
+    } = this.props;
+    const { categoryOptions } = this.state;
+
+    return (
+      <DataToolbar
+        categoryOptions={categoryOptions}
+        groupBy={groupBy}
+        isAllSelected={isAllSelected}
+        isBulkSelectDisabled={isBulkSelectDisabled}
+        isExportDisabled={isExportDisabled}
+        itemsPerPage={itemsPerPage}
+        itemsTotal={itemsTotal}
+        onBulkSelected={onBulkSelected}
+        onExportClicked={onExportClicked}
+        onFilterAdded={onFilterAdded}
+        onFilterRemoved={onFilterRemoved}
+        orgReport={orgReport}
+        pagination={pagination}
+        query={query}
+        selectedItems={selectedItems}
+        showExport
+        tagReport={tagReport}
+      />
+    );
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<ExplorerToolbarOwnProps, ExplorerToolbarStateProps>((state, props) => {
+  // Omitting key_only to share a single request -- the toolbar needs key values
+  const queryString = getQuery({
+    // key_only: true
+  });
+  const orgReport = orgSelectors.selectOrg(state, orgReportPathsType, orgReportType, queryString);
+  const orgReportFetchStatus = orgSelectors.selectOrgFetchStatus(state, orgReportPathsType, orgReportType, queryString);
+  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
+  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);
+  return {
+    queryString,
+    orgReport,
+    orgReportFetchStatus,
+    tagReport,
+    tagReportFetchStatus,
+  };
+});
+
+const mapDispatchToProps: ExplorerToolbarDispatchProps = {
+  fetchOrg: orgActions.fetchOrg,
+  fetchTag: tagActions.fetchTag,
+};
+
+const ExplorerToolbar = withTranslation()(connect(mapStateToProps, mapDispatchToProps)(ExplorerToolbarBase));
+
+export { ExplorerToolbar, ExplorerToolbarProps };

--- a/src/pages/explorer/index.ts
+++ b/src/pages/explorer/index.ts
@@ -1,0 +1,3 @@
+import Explorer from './explorer';
+
+export default Explorer;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -8,6 +8,7 @@ const AwsBreakdown = asyncComponent(() => import(/* webpackChunkName: "aws" */ '
 const AwsDetails = asyncComponent(() => import(/* webpackChunkName: "aws" */ './pages/details/awsDetails'));
 const AzureBreakdown = asyncComponent(() => import(/* webpackChunkName: "azure" */ './pages/details/azureBreakdown'));
 const AzureDetails = asyncComponent(() => import(/* webpackChunkName: "azure" */ './pages/details/azureDetails'));
+const Explorer = asyncComponent(() => import(/* webpackChunkName: "azure" */ './pages/explorer'));
 const GcpBreakdown = asyncComponent(() => import(/* webpackChunkName: "gcp" */ './pages/details/gcpBreakdown'));
 const GcpDetails = asyncComponent(() => import(/* webpackChunkName: "gcp" */ './pages/details/gcpDetails'));
 const OcpDetails = asyncComponent(() => import(/* webpackChunkName: "ocp" */ './pages/details/ocpDetails'));
@@ -26,6 +27,7 @@ const paths = {
   azureDetails: '/infrastructure/azure',
   azureDetailsBreakdown: '/infrastructure/azure/breakdown',
   costModels: '/cost-models',
+  explorer: '/explorer',
   gcpDetails: '/infrastructure/gcp',
   gcpDetailsBreakdown: '/infrastructure/gcp/breakdown',
   ocpDetails: '/ocp',
@@ -74,6 +76,12 @@ const routes = [
     path: paths.azureDetailsBreakdown,
     labelKey: 'navigation.azure_details_breakdown',
     component: permissionsComponent(AzureBreakdown),
+    exact: true,
+  },
+  {
+    path: paths.explorer,
+    labelKey: 'navigation.explorer',
+    component: permissionsComponent(Explorer),
     exact: true,
   },
   {

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -70,19 +70,19 @@ export function getComputedReportItems<R extends Report, T extends ReportItem>({
 function getCostData(val, key, item?: any) {
   return {
     markup: {
-      value: item ? item[key].markup.value : 0 + val[key] && val[key].markup ? val[key].markup.value : 0,
+      value: (item ? item[key].markup.value : 0) + val[key] && val[key].markup ? val[key].markup.value : 0,
       units: val[key] && val[key].markup ? val[key].markup.units : 'USD',
     },
     raw: {
-      value: item ? item[key].raw.value : 0 + val[key] && val[key].raw ? val[key].raw.value : 0,
+      value: (item ? item[key].raw.value : 0) + val[key] && val[key].raw ? val[key].raw.value : 0,
       units: val[key] && val[key].raw ? val[key].raw.units : 'USD',
     },
     total: {
-      value: item ? item[key].total.value : 0 + val[key] && val[key].total ? Number(val[key].total.value) : 0,
+      value: (item ? item[key].total.value : 0) + val[key] && val[key].total ? Number(val[key].total.value) : 0,
       units: val[key] && val[key].total ? val[key].total.units : null,
     },
     usage: {
-      value: item ? item[key].usage.value : 0 + val[key] && val[key].usage ? Number(val[key].usage.value) : 0,
+      value: (item ? item[key].usage.value : 0) + val[key] && val[key].usage ? Number(val[key].usage.value) : 0,
       units: val[key] && val[key].usage ? val[key].usage.units : null,
     },
   };
@@ -91,19 +91,19 @@ function getCostData(val, key, item?: any) {
 function getUsageData(val, item?: any) {
   return {
     capacity: {
-      value: item ? item.capacity.value : 0 + val.capacity ? val.capacity.value : 0,
+      value: (item ? item.capacity.value : 0) + val.capacity ? val.capacity.value : 0,
       units: val.capacity ? val.capacity.units : 'Core-Hours',
     },
     limit: {
-      value: item ? item.limit.value : 0 + val.limit ? val.limit.value : 0,
+      value: (item ? item.limit.value : 0) + val.limit ? val.limit.value : 0,
       units: val.limit ? val.limit.units : 'Core-Hours',
     },
     request: {
-      value: item ? item.request.value : 0 + val.request ? val.request.value : 0,
+      value: (item ? item.request.value : 0) + val.request ? val.request.value : 0,
       units: val.request ? val.request.units : 'Core-Hours',
     },
     usage: {
-      value: item ? item.usage.value : 0 + val.usage ? val.usage.value : 0,
+      value: (item ? item.usage.value : 0) + val.usage ? val.usage.value : 0,
       units: val.usage ? val.usage.units : 'Core-Hours',
     },
   };


### PR DESCRIPTION
Created initial Historical Cost Explorer page, based on AWS for now. More updates to follow...

- The page is only accessible via a direct URL -- Insights nav will be updated after user-access API is ready.
- Refactored some existing code so the data table can show daily data. 
- Refactored existing details components to allow filter controls to be displayed in header.

<img width="1631" alt="Screen Shot 2021-02-03 at 12 14 54 PM" src="https://user-images.githubusercontent.com/17481322/106783990-d8a77200-6619-11eb-8959-c601a8836ff3.png">

https://issues.redhat.com/browse/COST-915