### PR TITLE
Add date ranges to Historical Cost Explorer

### DIFF
--- a/src/api/queries/query.ts
+++ b/src/api/queries/query.ts
@@ -27,12 +27,15 @@ export interface Filters {
 }
 
 export interface Query {
+  dateRange?: any;
+  end_date?: any;
   filter?: any;
   filter_by?: FilterBys;
   group_by?: any;
   key_only?: boolean;
   order_by?: any;
   perspective?: any;
+  start_date?: any;
 }
 
 // Adds group_by prefix -- https://github.com/project-koku/koku-ui/issues/704

--- a/src/components/charts/common/chartDatumUtils.ts
+++ b/src/components/charts/common/chartDatumUtils.ts
@@ -9,6 +9,7 @@ import { SortDirection } from 'utils/sort';
 
 export interface ChartDatum {
   childName?: string;
+  date?: string;
   key: string | number;
   name?: string | number;
   show?: boolean;

--- a/src/components/charts/historicalExplorerChart/historicalExplorerChart.tsx
+++ b/src/components/charts/historicalExplorerChart/historicalExplorerChart.tsx
@@ -362,7 +362,7 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
     // Prune tick values
     const tickValues = [];
     for (let i = 0; i < values.length; i++) {
-      if (i % 3 === 0) {
+      if (i % 3 === 0 && i + 2 < values.length) {
         tickValues.push(values[i]);
       }
     }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -476,9 +476,9 @@
     "daily_column_title": "{{date}}-$t(months_abbr.{{month}})",
     "date_range": {
       "current_month_to_date": "Current month to date",
-      "previous_month_to_date": "Previous month to date",
       "last_sixy_days": "Last 60 days",
-      "last_thirty_days": "Last 30 days"
+      "last_thirty_days": "Last 30 days",
+      "previous_month_to_date": "Previous month to date"
     },
     "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "name_column_title": "Names",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -474,6 +474,12 @@
   },
   "explorer": {
     "daily_column_title": "{{date}}-$t(months_abbr.{{month}})",
+    "date_range": {
+      "current_month_to_date": "Current month to date",
+      "previous_month_to_date": "Previous month to date",
+      "last_sixy_days": "Last 60 days",
+      "last_thirty_days": "Last 30 days"
+    },
     "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "name_column_title": "Names",
     "no_data": "no data",

--- a/src/pages/details/components/dataToolbar/dataToolbar.tsx
+++ b/src/pages/details/components/dataToolbar/dataToolbar.tsx
@@ -43,6 +43,7 @@ interface Filters {
 
 interface DataToolbarOwnProps {
   categoryOptions?: ToolbarChipGroup[]; // Options for category menu
+  dateRange?: React.ReactNode; // Optional date range controls to display in toolbar
   groupBy?: string; // Sync category selection with groupBy value
   isAllSelected?: boolean;
   isBulkSelectDisabled?: boolean;
@@ -835,7 +836,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
   };
 
   public render() {
-    const { categoryOptions, pagination, showBulkSelect, showExport, showFilter, style } = this.props;
+    const { categoryOptions, dateRange, pagination, showBulkSelect, showExport, showFilter, style } = this.props;
     const options = categoryOptions ? categoryOptions : this.getDefaultCategoryOptions();
 
     // Todo: clearAllFilters workaround https://github.com/patternfly/patternfly-react/issues/4222
@@ -858,6 +859,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
                 </ToolbarGroup>
               )}
               {Boolean(showExport) && <ToolbarGroup>{this.getExportButton()}</ToolbarGroup>}
+              {dateRange && <ToolbarGroup>{dateRange}</ToolbarGroup>}
             </ToolbarToggleGroup>
             <ToolbarItem alignment={{ default: 'alignRight' }} variant="pagination">
               {pagination}

--- a/src/pages/explorer/dateRange.tsx
+++ b/src/pages/explorer/dateRange.tsx
@@ -1,0 +1,91 @@
+import { Dropdown, DropdownItem, DropdownToggle } from '@patternfly/react-core';
+import React from 'react';
+import { WithTranslation, withTranslation } from 'react-i18next';
+
+interface DateRangeOwnProps {
+  currentItem?: string;
+  isDisabled?: boolean;
+  onItemClicked(value: string);
+  options?: {
+    label: string;
+    value: string;
+  }[];
+}
+
+interface DateRangeState {
+  isDateRangeOpen: boolean;
+}
+
+type DateRangeProps = DateRangeOwnProps & WithTranslation;
+
+class DateRangeBase extends React.Component<DateRangeProps> {
+  protected defaultState: DateRangeState = {
+    isDateRangeOpen: false,
+  };
+  public state: DateRangeState = { ...this.defaultState };
+
+  private getDropDownItems = () => {
+    const { options, t } = this.props;
+
+    return options.map(option => (
+      <DropdownItem component="button" key={option.value} onClick={() => this.handleClick(option.value)}>
+        {t(option.label)}
+      </DropdownItem>
+    ));
+  };
+
+  private getCurrentLabel = () => {
+    const { currentItem, options, t } = this.props;
+
+    let label = '';
+    for (const option of options) {
+      if (currentItem === option.value) {
+        label = t(option.label);
+        break;
+      }
+    }
+    return label;
+  };
+
+  public handleClick = value => {
+    const { onItemClicked } = this.props;
+    if (onItemClicked) {
+      onItemClicked(value);
+    }
+  };
+
+  private handleSelect = () => {
+    this.setState({
+      isDateRangeOpen: !this.state.isDateRangeOpen,
+    });
+  };
+
+  private handleToggle = isDateRangeOpen => {
+    this.setState({
+      isDateRangeOpen,
+    });
+  };
+
+  public render() {
+    const { isDisabled } = this.props;
+    const { isDateRangeOpen } = this.state;
+    const dropdownItems = this.getDropDownItems();
+
+    return (
+      <Dropdown
+        onSelect={this.handleSelect}
+        toggle={
+          <DropdownToggle isDisabled={isDisabled} onToggle={this.handleToggle}>
+            {this.getCurrentLabel()}
+          </DropdownToggle>
+        }
+        isOpen={isDateRangeOpen}
+        dropdownItems={dropdownItems}
+      />
+    );
+  }
+}
+
+const DateRange = withTranslation()(DateRangeBase);
+
+export { DateRange };

--- a/src/pages/explorer/explorer.tsx
+++ b/src/pages/explorer/explorer.tsx
@@ -37,7 +37,10 @@ import { ExplorerTable } from './explorerTable';
 import { ExplorerToolbar } from './explorerToolbar';
 import {
   baseQuery,
+  DateRangeType,
   getComputedReportItemType,
+  getDateRange,
+  getDateRangeDefault,
   getGroupByDefault,
   getPerspectiveDefault,
   getReportPathsType,
@@ -57,6 +60,7 @@ interface ExplorerStateProps {
   azureProviders: Providers;
   azureProvidersFetchStatus: FetchStatus;
   azureProvidersQueryString: string;
+  dateRange: DateRangeType;
   gcpProviders: Providers;
   gcpProvidersFetchStatus: FetchStatus;
   gcpProvidersQueryString: string;
@@ -81,7 +85,6 @@ interface ExplorerDispatchProps {
 
 interface ExplorerState {
   columns: any[];
-  currentPerspective?: string;
   isAllSelected: boolean;
   isExportModalOpen: boolean;
   rows: any[];
@@ -480,6 +483,9 @@ class Explorer extends React.Component<ExplorerProps> {
 const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStateProps>((state, props) => {
   const queryFromRoute = parseQuery<Query>(location.search);
   const perspective = getPerspectiveDefault(queryFromRoute);
+  const dateRange = getDateRangeDefault(queryFromRoute);
+  const { end_date, start_date } = getDateRange(queryFromRoute);
+
   const query = {
     filter: {
       ...baseQuery.filter,
@@ -489,10 +495,14 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
     group_by: queryFromRoute.group_by || { [getGroupByDefault(perspective)]: '*' } || baseQuery.group_by,
     order_by: queryFromRoute.order_by || baseQuery.order_by,
     perspective,
+    dateRange,
+    end_date,
+    start_date,
   };
   const queryString = getQuery({
     ...query,
     perspective: undefined,
+    dateRange: undefined,
   });
 
   const reportPathsType = getReportPathsType(perspective);
@@ -550,6 +560,7 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
     azureProviders,
     azureProvidersFetchStatus,
     azureProvidersQueryString,
+    dateRange,
     gcpProviders,
     gcpProvidersFetchStatus,
     gcpProvidersQueryString,

--- a/src/pages/explorer/explorerChart.tsx
+++ b/src/pages/explorer/explorerChart.tsx
@@ -310,9 +310,6 @@ const mapStateToProps = createMapStateToProps<ExplorerChartOwnProps, ExplorerCha
     },
     filter_by: queryFromRoute.filter_by || baseQuery.filter_by,
     group_by: queryFromRoute.group_by || { [getGroupByDefault(perspective)]: '*' } || baseQuery.group_by,
-    order_by: {
-      cost: 'desc',
-    },
     perspective,
     dateRange,
     end_date,

--- a/src/pages/explorer/explorerChart.tsx
+++ b/src/pages/explorer/explorerChart.tsx
@@ -3,9 +3,14 @@ import { Skeleton } from '@redhat-cloud-services/frontend-components/components/
 import { getQuery, orgUnitIdKey, parseQuery, Query, tagPrefix } from 'api/queries/query';
 import { Report } from 'api/reports/report';
 import { AxiosError } from 'axios';
-import { ChartDatum, ComputedReportItemType, isFloat, isInt } from 'components/charts/common/chartDatumUtils';
+import {
+  ChartDatum,
+  ComputedReportItemType,
+  isFloat,
+  isInt,
+} from 'components/charts/common/chartDatumUtils';
 import { HistoricalExplorerChart } from 'components/charts/historicalExplorerChart';
-import { getDate, getMonth } from 'date-fns';
+import { format, getDate, getMonth } from 'date-fns';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -19,6 +24,8 @@ import { formatValue } from 'utils/formatValue';
 import { chartStyles, styles } from './explorerChart.styles';
 import {
   baseQuery,
+  getDateRange,
+  getDateRangeDefault,
   getGroupByDefault,
   getPerspectiveDefault,
   getReportPathsType,
@@ -31,12 +38,14 @@ interface ExplorerChartOwnProps extends RouteComponentProps<void>, WithTranslati
 }
 
 interface ExplorerChartStateProps {
+  end_date?: string;
   perspective: PerspectiveType;
   query: Query;
   queryString: string;
   report: Report;
   reportError: AxiosError;
   reportFetchStatus: FetchStatus;
+  start_date?: string;
 }
 
 interface ExplorerChartDispatchProps {
@@ -80,14 +89,15 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
   ): ChartDatum => {
     const { t } = this.props;
 
-    const computedItemDate = new Date(computedItem.date);
+    const computedItemDate = new Date(computedItem.date + 'T00:00:00');
     const xVal = t('chart.date', { date: getDate(computedItemDate), month: getMonth(computedItemDate) });
     const yVal = isFloat(value) ? parseFloat(value.toFixed(2)) : isInt(value) ? value : 0;
     return {
       x: xVal,
       y: value === null ? null : yVal, // For displaying "no data" labels in chart tooltips
+      date: computedItem.date,
       key: computedItem.id,
-      name: computedItem.label,
+      name: computedItem.label || computedItem.id,
       units: computedItem[reportItem]
         ? computedItem[reportItem][reportItemValue]
           ? computedItem[reportItem][reportItemValue].units // cost, infrastructure, supplementary
@@ -124,7 +134,7 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
       }
       chartDatums.push(datums);
     });
-    return chartDatums;
+    return this.padChartDatums(chartDatums);
   };
 
   private getChartTitle = (perspective: string) => {
@@ -220,6 +230,36 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
     );
   };
 
+  // This pads chart datums with null datum objects, representing missing data at the beginning and end of the
+  // data series. The remaining data is left as is to allow for extrapolation. This allows us to display a "no data"
+  // message in the tooltip, which helps distinguish between zero values and when there is no data available.
+  private padChartDatums = (items: any[]): ChartDatum[] => {
+    const { end_date, start_date } = this.props;
+    const result = [];
+
+    items.map(datums => {
+      const key = datums[0].key;
+      const newItems = [];
+
+      for (
+        let padDate = new Date(start_date + 'T00:00:00');
+        padDate <= new Date(end_date + 'T00:00:00');
+        padDate.setDate(padDate.getDate() + 1)
+      ) {
+        const id = format(padDate, 'yyyy-MM-dd');
+        const chartDatum = datums.find(val => val.date === id);
+        if (chartDatum) {
+          newItems.push(chartDatum);
+        } else {
+          const date = format(padDate, 'yyyy-MM-dd');
+          newItems.push(this.createReportDatum(null, { date, id: key }, 'cost', null));
+        }
+      }
+      result.push(newItems);
+    });
+    return result;
+  };
+
   public render() {
     const { perspective, reportFetchStatus, t } = this.props;
 
@@ -263,6 +303,9 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
 const mapStateToProps = createMapStateToProps<ExplorerChartOwnProps, ExplorerChartStateProps>((state, props) => {
   const queryFromRoute = parseQuery<Query>(location.search);
   const perspective = getPerspectiveDefault(queryFromRoute);
+  const dateRange = getDateRangeDefault(queryFromRoute);
+  const { end_date, start_date } = getDateRange(queryFromRoute);
+
   const query = {
     filter: {
       ...baseQuery.filter,
@@ -276,10 +319,14 @@ const mapStateToProps = createMapStateToProps<ExplorerChartOwnProps, ExplorerCha
       cost: 'desc',
     },
     perspective,
+    dateRange,
+    end_date,
+    start_date,
   };
   const queryString = getQuery({
     ...query,
     perspective: undefined,
+    dateRange: undefined,
   });
 
   const reportPathsType = getReportPathsType(perspective);
@@ -290,12 +337,14 @@ const mapStateToProps = createMapStateToProps<ExplorerChartOwnProps, ExplorerCha
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
 
   return {
+    end_date,
     perspective,
     query,
     queryString,
     report,
     reportError,
     reportFetchStatus,
+    start_date,
   };
 });
 

--- a/src/pages/explorer/explorerChart.tsx
+++ b/src/pages/explorer/explorerChart.tsx
@@ -3,12 +3,7 @@ import { Skeleton } from '@redhat-cloud-services/frontend-components/components/
 import { getQuery, orgUnitIdKey, parseQuery, Query, tagPrefix } from 'api/queries/query';
 import { Report } from 'api/reports/report';
 import { AxiosError } from 'axios';
-import {
-  ChartDatum,
-  ComputedReportItemType,
-  isFloat,
-  isInt,
-} from 'components/charts/common/chartDatumUtils';
+import { ChartDatum, ComputedReportItemType, isFloat, isInt } from 'components/charts/common/chartDatumUtils';
 import { HistoricalExplorerChart } from 'components/charts/historicalExplorerChart';
 import { format, getDate, getMonth } from 'date-fns';
 import React from 'react';

--- a/src/pages/explorer/explorerFilter.tsx
+++ b/src/pages/explorer/explorerFilter.tsx
@@ -1,19 +1,19 @@
-import {ToolbarChipGroup} from '@patternfly/react-core';
-import {Org, OrgPathsType, OrgType} from 'api/orgs/org';
-import {getQuery, orgUnitIdKey, parseQuery, Query, tagKey} from 'api/queries/query';
-import {Tag, TagPathsType, TagType} from 'api/tags/tag';
-import {DataToolbar} from 'pages/details/components/dataToolbar/dataToolbar';
+import { ToolbarChipGroup } from '@patternfly/react-core';
+import { Org, OrgPathsType, OrgType } from 'api/orgs/org';
+import { getQuery, orgUnitIdKey, parseQuery, Query, tagKey } from 'api/queries/query';
+import { Tag, TagPathsType, TagType } from 'api/tags/tag';
+import { DataToolbar } from 'pages/details/components/dataToolbar/dataToolbar';
 import React from 'react';
-import {WithTranslation, withTranslation} from 'react-i18next';
-import {connect} from 'react-redux';
-import {RouteComponentProps, withRouter} from 'react-router-dom';
-import {createMapStateToProps, FetchStatus} from 'store/common';
-import {orgActions, orgSelectors} from 'store/orgs';
-import {tagActions, tagSelectors} from 'store/tags';
-import {isEqual} from 'utils/equal';
+import { WithTranslation, withTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { orgActions, orgSelectors } from 'store/orgs';
+import { tagActions, tagSelectors } from 'store/tags';
+import { isEqual } from 'utils/equal';
 
-import {DateRange} from './dateRange';
-import {styles} from './explorerFilter.styles';
+import { DateRange } from './dateRange';
+import { styles } from './explorerFilter.styles';
 import {
   dateRangeOptions,
   DateRangeType,

--- a/src/pages/explorer/explorerHeader.tsx
+++ b/src/pages/explorer/explorerHeader.tsx
@@ -273,6 +273,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
 const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHeaderStateProps>((state, props) => {
   const queryFromRoute = parseQuery<Query>(location.search);
   const perspective = getPerspectiveDefault(queryFromRoute);
+
   const query = {
     filter: {
       ...baseQuery.filter,

--- a/src/pages/explorer/explorerTable.tsx
+++ b/src/pages/explorer/explorerTable.tsx
@@ -2,7 +2,7 @@ import './explorerTable.scss';
 
 import { Bullseye, EmptyState, EmptyStateBody, EmptyStateIcon, Spinner } from '@patternfly/react-core';
 import { CalculatorIcon } from '@patternfly/react-icons/dist/js/icons/calculator-icon';
-import { sortable, SortByDirection, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { nowrap,sortable, SortByDirection, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { AwsQuery, getQuery } from 'api/queries/awsQuery';
 import { orgUnitIdKey, tagPrefix } from 'api/queries/query';
 import { parseQuery, Query } from 'api/queries/query';
@@ -114,6 +114,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
         orderBy: groupById === 'account' && perspective !== PerspectiveType.gcp ? 'account_alias' : groupById,
         title: t('explorer.name_column_title', { groupBy: groupById }),
         transforms: [sortable],
+        cellTransforms: [nowrap],
       });
     }
 
@@ -137,6 +138,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
       const month = getMonth(mapIdDate);
       columns.push({
         title: t('explorer.daily_column_title', { date, month }),
+        cellTransforms: [nowrap],
       });
 
       computedItems.map(rowItem => {

--- a/src/pages/explorer/explorerTable.tsx
+++ b/src/pages/explorer/explorerTable.tsx
@@ -2,7 +2,7 @@ import './explorerTable.scss';
 
 import { Bullseye, EmptyState, EmptyStateBody, EmptyStateIcon, Spinner } from '@patternfly/react-core';
 import { CalculatorIcon } from '@patternfly/react-icons/dist/js/icons/calculator-icon';
-import { nowrap,sortable, SortByDirection, Table, TableBody, TableHeader } from '@patternfly/react-table';
+import { nowrap, sortable, SortByDirection, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { AwsQuery, getQuery } from 'api/queries/awsQuery';
 import { orgUnitIdKey, tagPrefix } from 'api/queries/query';
 import { parseQuery, Query } from 'api/queries/query';

--- a/src/pages/explorer/explorerUtils.ts
+++ b/src/pages/explorer/explorerUtils.ts
@@ -15,10 +15,10 @@ import { ComputedOcpReportItemsParams } from 'utils/computedReport/getComputedOc
 // The date range drop down has the options below (if today is Jan 18th…)
 // eslint-disable-next-line no-shadow
 export const enum DateRangeType {
-  currentMonthToDate = 'current_month_to_date', // current month (Jan 1 - Jan 18)
-  previousMonthToDate = 'previous_month_to_date', // previous and current month (Dec 1 - Jan 18)
-  lastThirtyDays = 'last_thirty_days', // last 30 days (Dec 18 - Jan 17)
-  lastSixtyDays = 'last_sixy_days', // last 60 days (Nov 18 - Jan 17)
+  currentMonthToDate = 'current_month_to_date', // Current month (Jan 1 - Jan 18)
+  previousMonthToDate = 'previous_month_to_date', // Previous and current month (Dec 1 - Jan 18)
+  lastThirtyDays = 'last_thirty_days', // Last 30 days (Dec 18 - Jan 17)
+  lastSixtyDays = 'last_sixy_days', // Last 60 days (Nov 18 - Jan 17)
 }
 
 // eslint-disable-next-line no-shadow

--- a/src/pages/explorer/explorerUtils.ts
+++ b/src/pages/explorer/explorerUtils.ts
@@ -56,7 +56,7 @@ export const dateRangeOptions: {
   { label: 'explorer.date_range.current_month_to_date', value: 'current_month_to_date' },
   { label: 'explorer.date_range.previous_month_to_date', value: 'previous_month_to_date' },
   { label: 'explorer.date_range.last_thirty_days', value: 'last_thirty_days' },
-  // { label: 'explorer.date_range.last_sixy_days', value: 'last_sixy_days' }, // Todo: this is not currently supported
+  { label: 'explorer.date_range.last_sixy_days', value: 'last_sixy_days' },
 ];
 
 export const groupByAwsOptions: {

--- a/src/pages/explorer/explorerUtils.ts
+++ b/src/pages/explorer/explorerUtils.ts
@@ -56,7 +56,7 @@ export const dateRangeOptions: {
   { label: 'explorer.date_range.current_month_to_date', value: 'current_month_to_date' },
   { label: 'explorer.date_range.previous_month_to_date', value: 'previous_month_to_date' },
   { label: 'explorer.date_range.last_thirty_days', value: 'last_thirty_days' },
-  { label: 'explorer.date_range.last_sixy_days', value: 'last_sixy_days' },
+  // { label: 'explorer.date_range.last_sixy_days', value: 'last_sixy_days' }, // Todo: this is not currently supported
 ];
 
 export const groupByAwsOptions: {


### PR DESCRIPTION
This adds a pre-canned date ranges to the Historical Cost Explorer.

Note that the "Last 60 days" option generates an error, since we currently do not support more than 2 months of data -- Doug suggested 3 months will be available shortly.

https://issues.redhat.com/browse/COST-1062

![chrome-capture](https://user-images.githubusercontent.com/17481322/108466895-5d1d0600-7252-11eb-84bf-b24f9d764b58.gif)
