### PR TITLE
Horizontal Cost Explorer

### DIFF
--- a/src/pages/explorer/explorerTable.scss
+++ b/src/pages/explorer/explorerTable.scss
@@ -31,14 +31,24 @@
 
 .tableOverride {
   &.pf-c-table {
-    thead th + th + th + th {
-      .pf-c-table__button {
-        margin-left: auto;
-      }
-      text-align: right;
+    thead th:first-child, tbody td:first-child {
+      background-clip: padding-box;
+      background-color: var(--pf-global--BackgroundColor--light-100);
+      left: 0px;
+      position: sticky;
+      z-index: 9999;
     }
-    tbody td + td + td + td {
-      text-align: right;
+    thead th:nth-child(2), tbody td:nth-child(2) {
+      background-clip: padding-box;
+      background-color: var(--pf-global--BackgroundColor--light-100);
+      left: 45px;
+      position: sticky;
+      z-index: 9999;
+    }
+    @media (min-width: 1200px) {
+      thead th:nth-child(2), tbody td:nth-child(2) {
+        left: 53px;
+      }
     }
   }
 }

--- a/src/pages/explorer/explorerTable.styles.ts
+++ b/src/pages/explorer/explorerTable.styles.ts
@@ -24,4 +24,8 @@ export const styles = {
     color: global_disabled_color_100.value,
     fontSize: global_FontSize_xs.value,
   },
+  tableContainer: {
+    position: 'relative',
+    overflowX: 'auto',
+  },
 } as { [className: string]: React.CSSProperties };

--- a/src/pages/explorer/explorerTable.tsx
+++ b/src/pages/explorer/explorerTable.tsx
@@ -330,7 +330,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
     const { columns, loadingRows, rows } = this.state;
 
     return (
-      <>
+      <div style={styles.tableContainer}>
         <Table
           aria-label="explorer-table"
           canSelectAll={false}
@@ -340,13 +340,12 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
           sortBy={this.getSortBy()}
           onSelect={isLoading ? undefined : this.handleOnSelect}
           onSort={this.handleOnSort}
-          gridBreakPoint="grid-2xl"
         >
           <TableHeader />
           <TableBody />
         </Table>
         {Boolean(rows.length === 0) && <div style={styles.emptyState}>{this.getEmptyState()}</div>}
-      </>
+      </div>
     );
   }
 }


### PR DESCRIPTION
Added horizontal scroll to explorer table. This change ensures the first two columns remain sticky, while the remainder of the table may be scrolled horizontally.

https://issues.redhat.com/browse/COST-915

![chrome-capture](https://user-images.githubusercontent.com/17481322/107868574-6de50a80-6e53-11eb-9c63-13168233b4a5.gif)
