### PR TITLE
Update prettier package to latest version

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
+  "arrowParens": "avoid",
   "parser": "typescript",
   "semi": true,
   "singleQuote": true,

--- a/koku-ui-manifest
+++ b/koku-ui-manifest
@@ -1139,7 +1139,7 @@ mgmt_services/cost-mgmt:koku-ui/postcss:8.2.6.yarnlock
 mgmt_services/cost-mgmt:koku-ui/prelude-ls:1.2.1.yarnlock
 mgmt_services/cost-mgmt:koku-ui/prelude-ls:1.1.2.yarnlock
 mgmt_services/cost-mgmt:koku-ui/prettier-linter-helpers:1.0.0.yarnlock
-mgmt_services/cost-mgmt:koku-ui/prettier:1.19.1.yarnlock
+mgmt_services/cost-mgmt:koku-ui/prettier:2.2.1.yarnlock
 mgmt_services/cost-mgmt:koku-ui/pretty-error:2.1.1.yarnlock
 mgmt_services/cost-mgmt:koku-ui/pretty-format:25.5.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/pretty-format:25.5.0.yarnlock

--- a/koku-ui-manifest
+++ b/koku-ui-manifest
@@ -1470,7 +1470,6 @@ mgmt_services/cost-mgmt:koku-ui/unset-value:1.0.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/upath:1.2.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/uri-js:4.4.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/urix:0.1.0.yarnlock
-mgmt_services/cost-mgmt:koku-ui/url-loader:4.1.1.yarnlock
 mgmt_services/cost-mgmt:koku-ui/url-parse:1.4.7.yarnlock
 mgmt_services/cost-mgmt:koku-ui/url-parse:1.4.7.yarnlock
 mgmt_services/cost-mgmt:koku-ui/url:0.11.0.yarnlock

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "jest": "26.6.3",
     "mini-css-extract-plugin": "^1.3.7",
     "null-loader": "4.0.1",
-    "prettier": "^1.19.1",
+    "prettier": "^2.2.1",
     "rimraf": "^3.0.2",
     "sass": "^1.32.7",
     "sass-loader": "^11.0.1",

--- a/package.json
+++ b/package.json
@@ -113,7 +113,6 @@
     "tsconfig-paths-webpack-plugin": "^3.3.0",
     "ts-jest": "26.5.1",
     "ts-loader": "7.0.5",
-    "url-loader": "4.1.1",
     "webpack": "^5.22.0",
     "webpack-cli": "^4.5.0",
     "webpack-dev-server": "^3.11.2",

--- a/src/components/async/permissionsComponent/permissionsComponent.tsx
+++ b/src/components/async/permissionsComponent/permissionsComponent.tsx
@@ -1,11 +1,11 @@
 import asyncComponent from 'components/async/asyncComponent';
 import React from 'react';
 
-const InactiveSources = asyncComponent(() =>
-  import(/* webpackChunkName: "notFound" */ 'components/sources/inactiveSources')
+const InactiveSources = asyncComponent(
+  () => import(/* webpackChunkName: "notFound" */ 'components/sources/inactiveSources')
 );
-const Permissions = asyncComponent(() =>
-  import(/* webpackChunkName: "notFound" */ 'components/async/permissionsComponent')
+const Permissions = asyncComponent(
+  () => import(/* webpackChunkName: "notFound" */ 'components/async/permissionsComponent')
 );
 
 interface State {

--- a/src/pages/costModels/costModel/addSourceStep.tsx
+++ b/src/pages/costModels/costModel/addSourceStep.tsx
@@ -149,9 +149,9 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
             },
             onSetPage: (_evt, newPage) => {
               this.props.fetch(
-                `source_type=${source_type}&limit=${this.props.pagination.perPage}&offset=${this.props.pagination
-                  .perPage *
-                  (newPage - 1)}&${this.props.query.name ? `name=${this.props.query.name}` : ''}`
+                `source_type=${source_type}&limit=${this.props.pagination.perPage}&offset=${
+                  this.props.pagination.perPage * (newPage - 1)
+                }&${this.props.query.name ? `name=${this.props.query.name}` : ''}`
               );
             },
           }}

--- a/src/pages/costModels/costModelsDetails/utils/table.tsx
+++ b/src/pages/costModels/costModelsDetails/utils/table.tsx
@@ -56,7 +56,7 @@ export function getRowsByStateName(stateName: string, data: any) {
 }
 
 export function createOnSort(cells: ICell[], query: CostModelsQuery, push: (path: string) => void) {
-  return function(_event, index: number, direction: SortByDirection) {
+  return function (_event, index: number, direction: SortByDirection) {
     const name = cells[index] && cells[index].data ? cells[index].data.orderName : null;
     if (name === null) {
       return;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -14,8 +14,8 @@ const GcpDetails = asyncComponent(() => import(/* webpackChunkName: "gcp" */ './
 const OcpDetails = asyncComponent(() => import(/* webpackChunkName: "ocp" */ './pages/details/ocpDetails'));
 const OcpBreakdown = asyncComponent(() => import(/* webpackChunkName: "ocp" */ './pages/details/ocpBreakdown'));
 const Overview = asyncComponent(() => import(/* webpackChunkName: "overview" */ './pages/overview'));
-const CostModelsDetails = asyncComponent(() =>
-  import(/* webpackChunkName: "costModels" */ './pages/costModels/costModelsDetails')
+const CostModelsDetails = asyncComponent(
+  () => import(/* webpackChunkName: "costModels" */ './pages/costModels/costModelsDetails')
 );
 // import(/* webpackChunkName: "costModels" */ './pages/costModels/costModelList')
 const CostModel = asyncComponent(() => import(/* webpackChunkName: "costModel" */ './pages/costModels/costModel'));

--- a/src/utils/equal.ts
+++ b/src/utils/equal.ts
@@ -7,14 +7,5 @@ export function isEqual(obj1, obj2): boolean {
   if (!b) {
     b = '';
   }
-  return (
-    a
-      .split('')
-      .sort()
-      .join('') ===
-    b
-      .split('')
-      .sort()
-      .join('')
-  );
+  return a.split('').sort().join('') === b.split('').sort().join('');
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6994,10 +6994,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
+prettier@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.2.1.tgz#795a1a78dd52f073da0cd42b21f9c91381923ff5"
+  integrity sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
 
 pretty-error@^2.1.1:
   version "2.1.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8854,15 +8854,6 @@ urix@^0.1.0:
   resolved "https://registry.yarnpkg.com/urix/-/urix-0.1.0.tgz#da937f7a62e21fec1fd18d49b35c2935067a6c72"
   integrity sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
 
-url-loader@4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/url-loader/-/url-loader-4.1.1.tgz#28505e905cae158cf07c92ca622d7f237e70a4e2"
-  integrity sha512-3BTV812+AVHHOJQO8O5MkWgZ5aosP7GnROJwvzLS9hWDj00lZ6Z0wNak423Lp9PBZN05N+Jk/N5Si8jRAlGyWA==
-  dependencies:
-    loader-utils "^2.0.0"
-    mime-types "^2.1.27"
-    schema-utils "^3.0.0"
-
 url-parse@^1.4.3, url-parse@^1.4.7:
   version "1.4.7"
   resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.4.7.tgz#a8a83535e8c00a316e403a5db4ac1b9b853ae278"


### PR DESCRIPTION
https://issues.redhat.com/browse/COST-1053

This adds the `arrowParens` property to match eslint. It allows functions to skip parens if they use a single parameter.

Also removed the unused `url-loader` package.