### PR TITLE
Azure drop down is cut off by sticky explorer table styles

### DIFF
--- a/src/pages/explorer/explorerTable.scss
+++ b/src/pages/explorer/explorerTable.scss
@@ -29,21 +29,21 @@
   }
 }
 
-.tableOverride {
+.explorerTableOverride {
   &.pf-c-table {
     thead th:first-child, tbody td:first-child {
       background-clip: padding-box;
       background-color: var(--pf-global--BackgroundColor--light-100);
       left: 0px;
       position: sticky;
-      z-index: 9999;
+      z-index: 999;
     }
     thead th:nth-child(2), tbody td:nth-child(2) {
       background-clip: padding-box;
       background-color: var(--pf-global--BackgroundColor--light-100);
       left: 45px;
       position: sticky;
-      z-index: 9999;
+      z-index: 999;
     }
     @media (min-width: 1200px) {
       thead th:nth-child(2), tbody td:nth-child(2) {

--- a/src/pages/explorer/explorerTable.tsx
+++ b/src/pages/explorer/explorerTable.tsx
@@ -335,7 +335,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
           aria-label="explorer-table"
           canSelectAll={false}
           cells={columns}
-          className="tableOverride"
+          className="explorerTableOverride"
           rows={isLoading ? loadingRows : rows}
           sortBy={this.getSortBy()}
           onSelect={isLoading ? undefined : this.handleOnSelect}


### PR DESCRIPTION
Renamed the class used by the explorer table so other pages don't pick up those styles.

https://issues.redhat.com/browse/COST-1027

<img width="908" alt="Screen Shot 2021-02-15 at 3 01 33 PM" src="https://user-images.githubusercontent.com/17481322/107988774-b5c47880-6f9e-11eb-9aff-084d46195f13.png">
