### PR TITLE
Update date-fns package to latest version

### DIFF
--- a/koku-ui-manifest
+++ b/koku-ui-manifest
@@ -432,7 +432,7 @@ mgmt_services/cost-mgmt:koku-ui/damerau-levenshtein:1.0.6.yarnlock
 mgmt_services/cost-mgmt:koku-ui/dashdash:1.14.1.yarnlock
 mgmt_services/cost-mgmt:koku-ui/data-urls:2.0.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/date-fns:2.16.1.yarnlock
-mgmt_services/cost-mgmt:koku-ui/date-fns:1.29.0.yarnlock
+mgmt_services/cost-mgmt:koku-ui/date-fns:2.17.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/debounce-promise:3.1.2.yarnlock
 mgmt_services/cost-mgmt:koku-ui/debug:2.6.9.yarnlock
 mgmt_services/cost-mgmt:koku-ui/debug:2.6.9.yarnlock

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/webpack": "4.41.26",
     "axios": "0.21.1",
     "cross-env": "7.0.3",
-    "date-fns": "1.29.0",
+    "date-fns": "2.17.0",
     "hook-into-props": "4.0.1",
     "human-date": "1.4.0",
     "i18next": "19.8.8",

--- a/src/components/charts/common/chartDatumUtils.ts
+++ b/src/components/charts/common/chartDatumUtils.ts
@@ -350,9 +350,9 @@ export function getDateRangeString(
 
   return i18next.t(`chart.date_range`, {
     count: getDate(end),
-    endDate: format(end, 'DD'),
-    month: Number(format(start, 'M')) - 1,
-    startDate: format(start, 'DD'),
+    endDate: format(end, 'dd'),
+    month: Number(format(start, 'm')) - 1,
+    startDate: format(start, 'dd'),
     year: getYear(end),
   });
 }

--- a/src/components/charts/common/chartDatumUtils.ts
+++ b/src/components/charts/common/chartDatumUtils.ts
@@ -1,7 +1,6 @@
 import { Forecast } from 'api/forecasts/forecast';
 import { Report } from 'api/reports/report';
 import { endOfMonth, format, getDate, getYear, startOfMonth } from 'date-fns';
-import formatDate from 'date-fns/format';
 import i18next from 'i18next';
 import { ComputedForecastItem, getComputedForecastItems } from 'utils/computedForecast/getComputedForecastItems';
 import { ComputedReportItem, getComputedReportItems } from 'utils/computedReport/getComputedReportItems';
@@ -226,7 +225,7 @@ export function fillChartDatums(datums: ChartDatum[], type: ChartType = ChartTyp
   let prevChartDatum;
   for (let i = padDate.getDate(); i <= endOfMonth(lastDate).getDate(); i++) {
     padDate.setDate(i);
-    const id = formatDate(padDate, 'yyyy-mm-dd');
+    const id = format(padDate, 'yyyy-mm-dd');
     const chartDatum = datums.find(val => val.key === id);
     if (chartDatum) {
       result.push(chartDatum);
@@ -270,7 +269,7 @@ export function padChartDatums(datums: ChartDatum[], type: ChartType = ChartType
   let padDate = startOfMonth(firstDate);
   for (let i = padDate.getDate(); i < firstDate.getDate(); i++) {
     padDate.setDate(i);
-    const id = formatDate(padDate, 'yyyy-mm-dd');
+    const id = format(padDate, 'yyyy-mm-dd');
     result.push(createReportDatum(null, { id }, 'date', null));
   }
 
@@ -281,7 +280,7 @@ export function padChartDatums(datums: ChartDatum[], type: ChartType = ChartType
   padDate = new Date(lastDate);
   for (let i = padDate.getDate() + 1; i <= endOfMonth(lastDate).getDate(); i++) {
     padDate.setDate(i);
-    const id = formatDate(padDate, 'yyyy-mm-dd');
+    const id = format(padDate, 'yyyy-mm-dd');
     result.push(createReportDatum(null, { id }, 'date', null));
   }
   return fillChartDatums(result, type);
@@ -351,9 +350,9 @@ export function getDateRangeString(
 
   return i18next.t(`chart.date_range`, {
     count: getDate(end),
-    endDate: formatDate(end, 'DD'),
-    month: Number(formatDate(start, 'M')) - 1,
-    startDate: formatDate(start, 'DD'),
+    endDate: format(end, 'DD'),
+    month: Number(format(start, 'M')) - 1,
+    startDate: format(start, 'DD'),
     year: getYear(end),
   });
 }
@@ -367,10 +366,10 @@ export function getMonthRangeString(
 
   return [
     i18next.t(key, {
-      month: Number(formatDate(start, 'M')) - 1,
+      month: Number(format(start, 'M')) - 1,
     }),
     i18next.t(key, {
-      month: Number(formatDate(end, 'M')) - 1,
+      month: Number(format(end, 'M')) - 1,
     }),
   ];
 }
@@ -455,9 +454,9 @@ export function getCostRangeString(
 
   return i18next.t(key, {
     count: getDate(end),
-    endDate: formatDate(end, 'd'),
-    month: Number(formatDate(start, 'M')) - 1,
-    startDate: formatDate(start, 'd'),
+    endDate: format(end, 'd'),
+    month: Number(format(start, 'M')) - 1,
+    startDate: format(start, 'd'),
     year: getYear(end),
   });
 }

--- a/src/components/charts/common/chartDatumUtils.ts
+++ b/src/components/charts/common/chartDatumUtils.ts
@@ -1,11 +1,7 @@
 import { Forecast } from 'api/forecasts/forecast';
 import { Report } from 'api/reports/report';
-import endOfMonth from 'date-fns/end_of_month';
-import format from 'date-fns/format';
+import { endOfMonth, format, getDate, getYear, startOfMonth } from 'date-fns';
 import formatDate from 'date-fns/format';
-import getDate from 'date-fns/get_date';
-import getYear from 'date-fns/get_year';
-import startOfMonth from 'date-fns/start_of_month';
 import i18next from 'i18next';
 import { ComputedForecastItem, getComputedForecastItems } from 'utils/computedForecast/getComputedForecastItems';
 import { ComputedReportItem, getComputedReportItems } from 'utils/computedReport/getComputedReportItems';
@@ -161,7 +157,7 @@ export function createForecastDatum<T extends ComputedForecastItem>(
   forecastItem: string = 'cost',
   forecastItemValue: string = 'total'
 ): ChartDatum {
-  const xVal = getDate(computedItem.date);
+  const xVal = getDate(new Date(computedItem.date));
   const yVal = isFloat(value) ? parseFloat(value.toFixed(2)) : isInt(value) ? value : 0;
   return {
     x: xVal,
@@ -181,7 +177,7 @@ export function createForecastConeDatum<T extends ComputedForecastItem>(
   forecastItem: string = 'cost',
   forecastItemValue: string = 'total'
 ): ChartDatum {
-  const xVal = getDate(computedItem.date);
+  const xVal = getDate(new Date(computedItem.date));
   const yVal = isFloat(maxValue) ? parseFloat(maxValue.toFixed(2)) : isInt(maxValue) ? maxValue : 0;
   const y0Val = isFloat(minValue) ? parseFloat(minValue.toFixed(2)) : isInt(minValue) ? minValue : 0;
   return {
@@ -203,7 +199,7 @@ export function createReportDatum<T extends ComputedReportItem>(
   reportItem: string = 'cost',
   reportItemValue: string = 'total' // useful for infrastructure.usage values
 ): ChartDatum {
-  const xVal = idKey === 'date' ? getDate(computedItem.id) : computedItem.label;
+  const xVal = idKey === 'date' ? getDate(new Date(computedItem.id)) : computedItem.label;
   const yVal = isFloat(value) ? parseFloat(value.toFixed(2)) : isInt(value) ? value : 0;
   return {
     x: xVal,
@@ -230,7 +226,7 @@ export function fillChartDatums(datums: ChartDatum[], type: ChartType = ChartTyp
   let prevChartDatum;
   for (let i = padDate.getDate(); i <= endOfMonth(lastDate).getDate(); i++) {
     padDate.setDate(i);
-    const id = formatDate(padDate, 'YYYY-MM-DD');
+    const id = formatDate(padDate, 'yyyy-mm-dd');
     const chartDatum = datums.find(val => val.key === id);
     if (chartDatum) {
       result.push(chartDatum);
@@ -238,7 +234,7 @@ export function fillChartDatums(datums: ChartDatum[], type: ChartType = ChartTyp
       result.push({
         ...prevChartDatum,
         key: id,
-        x: getDate(id),
+        x: getDate(new Date(id)),
       });
     }
     if (chartDatum) {
@@ -248,7 +244,7 @@ export function fillChartDatums(datums: ChartDatum[], type: ChartType = ChartTyp
       if (type === ChartType.daily) {
         prevChartDatum = {
           key: id,
-          x: getDate(id),
+          x: getDate(new Date(id)),
           y: null,
         };
       } else {
@@ -274,7 +270,7 @@ export function padChartDatums(datums: ChartDatum[], type: ChartType = ChartType
   let padDate = startOfMonth(firstDate);
   for (let i = padDate.getDate(); i < firstDate.getDate(); i++) {
     padDate.setDate(i);
-    const id = formatDate(padDate, 'YYYY-MM-DD');
+    const id = formatDate(padDate, 'yyyy-mm-dd');
     result.push(createReportDatum(null, { id }, 'date', null));
   }
 
@@ -285,7 +281,7 @@ export function padChartDatums(datums: ChartDatum[], type: ChartType = ChartType
   padDate = new Date(lastDate);
   for (let i = padDate.getDate() + 1; i <= endOfMonth(lastDate).getDate(); i++) {
     padDate.setDate(i);
-    const id = formatDate(padDate, 'YYYY-MM-DD');
+    const id = formatDate(padDate, 'yyyy-mm-dd');
     result.push(createReportDatum(null, { id }, 'date', null));
   }
   return fillChartDatums(result, type);
@@ -439,7 +435,7 @@ export function getTooltipLabel(
     return '';
   }
   if (idKey === 'date') {
-    const date = format(datum.key, 'DD MMM YYYY');
+    const date = format(new Date(datum.key), 'dd mmm yyyy');
     return `${date} ${formatValue(datum.y, units ? units : datum.units, formatOptions)}`;
   }
   return datum.key.toString();
@@ -459,9 +455,9 @@ export function getCostRangeString(
 
   return i18next.t(key, {
     count: getDate(end),
-    endDate: formatDate(end, 'D'),
+    endDate: formatDate(end, 'd'),
     month: Number(formatDate(start, 'M')) - 1,
-    startDate: formatDate(start, 'D'),
+    startDate: formatDate(start, 'd'),
     year: getYear(end),
   });
 }

--- a/src/components/charts/common/chartDatumUtils.ts
+++ b/src/components/charts/common/chartDatumUtils.ts
@@ -225,7 +225,7 @@ export function fillChartDatums(datums: ChartDatum[], type: ChartType = ChartTyp
   let prevChartDatum;
   for (let i = padDate.getDate(); i <= endOfMonth(lastDate).getDate(); i++) {
     padDate.setDate(i);
-    const id = format(padDate, 'yyyy-mm-dd');
+    const id = format(padDate, 'yyyy-MM-dd');
     const chartDatum = datums.find(val => val.key === id);
     if (chartDatum) {
       result.push(chartDatum);
@@ -269,7 +269,7 @@ export function padChartDatums(datums: ChartDatum[], type: ChartType = ChartType
   let padDate = startOfMonth(firstDate);
   for (let i = padDate.getDate(); i < firstDate.getDate(); i++) {
     padDate.setDate(i);
-    const id = format(padDate, 'yyyy-mm-dd');
+    const id = format(padDate, 'yyyy-MM-dd');
     result.push(createReportDatum(null, { id }, 'date', null));
   }
 
@@ -280,7 +280,7 @@ export function padChartDatums(datums: ChartDatum[], type: ChartType = ChartType
   padDate = new Date(lastDate);
   for (let i = padDate.getDate() + 1; i <= endOfMonth(lastDate).getDate(); i++) {
     padDate.setDate(i);
-    const id = format(padDate, 'yyyy-mm-dd');
+    const id = format(padDate, 'yyyy-MM-dd');
     result.push(createReportDatum(null, { id }, 'date', null));
   }
   return fillChartDatums(result, type);
@@ -351,7 +351,7 @@ export function getDateRangeString(
   return i18next.t(`chart.date_range`, {
     count: getDate(end),
     endDate: format(end, 'dd'),
-    month: Number(format(start, 'm')) - 1,
+    month: Number(format(start, 'M')) - 1,
     startDate: format(start, 'dd'),
     year: getYear(end),
   });
@@ -434,7 +434,7 @@ export function getTooltipLabel(
     return '';
   }
   if (idKey === 'date') {
-    const date = format(new Date(datum.key), 'dd mmm yyyy');
+    const date = format(new Date(datum.key), 'dd MMM yyyy');
     return `${date} ${formatValue(datum.y, units ? units : datum.units, formatOptions)}`;
   }
   return datum.key.toString();

--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -22,7 +22,7 @@ import {
   isDataAvailable,
   isSeriesHidden,
 } from 'components/charts/common/chartUtils';
-import getDate from 'date-fns/get_date';
+import { getDate } from 'date-fns';
 import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';

--- a/src/components/charts/dailyCostChart/dailyCostChart.tsx
+++ b/src/components/charts/dailyCostChart/dailyCostChart.tsx
@@ -25,7 +25,7 @@ import {
   isDataHidden,
   isSeriesHidden,
 } from 'components/charts/common/chartUtils';
-import getDate from 'date-fns/get_date';
+import { getDate } from 'date-fns';
 import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';

--- a/src/components/charts/dailyTrendChart/dailyTrendChart.tsx
+++ b/src/components/charts/dailyTrendChart/dailyTrendChart.tsx
@@ -25,7 +25,7 @@ import {
   isDataHidden,
   isSeriesHidden,
 } from 'components/charts/common/chartUtils';
-import getDate from 'date-fns/get_date';
+import { getDate } from 'date-fns';
 import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -23,7 +23,7 @@ import {
   isDataAvailable,
   isSeriesHidden,
 } from 'components/charts/common/chartUtils';
-import getDate from 'date-fns/get_date';
+import { getDate } from 'date-fns';
 import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -22,7 +22,7 @@ import {
   isDataAvailable,
   isSeriesHidden,
 } from 'components/charts/common/chartUtils';
-import getDate from 'date-fns/get_date';
+import { getDate } from 'date-fns';
 import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -23,7 +23,7 @@ import {
   isDataAvailable,
   isSeriesHidden,
 } from 'components/charts/common/chartUtils';
-import getDate from 'date-fns/get_date';
+import { getDate } from 'date-fns';
 import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -22,7 +22,7 @@ import {
   isDataAvailable,
   isSeriesHidden,
 } from 'components/charts/common/chartUtils';
-import getDate from 'date-fns/get_date';
+import { getDate } from 'date-fns';
 import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -22,7 +22,7 @@ import {
   isDataAvailable,
   isSeriesHidden,
 } from 'components/charts/common/chartUtils';
-import getDate from 'date-fns/get_date';
+import { getDate } from 'date-fns';
 import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';

--- a/src/pages/dashboard/awsDashboard/awsDashboardWidget.test.tsx
+++ b/src/pages/dashboard/awsDashboard/awsDashboardWidget.test.tsx
@@ -1,13 +1,7 @@
-jest
-  .mock('date-fns/start_of_month')
-  .mock('date-fns/get_date')
-  .mock('date-fns/format')
-  .mock('date-fns/get_month');
+jest.mock('date-fns').mock('date-fns/format');
 
+import { getDate, getMonth, startOfMonth } from 'date-fns';
 import formatDate from 'date-fns/format';
-import getDate from 'date-fns/get_date';
-import getMonth from 'date-fns/get_month';
-import startOfMonth from 'date-fns/start_of_month';
 import { AwsDashboardTab } from 'store/dashboard/awsDashboard';
 import { mockDate } from 'testUtils';
 

--- a/src/pages/dashboard/awsDashboard/awsDashboardWidget.test.tsx
+++ b/src/pages/dashboard/awsDashboard/awsDashboardWidget.test.tsx
@@ -1,21 +1,20 @@
-jest.mock('date-fns').mock('date-fns/format');
+jest.mock('date-fns');
 
-import { getDate, getMonth, startOfMonth } from 'date-fns';
-import formatDate from 'date-fns/format';
+import { format, getDate, getMonth, startOfMonth } from 'date-fns';
 import { AwsDashboardTab } from 'store/dashboard/awsDashboard';
 import { mockDate } from 'testUtils';
 
 import { getIdKeyForTab } from './awsDashboardWidget';
 
 const getDateMock = getDate as jest.Mock;
-const formatDateMock = formatDate as jest.Mock;
+const formatMock = format as jest.Mock;
 const startOfMonthMock = startOfMonth as jest.Mock;
 const getMonthMock = getMonth as jest.Mock;
 
 beforeEach(() => {
   mockDate();
   getDateMock.mockReturnValue(1);
-  formatDateMock.mockReturnValue('formated date');
+  formatMock.mockReturnValue('formated date');
   startOfMonthMock.mockReturnValue(1);
   getMonthMock.mockReturnValue(1);
 });

--- a/src/pages/dashboard/azureDashboard/azureDashboardWidget.test.tsx
+++ b/src/pages/dashboard/azureDashboard/azureDashboardWidget.test.tsx
@@ -1,13 +1,7 @@
-jest
-  .mock('date-fns/start_of_month')
-  .mock('date-fns/get_date')
-  .mock('date-fns/format')
-  .mock('date-fns/get_month');
+jest.mock('date-fns').mock('date-fns/format');
 
+import { getDate, getMonth, startOfMonth } from 'date-fns';
 import formatDate from 'date-fns/format';
-import getDate from 'date-fns/get_date';
-import getMonth from 'date-fns/get_month';
-import startOfMonth from 'date-fns/start_of_month';
 import { AzureDashboardTab } from 'store/dashboard/azureDashboard';
 import { mockDate } from 'testUtils';
 

--- a/src/pages/dashboard/azureDashboard/azureDashboardWidget.test.tsx
+++ b/src/pages/dashboard/azureDashboard/azureDashboardWidget.test.tsx
@@ -1,21 +1,20 @@
-jest.mock('date-fns').mock('date-fns/format');
+jest.mock('date-fns');
 
-import { getDate, getMonth, startOfMonth } from 'date-fns';
-import formatDate from 'date-fns/format';
+import { format, getDate, getMonth, startOfMonth } from 'date-fns';
 import { AzureDashboardTab } from 'store/dashboard/azureDashboard';
 import { mockDate } from 'testUtils';
 
 import { getIdKeyForTab } from './azureDashboardWidget';
 
 const getDateMock = getDate as jest.Mock;
-const formatDateMock = formatDate as jest.Mock;
+const formatMock = format as jest.Mock;
 const startOfMonthMock = startOfMonth as jest.Mock;
 const getMonthMock = getMonth as jest.Mock;
 
 beforeEach(() => {
   mockDate();
   getDateMock.mockReturnValue(1);
-  formatDateMock.mockReturnValue('formated date');
+  formatMock.mockReturnValue('formated date');
   startOfMonthMock.mockReturnValue(1);
   getMonthMock.mockReturnValue(1);
 });

--- a/src/pages/dashboard/components/dashboardWidget.test.tsx
+++ b/src/pages/dashboard/components/dashboardWidget.test.tsx
@@ -1,8 +1,7 @@
 jest.mock('date-fns').mock('date-fns/format');
 
 import { ChartType } from 'components/charts/common/chartDatumUtils';
-import { getDate, getMonth, startOfMonth } from 'date-fns';
-import formatDate from 'date-fns/format';
+import { format, getDate, getMonth, startOfMonth } from 'date-fns';
 import { shallow } from 'enzyme';
 import { DashboardWidgetBase, DashboardWidgetProps } from 'pages/dashboard/components/dashboardWidgetBase';
 import React from 'react';
@@ -37,14 +36,14 @@ const props: DashboardWidgetProps = {
 } as any;
 
 const getDateMock = getDate as jest.Mock;
-const formatDateMock = formatDate as jest.Mock;
+const formatMock = format as jest.Mock;
 const startOfMonthMock = startOfMonth as jest.Mock;
 const getMonthMock = getMonth as jest.Mock;
 
 beforeEach(() => {
   mockDate();
   getDateMock.mockReturnValue(1);
-  formatDateMock.mockReturnValue('formated date');
+  formatMock.mockReturnValue('formated date');
   startOfMonthMock.mockReturnValue(1);
   getMonthMock.mockReturnValue(1);
 });

--- a/src/pages/dashboard/components/dashboardWidget.test.tsx
+++ b/src/pages/dashboard/components/dashboardWidget.test.tsx
@@ -1,14 +1,8 @@
-jest
-  .mock('date-fns/start_of_month')
-  .mock('date-fns/get_date')
-  .mock('date-fns/format')
-  .mock('date-fns/get_month');
+jest.mock('date-fns').mock('date-fns/format');
 
 import { ChartType } from 'components/charts/common/chartDatumUtils';
+import { getDate, getMonth, startOfMonth } from 'date-fns';
 import formatDate from 'date-fns/format';
-import getDate from 'date-fns/get_date';
-import getMonth from 'date-fns/get_month';
-import startOfMonth from 'date-fns/start_of_month';
 import { shallow } from 'enzyme';
 import { DashboardWidgetBase, DashboardWidgetProps } from 'pages/dashboard/components/dashboardWidgetBase';
 import React from 'react';

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -21,8 +21,7 @@ import {
   ReportSummaryTrend,
   ReportSummaryUsage,
 } from 'components/reports/reportSummary';
-import formatDate from 'date-fns/format';
-import { getDate, getMonth, startOfMonth } from 'date-fns';
+import { format, getDate, getMonth, startOfMonth } from 'date-fns';
 import { cloneDeep } from 'lodash';
 import React from 'react';
 import { WithTranslation } from 'react-i18next';
@@ -497,8 +496,8 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
 
     const today = new Date();
     const month = getMonth(today);
-    const endDate = formatDate(today, 'd');
-    const startDate = formatDate(startOfMonth(today), 'd');
+    const endDate = format(today, 'd');
+    const startDate = format(startOfMonth(today), 'd');
 
     return t('dashboard.widget_subtitle', {
       count: getDate(today),
@@ -595,8 +594,8 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
 
     const today = new Date();
     const month = getMonth(today);
-    const endDate = formatDate(today, 'Do');
-    const startDate = formatDate(startOfMonth(today), 'Do');
+    const endDate = format(today, 'Do');
+    const startDate = format(startOfMonth(today), 'Do');
 
     return t(titleKey, { endDate, month, startDate });
   };

--- a/src/pages/dashboard/components/dashboardWidgetBase.tsx
+++ b/src/pages/dashboard/components/dashboardWidgetBase.tsx
@@ -22,9 +22,7 @@ import {
   ReportSummaryUsage,
 } from 'components/reports/reportSummary';
 import formatDate from 'date-fns/format';
-import getDate from 'date-fns/get_date';
-import getMonth from 'date-fns/get_month';
-import startOfMonth from 'date-fns/start_of_month';
+import { getDate, getMonth, startOfMonth } from 'date-fns';
 import { cloneDeep } from 'lodash';
 import React from 'react';
 import { WithTranslation } from 'react-i18next';
@@ -499,8 +497,8 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
 
     const today = new Date();
     const month = getMonth(today);
-    const endDate = formatDate(today, 'D');
-    const startDate = formatDate(startOfMonth(today), 'D');
+    const endDate = formatDate(today, 'd');
+    const startDate = formatDate(startOfMonth(today), 'd');
 
     return t('dashboard.widget_subtitle', {
       count: getDate(today),

--- a/src/pages/dashboard/gcpDashboard/gcpDashboardWidget.test.tsx
+++ b/src/pages/dashboard/gcpDashboard/gcpDashboardWidget.test.tsx
@@ -1,21 +1,20 @@
-jest.mock('date-fns').mock('date-fns/format');
+jest.mock('date-fns');
 
-import { getDate, getMonth, startOfMonth } from 'date-fns';
-import formatDate from 'date-fns/format';
+import { format, getDate, getMonth, startOfMonth } from 'date-fns';
 import { GcpDashboardTab } from 'store/dashboard/gcpDashboard';
 import { mockDate } from 'testUtils';
 
 import { getIdKeyForTab } from './gcpDashboardWidget';
 
 const getDateMock = getDate as jest.Mock;
-const formatDateMock = formatDate as jest.Mock;
+const formatMock = format as jest.Mock;
 const startOfMonthMock = startOfMonth as jest.Mock;
 const getMonthMock = getMonth as jest.Mock;
 
 beforeEach(() => {
   mockDate();
   getDateMock.mockReturnValue(1);
-  formatDateMock.mockReturnValue('formated date');
+  formatMock.mockReturnValue('formated date');
   startOfMonthMock.mockReturnValue(1);
   getMonthMock.mockReturnValue(1);
 });

--- a/src/pages/dashboard/gcpDashboard/gcpDashboardWidget.test.tsx
+++ b/src/pages/dashboard/gcpDashboard/gcpDashboardWidget.test.tsx
@@ -1,13 +1,7 @@
-jest
-  .mock('date-fns/start_of_month')
-  .mock('date-fns/get_date')
-  .mock('date-fns/format')
-  .mock('date-fns/get_month');
+jest.mock('date-fns').mock('date-fns/format');
 
+import { getDate, getMonth, startOfMonth } from 'date-fns';
 import formatDate from 'date-fns/format';
-import getDate from 'date-fns/get_date';
-import getMonth from 'date-fns/get_month';
-import startOfMonth from 'date-fns/start_of_month';
 import { GcpDashboardTab } from 'store/dashboard/gcpDashboard';
 import { mockDate } from 'testUtils';
 

--- a/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboardWidget.test.tsx
+++ b/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboardWidget.test.tsx
@@ -1,21 +1,20 @@
-jest.mock('date-fns').mock('date-fns/format');
+jest.mock('date-fns');
 
-import { getDate, getMonth, startOfMonth } from 'date-fns';
-import formatDate from 'date-fns/format';
+import { format, getDate, getMonth, startOfMonth } from 'date-fns';
 import { OcpCloudDashboardTab } from 'store/dashboard/ocpCloudDashboard';
 import { mockDate } from 'testUtils';
 
 import { getIdKeyForTab } from './ocpCloudDashboardWidget';
 
 const getDateMock = getDate as jest.Mock;
-const formatDateMock = formatDate as jest.Mock;
+const formatMock = format as jest.Mock;
 const startOfMonthMock = startOfMonth as jest.Mock;
 const getMonthMock = getMonth as jest.Mock;
 
 beforeEach(() => {
   mockDate();
   getDateMock.mockReturnValue(1);
-  formatDateMock.mockReturnValue('formated date');
+  formatMock.mockReturnValue('formated date');
   startOfMonthMock.mockReturnValue(1);
   getMonthMock.mockReturnValue(1);
 });

--- a/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboardWidget.test.tsx
+++ b/src/pages/dashboard/ocpCloudDashboard/ocpCloudDashboardWidget.test.tsx
@@ -1,13 +1,7 @@
-jest
-  .mock('date-fns/start_of_month')
-  .mock('date-fns/get_date')
-  .mock('date-fns/format')
-  .mock('date-fns/get_month');
+jest.mock('date-fns').mock('date-fns/format');
 
+import { getDate, getMonth, startOfMonth } from 'date-fns';
 import formatDate from 'date-fns/format';
-import getDate from 'date-fns/get_date';
-import getMonth from 'date-fns/get_month';
-import startOfMonth from 'date-fns/start_of_month';
 import { OcpCloudDashboardTab } from 'store/dashboard/ocpCloudDashboard';
 import { mockDate } from 'testUtils';
 

--- a/src/pages/dashboard/ocpDashboard/ocpDashboardWidget.test.tsx
+++ b/src/pages/dashboard/ocpDashboard/ocpDashboardWidget.test.tsx
@@ -1,13 +1,7 @@
-jest
-  .mock('date-fns/start_of_month')
-  .mock('date-fns/get_date')
-  .mock('date-fns/format')
-  .mock('date-fns/get_month');
+jest.mock('date-fns').mock('date-fns/format');
 
+import { getDate, getMonth, startOfMonth } from 'date-fns';
 import formatDate from 'date-fns/format';
-import getDate from 'date-fns/get_date';
-import getMonth from 'date-fns/get_month';
-import startOfMonth from 'date-fns/start_of_month';
 import { OcpDashboardTab } from 'store/dashboard/ocpDashboard';
 import { mockDate } from 'testUtils';
 

--- a/src/pages/dashboard/ocpDashboard/ocpDashboardWidget.test.tsx
+++ b/src/pages/dashboard/ocpDashboard/ocpDashboardWidget.test.tsx
@@ -1,21 +1,20 @@
-jest.mock('date-fns').mock('date-fns/format');
+jest.mock('date-fns');
 
-import { getDate, getMonth, startOfMonth } from 'date-fns';
-import formatDate from 'date-fns/format';
+import { format, getDate, getMonth, startOfMonth } from 'date-fns';
 import { OcpDashboardTab } from 'store/dashboard/ocpDashboard';
 import { mockDate } from 'testUtils';
 
 import { getIdKeyForTab } from './ocpDashboardWidget';
 
 const getDateMock = getDate as jest.Mock;
-const formatDateMock = formatDate as jest.Mock;
+const formatMock = format as jest.Mock;
 const startOfMonthMock = startOfMonth as jest.Mock;
 const getMonthMock = getMonth as jest.Mock;
 
 beforeEach(() => {
   mockDate();
   getDateMock.mockReturnValue(1);
-  formatDateMock.mockReturnValue('formated date');
+  formatMock.mockReturnValue('formated date');
   startOfMonthMock.mockReturnValue(1);
   getMonthMock.mockReturnValue(1);
 });

--- a/src/pages/details/components/export/exportModal.tsx
+++ b/src/pages/details/components/export/exportModal.tsx
@@ -2,7 +2,7 @@ import { Button, ButtonVariant, Form, FormGroup, Modal, Radio } from '@patternfl
 import { Query, tagPrefix } from 'api/queries/query';
 import { ReportPathsType } from 'api/reports/report';
 import { AxiosError } from 'axios';
-import formatDate from 'date-fns/format';
+import { format } from 'date-fns';
 import { orderBy } from 'lodash';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
@@ -111,8 +111,8 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
 
     const thisMonth = new Date();
     const lastMonth = new Date().setMonth(thisMonth.getMonth() - 1);
-    const currentMonth = formatDate(thisMonth, 'mmmm yyyy');
-    const previousMonth = formatDate(lastMonth - 1, 'mmmm yyyy');
+    const currentMonth = format(thisMonth, 'mmmm yyyy');
+    const previousMonth = format(lastMonth - 1, 'mmmm yyyy');
 
     return (
       <Modal

--- a/src/pages/details/components/export/exportModal.tsx
+++ b/src/pages/details/components/export/exportModal.tsx
@@ -111,8 +111,8 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
 
     const thisMonth = new Date();
     const lastMonth = new Date().setMonth(thisMonth.getMonth() - 1);
-    const currentMonth = formatDate(thisMonth, 'MMMM YYYY');
-    const previousMonth = formatDate(lastMonth - 1, 'MMMM YYYY');
+    const currentMonth = formatDate(thisMonth, 'mmmm yyyy');
+    const previousMonth = formatDate(lastMonth - 1, 'mmmm yyyy');
 
     return (
       <Modal

--- a/src/pages/details/components/export/exportModal.tsx
+++ b/src/pages/details/components/export/exportModal.tsx
@@ -111,8 +111,8 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
 
     const thisMonth = new Date();
     const lastMonth = new Date().setMonth(thisMonth.getMonth() - 1);
-    const currentMonth = format(thisMonth, 'mmmm yyyy');
-    const previousMonth = format(lastMonth - 1, 'mmmm yyyy');
+    const currentMonth = format(thisMonth, 'MMMM yyyy');
+    const previousMonth = format(lastMonth - 1, 'MMMM yyyy');
 
     return (
       <Modal

--- a/src/pages/details/components/export/exportSubmit.tsx
+++ b/src/pages/details/components/export/exportSubmit.tsx
@@ -78,7 +78,7 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
     const fileName = t('export.file_name', {
       provider: reportPathsType,
       groupBy,
-      date: format(new Date(), 'yyyy-mm-dd'),
+      date: format(new Date(), 'yyyy-MM-dd'),
     });
 
     return `${fileName}.csv`;

--- a/src/pages/details/components/export/exportSubmit.tsx
+++ b/src/pages/details/components/export/exportSubmit.tsx
@@ -78,7 +78,7 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
     const fileName = t('export.file_name', {
       provider: reportPathsType,
       groupBy,
-      date: formatDate(new Date(), 'YYYY-MM-DD'),
+      date: formatDate(new Date(), 'yyyy-mm-dd'),
     });
 
     return `${fileName}.csv`;

--- a/src/pages/details/components/export/exportSubmit.tsx
+++ b/src/pages/details/components/export/exportSubmit.tsx
@@ -3,7 +3,7 @@ import { Export } from 'api/exports/export';
 import { getQuery, orgUnitIdKey, Query } from 'api/queries/query';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { AxiosError } from 'axios';
-import formatDate from 'date-fns/format';
+import { format } from 'date-fns';
 import fileDownload from 'js-file-download';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
@@ -78,7 +78,7 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
     const fileName = t('export.file_name', {
       provider: reportPathsType,
       groupBy,
-      date: formatDate(new Date(), 'yyyy-mm-dd'),
+      date: format(new Date(), 'yyyy-mm-dd'),
     });
 
     return `${fileName}.csv`;

--- a/src/pages/explorer/explorerChart.tsx
+++ b/src/pages/explorer/explorerChart.tsx
@@ -5,8 +5,7 @@ import { Report } from 'api/reports/report';
 import { AxiosError } from 'axios';
 import { ChartDatum, ComputedReportItemType, isFloat, isInt } from 'components/charts/common/chartDatumUtils';
 import { HistoricalExplorerChart } from 'components/charts/historicalExplorerChart';
-import getDate from 'date-fns/get_date';
-import getMonth from 'date-fns/get_month';
+import { getDate, getMonth } from 'date-fns';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -81,7 +80,8 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
   ): ChartDatum => {
     const { t } = this.props;
 
-    const xVal = t('chart.date', { date: getDate(computedItem.date), month: getMonth(computedItem.date) });
+    const computedItemDate = new Date(computedItem.date);
+    const xVal = t('chart.date', { date: getDate(computedItemDate), month: getMonth(computedItemDate) });
     const yVal = isFloat(value) ? parseFloat(value.toFixed(2)) : isInt(value) ? value : 0;
     return {
       x: xVal,

--- a/src/pages/explorer/explorerTable.tsx
+++ b/src/pages/explorer/explorerTable.tsx
@@ -128,7 +128,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
 
     // Fill in missing data
     for (let currentDate = firstDate; currentDate <= lastDate; currentDate.setDate(currentDate.getDate() + 1)) {
-      const mapId = format(currentDate, 'yyyy-mm-dd');
+      const mapId = format(currentDate, 'yyyy-MM-dd');
 
       // Add column headings
       const mapIdDate = new Date(mapId);

--- a/src/pages/explorer/explorerTable.tsx
+++ b/src/pages/explorer/explorerTable.tsx
@@ -8,8 +8,7 @@ import { orgUnitIdKey, tagPrefix } from 'api/queries/query';
 import { AwsReport } from 'api/reports/awsReports';
 import { ComputedReportItemType } from 'components/charts/common/chartDatumUtils';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
-import { getDate, getMonth } from 'date-fns';
-import formatDate from 'date-fns/format';
+import { format, getDate, getMonth } from 'date-fns';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
@@ -129,7 +128,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
 
     // Fill in missing data
     for (let currentDate = firstDate; currentDate <= lastDate; currentDate.setDate(currentDate.getDate() + 1)) {
-      const mapId = formatDate(currentDate, 'yyyy-mm-dd');
+      const mapId = format(currentDate, 'yyyy-mm-dd');
 
       // Add column headings
       const mapIdDate = new Date(mapId);

--- a/src/pages/explorer/explorerTable.tsx
+++ b/src/pages/explorer/explorerTable.tsx
@@ -8,9 +8,8 @@ import { orgUnitIdKey, tagPrefix } from 'api/queries/query';
 import { AwsReport } from 'api/reports/awsReports';
 import { ComputedReportItemType } from 'components/charts/common/chartDatumUtils';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
+import { getDate, getMonth } from 'date-fns';
 import formatDate from 'date-fns/format';
-import getDate from 'date-fns/get_date';
-import getMonth from 'date-fns/get_month';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
@@ -130,11 +129,12 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
 
     // Fill in missing data
     for (let currentDate = firstDate; currentDate <= lastDate; currentDate.setDate(currentDate.getDate() + 1)) {
-      const mapId = formatDate(currentDate, 'YYYY-MM-DD');
+      const mapId = formatDate(currentDate, 'yyyy-mm-dd');
 
       // Add column headings
-      const date = getDate(mapId);
-      const month = getMonth(mapId);
+      const mapIdDate = new Date(mapId);
+      const date = getDate(mapIdDate);
+      const month = getMonth(mapIdDate);
       columns.push({
         title: t('explorer.daily_column_title', { date, month }),
       });

--- a/src/utils/dateRange.ts
+++ b/src/utils/dateRange.ts
@@ -1,5 +1,4 @@
-import { getDate, getMonth, startOfMonth } from 'date-fns';
-import formatDate from 'date-fns/format';
+import { format, getDate, getMonth, startOfMonth } from 'date-fns';
 import i18next from 'i18next';
 
 export function getNoDataForDateRangeString(key: string = 'no_data_for_date', offset: number = 1) {
@@ -9,8 +8,8 @@ export function getNoDataForDateRangeString(key: string = 'no_data_for_date', of
   }
 
   const month = getMonth(today);
-  const endDate = formatDate(today, 'd');
-  const startDate = formatDate(startOfMonth(today), 'd');
+  const endDate = format(today, 'd');
+  const startDate = format(startOfMonth(today), 'd');
 
   return i18next.t(key, {
     count: getDate(today),
@@ -27,8 +26,8 @@ export function getForDateRangeString(value: string | number, key: string = 'for
   }
 
   const month = getMonth(today);
-  const endDate = formatDate(today, 'd');
-  const startDate = formatDate(startOfMonth(today), 'd');
+  const endDate = format(today, 'd');
+  const startDate = format(startOfMonth(today), 'd');
 
   return i18next.t(key, {
     count: getDate(today),
@@ -42,8 +41,8 @@ export function getForDateRangeString(value: string | number, key: string = 'for
 export function getSinceDateRangeString(key: string = 'since_date') {
   const today = new Date();
   const month = getMonth(today);
-  const endDate = formatDate(today, 'd');
-  const startDate = formatDate(startOfMonth(today), 'd');
+  const endDate = format(today, 'd');
+  const startDate = format(startOfMonth(today), 'd');
 
   return i18next.t(key, {
     count: getDate(today),

--- a/src/utils/dateRange.ts
+++ b/src/utils/dateRange.ts
@@ -1,7 +1,5 @@
+import { getDate, getMonth, startOfMonth } from 'date-fns';
 import formatDate from 'date-fns/format';
-import getDate from 'date-fns/get_date';
-import getMonth from 'date-fns/get_month';
-import startOfMonth from 'date-fns/start_of_month';
 import i18next from 'i18next';
 
 export function getNoDataForDateRangeString(key: string = 'no_data_for_date', offset: number = 1) {
@@ -11,8 +9,8 @@ export function getNoDataForDateRangeString(key: string = 'no_data_for_date', of
   }
 
   const month = getMonth(today);
-  const endDate = formatDate(today, 'D');
-  const startDate = formatDate(startOfMonth(today), 'D');
+  const endDate = formatDate(today, 'd');
+  const startDate = formatDate(startOfMonth(today), 'd');
 
   return i18next.t(key, {
     count: getDate(today),
@@ -29,8 +27,8 @@ export function getForDateRangeString(value: string | number, key: string = 'for
   }
 
   const month = getMonth(today);
-  const endDate = formatDate(today, 'D');
-  const startDate = formatDate(startOfMonth(today), 'D');
+  const endDate = formatDate(today, 'd');
+  const startDate = formatDate(startOfMonth(today), 'd');
 
   return i18next.t(key, {
     count: getDate(today),
@@ -44,8 +42,8 @@ export function getForDateRangeString(value: string | number, key: string = 'for
 export function getSinceDateRangeString(key: string = 'since_date') {
   const today = new Date();
   const month = getMonth(today);
-  const endDate = formatDate(today, 'D');
-  const startDate = formatDate(startOfMonth(today), 'D');
+  const endDate = formatDate(today, 'd');
+  const startDate = formatDate(startOfMonth(today), 'd');
 
   return i18next.t(key, {
     count: getDate(today),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2702,10 +2702,10 @@ date-fns@*:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
 
-date-fns@1.29.0:
-  version "1.29.0"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.29.0.tgz#12e609cdcb935127311d04d33334e2960a2a54e6"
-  integrity sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==
+date-fns@2.17.0:
+  version "2.17.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.17.0.tgz#afa55daea539239db0a64e236ce716ef3d681ba1"
+  integrity sha512-ZEhqxUtEZeGgg9eHNSOAJ8O9xqSgiJdrL0lzSSfMF54x6KXWJiOH/xntSJ9YomJPrYH/p08t6gWjGWq1SDJlSA==
 
 debounce-promise@^3.1.0:
   version "3.1.2"


### PR DESCRIPTION
The latest date-fns package has updated a few things.

- `formatDate` was renamed `format`
- `format` uses a Date object instead of date strings
- Formatting changed from "YYYY-MM-DD" to "yyyy-MM-dd"
- `import getDate from 'date-fns/get_date'` is now `import { getDate } from 'date-fns'`

