### PR TITLE
915 group by

### DIFF
--- a/src/components/charts/historicalExplorerChart/historicalExplorerChart.styles.ts
+++ b/src/components/charts/historicalExplorerChart/historicalExplorerChart.styles.ts
@@ -25,9 +25,11 @@ export const chartStyles = {
     ticks: {
       stroke: 'none',
     },
-    // tickLabels: {
-    //   fontSize: 0,
-    // },
+  },
+  yAxisAlt: {
+    tickLabels: {
+      fontSize: 0,
+    },
   },
   xAxis: {
     axisLabel: {

--- a/src/components/charts/historicalExplorerChart/historicalExplorerChart.tsx
+++ b/src/components/charts/historicalExplorerChart/historicalExplorerChart.tsx
@@ -12,7 +12,7 @@ import {
   getInteractiveLegendEvents,
 } from '@patternfly/react-charts';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import {getDateRange, getMaxValue} from 'components/charts/common/chartDatumUtils';
+import { getDateRange, getMaxValue } from 'components/charts/common/chartDatumUtils';
 import {
   ChartSeries,
   getChartNames,
@@ -282,7 +282,7 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
       domain = { y: [0, 1] };
     }
     return domain;
-  };
+  }
 
   private getEndDate() {
     const { top1stData, top2ndData, top3rdData, top4thData, top5thData, top6thData } = this.props;

--- a/src/components/charts/historicalExplorerChart/historicalExplorerChart.tsx
+++ b/src/components/charts/historicalExplorerChart/historicalExplorerChart.tsx
@@ -12,7 +12,7 @@ import {
   getInteractiveLegendEvents,
 } from '@patternfly/react-charts';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import { getDateRange } from 'components/charts/common/chartDatumUtils';
+import {getDateRange, getMaxValue} from 'components/charts/common/chartDatumUtils';
 import {
   ChartSeries,
   getChartNames,
@@ -230,7 +230,7 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
     if (!hiddenSeries.has(index)) {
       return (
         <ChartBar
-          alignment="middle"
+          alignment="start"
           data={series.data}
           key={series.childName}
           name={series.childName}
@@ -262,6 +262,26 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
         }}
       />
     );
+  };
+
+  // Returns domain only if max y values are zero
+  private getDomain(series: ChartSeries[], hiddenSeries: Set<number>) {
+    let maxValue = -1;
+    let domain;
+
+    if (series) {
+      series.forEach((s: any, index) => {
+        if (!isSeriesHidden(hiddenSeries, index) && s.data && s.data.length !== 0) {
+          const max = getMaxValue(s.data);
+          maxValue = Math.max(maxValue, max);
+        }
+      });
+    }
+
+    if (maxValue <= 0) {
+      domain = { y: [0, 1] };
+    }
+    return domain;
   };
 
   private getEndDate() {
@@ -369,7 +389,7 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
         <div style={{ height, width }}>
           <Chart
             containerComponent={container}
-            domain={{ x: [0, 31] }}
+            domain={this.getDomain(series, hiddenSeries)}
             events={this.getEvents()}
             height={height}
             legendAllowWrap

--- a/src/pages/details/components/groupBy/groupBy.tsx
+++ b/src/pages/details/components/groupBy/groupBy.tsx
@@ -105,16 +105,13 @@ class GroupByBase extends React.Component<GroupByProps> {
       tagReportPathsType,
     } = this.props;
     if (prevProps.groupBy !== groupBy) {
-      const options: any = {};
       if (showOrgs) {
         fetchOrg(orgReportPathsType, orgReportType, queryString);
-        options.isGroupByOrgVisible = false;
       }
       if (showTags) {
         fetchTag(tagReportPathsType, tagReportType, queryString);
-        options.isGroupByTagVisible = false;
       }
-      this.setState({ currentItem: this.getCurrentGroupBy(), ...options });
+      this.setState({ currentItem: this.getCurrentGroupBy(), isGroupByOrgVisible: false, isGroupByTagVisible: false });
     }
   }
 

--- a/src/pages/details/components/groupBy/groupBy.tsx
+++ b/src/pages/details/components/groupBy/groupBy.tsx
@@ -105,13 +105,16 @@ class GroupByBase extends React.Component<GroupByProps> {
       tagReportPathsType,
     } = this.props;
     if (prevProps.groupBy !== groupBy) {
+      const options: any = {};
       if (showOrgs) {
         fetchOrg(orgReportPathsType, orgReportType, queryString);
+        options.isGroupByOrgVisible = false;
       }
       if (showTags) {
         fetchTag(tagReportPathsType, tagReportType, queryString);
+        options.isGroupByTagVisible = false;
       }
-      this.setState({ currentItem: this.getCurrentGroupBy() });
+      this.setState({ currentItem: this.getCurrentGroupBy(), ...options });
     }
   }
 

--- a/src/pages/explorer/explorerHeader.tsx
+++ b/src/pages/explorer/explorerHeader.tsx
@@ -108,9 +108,13 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
       gcpProvidersFetchStatus,
       ocpProviders,
       ocpProvidersFetchStatus,
+      perspective,
       userAccess,
     } = this.props;
 
+    if (perspective) {
+      return perspective;
+    }
     if (isOcpAvailable(ocpProviders, ocpProvidersFetchStatus, userAccess)) {
       return PerspectiveType.ocp;
     }


### PR DESCRIPTION
Added some fixes to the explorer's perspective and group-by dropdown menus.

- Set explorer’s default perspective option
- Reset explorer group by tag dropdown
- Reset explorer group by org unit dropdown
- Removed x-domain so bars spread out across range
- Adjust y-axis labels by adding y-domain when max values are zero

https://issues.redhat.com/browse/COST-915

<img width="1598" alt="Screen Shot 2021-02-11 at 9 47 33 PM" src="https://user-images.githubusercontent.com/17481322/107724834-c8933080-6cb2-11eb-9929-7f1615398b23.png">
