### PR TITLE
Historical Cost Explorer

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -490,10 +490,15 @@
     },
     "tag_column_title": "Tag names",
     "title": {
-      "aws": "Amazon Web Services - All Cost Top 5 Costliest",
-      "azure": "Microsoft Azure - All Cost Top 5 Costliest",
-      "gcp": "Google Cloud Platform - All Cost Top 5 Costliest",
-      "ocp": "OpenShift - All Cost Top 5 Costliest"
+      "all_cloud": "All cloud filtered by OpenShift - Top 5 Costliest",
+      "aws": "Amazon Web Services - Top 5 Costliest",
+      "aws_cloud": "Amazon Web Services filtered by OpenShift - Top 5 Costliest",
+      "azure": "Microsoft Azure - Top 5 Costliest",
+      "azure_cloud": "Microsoft Azure filtered by OpenShift - Top 5 Costliest",
+      "gcp": "Google Cloud Platform - Top 5 Costliest",
+      "ocp": "All OpenShift cost - Top 5 Costliest",
+      "ocp_supplementary": "OpenShift supplementary cost - Top 5 Costliest",
+      "ocp_usage": "OpenShift usage - Top 5 Costliest"
     },
     "total_cost": "Total cost"
   },

--- a/src/pages/explorer/explorerChart.tsx
+++ b/src/pages/explorer/explorerChart.tsx
@@ -1,7 +1,7 @@
 import { Title } from '@patternfly/react-core';
 import { Skeleton } from '@redhat-cloud-services/frontend-components/components/Skeleton';
 import { getQuery, orgUnitIdKey, parseQuery, Query, tagPrefix } from 'api/queries/query';
-import { AwsReport } from 'api/reports/awsReports';
+import { Report } from 'api/reports/report';
 import { AxiosError } from 'axios';
 import { ChartDatum, ComputedReportItemType, isFloat, isInt } from 'components/charts/common/chartDatumUtils';
 import { HistoricalExplorerChart } from 'components/charts/historicalExplorerChart';
@@ -13,7 +13,7 @@ import { connect } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
-import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedAwsReportItems';
+import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { formatValue } from 'utils/formatValue';
 
@@ -35,7 +35,7 @@ interface ExplorerChartStateProps {
   perspective: PerspectiveType;
   query: Query;
   queryString: string;
-  report: AwsReport;
+  report: Report;
   reportError: AxiosError;
   reportFetchStatus: FetchStatus;
 }
@@ -127,6 +127,43 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
     return chartDatums;
   };
 
+  private getChartTitle = (perspective: string) => {
+    let result;
+    switch (perspective) {
+      case PerspectiveType.allCloud:
+        result = 'explorer.title.all_cloud';
+        break;
+      case PerspectiveType.aws:
+        result = 'explorer.title.aws';
+        break;
+      case PerspectiveType.awsCloud:
+        result = 'explorer.title.aws_cloud';
+        break;
+      case PerspectiveType.azure:
+        result = 'explorer.title.azure';
+        break;
+      case PerspectiveType.azureCloud:
+        result = 'explorer.title.azure_cloud';
+        break;
+      case PerspectiveType.gcp:
+        result = 'explorer.title.gcp';
+        break;
+      case PerspectiveType.ocp:
+        result = 'explorer.title.ocp';
+        break;
+      case PerspectiveType.ocpSupplementary:
+        result = 'explorer.title.ocp_supplementary';
+        break;
+      case PerspectiveType.ocpUsage:
+        result = 'explorer.title.ocp_usage';
+        break;
+      default:
+        result = undefined;
+        break;
+    }
+    return result;
+  };
+
   private getComputedItems = () => {
     const { report } = this.props;
 
@@ -184,7 +221,7 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
   };
 
   public render() {
-    const { reportFetchStatus, t } = this.props;
+    const { perspective, reportFetchStatus, t } = this.props;
 
     const datums = this.getChartDatums(this.getComputedItems());
 
@@ -193,7 +230,7 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
       <>
         <div style={styles.titleContainer}>
           <Title headingLevel="h3" size="md">
-            {t(`explorer.title.aws`)}
+            {t(this.getChartTitle(perspective))}
           </Title>
         </div>
         <div style={styles.chartContainer}>

--- a/src/pages/explorer/explorerTable.tsx
+++ b/src/pages/explorer/explorerTable.tsx
@@ -12,7 +12,7 @@ import getDate from 'date-fns/get_date';
 import getMonth from 'date-fns/get_month';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
-import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedAwsReportItems';
+import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { formatCurrency } from 'utils/formatValue';
 


### PR DESCRIPTION
Some refactoring to remove the last AWS references. The table, chart, and filter should all reflect the selected perspective now.

- Show dynamic chart titles per selected perspective
- Filter should match specific group by options for OCP, Azure, GCP, etc.
- Table should not use AWS computed report items