### PR TITLE
Historical Cost Explorer fixes

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -35,7 +35,8 @@
     "change_column_title": "Month over month change",
     "cost_column_title": "Cost",
     "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
-    "name_column_title": "Names",
+    "name_column_title": "$t(group_by.values.{{groupBy}}) names",
+    "org_unit_column_title": "Names",
     "tag_column_title": "Tag names",
     "total_cost": "Total cost"
   },
@@ -481,8 +482,9 @@
       "previous_month_to_date": "Previous month to date"
     },
     "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
-    "name_column_title": "Names",
+    "name_column_title": "$t(group_by.values.{{groupBy}}) names",
     "no_data": "no data",
+    "org_unit_column_title": "Names",
     "perspective": {
       "all_cloud": "All cloud filtered by OpenShift",
       "aws": "Amazon Web Services",
@@ -637,7 +639,7 @@
     "change_column_title": "Month over month change",
     "cost_column_title": "Cost",
     "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
-    "name_column_title": "Names",
+    "name_column_title": "$t(group_by.values.{{groupBy}}) names",
     "tag_column_title": "Tag names",
     "total_cost": "Total cost"
   },

--- a/src/pages/details/awsDetails/awsDetails.tsx
+++ b/src/pages/details/awsDetails/awsDetails.tsx
@@ -144,6 +144,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={reportPathsType}
+        showAggregate
       />
     );
   };

--- a/src/pages/details/awsDetails/detailsTable.tsx
+++ b/src/pages/details/awsDetails/detailsTable.tsx
@@ -212,6 +212,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           { title: <div>{cost}</div> },
           { title: <div>{actions}</div> },
         ],
+        disableSelection: item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`,
         item,
         selected: isAllSelected || (selectedItems && selectedItems.find(val => val.id === item.id) !== undefined),
       });

--- a/src/pages/details/awsDetails/detailsTable.tsx
+++ b/src/pages/details/awsDetails/detailsTable.tsx
@@ -133,7 +133,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       groupByTagKey || groupByOrg
         ? [
             {
-              title: groupByOrg ? t('aws_details.name_column_title') : t('aws_details.tag_column_title'),
+              title: groupByOrg ? t('aws_details.org_unit_column_title') : t('aws_details.tag_column_title'),
             },
             {
               title: t('aws_details.change_column_title'),

--- a/src/pages/details/azureDetails/azureDetails.tsx
+++ b/src/pages/details/azureDetails/azureDetails.tsx
@@ -144,6 +144,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={reportPathsType}
+        showAggregate
       />
     );
   };

--- a/src/pages/details/azureDetails/detailsTable.tsx
+++ b/src/pages/details/azureDetails/detailsTable.tsx
@@ -170,6 +170,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           { title: <div>{cost}</div> },
           { title: <div>{actions}</div> },
         ],
+        disableSelection: item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`,
         isOpen: false,
         item,
         selected: isAllSelected || (selectedItems && selectedItems.find(val => val.id === item.id) !== undefined),

--- a/src/pages/details/common/detailsUtils.ts
+++ b/src/pages/details/common/detailsUtils.ts
@@ -1,4 +1,16 @@
-import { Query, tagPrefix } from 'api/queries/query';
+import { orgUnitIdKey, Query, tagPrefix } from 'api/queries/query';
+
+export const getGroupByOrg = (query: Query) => {
+  let groupByOrg;
+
+  for (const groupBy of Object.keys(query.group_by)) {
+    if (groupBy === orgUnitIdKey) {
+      groupByOrg = query.group_by[orgUnitIdKey];
+      break;
+    }
+  }
+  return groupByOrg;
+};
 
 export const getGroupByTagKey = (query: Query) => {
   let groupByTagKey;

--- a/src/pages/details/components/actions/actions.tsx
+++ b/src/pages/details/components/actions/actions.tsx
@@ -64,6 +64,7 @@ class DetailsActionsBase extends React.Component<DetailsActionsProps> {
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={reportPathsType}
+        showAggregate
       />
     );
   };

--- a/src/pages/details/components/export/exportModal.tsx
+++ b/src/pages/details/components/export/exportModal.tsx
@@ -26,6 +26,11 @@ export interface ExportModalOwnProps extends WithTranslation {
   query?: Query;
   queryString?: string;
   reportPathsType: ReportPathsType;
+  useDateRange?: boolean; // resolution and timeScope filters are not valid with date range
+}
+
+interface ExportModalStateProps {
+  // TBD...
 }
 
 interface ExportModalDispatchProps {
@@ -37,7 +42,7 @@ interface ExportModalState {
   resolution: string;
 }
 
-type ExportModalProps = ExportModalOwnProps & ExportModalDispatchProps & WithTranslation;
+type ExportModalProps = ExportModalOwnProps & ExportModalDispatchProps & ExportModalStateProps & WithTranslation;
 
 const resolutionOptions: {
   label: string;
@@ -88,7 +93,7 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
   };
 
   public render() {
-    const { groupBy, isAllItems, items, query, reportPathsType, t } = this.props;
+    const { groupBy, isAllItems, items, query, reportPathsType, t, useDateRange } = this.props;
     const { resolution, timeScope } = this.state;
 
     let sortedItems = [...items];
@@ -132,6 +137,7 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
             query={query}
             reportPathsType={reportPathsType}
             resolution={resolution}
+            useDateRange={useDateRange}
           />,
           <Button
             {...getTestProps(testIds.export.cancel_btn)}
@@ -147,40 +153,44 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
           <span>{t('export.heading', { groupBy })}</span>
         </div>
         <Form style={styles.form}>
-          <FormGroup label={t('export.aggregate_type')} fieldId="aggregate-type">
-            <React.Fragment>
-              {resolutionOptions.map((option, index) => (
-                <Radio
-                  key={index}
-                  id={`resolution-${index}`}
-                  isValid={option.value !== undefined}
-                  label={t(option.label)}
-                  value={option.value}
-                  checked={resolution === option.value}
-                  name="resolution"
-                  onChange={this.handleResolutionChange}
-                  aria-label={t(option.label)}
-                />
-              ))}
-            </React.Fragment>
-          </FormGroup>
-          <FormGroup label={t('export.time_scope_title')} fieldId="timeScope">
-            <React.Fragment>
-              {timeScopeOptions.map((option, index) => (
-                <Radio
-                  key={index}
-                  id={`timeScope-${index}`}
-                  isValid={option.value !== undefined}
-                  label={t(option.label, { date: option.value === -2 ? previousMonth : currentMonth })}
-                  value={option.value}
-                  checked={timeScope === option.value}
-                  name="timeScope"
-                  onChange={this.handleMonthChange}
-                  aria-label={t(option.label)}
-                />
-              ))}
-            </React.Fragment>
-          </FormGroup>
+          {!useDateRange && (
+            <>
+              <FormGroup label={t('export.aggregate_type')} fieldId="aggregate-type">
+                <React.Fragment>
+                  {resolutionOptions.map((option, index) => (
+                    <Radio
+                      key={index}
+                      id={`resolution-${index}`}
+                      isValid={option.value !== undefined}
+                      label={t(option.label)}
+                      value={option.value}
+                      checked={resolution === option.value}
+                      name="resolution"
+                      onChange={this.handleResolutionChange}
+                      aria-label={t(option.label)}
+                    />
+                  ))}
+                </React.Fragment>
+              </FormGroup>
+              <FormGroup label={t('export.time_scope_title')} fieldId="timeScope">
+                <React.Fragment>
+                  {timeScopeOptions.map((option, index) => (
+                    <Radio
+                      key={index}
+                      id={`timeScope-${index}`}
+                      isValid={option.value !== undefined}
+                      label={t(option.label, { date: option.value === -2 ? previousMonth : currentMonth })}
+                      value={option.value}
+                      checked={timeScope === option.value}
+                      name="timeScope"
+                      onChange={this.handleMonthChange}
+                      aria-label={t(option.label)}
+                    />
+                  ))}
+                </React.Fragment>
+              </FormGroup>
+            </>
+          )}
           <FormGroup label={selectedLabel} fieldId="selected-labels">
             <ul>
               {sortedItems.map((groupItem, index) => {

--- a/src/pages/details/components/export/exportModal.tsx
+++ b/src/pages/details/components/export/exportModal.tsx
@@ -26,7 +26,7 @@ export interface ExportModalOwnProps extends WithTranslation {
   query?: Query;
   queryString?: string;
   reportPathsType: ReportPathsType;
-  useDateRange?: boolean; // resolution and timeScope filters are not valid with date range
+  showAggregate?: boolean; // resolution and timeScope filters are not valid with date range
 }
 
 interface ExportModalStateProps {
@@ -93,7 +93,7 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
   };
 
   public render() {
-    const { groupBy, isAllItems, items, query, reportPathsType, t, useDateRange } = this.props;
+    const { groupBy, isAllItems, items, query, reportPathsType, showAggregate, t } = this.props;
     const { resolution, timeScope } = this.state;
 
     let sortedItems = [...items];
@@ -132,12 +132,11 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
             isAllItems={isAllItems}
             items={items}
             key="confirm"
-            timeScope={timeScope}
+            timeScope={showAggregate ? timeScope : undefined}
             onClose={this.handleClose}
             query={query}
             reportPathsType={reportPathsType}
-            resolution={resolution}
-            useDateRange={useDateRange}
+            resolution={showAggregate ? resolution : undefined}
           />,
           <Button
             {...getTestProps(testIds.export.cancel_btn)}
@@ -153,7 +152,7 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
           <span>{t('export.heading', { groupBy })}</span>
         </div>
         <Form style={styles.form}>
-          {!useDateRange && (
+          {showAggregate && (
             <>
               <FormGroup label={t('export.aggregate_type')} fieldId="aggregate-type">
                 <React.Fragment>

--- a/src/pages/details/components/export/exportSubmit.tsx
+++ b/src/pages/details/components/export/exportSubmit.tsx
@@ -22,7 +22,6 @@ export interface ExportSubmitOwnProps extends WithTranslation {
   reportPathsType: ReportPathsType;
   resolution: string;
   timeScope: number;
-  useDateRange?: boolean; // resolution and timeScope filters are not valid with date range
 }
 
 interface ExportSubmitStateProps {
@@ -130,7 +129,7 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
 }
 
 const mapStateToProps = createMapStateToProps<ExportSubmitOwnProps, ExportSubmitStateProps>((state, props) => {
-  const { groupBy, isAllItems, items, query, reportPathsType, resolution, timeScope = -1, useDateRange } = props;
+  const { groupBy, isAllItems, items, query, reportPathsType, resolution, timeScope } = props;
 
   const getQueryString = () => {
     const newQuery: Query = {
@@ -138,8 +137,8 @@ const mapStateToProps = createMapStateToProps<ExportSubmitOwnProps, ExportSubmit
       filter: {
         limit: undefined,
         offset: undefined,
-        resolution: !useDateRange ? resolution : undefined,
-        time_scope_value: !useDateRange ? timeScope : undefined,
+        resolution: resolution ? resolution : undefined,
+        time_scope_value: timeScope ? timeScope : undefined,
       },
       filter_by: {},
       order_by: undefined,

--- a/src/pages/details/components/export/exportSubmit.tsx
+++ b/src/pages/details/components/export/exportSubmit.tsx
@@ -22,6 +22,15 @@ export interface ExportSubmitOwnProps extends WithTranslation {
   reportPathsType: ReportPathsType;
   resolution: string;
   timeScope: number;
+  useDateRange?: boolean; // resolution and timeScope filters are not valid with date range
+}
+
+interface ExportSubmitStateProps {
+  // TBD...
+}
+
+interface ExportSubmitDispatchProps {
+  exportReport?: typeof exportActions.exportReport;
 }
 
 interface ExportSubmitStateProps {
@@ -31,15 +40,11 @@ interface ExportSubmitStateProps {
   reportFetchStatus?: FetchStatus;
 }
 
-interface ExportSubmitDispatchProps {
-  exportReport?: typeof exportActions.exportReport;
-}
-
 interface ExportSubmitState {
   fetchReportClicked: boolean;
 }
 
-type ExportSubmitProps = ExportSubmitOwnProps & ExportSubmitStateProps & ExportSubmitDispatchProps & WithTranslation;
+type ExportSubmitProps = ExportSubmitOwnProps & ExportSubmitDispatchProps & ExportSubmitStateProps & WithTranslation;
 
 const reportType = ReportType.cost;
 
@@ -125,18 +130,22 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
 }
 
 const mapStateToProps = createMapStateToProps<ExportSubmitOwnProps, ExportSubmitStateProps>((state, props) => {
-  const { groupBy, isAllItems, items, query, reportPathsType, resolution, timeScope = -1 } = props;
+  const { groupBy, isAllItems, items, query, reportPathsType, resolution, timeScope = -1, useDateRange } = props;
 
   const getQueryString = () => {
     const newQuery: Query = {
       ...JSON.parse(JSON.stringify(query)),
+      filter: {
+        limit: undefined,
+        offset: undefined,
+        resolution: !useDateRange ? resolution : undefined,
+        time_scope_value: !useDateRange ? timeScope : undefined,
+      },
       filter_by: {},
       order_by: undefined,
+      perspective: undefined,
+      dateRange: undefined,
     };
-    newQuery.filter.limit = undefined;
-    newQuery.filter.offset = undefined;
-    newQuery.filter.resolution = resolution as any;
-    newQuery.filter.time_scope_value = timeScope;
 
     // Store filter_by as an array so we can add to it below
     if (query.filter_by) {

--- a/src/pages/details/gcpDetails/detailsTable.tsx
+++ b/src/pages/details/gcpDetails/detailsTable.tsx
@@ -170,6 +170,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           { title: <div>{cost}</div> },
           { title: <div>{actions}</div> },
         ],
+        disableSelection: item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`,
         isOpen: false,
         item,
         selected: isAllSelected || (selectedItems && selectedItems.find(val => val.id === item.id) !== undefined),

--- a/src/pages/details/gcpDetails/gcpDetails.tsx
+++ b/src/pages/details/gcpDetails/gcpDetails.tsx
@@ -144,6 +144,7 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={reportPathsType}
+        showAggregate
       />
     );
   };

--- a/src/pages/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/details/ocpDetails/detailsTable.tsx
@@ -195,6 +195,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           { title: <div>{cost}</div> },
           { title: <div>{actions}</div> },
         ],
+        disableSelection: item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`,
         isOpen: false,
         item,
         selected: isAllSelected || (selectedItems && selectedItems.find(val => val.id === item.id) !== undefined),

--- a/src/pages/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/details/ocpDetails/ocpDetails.tsx
@@ -144,6 +144,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={reportPathsType}
+        showAggregate
       />
     );
   };

--- a/src/pages/explorer/explorer.tsx
+++ b/src/pages/explorer/explorer.tsx
@@ -166,7 +166,6 @@ class Explorer extends React.Component<ExplorerProps> {
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={getReportPathsType(perspective)}
-        useDateRange
       />
     );
   };

--- a/src/pages/explorer/explorer.tsx
+++ b/src/pages/explorer/explorer.tsx
@@ -7,7 +7,7 @@ import { getUserAccessQuery } from 'api/queries/userAccessQuery';
 import { Report } from 'api/reports/report';
 import { UserAccess, UserAccessType } from 'api/userAccess';
 import { AxiosError } from 'axios';
-import { addQueryFilter, getGroupByTagKey, removeQueryFilter } from 'pages/details/common/detailsUtils';
+import { addQueryFilter, getGroupByOrg, getGroupByTagKey, removeQueryFilter } from 'pages/details/common/detailsUtils';
 import { ExportModal } from 'pages/details/components/export/exportModal';
 import Loading from 'pages/state/loading';
 import NoData from 'pages/state/noData';
@@ -141,11 +141,13 @@ class Explorer extends React.Component<ExplorerProps> {
     const { query, report } = this.props;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
+    const groupByOrg = getGroupByOrg(query);
     const groupByTagKey = getGroupByTagKey(query);
 
     return getUnsortedComputedReportItems({
       report,
-      idKey: (groupByTagKey as any) || groupById,
+      idKey: groupByTagKey ? groupByTagKey : groupByOrg ? 'org_entities' : groupById,
+      daily: true,
     });
   };
 

--- a/src/pages/explorer/explorer.tsx
+++ b/src/pages/explorer/explorer.tsx
@@ -313,7 +313,7 @@ class Explorer extends React.Component<ExplorerProps> {
     history.replace(filteredQuery);
   };
 
-  private handlePerspectiveClick = (value: string) => {
+  private handlePerspectiveClick = () => {
     this.setState({ isAllSelected: false, selectedItems: [] });
   };
 

--- a/src/pages/explorer/explorer.tsx
+++ b/src/pages/explorer/explorer.tsx
@@ -113,6 +113,7 @@ class Explorer extends React.Component<ExplorerProps> {
     this.handleFilterAdded = this.handleFilterAdded.bind(this);
     this.handleFilterRemoved = this.handleFilterRemoved.bind(this);
     this.handlePerPageSelect = this.handlePerPageSelect.bind(this);
+    this.handlePerspectiveClick = this.handlePerspectiveClick.bind(this);
     this.handleSelected = this.handleSelected.bind(this);
     this.handleSetPage = this.handleSetPage.bind(this);
     this.handleSort = this.handleSort.bind(this);
@@ -165,6 +166,7 @@ class Explorer extends React.Component<ExplorerProps> {
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={getReportPathsType(perspective)}
+        useDateRange
       />
     );
   };
@@ -212,7 +214,6 @@ class Explorer extends React.Component<ExplorerProps> {
         isLoading={reportFetchStatus === FetchStatus.inProgress}
         onSelected={this.handleSelected}
         onSort={this.handleSort}
-        perspective={perspective}
         query={query}
         report={report}
         selectedItems={selectedItems}
@@ -311,6 +312,10 @@ class Explorer extends React.Component<ExplorerProps> {
     };
     const filteredQuery = getRouteForQuery(history, newQuery, true);
     history.replace(filteredQuery);
+  };
+
+  private handlePerspectiveClick = (value: string) => {
+    this.setState({ isAllSelected: false, selectedItems: [] });
   };
 
   private handleSelected = (items: ComputedReportItem[], isSelected: boolean = false) => {
@@ -449,9 +454,10 @@ class Explorer extends React.Component<ExplorerProps> {
       <div style={styles.explorer}>
         <ExplorerHeader
           groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
-          onGroupByClicked={this.handleGroupByClick}
           onFilterAdded={this.handleFilterAdded}
           onFilterRemoved={this.handleFilterRemoved}
+          onGroupByClicked={this.handleGroupByClick}
+          onPerspectiveClicked={this.handlePerspectiveClick}
         />
         {itemsTotal > 0 && (
           <div style={styles.chartContent}>

--- a/src/pages/explorer/explorer.tsx
+++ b/src/pages/explorer/explorer.tsx
@@ -144,11 +144,12 @@ class Explorer extends React.Component<ExplorerProps> {
     const groupByOrg = getGroupByOrg(query);
     const groupByTagKey = getGroupByTagKey(query);
 
-    return getUnsortedComputedReportItems({
+    const computedItems = getUnsortedComputedReportItems({
       report,
       idKey: groupByTagKey ? groupByTagKey : groupByOrg ? 'org_entities' : groupById,
-      daily: true,
+      daily: false, // Don't use daily here, so we can use a flattened data structure with row selection
     });
+    return computedItems;
   };
 
   private getExportModal = (computedItems: ComputedReportItem[]) => {

--- a/src/pages/explorer/explorerHeader.tsx
+++ b/src/pages/explorer/explorerHeader.tsx
@@ -49,9 +49,10 @@ import {
 
 interface ExplorerHeaderOwnProps {
   groupBy?: string;
-  onGroupByClicked(value: string);
   onFilterAdded(filterType: string, filterValue: string);
   onFilterRemoved(filterType: string, filterValue?: string);
+  onGroupByClicked(value: string);
+  onPerspectiveClicked(value: string);
 }
 
 interface ExplorerHeaderStateProps {
@@ -188,7 +189,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
   };
 
   private handlePerspectiveClick = (value: string) => {
-    const { history, query } = this.props;
+    const { history, onPerspectiveClicked, query } = this.props;
 
     const newQuery = {
       ...JSON.parse(JSON.stringify(query)),
@@ -198,7 +199,11 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
       perspective: value,
     };
     history.replace(getRouteForQuery(history, newQuery, true));
-    this.setState({ currentPerspective: value });
+    this.setState({ currentPerspective: value }, () => {
+      if (onPerspectiveClicked) {
+        onPerspectiveClicked(value);
+      }
+    });
   };
 
   public render() {

--- a/src/pages/explorer/explorerTable.scss
+++ b/src/pages/explorer/explorerTable.scss
@@ -36,14 +36,14 @@
       background-color: var(--pf-global--BackgroundColor--light-100);
       left: 0px;
       position: sticky;
-      z-index: 999;
+      z-index: 199;
     }
     thead th:nth-child(2), tbody td:nth-child(2) {
       background-clip: padding-box;
       background-color: var(--pf-global--BackgroundColor--light-100);
       left: 45px;
       position: sticky;
-      z-index: 999;
+      z-index: 199;
     }
     @media (min-width: 1200px) {
       thead th:nth-child(2), tbody td:nth-child(2) {

--- a/src/pages/explorer/explorerTable.scss
+++ b/src/pages/explorer/explorerTable.scss
@@ -31,6 +31,9 @@
 
 .explorerTableOverride {
   &.pf-c-table {
+    thead th + th + th {
+      min-width: 100px;
+    }
     thead th:first-child, tbody td:first-child {
       background-clip: padding-box;
       background-color: var(--pf-global--BackgroundColor--light-100);

--- a/src/pages/explorer/explorerTable.scss
+++ b/src/pages/explorer/explorerTable.scss
@@ -42,6 +42,7 @@
       background-clip: padding-box;
       background-color: var(--pf-global--BackgroundColor--light-100);
       left: 45px;
+      min-width: 175px;
       position: sticky;
       z-index: 199;
     }

--- a/src/pages/explorer/explorerTable.tsx
+++ b/src/pages/explorer/explorerTable.tsx
@@ -4,12 +4,12 @@ import { Bullseye, EmptyState, EmptyStateBody, EmptyStateIcon, Spinner } from '@
 import { CalculatorIcon } from '@patternfly/react-icons/dist/js/icons/calculator-icon';
 import { nowrap, sortable, SortByDirection, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { AwsQuery, getQuery } from 'api/queries/awsQuery';
-import { orgUnitIdKey, tagPrefix } from 'api/queries/query';
 import { parseQuery, Query } from 'api/queries/query';
 import { AwsReport } from 'api/reports/awsReports';
 import { ComputedReportItemType } from 'components/charts/common/chartDatumUtils';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import { format, getDate, getMonth } from 'date-fns';
+import { getGroupByOrg, getGroupByTagKey } from 'pages/details/common/detailsUtils';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -105,8 +105,8 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
     }
 
     const groupById = getIdKeyForGroupBy(query.group_by);
-    const groupByOrg = this.getGroupByOrg();
-    const groupByTagKey = this.getGroupByTagKey();
+    const groupByOrg = getGroupByOrg(query);
+    const groupByTagKey = getGroupByTagKey(query);
     const rows = [];
 
     // Add first column heading (i.e., name)
@@ -257,33 +257,6 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
         <EmptyStateBody>{t('explorer.empty_state')}</EmptyStateBody>
       </EmptyState>
     );
-  };
-
-  private getGroupByOrg = () => {
-    const { query } = this.props;
-    let groupByOrg;
-
-    for (const groupBy of Object.keys(query.group_by)) {
-      if (groupBy === orgUnitIdKey) {
-        groupByOrg = query.group_by[orgUnitIdKey];
-        break;
-      }
-    }
-    return groupByOrg;
-  };
-
-  private getGroupByTagKey = () => {
-    const { query } = this.props;
-    let groupByTagKey;
-
-    for (const groupBy of Object.keys(query.group_by)) {
-      const tagIndex = groupBy.indexOf(tagPrefix);
-      if (tagIndex !== -1) {
-        groupByTagKey = groupBy.substring(tagIndex + tagPrefix.length) as any;
-        break;
-      }
-    }
-    return groupByTagKey;
   };
 
   public getSortBy = () => {

--- a/src/pages/explorer/explorerTable.tsx
+++ b/src/pages/explorer/explorerTable.tsx
@@ -98,25 +98,28 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
       return;
     }
 
-    const rows = [];
-    const columns = [];
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByOrg = this.getGroupByOrg();
     const groupByTagKey = this.getGroupByTagKey();
+    const rows = [];
 
     // Add first column heading (i.e., name)
-    if (groupByTagKey || groupByOrg) {
-      columns.push({
-        title: groupByOrg ? t('explorer.name_column_title') : t('explorer.tag_column_title'),
-      });
-    } else {
-      columns.push({
-        orderBy: groupById === 'account' && perspective !== PerspectiveType.gcp ? 'account_alias' : groupById,
-        title: t('explorer.name_column_title', { groupBy: groupById }),
-        transforms: [sortable],
-        cellTransforms: [nowrap],
-      });
-    }
+    const columns =
+      groupByTagKey || groupByOrg
+        ? [
+            {
+              cellTransforms: [nowrap],
+              title: groupByOrg ? t('explorer.org_unit_column_title') : t('explorer.tag_column_title'),
+            },
+          ]
+        : [
+            {
+              cellTransforms: [nowrap],
+              orderBy: groupById === 'account' && perspective !== PerspectiveType.gcp ? 'account_alias' : groupById,
+              title: t('explorer.name_column_title', { groupBy: groupById }),
+              transforms: [sortable],
+            },
+          ];
 
     const computedItems = getUnsortedComputedReportItems({
       report,
@@ -137,8 +140,10 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
       const date = getDate(mapIdDate);
       const month = getMonth(mapIdDate);
       columns.push({
-        title: t('explorer.daily_column_title', { date, month }),
         cellTransforms: [nowrap],
+        orderBy: undefined, // TBD...
+        title: t('explorer.daily_column_title', { date, month }),
+        transforms: undefined,
       });
 
       computedItems.map(rowItem => {

--- a/src/pages/explorer/explorerTable.tsx
+++ b/src/pages/explorer/explorerTable.tsx
@@ -124,7 +124,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
       daily: true,
     });
 
-    // Fill in missing data
+    // Fill in missing columns
     for (
       let currentDate = new Date(start_date + 'T00:00:00');
       currentDate <= new Date(end_date + 'T00:00:00');
@@ -151,11 +151,12 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
       });
     }
 
+    // Sort by date and fill in missing cells
     computedItems.map(rowItem => {
       const cells = [];
-      let desc;
-      let label;
-      let id;
+      let desc; // First column description (i.e., show ID if different than label)
+      let name; // For first column resource name
+      let selectItem; // Save for row selection
 
       const items: any = Array.from(rowItem.values()).sort((a: any, b: any) => {
         if (new Date(a.date) > new Date(b.date)) {
@@ -168,14 +169,14 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
       });
 
       items.map(item => {
-        if (!label) {
-          label = item && item.label && item.label !== null ? item.label : null;
+        if (!name) {
+          name = item && item.label && item.label !== null ? item.label : null;
         }
         if (!desc) {
           desc = item.id && item.id !== item.label ? <div style={styles.infoDescription}>{item.id}</div> : null;
         }
-        if (!id) {
-          id = item.id;
+        if (item.id && !selectItem) {
+          selectItem = item;
         }
 
         // Add row cells
@@ -191,7 +192,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
       cells.unshift({
         title: (
           <div>
-            {label}
+            {name}
             {desc}
           </div>
         ),
@@ -199,8 +200,9 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
 
       rows.push({
         cells,
-        item: items[0], // Any row cell contains the ID needed for row selection
-        selected: isAllSelected || (selectedItems && selectedItems.find(val => val.id === id) !== undefined),
+        disableSelection: selectItem.label === `no-${groupById}` || selectItem.label === `no-${groupByTagKey}`,
+        item: selectItem,
+        selected: isAllSelected || (selectedItems && selectedItems.find(val => val.id === selectItem.id) !== undefined),
       });
     });
 

--- a/src/pages/explorer/explorerTable.tsx
+++ b/src/pages/explorer/explorerTable.tsx
@@ -19,7 +19,13 @@ import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/comput
 import { formatCurrency } from 'utils/formatValue';
 
 import { styles } from './explorerTable.styles';
-import { DateRangeType, getDateRange, getDateRangeDefault, PerspectiveType } from './explorerUtils';
+import {
+  DateRangeType,
+  getDateRange,
+  getDateRangeDefault,
+  getPerspectiveDefault,
+  PerspectiveType,
+} from './explorerUtils';
 
 interface ExplorerTableOwnProps {
   computedReportItemType?: ComputedReportItemType;
@@ -28,7 +34,6 @@ interface ExplorerTableOwnProps {
   isLoading?: boolean;
   onSelected(items: ComputedReportItem[], isSelected: boolean);
   onSort(value: string, isSortAscending: boolean);
-  perspective: PerspectiveType;
   query: AwsQuery;
   report: AwsReport;
   selectedItems?: ComputedReportItem[];
@@ -37,6 +42,7 @@ interface ExplorerTableOwnProps {
 interface ExplorerTableStateProps {
   dateRange: DateRangeType;
   end_date?: string;
+  perspective: PerspectiveType;
   start_date?: string;
 }
 
@@ -362,12 +368,14 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<ExplorerTableOwnProps, ExplorerTableStateProps>((state, props) => {
   const queryFromRoute = parseQuery<Query>(location.search);
+  const perspective = getPerspectiveDefault(queryFromRoute);
   const dateRange = getDateRangeDefault(queryFromRoute);
   const { end_date, start_date } = getDateRange(queryFromRoute);
 
   return {
     dateRange,
     end_date,
+    perspective,
     start_date,
   };
 });

--- a/src/pages/explorer/explorerUtils.ts
+++ b/src/pages/explorer/explorerUtils.ts
@@ -38,7 +38,6 @@ export const baseQuery: Query = {
   filter: {
     limit: 10,
     offset: 0,
-    resolution: 'daily',
   },
   filter_by: {},
   group_by: {


### PR DESCRIPTION
Fixed a couple small issues with the Historical Cost Explorer.

- Since we're using a date range, the export should not have options for current and previous months.
- The cost explorer bulk selector dropdown is hidden by the z-index used for table scrolling.
- Check boxes are not selected when clicked.
- Update getComputedReportItems to account for AWS org units, while grouped by services and regions

https://issues.redhat.com/browse/COST-1072
https://issues.redhat.com/browse/COST-1073
https://issues.redhat.com/browse/COST-1074

**Bulk selector before**
<img width="449" alt="hidden bulk selector" src="https://user-images.githubusercontent.com/17481322/108615657-53bba700-73d4-11eb-8143-b8ad430ebf29.png">

**Bulk selector after (with selected row)**
<img width="449" alt="Screen Shot 2021-02-20 at 10 02 05 PM" src="https://user-images.githubusercontent.com/17481322/108615661-59b18800-73d4-11eb-8002-4d45a8530d8f.png">

**Export before**
<img width="581" alt="export" src="https://user-images.githubusercontent.com/17481322/108615665-5fa76900-73d4-11eb-9ffc-30c8913e1e27.png">

**Export after**
<img width="578" alt="Screen Shot 2021-02-20 at 11 36 22 PM" src="https://user-images.githubusercontent.com/17481322/108615676-76e65680-73d4-11eb-87e5-a27ce0bc98b6.png">

