### PR TITLE
Using resource observer to resize charts

### DIFF
--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -26,6 +26,7 @@ import { getDate } from 'date-fns';
 import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
+import { noop } from 'utils/noop';
 
 import { chartStyles } from './costChart.styles';
 
@@ -58,21 +59,16 @@ interface State {
 
 class CostChart extends React.Component<CostChartProps, State> {
   private containerRef = React.createRef<HTMLDivElement>();
-  public navToggle: any;
+  private resizeObserver: any = noop;
+  private navToggle: any = noop;
   public state: State = {
     hiddenSeries: new Set(),
     width: 0,
   };
 
   public componentDidMount() {
-    setTimeout(() => {
-      if (this.containerRef.current) {
-        this.setState({ width: this.containerRef.current.clientWidth });
-      }
-      window.addEventListener('resize', this.handleResize);
-      this.navToggle = insights.chrome.on('NAVIGATION_TOGGLE', this.handleNavToggle);
-    });
     this.initDatum();
+    this.initResizeObserve();
   }
 
   public componentDidUpdate(prevProps: CostChartProps) {
@@ -91,7 +87,9 @@ class CostChart extends React.Component<CostChartProps, State> {
   }
 
   public componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    if (this.resizeObserver) {
+      this.resizeObserver();
+    }
     if (this.navToggle) {
       this.navToggle();
     }
@@ -290,14 +288,46 @@ class CostChart extends React.Component<CostChartProps, State> {
     this.setState({ cursorVoronoiContainer, series });
   };
 
-  private handleNavToggle = () => {
-    setTimeout(this.handleResize, 500);
+  private initResizeObserve = () => {
+    const containerElement = this.containerRef.current;
+
+    const { ResizeObserver } = window as any;
+
+    if (containerElement && ResizeObserver) {
+      const resizeObserver = new ResizeObserver(this.handleResize);
+      resizeObserver.observe(containerElement);
+      this.resizeObserver = () => resizeObserver.unobserve(containerElement);
+    } else {
+      this.handleResize();
+      window.addEventListener('resize', this.handleResize);
+      this.resizeObserver = () => window.removeEventListener('resize', this.handleResize);
+      this.navToggle = insights.chrome.on('NAVIGATION_TOGGLE', this.handleNavToggle);
+    }
   };
 
-  private handleResize = () => {
-    if (this.containerRef.current) {
-      this.setState({ width: this.containerRef.current.clientWidth });
+  private getAdjustedContainerHeight = () => {
+    const { adjustContainerHeight, height, containerHeight = height, showForecast } = this.props;
+    const { width } = this.state;
+
+    let adjustedContainerHeight = containerHeight;
+    if (adjustContainerHeight) {
+      if (showForecast) {
+        if (width > 675 && width < 1175) {
+          adjustedContainerHeight += 25;
+        } else if (width > 450 && width < 675) {
+          adjustedContainerHeight += 50;
+        } else if (width <= 450) {
+          adjustedContainerHeight += 75;
+        }
+      } else {
+        if (width > 450 && width < 725) {
+          adjustedContainerHeight += 25;
+        } else if (width <= 450) {
+          adjustedContainerHeight += 50;
+        }
+      }
     }
+    return adjustedContainerHeight;
   };
 
   private getChart = (series: ChartSeries, index: number) => {
@@ -402,29 +432,17 @@ class CostChart extends React.Component<CostChartProps, State> {
     this.setState({ hiddenSeries });
   };
 
-  private getAdjustedContainerHeight = () => {
-    const { adjustContainerHeight, height, containerHeight = height, showForecast } = this.props;
-    const { width } = this.state;
+  private handleNavToggle = () => {
+    setTimeout(this.handleResize, 500);
+  };
 
-    let adjustedContainerHeight = containerHeight;
-    if (adjustContainerHeight) {
-      if (showForecast) {
-        if (width > 675 && width < 1175) {
-          adjustedContainerHeight += 25;
-        } else if (width > 450 && width < 675) {
-          adjustedContainerHeight += 50;
-        } else if (width <= 450) {
-          adjustedContainerHeight += 75;
-        }
-      } else {
-        if (width > 450 && width < 725) {
-          adjustedContainerHeight += 25;
-        } else if (width <= 450) {
-          adjustedContainerHeight += 50;
-        }
-      }
+  private handleResize = () => {
+    const { width } = this.state;
+    const { clientWidth = 0 } = this.containerRef.current || {};
+
+    if (clientWidth !== width) {
+      this.setState({ width: clientWidth });
     }
-    return adjustedContainerHeight;
   };
 
   public render() {

--- a/src/components/charts/dailyCostChart/dailyCostChart.tsx
+++ b/src/components/charts/dailyCostChart/dailyCostChart.tsx
@@ -29,6 +29,7 @@ import { getDate } from 'date-fns';
 import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
+import { noop } from 'utils/noop';
 
 import { chartStyles } from './dailyCostChart.styles';
 
@@ -61,21 +62,16 @@ interface State {
 
 class DailyCostChart extends React.Component<DailyCostChartProps, State> {
   private containerRef = React.createRef<HTMLDivElement>();
-  public navToggle: any;
+  private resizeObserver: any = noop;
+  private navToggle: any = noop;
   public state: State = {
     hiddenSeries: new Set(),
     width: 0,
   };
 
   public componentDidMount() {
-    setTimeout(() => {
-      if (this.containerRef.current) {
-        this.setState({ width: this.containerRef.current.clientWidth });
-      }
-      window.addEventListener('resize', this.handleResize);
-      this.navToggle = insights.chrome.on('NAVIGATION_TOGGLE', this.handleNavToggle);
-    });
     this.initDatum();
+    this.initResizeObserve();
   }
 
   public componentDidUpdate(prevProps: DailyCostChartProps) {
@@ -94,7 +90,9 @@ class DailyCostChart extends React.Component<DailyCostChartProps, State> {
   }
 
   public componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    if (this.resizeObserver) {
+      this.resizeObserver();
+    }
     if (this.navToggle) {
       this.navToggle();
     }
@@ -303,14 +301,46 @@ class DailyCostChart extends React.Component<DailyCostChartProps, State> {
     return data;
   };
 
-  private handleNavToggle = () => {
-    setTimeout(this.handleResize, 500);
+  private initResizeObserve = () => {
+    const containerElement = this.containerRef.current;
+
+    const { ResizeObserver } = window as any;
+
+    if (containerElement && ResizeObserver) {
+      const resizeObserver = new ResizeObserver(this.handleResize);
+      resizeObserver.observe(containerElement);
+      this.resizeObserver = () => resizeObserver.unobserve(containerElement);
+    } else {
+      this.handleResize();
+      window.addEventListener('resize', this.handleResize);
+      this.resizeObserver = () => window.removeEventListener('resize', this.handleResize);
+      this.navToggle = insights.chrome.on('NAVIGATION_TOGGLE', this.handleNavToggle);
+    }
   };
 
-  private handleResize = () => {
-    if (this.containerRef.current) {
-      this.setState({ width: this.containerRef.current.clientWidth });
+  private getAdjustedContainerHeight = () => {
+    const { adjustContainerHeight, height, containerHeight = height, showForecast } = this.props;
+    const { width } = this.state;
+
+    let adjustedContainerHeight = containerHeight;
+    if (adjustContainerHeight) {
+      if (showForecast) {
+        if (width > 675 && width < 1175) {
+          adjustedContainerHeight += 25;
+        } else if (width > 450 && width < 675) {
+          adjustedContainerHeight += 50;
+        } else if (width <= 450) {
+          adjustedContainerHeight += 75;
+        }
+      } else {
+        if (width > 450 && width < 725) {
+          adjustedContainerHeight += 25;
+        } else if (width <= 450) {
+          adjustedContainerHeight += 50;
+        }
+      }
     }
+    return adjustedContainerHeight;
   };
 
   private getChart = (series: ChartSeries, index: number) => {
@@ -458,29 +488,17 @@ class DailyCostChart extends React.Component<DailyCostChartProps, State> {
     this.setState({ hiddenSeries });
   };
 
-  private getAdjustedContainerHeight = () => {
-    const { adjustContainerHeight, height, containerHeight = height, showForecast } = this.props;
-    const { width } = this.state;
+  private handleNavToggle = () => {
+    setTimeout(this.handleResize, 500);
+  };
 
-    let adjustedContainerHeight = containerHeight;
-    if (adjustContainerHeight) {
-      if (showForecast) {
-        if (width > 675 && width < 1175) {
-          adjustedContainerHeight += 25;
-        } else if (width > 450 && width < 675) {
-          adjustedContainerHeight += 50;
-        } else if (width <= 450) {
-          adjustedContainerHeight += 75;
-        }
-      } else {
-        if (width > 450 && width < 725) {
-          adjustedContainerHeight += 25;
-        } else if (width <= 450) {
-          adjustedContainerHeight += 50;
-        }
-      }
+  private handleResize = () => {
+    const { width } = this.state;
+    const { clientWidth = 0 } = this.containerRef.current || {};
+
+    if (clientWidth !== width) {
+      this.setState({ width: clientWidth });
     }
-    return adjustedContainerHeight;
   };
 
   public render() {

--- a/src/components/charts/dailyTrendChart/dailyTrendChart.tsx
+++ b/src/components/charts/dailyTrendChart/dailyTrendChart.tsx
@@ -29,6 +29,7 @@ import { getDate } from 'date-fns';
 import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
+import { noop } from 'utils/noop';
 
 import { chartStyles } from './dailyTrendChart.styles';
 
@@ -60,21 +61,16 @@ interface State {
 
 class DailyTrendChart extends React.Component<DailyTrendChartProps, State> {
   private containerRef = React.createRef<HTMLDivElement>();
-  public navToggle: any;
+  private resizeObserver: any = noop;
+  private navToggle: any = noop;
   public state: State = {
     hiddenSeries: new Set(),
     width: 0,
   };
 
   public componentDidMount() {
-    setTimeout(() => {
-      if (this.containerRef.current) {
-        this.setState({ width: this.containerRef.current.clientWidth });
-      }
-      window.addEventListener('resize', this.handleResize);
-      this.navToggle = insights.chrome.on('NAVIGATION_TOGGLE', this.handleNavToggle);
-    });
     this.initDatum();
+    this.initResizeObserve();
   }
 
   public componentDidUpdate(prevProps: DailyTrendChartProps) {
@@ -89,7 +85,9 @@ class DailyTrendChart extends React.Component<DailyTrendChartProps, State> {
   }
 
   public componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    if (this.resizeObserver) {
+      this.resizeObserver();
+    }
     if (this.navToggle) {
       this.navToggle();
     }
@@ -209,14 +207,36 @@ class DailyTrendChart extends React.Component<DailyTrendChartProps, State> {
     return data;
   };
 
-  private handleNavToggle = () => {
-    setTimeout(this.handleResize, 500);
+  private initResizeObserve = () => {
+    const containerElement = this.containerRef.current;
+
+    const { ResizeObserver } = window as any;
+
+    if (containerElement && ResizeObserver) {
+      const resizeObserver = new ResizeObserver(this.handleResize);
+      resizeObserver.observe(containerElement);
+      this.resizeObserver = () => resizeObserver.unobserve(containerElement);
+    } else {
+      this.handleResize();
+      window.addEventListener('resize', this.handleResize);
+      this.resizeObserver = () => window.removeEventListener('resize', this.handleResize);
+      this.navToggle = insights.chrome.on('NAVIGATION_TOGGLE', this.handleNavToggle);
+    }
   };
 
-  private handleResize = () => {
-    if (this.containerRef.current) {
-      this.setState({ width: this.containerRef.current.clientWidth });
+  private getAdjustedContainerHeight = () => {
+    const { adjustContainerHeight, height, containerHeight = height, showForecast } = this.props;
+    const { width } = this.state;
+
+    let adjustedContainerHeight = containerHeight;
+    if (adjustContainerHeight) {
+      if (showForecast) {
+        if (width < 700) {
+          adjustedContainerHeight += 25;
+        }
+      }
     }
+    return adjustedContainerHeight;
   };
 
   private getChart = (series: ChartSeries, index: number) => {
@@ -342,19 +362,17 @@ class DailyTrendChart extends React.Component<DailyTrendChartProps, State> {
     this.setState({ hiddenSeries });
   };
 
-  private getAdjustedContainerHeight = () => {
-    const { adjustContainerHeight, height, containerHeight = height, showForecast } = this.props;
-    const { width } = this.state;
+  private handleNavToggle = () => {
+    setTimeout(this.handleResize, 500);
+  };
 
-    let adjustedContainerHeight = containerHeight;
-    if (adjustContainerHeight) {
-      if (showForecast) {
-        if (width < 700) {
-          adjustedContainerHeight += 25;
-        }
-      }
+  private handleResize = () => {
+    const { width } = this.state;
+    const { clientWidth = 0 } = this.containerRef.current || {};
+
+    if (clientWidth !== width) {
+      this.setState({ width: clientWidth });
     }
-    return adjustedContainerHeight;
   };
 
   public render() {

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -27,6 +27,7 @@ import { getDate } from 'date-fns';
 import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
+import { noop } from 'utils/noop';
 
 import { chartStyles, styles } from './historicalCostChart.styles';
 
@@ -56,19 +57,16 @@ interface State {
 
 class HistoricalCostChart extends React.Component<HistoricalCostChartProps, State> {
   private containerRef = React.createRef<HTMLDivElement>();
+  private resizeObserver: any = noop;
+  private navToggle: any = noop;
   public state: State = {
     hiddenSeries: new Set(),
     width: 0,
   };
 
   public componentDidMount() {
-    setTimeout(() => {
-      if (this.containerRef.current) {
-        this.setState({ width: this.containerRef.current.clientWidth });
-      }
-      window.addEventListener('resize', this.handleResize);
-    });
     this.initDatum();
+    this.initResizeObserve();
   }
 
   public componentDidUpdate(prevProps: HistoricalCostChartProps) {
@@ -83,7 +81,12 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
   }
 
   public componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    if (this.resizeObserver) {
+      this.resizeObserver();
+    }
+    if (this.navToggle) {
+      this.navToggle();
+    }
   }
 
   private initDatum = () => {
@@ -179,9 +182,20 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
     this.setState({ cursorVoronoiContainer, series });
   };
 
-  private handleResize = () => {
-    if (this.containerRef.current) {
-      this.setState({ width: this.containerRef.current.clientWidth });
+  private initResizeObserve = () => {
+    const containerElement = this.containerRef.current;
+
+    const { ResizeObserver } = window as any;
+
+    if (containerElement && ResizeObserver) {
+      const resizeObserver = new ResizeObserver(this.handleResize);
+      resizeObserver.observe(containerElement);
+      this.resizeObserver = () => resizeObserver.unobserve(containerElement);
+    } else {
+      this.handleResize();
+      window.addEventListener('resize', this.handleResize);
+      this.resizeObserver = () => window.removeEventListener('resize', this.handleResize);
+      this.navToggle = insights.chrome.on('NAVIGATION_TOGGLE', this.handleNavToggle);
     }
   };
 
@@ -267,6 +281,19 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
   private handleLegendClick = (index: number) => {
     const hiddenSeries = initHiddenSeries(this.state.series, this.state.hiddenSeries, index);
     this.setState({ hiddenSeries });
+  };
+
+  private handleNavToggle = () => {
+    setTimeout(this.handleResize, 500);
+  };
+
+  private handleResize = () => {
+    const { width } = this.state;
+    const { clientWidth = 0 } = this.containerRef.current || {};
+
+    if (clientWidth !== width) {
+      this.setState({ width: clientWidth });
+    }
   };
 
   public render() {

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -27,6 +27,7 @@ import { getDate } from 'date-fns';
 import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
+import { noop } from 'utils/noop';
 
 import { chartStyles, styles } from './historicalUsageChart.styles';
 
@@ -58,19 +59,16 @@ interface State {
 
 class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, State> {
   private containerRef = React.createRef<HTMLDivElement>();
+  private resizeObserver: any = noop;
+  private navToggle: any = noop;
   public state: State = {
     hiddenSeries: new Set(),
     width: 0,
   };
 
   public componentDidMount() {
-    setTimeout(() => {
-      if (this.containerRef.current) {
-        this.setState({ width: this.containerRef.current.clientWidth });
-      }
-      window.addEventListener('resize', this.handleResize);
-    });
     this.initDatum();
+    this.initResizeObserve();
   }
 
   public componentDidUpdate(prevProps: HistoricalUsageChartProps) {
@@ -87,7 +85,12 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
   }
 
   public componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    if (this.resizeObserver) {
+      this.resizeObserver();
+    }
+    if (this.navToggle) {
+      this.navToggle();
+    }
   }
 
   private initDatum = () => {
@@ -223,9 +226,20 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
     this.setState({ cursorVoronoiContainer, series });
   };
 
-  private handleResize = () => {
-    if (this.containerRef.current) {
-      this.setState({ width: this.containerRef.current.clientWidth });
+  private initResizeObserve = () => {
+    const containerElement = this.containerRef.current;
+
+    const { ResizeObserver } = window as any;
+
+    if (containerElement && ResizeObserver) {
+      const resizeObserver = new ResizeObserver(this.handleResize);
+      resizeObserver.observe(containerElement);
+      this.resizeObserver = () => resizeObserver.unobserve(containerElement);
+    } else {
+      this.handleResize();
+      window.addEventListener('resize', this.handleResize);
+      this.resizeObserver = () => window.removeEventListener('resize', this.handleResize);
+      this.navToggle = insights.chrome.on('NAVIGATION_TOGGLE', this.handleNavToggle);
     }
   };
 
@@ -310,6 +324,19 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
   private handleLegendClick = (index: number) => {
     const hiddenSeries = initHiddenSeries(this.state.series, this.state.hiddenSeries, index);
     this.setState({ hiddenSeries });
+  };
+
+  private handleNavToggle = () => {
+    setTimeout(this.handleResize, 500);
+  };
+
+  private handleResize = () => {
+    const { width } = this.state;
+    const { clientWidth = 0 } = this.containerRef.current || {};
+
+    if (clientWidth !== width) {
+      this.setState({ width: clientWidth });
+    }
   };
 
   public render() {

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -26,6 +26,7 @@ import { getDate } from 'date-fns';
 import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
+import { noop } from 'utils/noop';
 
 import { chartStyles } from './trendChart.styles';
 
@@ -57,21 +58,16 @@ interface State {
 
 class TrendChart extends React.Component<TrendChartProps, State> {
   private containerRef = React.createRef<HTMLDivElement>();
-  public navToggle: any;
+  private resizeObserver: any = noop;
+  private navToggle: any = noop;
   public state: State = {
     hiddenSeries: new Set(),
     width: 0,
   };
 
   public componentDidMount() {
-    setTimeout(() => {
-      if (this.containerRef.current) {
-        this.setState({ width: this.containerRef.current.clientWidth });
-      }
-      window.addEventListener('resize', this.handleResize);
-      this.navToggle = insights.chrome.on('NAVIGATION_TOGGLE', this.handleNavToggle);
-    });
     this.initDatum();
+    this.initResizeObserve();
   }
 
   public componentDidUpdate(prevProps: TrendChartProps) {
@@ -86,7 +82,9 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   }
 
   public componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    if (this.resizeObserver) {
+      this.resizeObserver();
+    }
     if (this.navToggle) {
       this.navToggle();
     }
@@ -198,14 +196,36 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     this.setState({ cursorVoronoiContainer, series });
   };
 
-  private handleNavToggle = () => {
-    setTimeout(this.handleResize, 500);
+  private initResizeObserve = () => {
+    const containerElement = this.containerRef.current;
+
+    const { ResizeObserver } = window as any;
+
+    if (containerElement && ResizeObserver) {
+      const resizeObserver = new ResizeObserver(this.handleResize);
+      resizeObserver.observe(containerElement);
+      this.resizeObserver = () => resizeObserver.unobserve(containerElement);
+    } else {
+      this.handleResize();
+      window.addEventListener('resize', this.handleResize);
+      this.resizeObserver = () => window.removeEventListener('resize', this.handleResize);
+      this.navToggle = insights.chrome.on('NAVIGATION_TOGGLE', this.handleNavToggle);
+    }
   };
 
-  private handleResize = () => {
-    if (this.containerRef.current) {
-      this.setState({ width: this.containerRef.current.clientWidth });
+  private getAdjustedContainerHeight = () => {
+    const { adjustContainerHeight, height, containerHeight = height, showForecast } = this.props;
+    const { width } = this.state;
+
+    let adjustedContainerHeight = containerHeight;
+    if (adjustContainerHeight) {
+      if (showForecast) {
+        if (width < 700) {
+          adjustedContainerHeight += 25;
+        }
+      }
     }
+    return adjustedContainerHeight;
   };
 
   private getChart = (series: ChartSeries, index: number) => {
@@ -290,19 +310,17 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     this.setState({ hiddenSeries });
   };
 
-  private getAdjustedContainerHeight = () => {
-    const { adjustContainerHeight, height, containerHeight = height, showForecast } = this.props;
-    const { width } = this.state;
+  private handleNavToggle = () => {
+    setTimeout(this.handleResize, 500);
+  };
 
-    let adjustedContainerHeight = containerHeight;
-    if (adjustContainerHeight) {
-      if (showForecast) {
-        if (width < 700) {
-          adjustedContainerHeight += 25;
-        }
-      }
+  private handleResize = () => {
+    const { width } = this.state;
+    const { clientWidth = 0 } = this.containerRef.current || {};
+
+    if (clientWidth !== width) {
+      this.setState({ width: clientWidth });
     }
-    return adjustedContainerHeight;
   };
 
   public render() {

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -26,6 +26,7 @@ import { getDate } from 'date-fns';
 import i18next from 'i18next';
 import React from 'react';
 import { FormatOptions, ValueFormatter } from 'utils/formatValue';
+import { noop } from 'utils/noop';
 
 import { chartStyles } from './usageChart.styles';
 
@@ -53,21 +54,16 @@ interface State {
 
 class UsageChart extends React.Component<UsageChartProps, State> {
   private containerRef = React.createRef<HTMLDivElement>();
-  public navToggle: any;
+  private resizeObserver: any = noop;
+  private navToggle: any = noop;
   public state: State = {
     hiddenSeries: new Set(),
     width: 0,
   };
 
   public componentDidMount() {
-    setTimeout(() => {
-      if (this.containerRef.current) {
-        this.setState({ width: this.containerRef.current.clientWidth });
-      }
-      window.addEventListener('resize', this.handleResize);
-      this.navToggle = insights.chrome.on('NAVIGATION_TOGGLE', this.handleNavToggle);
-    });
     this.initDatum();
+    this.initResizeObserve();
   }
 
   public componentDidUpdate(prevProps: UsageChartProps) {
@@ -82,7 +78,9 @@ class UsageChart extends React.Component<UsageChartProps, State> {
   }
 
   public componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    if (this.resizeObserver) {
+      this.resizeObserver();
+    }
     if (this.navToggle) {
       this.navToggle();
     }
@@ -156,14 +154,34 @@ class UsageChart extends React.Component<UsageChartProps, State> {
     this.setState({ cursorVoronoiContainer, series });
   };
 
-  private handleNavToggle = () => {
-    setTimeout(this.handleResize, 500);
+  private initResizeObserve = () => {
+    const containerElement = this.containerRef.current;
+
+    const { ResizeObserver } = window as any;
+
+    if (containerElement && ResizeObserver) {
+      const resizeObserver = new ResizeObserver(this.handleResize);
+      resizeObserver.observe(containerElement);
+      this.resizeObserver = () => resizeObserver.unobserve(containerElement);
+    } else {
+      this.handleResize();
+      window.addEventListener('resize', this.handleResize);
+      this.resizeObserver = () => window.removeEventListener('resize', this.handleResize);
+      this.navToggle = insights.chrome.on('NAVIGATION_TOGGLE', this.handleNavToggle);
+    }
   };
 
-  private handleResize = () => {
-    if (this.containerRef.current) {
-      this.setState({ width: this.containerRef.current.clientWidth });
+  private getAdjustedContainerHeight = () => {
+    const { adjustContainerHeight, height, containerHeight = height } = this.props;
+    const { width } = this.state;
+
+    let adjustedContainerHeight = containerHeight;
+    if (adjustContainerHeight) {
+      if (width < 480) {
+        adjustedContainerHeight += 20;
+      }
     }
+    return adjustedContainerHeight;
   };
 
   private getChart = (series: ChartSeries, index: number) => {
@@ -251,17 +269,17 @@ class UsageChart extends React.Component<UsageChartProps, State> {
     this.setState({ hiddenSeries });
   };
 
-  private getAdjustedContainerHeight = () => {
-    const { adjustContainerHeight, height, containerHeight = height } = this.props;
-    const { width } = this.state;
+  private handleNavToggle = () => {
+    setTimeout(this.handleResize, 500);
+  };
 
-    let adjustedContainerHeight = containerHeight;
-    if (adjustContainerHeight) {
-      if (width < 480) {
-        adjustedContainerHeight += 20;
-      }
+  private handleResize = () => {
+    const { width } = this.state;
+    const { clientWidth = 0 } = this.containerRef.current || {};
+
+    if (clientWidth !== width) {
+      this.setState({ width: clientWidth });
     }
-    return adjustedContainerHeight;
   };
 
   public render() {


### PR DESCRIPTION
This introduces a resource observer to resize charts. This should resize the chart when the Insights navigation pane is collapsed / expanded.

Note that we will fallback to using window resize and the Insights' NAVIGATION_TOGGLE events should this feature not be available. However, Insights has marked the NAVIGATION_TOGGLE event as deprecated, so it will likely be removed.

https://issues.redhat.com/browse/COST-1052