### PR TITLE
Fixed:

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,7 +1,7 @@
 {
+  "daily_usage_comparison": "Daily usage comparison ({{units}})",
   "aws_cloud_dashboard": {
     "compute_title": "Compute (EC2) instances usage",
-    "compute_trend_title": "Daily usage comparison ({{units}})",
     "cost_label": "Cost",
     "cost_title": "Amazon Web Services filtered by OpenShift cost",
     "cost_trend_title": "Amazon Web Services cumulative cost comparison ({{units}})",
@@ -12,12 +12,10 @@
     "network_title": "Network services cost",
     "network_trend_title": "Cumulative cost comparison ({{units}})",
     "storage_title": "Storage services usage",
-    "storage_trend_title": "Daily usage comparison ({{units}})",
     "usage_label": "Usage"
   },
   "aws_dashboard": {
     "compute_title": "Compute (EC2) instances usage",
-    "compute_trend_title": "Daily usage comparison ({{units}})",
     "cost_label": "Cost",
     "cost_title": "Amazon Web Services cost",
     "cost_trend_title": "Amazon Web Services cumulative cost comparison ({{units}})",
@@ -28,7 +26,6 @@
     "network_title": "Network services cost",
     "network_trend_title": "Cumulative cost comparison ({{units}})",
     "storage_title": "Storage services usage",
-    "storage_trend_title": "Daily usage comparison ({{units}})",
     "usage_label": "Usage"
   },
   "aws_details": {
@@ -42,7 +39,6 @@
   },
   "azure_cloud_dashboard": {
     "compute_title": "Virtual machines usage",
-    "compute_trend_title": "Daily usage comparison ({{units}})",
     "cost_label": "Cost",
     "cost_title": "Microsoft Azure filtered by OpenShift cost",
     "cost_trend_title": "Microsoft Azure cumulative cost comparison ({{units}})",
@@ -53,12 +49,10 @@
     "network_title": "Network services cost",
     "network_trend_title": "Cumulative cost comparison ({{units}})",
     "storage_title": "Storage services usage",
-    "storage_trend_title": "Daily usage comparison ({{units}})",
     "usage_label": "Usage"
   },
   "azure_dashboard": {
     "compute_title": "Virtual machines usage",
-    "compute_trend_title": "Daily usage comparison ({{units}})",
     "cost_label": "Cost",
     "cost_title": "Microsoft Azure cost",
     "cost_trend_title": "Microsoft Azure cumulative cost comparison ({{units}})",
@@ -69,7 +63,6 @@
     "network_title": "Network services cost",
     "network_trend_title": "Cumulative cost comparison ({{units}})",
     "storage_title": "Storage services usage",
-    "storage_trend_title": "Daily usage comparison ({{units}})",
     "usage_label": "Usage"
   },
   "azure_details": {
@@ -621,7 +614,6 @@
   "for_date_plural": "{{value}} for {{startDate}}-{{endDate}} $t(months_abbr.{{month}})",
   "gcp_dashboard": {
     "compute_title": "Compute instances usage",
-    "compute_trend_title": "Daily usage comparison ({{units}})",
     "cost_label": "Cost",
     "cost_title": "Google Cloud Platform Services cost",
     "cost_trend_title": "Google Cloud Platform Services cumulative cost comparison ({{units}})",
@@ -632,7 +624,6 @@
     "network_title": "Network services cost",
     "network_trend_title": "Cumulative cost comparison ({{units}})",
     "storage_title": "Storage services usage",
-    "storage_trend_title": "Daily usage comparison ({{units}})",
     "usage_label": "Usage"
   },
   "gcp_details": {
@@ -802,7 +793,6 @@
   },
   "ocp_cloud_dashboard": {
     "compute_title": "Compute services usage",
-    "compute_trend_title": "Daily usage comparison ({{units}})",
     "cost_label": "Cost",
     "cost_title": "All cloud filtered by OpenShift cost",
     "cost_trend_title": "All cloud filtered by OpenShift cumulative cost comparison ({{units}})",
@@ -813,7 +803,6 @@
     "network_title": "Network services cost",
     "network_trend_title": "Cumulative cost comparison ({{units}})",
     "storage_title": "Storage services usage",
-    "storage_trend_title": "Daily usage comparison ({{units}})",
     "usage_label": "Usage"
   },
   "ocp_dashboard": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,5 +1,4 @@
 {
-  "daily_usage_comparison": "Daily usage comparison ({{units}})",
   "aws_cloud_dashboard": {
     "compute_title": "Compute (EC2) instances usage",
     "cost_label": "Cost",
@@ -152,6 +151,7 @@
     "cost_supplementary_legend_label_no_data": "Supplementary cost (no data)",
     "cost_supplementary_legend_label_plural": "Supplementary cost ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
     "cost_supplementary_legend_tooltip": "Supplementary cost ($t(months_abbr.{{month}}))",
+    "daily_usage_comparison": "Daily usage comparison ({{units}})",
     "date": "{{date}}-$t(months_abbr.{{month}})",
     "date_range": "{{startDate}} $t(months_abbr.{{month}}) {{year}}",
     "date_range_plural": "{{startDate}}-{{endDate}} $t(months_abbr.{{month}}) {{year}}",

--- a/src/store/dashboard/awsCloudDashboard/awsCloudDashboardWidgets.ts
+++ b/src/store/dashboard/awsCloudDashboard/awsCloudDashboardWidgets.ts
@@ -43,7 +43,7 @@ export const computeWidget: AwsCloudDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'daily_usage_comparison',
+    titleKey: 'chart.daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {
@@ -190,7 +190,7 @@ export const storageWidget: AwsCloudDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'daily_usage_comparison',
+    titleKey: 'chart.daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {

--- a/src/store/dashboard/awsCloudDashboard/awsCloudDashboardWidgets.ts
+++ b/src/store/dashboard/awsCloudDashboard/awsCloudDashboardWidgets.ts
@@ -43,7 +43,7 @@ export const computeWidget: AwsCloudDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'aws_cloud_dashboard.compute_trend_title',
+    titleKey: 'daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {
@@ -190,7 +190,7 @@ export const storageWidget: AwsCloudDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'aws_cloud_dashboard.storage_trend_title',
+    titleKey: 'daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -44,7 +44,7 @@ export const computeWidget: AwsDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'daily_usage_comparison',
+    titleKey: 'chart.daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {
@@ -194,7 +194,7 @@ export const storageWidget: AwsDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'daily_usage_comparison',
+    titleKey: 'chart.daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -44,7 +44,7 @@ export const computeWidget: AwsDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'aws_dashboard.compute_trend_title',
+    titleKey: 'daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {
@@ -194,7 +194,7 @@ export const storageWidget: AwsDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'aws_dashboard.storage_trend_title',
+    titleKey: 'daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {

--- a/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
+++ b/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
@@ -156,7 +156,7 @@ export const storageWidget: AzureCloudDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'daily_usage_comparison',
+    titleKey: 'chart.daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {
@@ -202,7 +202,7 @@ export const virtualMachineWidget: AzureCloudDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'daily_usage_comparison',
+    titleKey: 'chart.daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {

--- a/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
+++ b/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
@@ -156,7 +156,7 @@ export const storageWidget: AzureCloudDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'azure_cloud_dashboard.storage_trend_title',
+    titleKey: 'daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {
@@ -202,7 +202,7 @@ export const virtualMachineWidget: AzureCloudDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'azure_cloud_dashboard.compute_trend_title',
+    titleKey: 'daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -160,7 +160,7 @@ export const storageWidget: AzureDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'azure_dashboard.storage_trend_title',
+    titleKey: 'daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {
@@ -206,7 +206,7 @@ export const virtualMachineWidget: AzureDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'azure_dashboard.compute_trend_title',
+    titleKey: 'daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -160,7 +160,7 @@ export const storageWidget: AzureDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'daily_usage_comparison',
+    titleKey: 'chart.daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {
@@ -206,7 +206,7 @@ export const virtualMachineWidget: AzureDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'daily_usage_comparison',
+    titleKey: 'chart.daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {

--- a/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
@@ -45,7 +45,7 @@ export const computeWidget: GcpDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'daily_usage_comparison',
+    titleKey: 'chart.daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {
@@ -197,7 +197,7 @@ export const storageWidget: GcpDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'daily_usage_comparison',
+    titleKey: 'chart.daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {

--- a/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
@@ -45,7 +45,7 @@ export const computeWidget: GcpDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'gcp_dashboard.compute_trend_title',
+    titleKey: 'daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {
@@ -197,7 +197,7 @@ export const storageWidget: GcpDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'gcp_dashboard.storage_trend_title',
+    titleKey: 'daily_usage_comparison',
     type: ChartType.daily,
   },
   topItems: {

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
@@ -76,7 +76,7 @@ export const computeWidget: OcpCloudDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'daily_usage_comparison',
+    titleKey: 'chart.daily_usage_comparison',
     type: ChartType.daily,
   },
   chartType: DashboardChartType.trend,
@@ -160,7 +160,7 @@ export const storageWidget: OcpCloudDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'daily_usage_comparison',
+    titleKey: 'chart.daily_usage_comparison',
     type: ChartType.daily,
   },
   chartType: DashboardChartType.trend,

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
@@ -76,7 +76,7 @@ export const computeWidget: OcpCloudDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'ocp_cloud_dashboard.compute_trend_title',
+    titleKey: 'daily_usage_comparison',
     type: ChartType.daily,
   },
   chartType: DashboardChartType.trend,
@@ -160,7 +160,7 @@ export const storageWidget: OcpCloudDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'ocp_cloud_dashboard.storage_trend_title',
+    titleKey: 'daily_usage_comparison',
     type: ChartType.daily,
   },
   chartType: DashboardChartType.trend,


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/COST-727

"Daily usage comparison ({{units}})"                                       [Found: 12]
	FOUND IN KEY: aws_dashboard.storage_trend_title
	FOUND IN KEY: azure_dashboard.storage_trend_title
	FOUND IN KEY: azure_cloud_dashboard.compute_trend_title
	FOUND IN KEY: ocp_cloud_dashboard.storage_trend_title
	FOUND IN KEY: azure_cloud_dashboard.storage_trend_title
	FOUND IN KEY: azure_dashboard.compute_trend_title
	FOUND IN KEY: aws_cloud_dashboard.compute_trend_title
	FOUND IN KEY: aws_dashboard.compute_trend_title
	FOUND IN KEY: aws_cloud_dashboard.storage_trend_title
	FOUND IN KEY: gcp_dashboard.storage_trend_title
	FOUND IN KEY: ocp_cloud_dashboard.compute_trend_title
	FOUND IN KEY: gcp_dashboard.compute_trend_title
	
Changed these above to one key: 
    "daily_usage_comparison": "Daily usage comparison ({{units}})",
	
Some quick snapshots of this still working:

![Screen Shot 2021-02-22 at 9 55 56 AM](https://user-images.githubusercontent.com/57504257/108725501-72b15a80-74f4-11eb-8b67-3724dd9d7677.png)

![Screen Shot 2021-02-22 at 9 56 16 AM](https://user-images.githubusercontent.com/57504257/108725515-75ac4b00-74f4-11eb-989e-6e82788d677f.png)

