### PR TITLE
Details pages to show IDs, along with alias

### DIFF
--- a/src/pages/details/awsDetails/detailsTable.tsx
+++ b/src/pages/details/awsDetails/detailsTable.tsx
@@ -196,7 +196,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         name = label as any;
       }
 
-      const id = item.id && item.id !== item.label ? <div style={styles.infoDescription}>{item.id}</div> : null;
+      const desc = item.id && item.id !== item.label ? <div style={styles.infoDescription}>{item.id}</div> : null;
 
       rows.push({
         cells: [
@@ -204,7 +204,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             title: (
               <div>
                 {name}
-                {id}
+                {desc}
               </div>
             ),
           },

--- a/src/pages/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/pages/details/azureBreakdown/azureBreakdown.tsx
@@ -1,7 +1,7 @@
 import { ProviderType } from 'api/providers';
 import { getQuery, OcpQuery, parseQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { Query } from 'api/queries/query';
+import { breakdownDescKey, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import { TagPathsType } from 'api/tags/tag';
 import { AxiosError } from 'axios';
@@ -45,9 +45,14 @@ const reportPathsType = ReportPathsType.azure;
 const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateProps>((state, props) => {
   const queryFromRoute = parseQuery<OcpQuery>(location.search);
   const query = queryFromRoute;
-  const queryString = getQuery(query);
   const filterBy = getGroupByValue(query);
   const groupBy = getGroupById(query);
+
+  const newQuery: Query = {
+    ...query,
+    ...{ [breakdownDescKey]: undefined },
+  };
+  const queryString = getQuery(newQuery);
 
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
@@ -63,6 +68,7 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateP
 
   return {
     costOverviewComponent: <CostOverview filterBy={filterBy} groupBy={groupBy} report={report} />,
+    description: query[breakdownDescKey],
     detailsURL,
     emptyStateTitle: props.t('navigation.azure_details'),
     filterBy,

--- a/src/pages/details/azureDetails/detailsTable.tsx
+++ b/src/pages/details/azureDetails/detailsTable.tsx
@@ -5,7 +5,7 @@ import { CalculatorIcon } from '@patternfly/react-icons/dist/js/icons/calculator
 import { sortable, SortByDirection, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { getQueryRoute } from 'api/queries/azureQuery';
 import { AzureQuery, getQuery } from 'api/queries/azureQuery';
-import { tagPrefix } from 'api/queries/query';
+import { breakdownDescKey, tagPrefix } from 'api/queries/query';
 import { AzureReport } from 'api/reports/azureReports';
 import { ReportPathsType } from 'api/reports/report';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
@@ -73,11 +73,12 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     }
   }
 
-  private buildCostLink = (label: string) => {
+  private buildCostLink = (label: string, description: string) => {
     const { groupBy, query } = this.props;
 
     const newQuery = {
       ...query,
+      ...(description && description !== label && { [breakdownDescKey]: description }),
       group_by: {
         [groupBy]: label,
       },
@@ -148,14 +149,23 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       const cost = this.getTotalCost(item, index);
       const actions = this.getActions(item);
 
-      let name = <Link to={this.buildCostLink(label.toString())}>{label}</Link>;
+      let name = <Link to={this.buildCostLink(label.toString(), item.id)}>{label}</Link>;
       if (label === `no-${groupById}` || label === `no-${groupByTagKey}`) {
         name = label as any;
       }
 
+      const desc = item.id && item.id !== item.label ? <div style={styles.infoDescription}>{item.id}</div> : null;
+
       rows.push({
         cells: [
-          { title: <div>{name}</div> },
+          {
+            title: (
+              <div>
+                {name}
+                {desc}
+              </div>
+            ),
+          },
           { title: <div>{monthOverMonth}</div> },
           { title: <div>{cost}</div> },
           { title: <div>{actions}</div> },

--- a/src/pages/details/gcpDetails/detailsTable.tsx
+++ b/src/pages/details/gcpDetails/detailsTable.tsx
@@ -5,7 +5,7 @@ import { CalculatorIcon } from '@patternfly/react-icons/dist/js/icons/calculator
 import { sortable, SortByDirection, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { getQueryRoute } from 'api/queries/azureQuery';
 import { GcpQuery, getQuery } from 'api/queries/gcpQuery';
-import { tagPrefix } from 'api/queries/query';
+import { breakdownDescKey, tagPrefix } from 'api/queries/query';
 import { GcpReport } from 'api/reports/gcpReports';
 import { ReportPathsType } from 'api/reports/report';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
@@ -73,11 +73,12 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     }
   }
 
-  private buildCostLink = (label: string) => {
+  private buildCostLink = (label: string, description: string) => {
     const { groupBy, query } = this.props;
 
     const newQuery = {
       ...query,
+      ...(description && description !== label && { [breakdownDescKey]: description }),
       group_by: {
         [groupBy]: label,
       },
@@ -148,14 +149,23 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       const cost = this.getTotalCost(item, index);
       const actions = this.getActions(item);
 
-      let name = <Link to={this.buildCostLink(label.toString())}>{label}</Link>;
+      let name = <Link to={this.buildCostLink(label.toString(), item.id)}>{label}</Link>;
       if (label === `no-${groupById}` || label === `no-${groupByTagKey}`) {
         name = label as any;
       }
 
+      const desc = item.id && item.id !== item.label ? <div style={styles.infoDescription}>{item.id}</div> : null;
+
       rows.push({
         cells: [
-          { title: <div>{name}</div> },
+          {
+            title: (
+              <div>
+                {name}
+                {desc}
+              </div>
+            ),
+          },
           { title: <div>{monthOverMonth}</div> },
           { title: <div>{cost}</div> },
           { title: <div>{actions}</div> },

--- a/src/pages/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/pages/details/ocpBreakdown/ocpBreakdown.tsx
@@ -1,7 +1,7 @@
 import { ProviderType } from 'api/providers';
 import { getQuery, OcpQuery, parseQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { Query } from 'api/queries/query';
+import { breakdownDescKey, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import { TagPathsType } from 'api/tags/tag';
 import { AxiosError } from 'axios';
@@ -45,9 +45,14 @@ const reportPathsType = ReportPathsType.ocp;
 const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdownStateProps>((state, props) => {
   const queryFromRoute = parseQuery<OcpQuery>(location.search);
   const query = queryFromRoute;
-  const queryString = getQuery(query);
   const filterBy = getGroupByValue(query);
   const groupBy = getGroupById(query);
+
+  const newQuery: Query = {
+    ...query,
+    ...{ [breakdownDescKey]: undefined },
+  };
+  const queryString = getQuery(newQuery);
 
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
@@ -63,6 +68,7 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
 
   return {
     costOverviewComponent: <CostOverview filterBy={filterBy} groupBy={groupBy} report={report} />,
+    description: query[breakdownDescKey],
     detailsURL,
     emptyStateTitle: props.t('navigation.ocp_details'),
     filterBy,

--- a/src/pages/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/details/ocpDetails/detailsTable.tsx
@@ -5,7 +5,7 @@ import { CalculatorIcon } from '@patternfly/react-icons/dist/js/icons/calculator
 import { sortable, SortByDirection, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { ProviderType } from 'api/providers';
 import { getQuery, getQueryRoute, OcpQuery } from 'api/queries/ocpQuery';
-import { tagPrefix } from 'api/queries/query';
+import { breakdownDescKey, tagPrefix } from 'api/queries/query';
 import { OcpReport } from 'api/reports/ocpReports';
 import { ReportPathsType } from 'api/reports/report';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
@@ -73,11 +73,12 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     }
   }
 
-  private buildCostLink = (label: string) => {
+  private buildCostLink = (label: string, description: string) => {
     const { groupBy, query } = this.props;
 
     const newQuery = {
       ...query,
+      ...(description && description !== label && { [breakdownDescKey]: description }),
       group_by: {
         [groupBy]: label,
       },
@@ -171,14 +172,23 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       const cost = this.getTotalCost(item, index);
       const actions = this.getActions(item);
 
-      let name = <Link to={this.buildCostLink(label.toString())}>{label}</Link>;
+      let name = <Link to={this.buildCostLink(label.toString(), item.id)}>{label}</Link>;
       if (label === `no-${groupById}` || label === `no-${groupByTagKey}`) {
         name = label as any;
       }
 
+      const desc = item.id && item.id !== item.label ? <div style={styles.infoDescription}>{item.id}</div> : null;
+
       rows.push({
         cells: [
-          { title: <div>{name}</div> },
+          {
+            title: (
+              <div>
+                {name}
+                {desc}
+              </div>
+            ),
+          },
           { title: <div>{monthOverMonth}</div> },
           { title: <div>{InfrastructureCost}</div> },
           { title: <div>{supplementaryCost}</div> },


### PR DESCRIPTION
Currently, the AWS details / breakdown pages show an ID underneath the (cluster / account) name. However, OCP, Azure, and GCP do not. This update makes all the pages behave similarly, providing there is an alias in use.

https://issues.redhat.com/browse/COST-955

**OCP Details**
![ocp details](https://user-images.githubusercontent.com/17481322/106806535-15816200-6636-11eb-8382-72566d6d6eb0.jpg)

**OCP breakdown**
![ocp breakdown](https://user-images.githubusercontent.com/17481322/106806554-1a461600-6636-11eb-9635-4f4fb99bf734.jpg)
