### PR TITLE
Update documentation links

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -458,9 +458,9 @@
     "title": "Delete {{rate.metric.label_metric}}-{{rate.metric.label_measurement}} ({{rate.metric.label_measurement_unit}}) rate?"
   },
   "docs": {
-    "add_ocp_sources": "https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/getting_started_with_cost_management/assembly_adding_sources_cost#assembly_adding_ocp_sources",
-    "config_cost_models": "https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/using_cost_models/configuring-cost-models",
-    "using_cost_model": "https://access.redhat.com/documentation/en-us/openshift_container_platform/4.5/html/using_cost_models/using_cost_models#cost-model-terminology"
+    "add_ocp_sources": "https://access.redhat.com/documentation/en-us/cost_management_service/2021/html/getting_started_with_cost_management/assembly_adding_sources_cost#assembly_adding_ocp_sources",
+    "config_cost_models": "https://access.redhat.com/documentation/en-us/cost_management_service/2021/html/using_cost_models/configuring-cost-models",
+    "using_cost_model": "https://access.redhat.com/documentation/en-us/cost_management_service/2021/html/using_cost_models/using_cost_models#cost-model-terminology"
   },
   "empty_filter_state": {
     "subtitle": "Sorry, no data with the given filter was found.",


### PR DESCRIPTION
Update documentation links for the Cost Management UI. Note that this does not include the setting page, which is a different repo

https://issues.redhat.com/browse/COST-961