### PR TITLE
fix for GCP compute and storage widget labels and tooltips

### DIFF
--- a/src/components/charts/common/chartDatumUtils.ts
+++ b/src/components/charts/common/chartDatumUtils.ts
@@ -410,8 +410,8 @@ export function getTooltipContent(formatValue) {
     const lookup = unitLookupKey(unit);
     switch (lookup) {
       case 'core-hours':
-      case 'hrs':
       case 'hour':
+      case 'hrs':
       case 'gb':
       case 'gb-hours':
       case 'gb-mo':

--- a/src/components/charts/common/chartDatumUtils.ts
+++ b/src/components/charts/common/chartDatumUtils.ts
@@ -411,9 +411,11 @@ export function getTooltipContent(formatValue) {
     switch (lookup) {
       case 'core-hours':
       case 'hrs':
+      case 'hour':
       case 'gb':
       case 'gb-hours':
       case 'gb-mo':
+      case 'gibibyte month':
       case 'vm-hours':
         return i18next.t(`unit_tooltips.${lookup}`, {
           value: `${formatValue(value, unit, options)}`,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -994,6 +994,8 @@
     "gb": "{{value}} GB",
     "gb-hours": "{{value}} GB-hours",
     "gb-mo": "{{value}} GB-month",
+    "gibibyte month": "{{value}} GiB-month",
+    "hour": "{{value}} hours",
     "hrs": "{{value}} hours",
     "usd": "{{value}}",
     "vm-hours": "{{value}} VM-hours"
@@ -1004,6 +1006,8 @@
     "gb": "GB",
     "gb-hours": "GB-hours",
     "gb-mo": "GB-month",
+    "gibibyte month": "GiB-month",
+    "hour": "hours",
     "hours": "hours",
     "hrs": "hours",
     "tag-mo": "Tag-month",

--- a/src/utils/formatValue.ts
+++ b/src/utils/formatValue.ts
@@ -11,8 +11,10 @@ export const unitLookupKey = unit => {
     case 'gb':
     case 'gb-hours':
     case 'gb-mo':
+    case 'gibibyte month':
     case 'core-hours':
     case 'hrs':
+    case 'hour':
     case 'tag-mo':
     case 'vm-hours':
       return lookup;
@@ -31,11 +33,13 @@ export const formatValue: ValueFormatter = (value: number, unit: string, options
     case 'gb':
     case 'gb-hours':
     case 'gb-mo':
+    case 'gibibyte month':
     case 'tag-mo':
     case 'vm-hours':
       return formatUsageGb(fValue, lookup, options);
     case 'core-hours':
     case 'hrs':
+    case 'hour':
       return formatUsageHrs(fValue, lookup, options);
     default:
       return unknownTypeFormatter(fValue, lookup, options);

--- a/src/utils/formatValue.ts
+++ b/src/utils/formatValue.ts
@@ -13,8 +13,8 @@ export const unitLookupKey = unit => {
     case 'gb-mo':
     case 'gibibyte month':
     case 'core-hours':
-    case 'hrs':
     case 'hour':
+    case 'hrs':
     case 'tag-mo':
     case 'vm-hours':
       return lookup;
@@ -38,8 +38,8 @@ export const formatValue: ValueFormatter = (value: number, unit: string, options
     case 'vm-hours':
       return formatUsageGb(fValue, lookup, options);
     case 'core-hours':
-    case 'hrs':
     case 'hour':
+    case 'hrs':
       return formatUsageHrs(fValue, lookup, options);
     default:
       return unknownTypeFormatter(fValue, lookup, options);


### PR DESCRIPTION
closes: https://issues.redhat.com/browse/COST-1070

Compute ToolTip Shown:
![Screen Shot 2021-02-22 at 5 00 08 PM](https://user-images.githubusercontent.com/57504257/108777475-d73eda80-7531-11eb-87d7-4fa17ddb7e0a.png)

Storage ToolTip Shown:
![Screen Shot 2021-02-22 at 5 00 25 PM](https://user-images.githubusercontent.com/57504257/108777481-da39cb00-7531-11eb-86ac-7f51d3361fba.png)
