### PR TITLE
Add tag release github action

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,0 +1,36 @@
+name: Tag Release
+on:
+  push:
+    branches:
+      - prod-stable
+jobs:
+  tag_release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          ref: prod-stable
+      - run: |
+          git fetch --prune --unshallow
+      - name: Tag this release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          DATE=$(date +"%Y.%m.%d")
+          PREV_RELEASE=$(git tag --list | tail -1)
+          MINOR_VERSION=0
+          case $PREV_RELEASE in
+            *"$DATE"*)
+              MINOR_VERSION="$PREV_RELEASE" | cut -d'.' -f5
+              MINOR_VERSION=$((MINOR_VERSION+1))
+              ;;
+            *)
+              MINOR_VERSION=0
+              ;;
+          esac
+          TAG="r.$DATE.$MINOR_VERSION"
+          git config --local user.email "cost-mgmt@redhat.com"
+          git config --local user.name "Cost Management Release Action"
+          git log $(git tag --list | tail -1)..prod-stable | git tag -a $TAG -F -
+          git push origin $TAG
+        shell: bash


### PR DESCRIPTION
## Summary
Add a GitHub Action to generate a tag with commit messages when we push to prod-stable.