### PR TITLE
Historical cost explorer tick values

### DIFF
--- a/src/components/charts/historicalExplorerChart/historicalExplorerChart.tsx
+++ b/src/components/charts/historicalExplorerChart/historicalExplorerChart.tsx
@@ -318,6 +318,9 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
     );
   };
 
+  // This ensures we show every 3rd tick value, including the first and last value
+  //
+  // Note: We're not using Victory's tickCount because it won't always include the last tick value.
   private getTickValues() {
     const { top1stData, top2ndData, top3rdData, top4thData, top5thData, top6thData } = this.props;
 
@@ -335,7 +338,7 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
       values.push(val.x);
     });
 
-    // Prune tick values to show every 3rd
+    // Prune tick values
     const tickValues = [];
     for (let i = 0; i < values.length; i++) {
       if (i % 3 === 0) {

--- a/src/components/charts/historicalExplorerChart/historicalExplorerChart.tsx
+++ b/src/components/charts/historicalExplorerChart/historicalExplorerChart.tsx
@@ -12,7 +12,7 @@ import {
   getInteractiveLegendEvents,
 } from '@patternfly/react-charts';
 import { default as ChartTheme } from 'components/charts/chartTheme';
-import { getDateRange, getMaxValue } from 'components/charts/common/chartDatumUtils';
+import { getMaxValue } from 'components/charts/common/chartDatumUtils';
 import {
   ChartSeries,
   getChartNames,
@@ -23,7 +23,6 @@ import {
   isDataHidden,
   isSeriesHidden,
 } from 'components/charts/common/chartUtils';
-import getDate from 'date-fns/get_date';
 import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
@@ -214,14 +213,21 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
     return data;
   };
 
-  private handleNavToggle = () => {
-    setTimeout(this.handleResize, 500);
-  };
+  private getAdjustedContainerHeight = () => {
+    const { adjustContainerHeight, height, containerHeight = height } = this.props;
+    const { width } = this.state;
 
-  private handleResize = () => {
-    if (this.containerRef.current) {
-      this.setState({ width: this.containerRef.current.clientWidth });
+    let adjustedContainerHeight = containerHeight;
+    if (adjustContainerHeight) {
+      if (width > 675 && width < 1175) {
+        adjustedContainerHeight += 25;
+      } else if (width > 450 && width < 675) {
+        adjustedContainerHeight += 50;
+      } else if (width <= 450) {
+        adjustedContainerHeight += 75;
+      }
     }
+    return adjustedContainerHeight;
   };
 
   private getChart = (series: ChartSeries, index: number) => {
@@ -284,21 +290,6 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
     return domain;
   }
 
-  private getEndDate() {
-    const { top1stData, top2ndData, top3rdData, top4thData, top5thData, top6thData } = this.props;
-
-    const top1stDate = top1stData ? getDate(getDateRange(top1stData, true, true)[1]) : 0;
-    const top2ndDate = top2ndData ? getDate(getDateRange(top2ndData, true, true)[1]) : 0;
-    const top3rdDate = top3rdData ? getDate(getDateRange(top3rdData, true, true)[1]) : 0;
-    const top4thDate = top4thData ? getDate(getDateRange(top4thData, true, true)[1]) : 0;
-    const top5thDate = top5thData ? getDate(getDateRange(top5thData, true, true)[1]) : 0;
-    const top6thDate = top6thData ? getDate(getDateRange(top6thData, true, true)[1]) : 0;
-
-    return top1stDate > 0 || top2ndDate > 0 || top3rdDate > 0 || top4thDate > 0 || top5thDate > 0 || top6thDate > 0
-      ? Math.max(top1stDate, top2ndDate, top3rdDate, top4thDate, top5thDate, top6thDate)
-      : 31; // Todo: this needs to work with more than current month's data
-  }
-
   // Returns onMouseOver, onMouseOut, and onClick events for the interactive legend
   private getEvents() {
     const { hiddenSeries, series } = this.state;
@@ -327,27 +318,48 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
     );
   };
 
+  private getTickValues() {
+    const { top1stData, top2ndData, top3rdData, top4thData, top5thData, top6thData } = this.props;
+
+    // Find the datum with the greatest number of values
+    const allDatums = [top1stData, top2ndData, top3rdData, top4thData, top5thData, top6thData];
+    let datum;
+    allDatums.map(val => {
+      if (!datum || datum.length < val.length) {
+        datum = val;
+      }
+    });
+
+    const values = [];
+    datum.map(val => {
+      values.push(val.x);
+    });
+
+    // Prune tick values to show every 3rd
+    const tickValues = [];
+    for (let i = 0; i < values.length; i++) {
+      if (i % 3 === 0) {
+        tickValues.push(values[i]);
+      }
+    }
+    tickValues.push(values[values.length - 1]);
+    return tickValues;
+  }
+
   // Hide each data series individually
   private handleLegendClick = (index: number) => {
     const hiddenSeries = initHiddenSeries(this.state.series, this.state.hiddenSeries, index);
     this.setState({ hiddenSeries });
   };
 
-  private getAdjustedContainerHeight = () => {
-    const { adjustContainerHeight, height, containerHeight = height } = this.props;
-    const { width } = this.state;
+  private handleNavToggle = () => {
+    setTimeout(this.handleResize, 500);
+  };
 
-    let adjustedContainerHeight = containerHeight;
-    if (adjustContainerHeight) {
-      if (width > 675 && width < 1175) {
-        adjustedContainerHeight += 25;
-      } else if (width > 450 && width < 675) {
-        adjustedContainerHeight += 50;
-      } else if (width <= 450) {
-        adjustedContainerHeight += 75;
-      }
+  private handleResize = () => {
+    if (this.containerRef.current) {
+      this.setState({ width: this.containerRef.current.clientWidth });
     }
-    return adjustedContainerHeight;
   };
 
   public render() {
@@ -361,14 +373,6 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
       },
     } = this.props;
     const { cursorVoronoiContainer, hiddenSeries, series, width } = this.state;
-
-    const lastDate = this.getEndDate();
-
-    const half = Math.floor(lastDate / 2);
-    const _1stDay = 1;
-    const _2ndDay = _1stDay + Math.floor(half / 2);
-    const _3rdDay = _1stDay + half;
-    const _4thDay = lastDate - Math.floor(half / 2);
 
     // Clone original container. See https://issues.redhat.com/browse/COST-762
     const container = cursorVoronoiContainer
@@ -404,7 +408,7 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
             {series && series.length > 0 && (
               <ChartStack>{series.map((s, index) => this.getChart(s, index))}</ChartStack>
             )}
-            <ChartAxis style={chartStyles.xAxis} tickValues={[_1stDay, _2ndDay, _3rdDay, _4thDay, lastDate]} />
+            <ChartAxis style={chartStyles.xAxis} tickValues={this.getTickValues()} />
             <ChartAxis dependentAxis style={chartStyles.yAxis} />
           </Chart>
         </div>

--- a/src/components/charts/historicalExplorerChart/historicalExplorerChart.tsx
+++ b/src/components/charts/historicalExplorerChart/historicalExplorerChart.tsx
@@ -100,7 +100,7 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
         childName: 'top1stData',
         data: this.initDatumChildName(top1stData, 'top1stData'),
         legendItem: {
-          name: top1stData[0].name, // Todo: get report label
+          name: top1stData[0].name,
           symbol: {
             fill: chartStyles.colorScale[0],
           },
@@ -219,12 +219,12 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
 
     let adjustedContainerHeight = containerHeight;
     if (adjustContainerHeight) {
-      if (width > 675 && width < 1175) {
+      if (width > 675 && width < 1250) {
         adjustedContainerHeight += 25;
-      } else if (width > 450 && width < 675) {
+      } else if (width > 400 && width < 650) {
         adjustedContainerHeight += 50;
-      } else if (width <= 450) {
-        adjustedContainerHeight += 75;
+      } else if (width <= 400) {
+        adjustedContainerHeight += 150;
       }
     }
     return adjustedContainerHeight;

--- a/src/components/charts/historicalExplorerChart/historicalExplorerChart.tsx
+++ b/src/components/charts/historicalExplorerChart/historicalExplorerChart.tsx
@@ -96,15 +96,16 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
 
     const series: ChartSeries[] = [];
     if (top1stData && top1stData.length) {
+      const name = this.getTruncatedString(top1stData[0].name);
       series.push({
         childName: 'top1stData',
         data: this.initDatumChildName(top1stData, 'top1stData'),
         legendItem: {
-          name: top1stData[0].name,
+          name,
           symbol: {
             fill: chartStyles.colorScale[0],
           },
-          tooltip: top1stData[0].name,
+          tooltip: name,
         },
         style: {
           data: {
@@ -114,15 +115,16 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
       });
     }
     if (top2ndData && top2ndData.length) {
+      const name = this.getTruncatedString(top2ndData[0].name);
       series.push({
         childName: 'top2ndData',
         data: this.initDatumChildName(top2ndData, 'top2ndData'),
         legendItem: {
-          name: top2ndData[0].name,
+          name,
           symbol: {
             fill: chartStyles.colorScale[1],
           },
-          tooltip: top2ndData[0].name,
+          tooltip: name,
         },
         style: {
           data: {
@@ -132,15 +134,16 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
       });
     }
     if (top3rdData && top3rdData.length) {
+      const name = this.getTruncatedString(top3rdData[0].name);
       series.push({
         childName: 'top3rdData',
         data: this.initDatumChildName(top3rdData, 'top3rdData'),
         legendItem: {
-          name: top3rdData[0].name,
+          name,
           symbol: {
             fill: chartStyles.colorScale[2],
           },
-          tooltip: top3rdData[0].name,
+          tooltip: name,
         },
         style: {
           data: {
@@ -150,15 +153,16 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
       });
     }
     if (top4thData && top4thData.length) {
+      const name = this.getTruncatedString(top4thData[0].name);
       series.push({
         childName: 'top4thData',
         data: this.initDatumChildName(top4thData, 'top4thData'),
         legendItem: {
-          name: top4thData[0].name,
+          name,
           symbol: {
             fill: chartStyles.colorScale[3],
           },
-          tooltip: top4thData[0].name,
+          tooltip: name,
         },
         style: {
           data: {
@@ -168,15 +172,16 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
       });
     }
     if (top5thData && top5thData.length) {
+      const name = this.getTruncatedString(top5thData[0].name);
       series.push({
         childName: 'top5thData',
         data: this.initDatumChildName(top5thData, 'top5thData'),
         legendItem: {
-          name: top5thData[0].name,
+          name,
           symbol: {
             fill: chartStyles.colorScale[4],
           },
-          tooltip: top5thData[0].name,
+          tooltip: name,
         },
         style: {
           data: {
@@ -186,15 +191,16 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
       });
     }
     if (top6thData && top6thData.length) {
+      const name = this.getTruncatedString(top6thData[0].name);
       series.push({
         childName: 'top6thData',
         data: this.initDatumChildName(top6thData, 'top6thData'),
         legendItem: {
-          name: top6thData[0].name,
+          name,
           symbol: {
             fill: chartStyles.colorScale[5],
           },
-          tooltip: top6thData[0].name,
+          tooltip: name,
         },
         style: {
           data: {
@@ -347,6 +353,11 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
     }
     tickValues.push(values[values.length - 1]);
     return tickValues;
+  }
+
+  private getTruncatedString(str: string) {
+    const maxChars = 20;
+    return str.length > maxChars ? str.substr(0, maxChars - 1) + '...' : str;
   }
 
   // Hide each data series individually

--- a/src/pages/details/components/dataToolbar/dataToolbar.tsx
+++ b/src/pages/details/components/dataToolbar/dataToolbar.tsx
@@ -128,7 +128,11 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
         const filters = this.getActiveFilters(query);
         return categoryOptions !== prevProps.categoryOptions || prevProps.groupBy !== groupBy
           ? {
+              categoryInput: '',
               currentCategory: this.getDefaultCategory(),
+              currentOrgUnit: '',
+              currentTagKey: '',
+              tagKeyValueInput: '',
               filters,
             }
           : {

--- a/src/pages/details/components/groupBy/groupBy.tsx
+++ b/src/pages/details/components/groupBy/groupBy.tsx
@@ -2,6 +2,7 @@ import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
 import { Org, OrgPathsType, OrgType } from 'api/orgs/org';
 import { getQuery, orgUnitIdKey, parseQuery, Query, tagKey, tagPrefix } from 'api/queries/query';
 import { Tag, TagPathsType, TagType } from 'api/tags/tag';
+import { PerspectiveType } from 'pages/explorer/explorerUtils';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -12,7 +13,6 @@ import { tagActions, tagSelectors } from 'store/tags';
 import { styles } from './groupBy.styles';
 import { GroupByOrg } from './groupByOrg';
 import { GroupByTag } from './groupByTag';
-import {PerspectiveType} from '../../../explorer/explorerUtils';
 
 interface GroupByOwnProps extends WithTranslation {
   getIdKeyForGroupBy: (groupBy: Query['group_by']) => string;

--- a/src/pages/details/components/groupBy/groupBy.tsx
+++ b/src/pages/details/components/groupBy/groupBy.tsx
@@ -12,6 +12,7 @@ import { tagActions, tagSelectors } from 'store/tags';
 import { styles } from './groupBy.styles';
 import { GroupByOrg } from './groupByOrg';
 import { GroupByTag } from './groupByTag';
+import {PerspectiveType} from '../../../explorer/explorerUtils';
 
 interface GroupByOwnProps extends WithTranslation {
   getIdKeyForGroupBy: (groupBy: Query['group_by']) => string;
@@ -23,6 +24,7 @@ interface GroupByOwnProps extends WithTranslation {
     value: string;
   }[];
   orgReportPathsType?: OrgPathsType;
+  perspective?: PerspectiveType;
   queryString?: string;
   showOrgs?: boolean;
   showTags?: boolean;
@@ -99,19 +101,28 @@ class GroupByBase extends React.Component<GroupByProps> {
       fetchTag,
       groupBy,
       orgReportPathsType,
+      perspective,
       queryString,
       showOrgs,
       showTags,
       tagReportPathsType,
     } = this.props;
-    if (prevProps.groupBy !== groupBy) {
+    if (prevProps.groupBy !== groupBy || prevProps.perspective !== perspective) {
       if (showOrgs) {
         fetchOrg(orgReportPathsType, orgReportType, queryString);
       }
       if (showTags) {
         fetchTag(tagReportPathsType, tagReportType, queryString);
       }
-      this.setState({ currentItem: this.getCurrentGroupBy(), isGroupByOrgVisible: false, isGroupByTagVisible: false });
+
+      let options;
+      if (prevProps.perspective !== perspective) {
+        options = {
+          isGroupByOrgVisible: false,
+          isGroupByTagVisible: false,
+        };
+      }
+      this.setState({ currentItem: this.getCurrentGroupBy(), ...(options ? options : {}) });
     }
   }
 

--- a/src/pages/explorer/explorer.styles.ts
+++ b/src/pages/explorer/explorer.styles.ts
@@ -5,10 +5,10 @@ import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md'
 export const styles = {
   chartContainer: {
     backgroundColor: global_BackgroundColor_light_100.value,
-    height: '375px',
     marginLeft: global_spacer_lg.value,
     marginRight: global_spacer_lg.value,
     paddingRight: global_spacer_lg.value,
+    paddingBottom: global_spacer_lg.value,
     paddingTop: global_spacer_lg.value,
   },
   chartContent: {

--- a/src/pages/explorer/explorer.tsx
+++ b/src/pages/explorer/explorer.tsx
@@ -396,6 +396,7 @@ class Explorer extends React.Component<ExplorerProps> {
       perspective,
       userAccessFetchStatus,
       query,
+      report,
       reportError,
       reportFetchStatus,
       t,
@@ -410,7 +411,9 @@ class Explorer extends React.Component<ExplorerProps> {
       userAccessFetchStatus === FetchStatus.inProgress;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
+    const groupByTagKey = getGroupByTagKey(query);
     const computedItems = this.getComputedItems();
+    const itemsTotal = report && report.meta ? report.meta.count : 0;
     const title = t('navigation.explorer');
 
     // Test for no providers
@@ -442,16 +445,18 @@ class Explorer extends React.Component<ExplorerProps> {
     return (
       <div style={styles.explorer}>
         <ExplorerHeader
-          groupBy={groupById}
+          groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
           onGroupByClicked={this.handleGroupByClick}
           onFilterAdded={this.handleFilterAdded}
           onFilterRemoved={this.handleFilterRemoved}
         />
-        <div style={styles.chartContent}>
-          <div style={styles.chartContainer}>
-            <ExplorerChart computedReportItemType={getComputedReportItemType(perspective)} />
+        {itemsTotal > 0 && (
+          <div style={styles.chartContent}>
+            <div style={styles.chartContainer}>
+              <ExplorerChart computedReportItemType={getComputedReportItemType(perspective)} />
+            </div>
           </div>
-        </div>
+        )}
         <div style={styles.tableContent}>
           {this.getToolbar(computedItems)}
           {this.getExportModal(computedItems)}

--- a/src/pages/explorer/explorerChart.tsx
+++ b/src/pages/explorer/explorerChart.tsx
@@ -240,7 +240,7 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
             ) : (
               <HistoricalExplorerChart
                 adjustContainerHeight
-                containerHeight={chartStyles.chartContainerHeight - 25}
+                containerHeight={chartStyles.chartContainerHeight}
                 formatDatumValue={formatValue}
                 formatDatumOptions={{}}
                 height={chartStyles.chartHeight}

--- a/src/pages/explorer/explorerFilter.styles.ts
+++ b/src/pages/explorer/explorerFilter.styles.ts
@@ -1,11 +1,12 @@
 import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
 import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
+import global_spacer_sm from '@patternfly/react-tokens/dist/js/global_spacer_sm';
 import React from 'react';
 
 export const styles = {
   toolbarContainer: {
     backgroundColor: global_BackgroundColor_light_100.value,
     marginLeft: `-${global_spacer_md.value}`,
-    paddingTop: global_spacer_md.value,
+    paddingTop: global_spacer_sm.value,
   },
 } as { [className: string]: React.CSSProperties };

--- a/src/pages/explorer/explorerHeader.tsx
+++ b/src/pages/explorer/explorerHeader.tsx
@@ -1,11 +1,10 @@
 import { Title } from '@patternfly/react-core';
 import { Providers, ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { getQuery, parseQuery, Query, tagPrefix } from 'api/queries/query';
+import { getQuery, parseQuery, Query } from 'api/queries/query';
 import { getUserAccessQuery } from 'api/queries/userAccessQuery';
 import { UserAccess, UserAccessType } from 'api/userAccess';
 import { AxiosError } from 'axios';
-import { getGroupByTagKey } from 'pages/details/common/detailsUtils';
 import { GroupBy } from 'pages/details/components/groupBy/groupBy';
 import { Perspective } from 'pages/overview/perspective';
 import React from 'react';
@@ -222,9 +221,6 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
       userAccess,
     } = this.props;
 
-    const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByTagKey = getGroupByTagKey(query);
-
     // Test for no providers
     const noProviders = !(
       isAwsAvailable(awsProviders, awsProvidersFetchStatus, userAccess) &&
@@ -253,6 +249,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
                 onItemClicked={onGroupByClicked}
                 options={groupByOptions}
                 orgReportPathsType={orgReportPathsType}
+                perspective={perspective}
                 showOrgs={orgReportPathsType}
                 showTags={tagReportPathsType}
                 tagReportPathsType={tagReportPathsType}
@@ -260,7 +257,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
             </div>
           </div>
           <ExplorerFilter
-            groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
+            groupBy={groupBy}
             isDisabled={noProviders}
             onFilterAdded={onFilterAdded}
             onFilterRemoved={onFilterRemoved}


### PR DESCRIPTION
This change ensures the explorer chart shows every 3rd tick value per our mocks. Should provide more room when displaying a lot of data.

Fixed some other issues below

- Adjust explorer chart container height
- Truncate long resource names shown in explorer chart
- Group by tag option should remain visible while selection is valid
- Reset filter tag selection when new group by is chosen

https://issues.redhat.com/browse/COST-915

<img width="1486" alt="Screen Shot 2021-02-12 at 10 42 14 AM" src="https://user-images.githubusercontent.com/17481322/107789351-789e8300-6d1f-11eb-9058-bf27be843f08.png">
