### PR TITLE
Historical Cost Explorer

### DIFF
--- a/src/api/queries/gcpQuery.ts
+++ b/src/api/queries/gcpQuery.ts
@@ -10,17 +10,17 @@ interface GcpGroupBys {
   service?: GcpGroupByValue;
   account?: GcpGroupByValue;
   instance_type?: GcpGroupByValue;
-  region?: GcpGroupByValue;
   project?: GcpGroupByValue;
+  region?: GcpGroupByValue;
 }
 
 interface GcpOrderBys {
   account?: string;
+  cost?: string;
+  project?: string;
   region?: string;
   service?: string;
-  cost?: string;
   usage?: string;
-  project?: string;
 }
 
 export interface GcpQuery extends utils.Query {

--- a/src/api/queries/query.ts
+++ b/src/api/queries/query.ts
@@ -31,6 +31,8 @@ export interface Query {
   filter_by?: FilterBys;
   group_by?: any;
   key_only?: boolean;
+  order_by?: any;
+  perspective?: any;
 }
 
 // Adds group_by prefix -- https://github.com/project-koku/koku-ui/issues/704

--- a/src/api/reports/explorerReports.ts
+++ b/src/api/reports/explorerReports.ts
@@ -1,0 +1,16 @@
+import { ReportItem } from './report';
+
+export interface ExplorerReportItem extends ReportItem {
+  account?: string;
+  account_alias?: string;
+  cluster?: string;
+  instance_type?: string;
+  node?: string;
+  org_unit_id?: string;
+  project?: string;
+  region?: string;
+  resource_location?: string;
+  service?: string;
+  service_name?: string;
+  subscription_guid?: string;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -477,6 +477,17 @@
     "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "name_column_title": "Names",
     "no_data": "no data",
+    "perspective": {
+      "all_cloud": "All cloud filtered by OpenShift",
+      "aws": "Amazon Web Services",
+      "aws_cloud": "Amazon Web Services filtered by OpenShift",
+      "azure": "Microsoft Azure",
+      "azure_cloud": "Microsoft Azure filtered by OpenShift",
+      "gcp": "Google Cloud Platform",
+      "ocp": "All OpenShift cost",
+      "ocp_supplementary": "OpenShift supplementary cost",
+      "ocp_usage": "OpenShift usage"
+    },
     "tag_column_title": "Tag names",
     "title": {
       "aws": "Amazon Web Services - All Cost Top 5 Costliest",

--- a/src/pages/explorer/explorerHeader.styles.ts
+++ b/src/pages/explorer/explorerHeader.styles.ts
@@ -26,6 +26,9 @@ export const styles = {
     fontSize: global_FontSize_sm.value,
     color: global_Color_200.var,
   },
+  groupBy: {
+    paddingLeft: global_spacer_lg.var,
+  },
   header: {
     display: 'flex',
     justifyContent: 'space-between',
@@ -34,6 +37,10 @@ export const styles = {
     paddingRight: global_spacer_lg.var,
     paddingTop: global_spacer_lg.var,
     backgroundColor: global_BackgroundColor_light_100.var,
+  },
+  perspectiveContainer: {
+    display: 'flex',
+    marginTop: global_spacer_md.var,
   },
   title: {
     paddingBottom: global_spacer_sm.var,

--- a/src/pages/explorer/explorerHeader.tsx
+++ b/src/pages/explorer/explorerHeader.tsx
@@ -1,80 +1,237 @@
 import { Title } from '@patternfly/react-core';
-import { OrgPathsType } from 'api/orgs/org';
 import { Providers, ProviderType } from 'api/providers';
-import { AwsQuery, getQuery } from 'api/queries/awsQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { Query, tagPrefix } from 'api/queries/query';
-import { AwsReport } from 'api/reports/awsReports';
-import { TagPathsType } from 'api/tags/tag';
+import { getQuery, parseQuery, Query, tagPrefix } from 'api/queries/query';
+import { getUserAccessQuery } from 'api/queries/userAccessQuery';
+import { UserAccess, UserAccessType } from 'api/userAccess';
 import { AxiosError } from 'axios';
 import { getGroupByTagKey } from 'pages/details/common/detailsUtils';
 import { GroupBy } from 'pages/details/components/groupBy/groupBy';
+import { Perspective } from 'pages/overview/perspective';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
+import { RouteComponentProps, withRouter } from 'react-router';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { awsProvidersQuery, providersSelectors } from 'store/providers';
-import { ComputedAwsReportItemsParams, getIdKeyForGroupBy } from 'utils/computedReport/getComputedAwsReportItems';
+import {
+  awsProvidersQuery,
+  azureProvidersQuery,
+  gcpProvidersQuery,
+  ocpProvidersQuery,
+  providersSelectors,
+} from 'store/providers';
+import { allUserAccessQuery, userAccessSelectors } from 'store/userAccess';
+import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
 
 import { ExplorerFilter } from './explorerFilter';
 import { styles } from './explorerHeader.styles';
+import {
+  baseQuery,
+  getGroupByDefault,
+  getGroupByOptions,
+  getOrgReportPathsType,
+  getPerspectiveDefault,
+  getRouteForQuery,
+  getTagReportPathsType,
+  infrastructureAllCloudOptions,
+  infrastructureAwsCloudOptions,
+  infrastructureAwsOptions,
+  infrastructureAzureCloudOptions,
+  infrastructureAzureOptions,
+  infrastructureGcpOptions,
+  infrastructureOcpOptions,
+  isAwsAvailable,
+  isAzureAvailable,
+  isGcpAvailable,
+  isOcpAvailable,
+  ocpOptions,
+  PerspectiveType,
+} from './explorerUtils';
 
 interface ExplorerHeaderOwnProps {
   groupBy?: string;
   onGroupByClicked(value: string);
   onFilterAdded(filterType: string, filterValue: string);
   onFilterRemoved(filterType: string, filterValue?: string);
-  report: AwsReport;
-  query?: Query;
 }
 
 interface ExplorerHeaderStateProps {
-  queryString?: string;
-  providers: Providers;
-  providersError: AxiosError;
-  providersFetchStatus: FetchStatus;
+  awsProviders: Providers;
+  awsProvidersFetchStatus: FetchStatus;
+  awsProvidersQueryString: string;
+  azureProviders: Providers;
+  azureProvidersFetchStatus: FetchStatus;
+  azureProvidersQueryString: string;
+  gcpProviders: Providers;
+  gcpProvidersFetchStatus: FetchStatus;
+  gcpProvidersQueryString: string;
+  ocpProviders: Providers;
+  ocpProvidersFetchStatus: FetchStatus;
+  ocpProvidersQueryString: string;
+  perspective: PerspectiveType;
+  query: Query;
+  queryString: string;
+  userAccess: UserAccess;
+  userAccessError: AxiosError;
+  userAccessFetchStatus: FetchStatus;
+  userAccessQueryString: string;
 }
 
-type ExplorerHeaderProps = ExplorerHeaderOwnProps & ExplorerHeaderStateProps & WithTranslation;
+interface ExplorerHeaderState {
+  currentPerspective?: PerspectiveType;
+}
 
-const baseQuery: AwsQuery = {
-  delta: 'cost',
-  filter: {
-    time_scope_units: 'month',
-    time_scope_value: -1,
-    resolution: 'monthly',
-  },
-};
-
-const groupByOptions: {
-  label: string;
-  value: ComputedAwsReportItemsParams['idKey'];
-}[] = [
-  { label: 'account', value: 'account' },
-  { label: 'service', value: 'service' },
-  { label: 'region', value: 'region' },
-];
-
-const orgReportPathsType = OrgPathsType.aws;
-const tagReportPathsType = TagPathsType.aws;
+type ExplorerHeaderProps = ExplorerHeaderOwnProps &
+  ExplorerHeaderStateProps &
+  RouteComponentProps<void> &
+  WithTranslation;
 
 class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
+  protected defaultState: ExplorerHeaderState = {
+    // TBD...
+  };
+  public state: ExplorerHeaderState = { ...this.defaultState };
+
+  public componentDidMount() {
+    this.setState({
+      currentPerspective: this.getDefaultPerspective(),
+    });
+  }
+
+  private getDefaultPerspective = () => {
+    const {
+      awsProviders,
+      awsProvidersFetchStatus,
+      azureProviders,
+      azureProvidersFetchStatus,
+      gcpProviders,
+      gcpProvidersFetchStatus,
+      ocpProviders,
+      ocpProvidersFetchStatus,
+      userAccess,
+    } = this.props;
+
+    if (isOcpAvailable(ocpProviders, ocpProvidersFetchStatus, userAccess)) {
+      return PerspectiveType.ocp;
+    }
+    if (isAwsAvailable(awsProviders, awsProvidersFetchStatus, userAccess)) {
+      return PerspectiveType.aws;
+    }
+    if (isAzureAvailable(azureProviders, azureProvidersFetchStatus, userAccess)) {
+      return PerspectiveType.azure;
+    }
+    if (isGcpAvailable(gcpProviders, gcpProvidersFetchStatus, userAccess)) {
+      return PerspectiveType.gcp;
+    }
+    return undefined;
+  };
+
+  private getPerspective = (isDisabled: boolean) => {
+    const {
+      awsProviders,
+      awsProvidersFetchStatus,
+      azureProviders,
+      azureProvidersFetchStatus,
+      gcpProviders,
+      gcpProvidersFetchStatus,
+      ocpProviders,
+      ocpProvidersFetchStatus,
+      userAccess,
+    } = this.props;
+    const { currentPerspective } = this.state;
+
+    const _isAwsAvailable = isAwsAvailable(awsProviders, awsProvidersFetchStatus, userAccess);
+    const _isAzureAvailable = isAzureAvailable(azureProviders, azureProvidersFetchStatus, userAccess);
+    const _isGcpAvailable = isGcpAvailable(gcpProviders, gcpProvidersFetchStatus, userAccess);
+    const _isOcpAvailable = isOcpAvailable(ocpProviders, ocpProvidersFetchStatus, userAccess);
+
+    if (!(_isAwsAvailable || _isAzureAvailable || _isGcpAvailable || _isOcpAvailable)) {
+      return null;
+    }
+
+    // Dynamically show options if providers are available
+    const options = [];
+    if (_isOcpAvailable) {
+      options.push(...ocpOptions);
+      options.push(...infrastructureAllCloudOptions);
+    }
+    if (_isAwsAvailable) {
+      options.push(...infrastructureAwsOptions);
+    }
+    if (_isOcpAvailable && isAwsAvailable) {
+      options.push(...infrastructureAwsCloudOptions);
+    }
+    if (_isGcpAvailable) {
+      options.push(...infrastructureGcpOptions);
+    }
+    if (_isAzureAvailable) {
+      options.push(...infrastructureAzureOptions);
+    }
+    if (_isOcpAvailable && isAzureAvailable) {
+      options.push(...infrastructureAzureCloudOptions);
+    }
+    if (_isOcpAvailable) {
+      options.push(...infrastructureOcpOptions);
+    }
+
+    return (
+      <Perspective
+        currentItem={currentPerspective || options[0].value}
+        isDisabled={isDisabled}
+        onItemClicked={this.handlePerspectiveClick}
+        options={options}
+      />
+    );
+  };
+
+  private handlePerspectiveClick = (value: string) => {
+    const { history, query } = this.props;
+
+    const newQuery = {
+      ...JSON.parse(JSON.stringify(query)),
+      filter_by: undefined,
+      group_by: { [getGroupByDefault(value)]: '*' },
+      order_by: { cost: 'desc' },
+      perspective: value,
+    };
+    history.replace(getRouteForQuery(history, newQuery, true));
+    this.setState({ currentPerspective: value });
+  };
+
   public render() {
     const {
+      awsProviders,
+      azureProviders,
+      gcpProviders,
+      ocpProviders,
+      awsProvidersFetchStatus,
+      azureProvidersFetchStatus,
+      gcpProvidersFetchStatus,
       groupBy,
+      ocpProvidersFetchStatus,
       onFilterAdded,
       onFilterRemoved,
       onGroupByClicked,
-      providers,
-      providersError,
+      perspective,
       query,
-      report,
       t,
+      userAccess,
     } = this.props;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByTagKey = getGroupByTagKey(query);
-    const showContent = report && !providersError && providers && providers.meta && providers.meta.count > 0;
+
+    // Test for no providers
+    const noProviders = !(
+      isAwsAvailable(awsProviders, awsProvidersFetchStatus, userAccess) &&
+      isAzureAvailable(azureProviders, azureProvidersFetchStatus, userAccess) &&
+      isGcpAvailable(gcpProviders, gcpProvidersFetchStatus, userAccess) &&
+      isOcpAvailable(ocpProviders, ocpProvidersFetchStatus, userAccess)
+    );
+
+    const groupByOptions = getGroupByOptions(perspective);
+    const orgReportPathsType = getOrgReportPathsType(perspective);
+    const tagReportPathsType = getTagReportPathsType(perspective);
 
     return (
       <header style={styles.header}>
@@ -82,20 +239,25 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
           <Title headingLevel="h2" style={styles.title} size="2xl">
             {t('navigation.explorer')}
           </Title>
-          <GroupBy
-            getIdKeyForGroupBy={getIdKeyForGroupBy}
-            groupBy={groupBy}
-            isDisabled={!showContent}
-            onItemClicked={onGroupByClicked}
-            options={groupByOptions}
-            orgReportPathsType={orgReportPathsType}
-            showOrgs
-            showTags
-            tagReportPathsType={tagReportPathsType}
-          />
+          <div style={styles.perspectiveContainer}>
+            {this.getPerspective(noProviders)}
+            <div style={styles.groupBy}>
+              <GroupBy
+                getIdKeyForGroupBy={getIdKeyForGroupBy}
+                groupBy={groupBy}
+                isDisabled={noProviders}
+                onItemClicked={onGroupByClicked}
+                options={groupByOptions}
+                orgReportPathsType={orgReportPathsType}
+                showOrgs={orgReportPathsType}
+                showTags={tagReportPathsType}
+                tagReportPathsType={tagReportPathsType}
+              />
+            </div>
+          </div>
           <ExplorerFilter
             groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
-            isDisabled={!showContent}
+            isDisabled={noProviders}
             onFilterAdded={onFilterAdded}
             onFilterRemoved={onFilterRemoved}
             query={query}
@@ -108,24 +270,87 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHeaderStateProps>((state, props) => {
-  const queryString = getQuery(baseQuery);
-  const providersQueryString = getProvidersQuery(awsProvidersQuery);
-  const providers = providersSelectors.selectProviders(state, ProviderType.aws, providersQueryString);
-  const providersError = providersSelectors.selectProvidersError(state, ProviderType.aws, providersQueryString);
-  const providersFetchStatus = providersSelectors.selectProvidersFetchStatus(
+  const queryFromRoute = parseQuery<Query>(location.search);
+  const perspective = getPerspectiveDefault(queryFromRoute);
+  const query = {
+    filter: {
+      ...baseQuery.filter,
+      ...queryFromRoute.filter,
+    },
+    filter_by: queryFromRoute.filter_by || baseQuery.filter_by,
+    group_by: queryFromRoute.group_by || { [getGroupByDefault(perspective)]: '*' } || baseQuery.group_by,
+    order_by: queryFromRoute.order_by || baseQuery.order_by,
+    perspective,
+  };
+  const queryString = getQuery({
+    ...query,
+    perspective: undefined,
+  });
+
+  const awsProvidersQueryString = getProvidersQuery(awsProvidersQuery);
+  const awsProviders = providersSelectors.selectProviders(state, ProviderType.aws, awsProvidersQueryString);
+  const awsProvidersFetchStatus = providersSelectors.selectProvidersFetchStatus(
     state,
     ProviderType.aws,
-    providersQueryString
+    awsProvidersQueryString
+  );
+
+  const azureProvidersQueryString = getProvidersQuery(azureProvidersQuery);
+  const azureProviders = providersSelectors.selectProviders(state, ProviderType.azure, azureProvidersQueryString);
+  const azureProvidersFetchStatus = providersSelectors.selectProvidersFetchStatus(
+    state,
+    ProviderType.azure,
+    azureProvidersQueryString
+  );
+
+  const gcpProvidersQueryString = getProvidersQuery(gcpProvidersQuery);
+  const gcpProviders = providersSelectors.selectProviders(state, ProviderType.gcp, gcpProvidersQueryString);
+  const gcpProvidersFetchStatus = providersSelectors.selectProvidersFetchStatus(
+    state,
+    ProviderType.gcp,
+    gcpProvidersQueryString
+  );
+
+  const ocpProvidersQueryString = getProvidersQuery(ocpProvidersQuery);
+  const ocpProviders = providersSelectors.selectProviders(state, ProviderType.ocp, ocpProvidersQueryString);
+  const ocpProvidersFetchStatus = providersSelectors.selectProvidersFetchStatus(
+    state,
+    ProviderType.ocp,
+    ocpProvidersQueryString
+  );
+
+  const userAccessQueryString = getUserAccessQuery(allUserAccessQuery);
+  const userAccess = userAccessSelectors.selectUserAccess(state, UserAccessType.all, userAccessQueryString);
+  const userAccessError = userAccessSelectors.selectUserAccessError(state, UserAccessType.all, userAccessQueryString);
+  const userAccessFetchStatus = userAccessSelectors.selectUserAccessFetchStatus(
+    state,
+    UserAccessType.all,
+    userAccessQueryString
   );
 
   return {
-    providers,
-    providersError,
-    providersFetchStatus,
+    awsProviders,
+    awsProvidersFetchStatus,
+    awsProvidersQueryString,
+    azureProviders,
+    azureProvidersFetchStatus,
+    azureProvidersQueryString,
+    gcpProviders,
+    gcpProvidersFetchStatus,
+    gcpProvidersQueryString,
+    ocpProviders,
+    ocpProvidersFetchStatus,
+    ocpProvidersQueryString,
+    perspective,
+    query,
     queryString,
+    userAccess,
+    userAccessError,
+    userAccessFetchStatus,
+    userAccessQueryString,
   };
 });
 
-const ExplorerHeader = withTranslation()(connect(mapStateToProps, {})(ExplorerHeaderBase));
+const ExplorerHeader = withRouter(withTranslation()(connect(mapStateToProps, {})(ExplorerHeaderBase)));
 
 export { ExplorerHeader, ExplorerHeaderProps };

--- a/src/pages/explorer/explorerTable.tsx
+++ b/src/pages/explorer/explorerTable.tsx
@@ -6,6 +6,7 @@ import { sortable, SortByDirection, Table, TableBody, TableHeader } from '@patte
 import { AwsQuery, getQuery } from 'api/queries/awsQuery';
 import { orgUnitIdKey, tagPrefix } from 'api/queries/query';
 import { AwsReport } from 'api/reports/awsReports';
+import { ComputedReportItemType } from 'components/charts/common/chartDatumUtils';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import getDate from 'date-fns/get_date';
 import getMonth from 'date-fns/get_month';
@@ -18,6 +19,7 @@ import { formatCurrency } from 'utils/formatValue';
 import { styles } from './explorerTable.styles';
 
 interface ExplorerTableOwnProps {
+  computedReportItemType?: ComputedReportItemType;
   groupBy: string;
   isAllSelected?: boolean;
   isLoading?: boolean;
@@ -67,7 +69,14 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
   }
 
   private initDatum = () => {
-    const { isAllSelected, query, report, selectedItems, t } = this.props;
+    const {
+      computedReportItemType = ComputedReportItemType.cost,
+      isAllSelected,
+      query,
+      report,
+      selectedItems,
+      t,
+    } = this.props;
     if (!query || !report) {
       return;
     }
@@ -117,7 +126,10 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
 
         // Add row cells
         cells.push({
-          title: item.cost && item.cost.total ? formatCurrency(item.cost.total.value) : t('explorer.no_data'),
+          title:
+            item[computedReportItemType] && item[computedReportItemType].total
+              ? formatCurrency(item[computedReportItemType].total.value)
+              : t('explorer.no_data'),
         });
       });
       // Fill in missing data

--- a/src/pages/explorer/explorerUtils.ts
+++ b/src/pages/explorer/explorerUtils.ts
@@ -1,0 +1,378 @@
+import { OrgPathsType } from 'api/orgs/org';
+import { Providers } from 'api/providers';
+import { getQueryRoute, Query } from 'api/queries/query';
+import { ReportPathsType, ReportType } from 'api/reports/report';
+import { TagPathsType } from 'api/tags/tag';
+import { UserAccess, UserAccessType } from 'api/userAccess';
+import { ComputedReportItemType } from 'components/charts/common/chartDatumUtils';
+import { FetchStatus } from 'store/common';
+import { ComputedAwsReportItemsParams } from 'utils/computedReport/getComputedAwsReportItems';
+import { ComputedAzureReportItemsParams } from 'utils/computedReport/getComputedAzureReportItems';
+import { ComputedGcpReportItemsParams } from 'utils/computedReport/getComputedGcpReportItems';
+import { ComputedOcpReportItemsParams } from 'utils/computedReport/getComputedOcpReportItems';
+
+// eslint-disable-next-line no-shadow
+export const enum PerspectiveType {
+  allCloud = 'all_cloud', // All filtered by Ocp
+  aws = 'aws',
+  awsCloud = 'aws_cloud', // Aws filtered by Ocp
+  azure = 'azure',
+  azureCloud = 'azure_cloud', // Azure filtered by Ocp
+  gcp = 'gcp',
+  ocp = 'ocp',
+  ocpSupplementary = 'ocp_supplementary',
+  ocpUsage = 'ocp_usage',
+}
+
+export const baseQuery: Query = {
+  filter: {
+    limit: 10,
+    offset: 0,
+    resolution: 'daily',
+    time_scope_units: 'month',
+    time_scope_value: -1,
+  },
+  filter_by: {},
+  group_by: {
+    account: '*',
+  },
+  order_by: {
+    cost: 'desc',
+  },
+};
+
+export const groupByAwsOptions: {
+  label: string;
+  value: ComputedAwsReportItemsParams['idKey'];
+}[] = [
+  { label: 'account', value: 'account' },
+  { label: 'service', value: 'service' },
+  { label: 'region', value: 'region' },
+];
+
+export const groupByAzureOptions: {
+  label: string;
+  value: ComputedAzureReportItemsParams['idKey'];
+}[] = [
+  { label: 'subscription_guid', value: 'subscription_guid' },
+  { label: 'service_name', value: 'service_name' },
+  { label: 'resource_location', value: 'resource_location' },
+];
+
+export const groupByGcpOptions: {
+  label: string;
+  value: ComputedGcpReportItemsParams['idKey'];
+}[] = [
+  { label: 'account', value: 'account' },
+  { label: 'project', value: 'project' },
+  { label: 'service', value: 'service' },
+  { label: 'region', value: 'region' },
+];
+
+export const groupByOcpOptions: {
+  label: string;
+  value: ComputedOcpReportItemsParams['idKey'];
+}[] = [
+  { label: 'cluster', value: 'cluster' },
+  { label: 'node', value: 'node' },
+  { label: 'project', value: 'project' },
+];
+
+// Infrastructure all cloud options
+export const infrastructureAllCloudOptions = [{ label: 'explorer.perspective.all_cloud', value: 'all_cloud' }];
+
+// Infrastructure AWS options
+export const infrastructureAwsOptions = [{ label: 'explorer.perspective.aws', value: 'aws' }];
+
+// Infrastructure AWS cloud options
+export const infrastructureAwsCloudOptions = [{ label: 'explorer.perspective.aws_cloud', value: 'aws_cloud' }];
+
+// Infrastructure Azure options
+export const infrastructureAzureOptions = [{ label: 'explorer.perspective.azure', value: 'azure' }];
+
+// Infrastructure Azure cloud options
+export const infrastructureAzureCloudOptions = [{ label: 'explorer.perspective.azure_cloud', value: 'azure_cloud' }];
+
+// Infrastructure GCP options
+export const infrastructureGcpOptions = [{ label: 'explorer.perspective.gcp', value: 'gcp' }];
+
+// Infrastructure Ocp options
+export const infrastructureOcpOptions = [{ label: 'explorer.perspective.ocp_usage', value: 'ocp_usage' }];
+
+// Ocp options
+export const ocpOptions = [
+  { label: 'explorer.perspective.ocp', value: 'ocp' },
+  { label: 'explorer.perspective.ocp_supplementary', value: 'ocp_supplementary' },
+];
+
+export const getComputedReportItemType = (perspective: string) => {
+  let result;
+  switch (perspective) {
+    case PerspectiveType.ocpSupplementary:
+      result = ComputedReportItemType.supplementary;
+      break;
+    case PerspectiveType.aws:
+    case PerspectiveType.allCloud:
+    case PerspectiveType.awsCloud:
+    case PerspectiveType.azure:
+    case PerspectiveType.azureCloud:
+    case PerspectiveType.gcp:
+    case PerspectiveType.ocp:
+    case PerspectiveType.ocpUsage:
+    default:
+      result = ComputedReportItemType.cost;
+      break;
+  }
+  return result;
+};
+
+export const getPerspectiveDefault = queryFromRoute => {
+  return queryFromRoute.perspective || PerspectiveType.ocp;
+};
+
+export const getGroupByDefault = (perspective: string) => {
+  let result;
+  switch (perspective) {
+    case PerspectiveType.aws:
+    case PerspectiveType.awsCloud:
+    case PerspectiveType.gcp:
+      result = 'account';
+      break;
+    case PerspectiveType.azure:
+    case PerspectiveType.azureCloud:
+      result = 'subscription_guid';
+      break;
+    case PerspectiveType.allCloud:
+    case PerspectiveType.ocp:
+    case PerspectiveType.ocpSupplementary:
+    case PerspectiveType.ocpUsage:
+      result = 'project';
+      break;
+    default:
+      result = undefined;
+      break;
+  }
+  return result;
+};
+
+export const getGroupByOptions = (perspective: string) => {
+  let result;
+  switch (perspective) {
+    case PerspectiveType.aws:
+    case PerspectiveType.awsCloud:
+      result = groupByAwsOptions;
+      break;
+    case PerspectiveType.azure:
+    case PerspectiveType.azureCloud:
+      result = groupByAzureOptions;
+      break;
+    case PerspectiveType.gcp:
+      result = groupByGcpOptions;
+      break;
+    case PerspectiveType.allCloud:
+    case PerspectiveType.ocp:
+    case PerspectiveType.ocpSupplementary:
+    case PerspectiveType.ocpUsage:
+      result = groupByOcpOptions;
+      break;
+    default:
+      result = undefined;
+      break;
+  }
+  return result;
+};
+
+export const getOrgReportPathsType = (perspective: string) => {
+  let result;
+  switch (perspective) {
+    case PerspectiveType.aws:
+      result = OrgPathsType.aws;
+      break;
+    case PerspectiveType.allCloud:
+    case PerspectiveType.awsCloud:
+    case PerspectiveType.azure:
+    case PerspectiveType.azureCloud:
+    case PerspectiveType.gcp:
+    case PerspectiveType.ocp:
+    case PerspectiveType.ocpSupplementary:
+    case PerspectiveType.ocpUsage:
+    default:
+      result = undefined;
+      break;
+  }
+  return result;
+};
+
+export const getReportType = (perspective: string) => {
+  let result;
+  switch (perspective) {
+    case PerspectiveType.allCloud:
+    case PerspectiveType.aws:
+    case PerspectiveType.awsCloud:
+    case PerspectiveType.azure:
+    case PerspectiveType.azureCloud:
+    case PerspectiveType.gcp:
+    case PerspectiveType.ocp:
+    case PerspectiveType.ocpSupplementary:
+    case PerspectiveType.ocpUsage:
+    default:
+      result = ReportType.cost;
+      break;
+  }
+  return result;
+};
+
+export const getReportPathsType = (perspective: string) => {
+  let result;
+  switch (perspective) {
+    case PerspectiveType.allCloud:
+      result = ReportPathsType.ocpCloud;
+      break;
+    case PerspectiveType.aws:
+      result = ReportPathsType.aws;
+      break;
+    case PerspectiveType.awsCloud:
+      result = ReportPathsType.awsCloud;
+      break;
+    case PerspectiveType.azure:
+      result = ReportPathsType.azure;
+      break;
+    case PerspectiveType.azureCloud:
+      result = ReportPathsType.azureCloud;
+      break;
+    case PerspectiveType.gcp:
+      result = ReportPathsType.gcp;
+      break;
+    case PerspectiveType.ocp:
+      result = ReportPathsType.ocp;
+      break;
+    case PerspectiveType.ocpSupplementary:
+      result = ReportPathsType.ocp;
+      break;
+    case PerspectiveType.ocpUsage:
+      result = ReportPathsType.ocpUsage;
+      break;
+    default:
+      result = undefined;
+      break;
+  }
+  return result;
+};
+
+export const getTagReportPathsType = (perspective: string) => {
+  let result;
+  switch (perspective) {
+    case PerspectiveType.aws:
+    case PerspectiveType.awsCloud:
+      return TagPathsType.aws;
+      break;
+    case PerspectiveType.azure:
+    case PerspectiveType.azureCloud:
+      return TagPathsType.azure;
+      break;
+    case PerspectiveType.gcp:
+      return TagPathsType.gcp;
+      break;
+    case PerspectiveType.allCloud:
+    case PerspectiveType.ocp:
+    case PerspectiveType.ocpSupplementary:
+    case PerspectiveType.ocpUsage:
+      return TagPathsType.ocp;
+      break;
+    default:
+      result = undefined;
+      break;
+  }
+  return result;
+};
+
+export const getRouteForQuery = (history, query: Query, reset: boolean = false) => {
+  // Reset pagination
+  if (reset) {
+    query.filter = {
+      ...query.filter,
+      offset: baseQuery.filter.offset,
+    };
+  }
+  return `${history.location.pathname}?${getQueryRoute(query)}`;
+};
+
+export const isAwsAvailable = (
+  awsProviders: Providers,
+  awsProvidersFetchStatus: FetchStatus,
+  userAccess: UserAccess
+) => {
+  let result = false;
+  if (awsProvidersFetchStatus === FetchStatus.complete) {
+    const data = (userAccess.data as any).find(d => d.type === UserAccessType.aws);
+    const isUserAccessAllowed = data && data.access;
+
+    // providers API returns empty data array for no sources
+    result =
+      isUserAccessAllowed &&
+      awsProviders !== undefined &&
+      awsProviders.meta !== undefined &&
+      awsProviders.meta.count > 0;
+  }
+  return result;
+};
+
+export const isAzureAvailable = (
+  azureProviders: Providers,
+  azureProvidersFetchStatus: FetchStatus,
+  userAccess: UserAccess
+) => {
+  let result = false;
+  if (azureProvidersFetchStatus === FetchStatus.complete) {
+    const data = (userAccess.data as any).find(d => d.type === UserAccessType.azure);
+    const isUserAccessAllowed = data && data.access;
+
+    // providers API returns empty data array for no sources
+    result =
+      isUserAccessAllowed &&
+      azureProviders !== undefined &&
+      azureProviders.meta !== undefined &&
+      azureProviders.meta.count > 0;
+  }
+  return result;
+};
+
+export const isGcpAvailable = (
+  gcpProviders: Providers,
+  gcpsProvidersFetchStatus: FetchStatus,
+  userAccess: UserAccess
+) => {
+  let result = false;
+  if (gcpsProvidersFetchStatus === FetchStatus.complete) {
+    const data = (userAccess.data as any).find(d => d.type === UserAccessType.gcp);
+    const isUserAccessAllowed = data && data.access;
+
+    // providers API returns empty data array for no sources
+    result =
+      isUserAccessAllowed &&
+      gcpProviders !== undefined &&
+      gcpProviders.meta !== undefined &&
+      gcpProviders.meta.count > 0;
+  }
+  return result;
+};
+
+export const isOcpAvailable = (
+  ocpProviders: Providers,
+  ocpProvidersFetchStatus: FetchStatus,
+  userAccess: UserAccess
+) => {
+  let result = false;
+  if (ocpProvidersFetchStatus === FetchStatus.complete) {
+    const data = (userAccess.data as any).find(d => d.type === UserAccessType.ocp);
+    const isUserAccessAllowed = data && data.access;
+
+    // providers API returns empty data array for no sources
+    result =
+      isUserAccessAllowed &&
+      ocpProviders !== undefined &&
+      ocpProviders.meta !== undefined &&
+      ocpProviders.meta.count > 0;
+  }
+  return result;
+};

--- a/src/pages/overview/overview.tsx
+++ b/src/pages/overview/overview.tsx
@@ -40,7 +40,7 @@ import { Perspective } from './perspective';
 const enum InfrastructurePerspective {
   allCloud = 'all_cloud', // All filtered by Ocp
   aws = 'aws',
-  awsFiltered = 'aws_cloud', // Aws filtered by Ocp
+  awsCloud = 'aws_cloud', // Aws filtered by Ocp
   azure = 'azure',
   azureCloud = 'azure_cloud', // Azure filtered by Ocp
   gcp = 'gcp',
@@ -345,7 +345,7 @@ class OverviewBase extends React.Component<OverviewProps> {
         return this.hasCurrentMonthData(ocpProviders) ? <OcpCloudDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.aws) {
         return this.hasCurrentMonthData(awsProviders) ? <AwsDashboard /> : noData;
-      } else if (currentInfrastructurePerspective === InfrastructurePerspective.awsFiltered) {
+      } else if (currentInfrastructurePerspective === InfrastructurePerspective.awsCloud) {
         return this.hasCurrentMonthData(awsProviders) ? <AwsCloudDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.gcp) {
         return this.hasCurrentMonthData(gcpProviders) ? <GcpDashboard /> : noData;

--- a/src/pages/overview/perspective.tsx
+++ b/src/pages/overview/perspective.tsx
@@ -6,6 +6,7 @@ import { styles } from './perspective.styles';
 
 interface PerspectiveOwnProps {
   currentItem?: string;
+  isDisabled?: boolean;
   onItemClicked(value: string);
   options?: {
     label: string;
@@ -68,7 +69,7 @@ class PerspectiveBase extends React.Component<PerspectiveProps> {
   };
 
   public render() {
-    const { t } = this.props;
+    const { isDisabled, t } = this.props;
     const { isPerspectiveOpen } = this.state;
     const dropdownItems = this.getDropDownItems();
 
@@ -77,7 +78,11 @@ class PerspectiveBase extends React.Component<PerspectiveProps> {
         <label style={styles.perspectiveLabel}>{t('overview.perspective.label')}</label>
         <Dropdown
           onSelect={this.handleSelect}
-          toggle={<DropdownToggle onToggle={this.handleToggle}>{this.getCurrentLabel()}</DropdownToggle>}
+          toggle={
+            <DropdownToggle isDisabled={isDisabled} onToggle={this.handleToggle}>
+              {this.getCurrentLabel()}
+            </DropdownToggle>
+          }
           isOpen={isPerspectiveOpen}
           dropdownItems={dropdownItems}
         />

--- a/src/utils/computedReport/getComputedExplorerReportItems.ts
+++ b/src/utils/computedReport/getComputedExplorerReportItems.ts
@@ -1,0 +1,44 @@
+import { Query } from 'api/queries/query';
+import { ExplorerReportItem } from 'api/reports/explorerReports';
+import { Report } from 'api/reports/report';
+
+import { ComputedReportItemsParams } from './getComputedReportItems';
+
+export interface ComputedExplorerReportItemsParams extends ComputedReportItemsParams<Report, ExplorerReportItem> {}
+
+export function getIdKeyForGroupBy(groupBy: Query['group_by'] = {}): ComputedExplorerReportItemsParams['idKey'] {
+  if (groupBy.account) {
+    return 'account';
+  }
+  if (groupBy.cluster) {
+    return 'cluster';
+  }
+  if (groupBy.instance_type) {
+    return 'instance_type';
+  }
+  if (groupBy.node) {
+    return 'node';
+  }
+  if (groupBy.org_unit_id) {
+    return 'org_unit_id';
+  }
+  if (groupBy.project) {
+    return 'project';
+  }
+  if (groupBy.region) {
+    return 'region';
+  }
+  if (groupBy.resource_location) {
+    return 'resource_location';
+  }
+  if (groupBy.service) {
+    return 'service';
+  }
+  if (groupBy.service_name) {
+    return 'service_name';
+  }
+  if (groupBy.subscription_guid) {
+    return 'subscription_guid';
+  }
+  return 'date';
+}


### PR DESCRIPTION
Refactored to add a perspective menu, which allows users to choose more views; OCP, GCP, Azure, etc. Currently, we're showing all the views available in the overview page.

https://issues.redhat.com/browse/COST-915

<img width="1965" alt="Screen Shot 2021-02-10 at 9 50 04 AM" src="https://user-images.githubusercontent.com/17481322/107527094-8076ef80-6b86-11eb-9416-32e2fa7e4d0f.png">
