### PR TITLE
Cost icon is not being loaded via require after updating webpack

### DIFF
--- a/koku-ui-manifest
+++ b/koku-ui-manifest
@@ -620,7 +620,6 @@ mgmt_services/cost-mgmt:koku-ui/fastq:1.8.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/faye-websocket:0.11.3.yarnlock
 mgmt_services/cost-mgmt:koku-ui/fb-watchman:2.0.1.yarnlock
 mgmt_services/cost-mgmt:koku-ui/file-entry-cache:6.0.0.yarnlock
-mgmt_services/cost-mgmt:koku-ui/file-loader:6.2.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/file-selector:0.1.13.yarnlock
 mgmt_services/cost-mgmt:koku-ui/file-uri-to-path:1.0.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/fill-range:4.0.0.yarnlock

--- a/package.json
+++ b/package.json
@@ -97,7 +97,6 @@
     "eslint-plugin-prettier": "^3.3.1",
     "eslint-plugin-react": "^7.22.0",
     "eslint-plugin-simple-import-sort": "^5.0.3",
-    "file-loader": "6.2.0",
     "git-revision-webpack-plugin": "3.0.6",
     "html-loader": "2.0.0",
     "html-replace-webpack-plugin": "2.6.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -132,7 +132,7 @@ module.exports = (_env, argv) => {
         },
         {
           test: fileRegEx,
-          loader: 'file-loader',
+          type: 'asset/resource',
         },
       ],
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -3933,14 +3933,6 @@ file-entry-cache@^6.0.0:
   dependencies:
     flat-cache "^3.0.4"
 
-file-loader@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-6.2.0.tgz#baef7cf8e1840df325e4390b4484879480eebe4d"
-  integrity sha512-qo3glqyTa61Ytg4u73GultjHGjdRyig3tG6lPtyX/jOEJvHif9uB0/OCI2Kif6ctF3caQTW2G5gym21oAsI4pw==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 file-selector@^0.1.8:
   version "0.1.13"
   resolved "https://registry.yarnpkg.com/file-selector/-/file-selector-0.1.13.tgz#5efd977ca2bca1700992df1b10e254f4e73d2df4"


### PR DESCRIPTION
The cost icon, used on our empty provider state page, is not being loaded via require after updating to webpack 5.x.

This change eliminates the file-loader package.
See https://webpack.js.org/guides/asset-management/#loading-images

https://issues.redhat.com/browse/COST-1049

<img width="1590" alt="Screen Shot 2021-02-17 at 3 59 44 PM" src="https://user-images.githubusercontent.com/17481322/108267633-754d3200-7139-11eb-9671-2130941312ba.png">
