### PR TITLE
remove duplicate "Cost" i18n keys and create one chart.cost key

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -824,7 +824,6 @@
     "supplementary_cost_title": "Supplementary cost",
     "tag_column_title": "Tag names",
     "title": "OpenShift details",
-    "total_cost": "Cost",
     "total_cost_tooltip": "This total cost is the sum of the infrastructure cost: {{infrastructureCost}} and supplementary cost: {{supplementaryCost}}"
   },
   "ocp_supplementary_dashboard": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -115,7 +115,6 @@
     "usage_cost_title": "Usage cost"
   },
   "chart": {
-    "cost": "Cost",
     "cost_forecast_cone_legend_label": "Cost confidence ({{startDate}} $t(months_abbr.{{month}}))",
     "cost_forecast_cone_legend_label_no_data": "Cost confidence (no data)",
     "cost_forecast_cone_legend_label_plural": "Cost confidence ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
@@ -166,6 +165,7 @@
     "usage_legend_label_plural": "Usage ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
     "usage_legend_tooltip": "Usage ($t(months_abbr.{{month}}))"
   },
+  "cost": "Cost",
   "cost_management": "Cost Management",
   "cost_models": {
     "add_rate_form": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1,7 +1,6 @@
 {
   "aws_cloud_dashboard": {
     "compute_title": "Compute (EC2) instances usage",
-    "cost_label": "Cost",
     "cost_title": "Amazon Web Services filtered by OpenShift cost",
     "cost_trend_title": "Amazon Web Services cumulative cost comparison ({{units}})",
     "cumulative_cost_label": "Cumulative cost",
@@ -15,7 +14,6 @@
   },
   "aws_dashboard": {
     "compute_title": "Compute (EC2) instances usage",
-    "cost_label": "Cost",
     "cost_title": "Amazon Web Services cost",
     "cost_trend_title": "Amazon Web Services cumulative cost comparison ({{units}})",
     "cumulative_cost_label": "Cumulative cost",
@@ -29,7 +27,6 @@
   },
   "aws_details": {
     "change_column_title": "Month over month change",
-    "cost_column_title": "Cost",
     "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "name_column_title": "$t(group_by.values.{{groupBy}}) names",
     "org_unit_column_title": "Names",
@@ -38,7 +35,6 @@
   },
   "azure_cloud_dashboard": {
     "compute_title": "Virtual machines usage",
-    "cost_label": "Cost",
     "cost_title": "Microsoft Azure filtered by OpenShift cost",
     "cost_trend_title": "Microsoft Azure cumulative cost comparison ({{units}})",
     "cumulative_cost_label": "Cumulative cost",
@@ -52,7 +48,6 @@
   },
   "azure_dashboard": {
     "compute_title": "Virtual machines usage",
-    "cost_label": "Cost",
     "cost_title": "Microsoft Azure cost",
     "cost_trend_title": "Microsoft Azure cumulative cost comparison ({{units}})",
     "cumulative_cost_label": "Cumulative cost",
@@ -66,7 +61,6 @@
   },
   "azure_details": {
     "change_column_title": "Month over month change",
-    "cost_column_title": "Cost",
     "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "name_column_title": "$t(group_by.values.{{groupBy}}) names",
     "tag_column_title": "Tag names",
@@ -121,6 +115,7 @@
     "usage_cost_title": "Usage cost"
   },
   "chart": {
+    "cost": "Cost",
     "cost_forecast_cone_legend_label": "Cost confidence ({{startDate}} $t(months_abbr.{{month}}))",
     "cost_forecast_cone_legend_label_no_data": "Cost confidence (no data)",
     "cost_forecast_cone_legend_label_plural": "Cost confidence ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",
@@ -614,7 +609,6 @@
   "for_date_plural": "{{value}} for {{startDate}}-{{endDate}} $t(months_abbr.{{month}})",
   "gcp_dashboard": {
     "compute_title": "Compute instances usage",
-    "cost_label": "Cost",
     "cost_title": "Google Cloud Platform Services cost",
     "cost_trend_title": "Google Cloud Platform Services cumulative cost comparison ({{units}})",
     "cumulative_cost_label": "Cumulative cost",
@@ -628,7 +622,6 @@
   },
   "gcp_details": {
     "change_column_title": "Month over month change",
-    "cost_column_title": "Cost",
     "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "name_column_title": "$t(group_by.values.{{groupBy}}) names",
     "tag_column_title": "Tag names",
@@ -793,7 +786,6 @@
   },
   "ocp_cloud_dashboard": {
     "compute_title": "Compute services usage",
-    "cost_label": "Cost",
     "cost_title": "All cloud filtered by OpenShift cost",
     "cost_trend_title": "All cloud filtered by OpenShift cumulative cost comparison ({{units}})",
     "cumulative_cost_label": "Cumulative cost",
@@ -821,7 +813,6 @@
   },
   "ocp_details": {
     "change_column_title": "Month over month change",
-    "cost_column_title": "Cost",
     "empty_state": "Processing data to generate a list of all services that sums to a total cost...",
     "infrastructure_cost_column_title": "Infrastructure cost",
     "infrastructure_cost_desc": "The cost based on raw usage data from the underlying infrastructure.",

--- a/src/pages/views/details/awsDetails/detailsTable.tsx
+++ b/src/pages/views/details/awsDetails/detailsTable.tsx
@@ -140,7 +140,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             },
             {
               orderBy: 'cost',
-              title: t('aws_details.cost_column_title', { total }),
+              title: t('chart.cost', { total }),
               transforms: [sortable],
             },
             {
@@ -158,7 +158,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             },
             {
               orderBy: 'cost',
-              title: t('aws_details.cost_column_title'),
+              title: t('chart.cost'),
               transforms: [sortable],
             },
             {

--- a/src/pages/views/details/awsDetails/detailsTable.tsx
+++ b/src/pages/views/details/awsDetails/detailsTable.tsx
@@ -140,7 +140,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             },
             {
               orderBy: 'cost',
-              title: t('chart.cost', { total }),
+              title: t('cost', { total }),
               transforms: [sortable],
             },
             {
@@ -158,7 +158,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             },
             {
               orderBy: 'cost',
-              title: t('chart.cost'),
+              title: t('cost'),
               transforms: [sortable],
             },
             {

--- a/src/pages/views/details/azureDetails/detailsTable.tsx
+++ b/src/pages/views/details/azureDetails/detailsTable.tsx
@@ -111,7 +111,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           },
           {
             orderBy: 'cost',
-            title: t('chart.cost', { total }),
+            title: t('cost', { total }),
             transforms: [sortable],
           },
           {
@@ -129,7 +129,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           },
           {
             orderBy: 'cost',
-            title: t('chart.cost'),
+            title: t('cost'),
             transforms: [sortable],
           },
           {

--- a/src/pages/views/details/azureDetails/detailsTable.tsx
+++ b/src/pages/views/details/azureDetails/detailsTable.tsx
@@ -111,7 +111,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           },
           {
             orderBy: 'cost',
-            title: t('azure_details.cost_column_title', { total }),
+            title: t('chart.cost', { total }),
             transforms: [sortable],
           },
           {
@@ -129,7 +129,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           },
           {
             orderBy: 'cost',
-            title: t('azure_details.cost_column_title'),
+            title: t('chart.cost'),
             transforms: [sortable],
           },
           {

--- a/src/pages/views/details/gcpDetails/detailsTable.tsx
+++ b/src/pages/views/details/gcpDetails/detailsTable.tsx
@@ -111,7 +111,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           },
           {
             orderBy: 'cost',
-            title: t('chart.cost', { total }),
+            title: t('cost', { total }),
             transforms: [sortable],
           },
           {
@@ -129,7 +129,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           },
           {
             orderBy: 'cost',
-            title: t('chart.cost'),
+            title: t('cost'),
             transforms: [sortable],
           },
           {

--- a/src/pages/views/details/gcpDetails/detailsTable.tsx
+++ b/src/pages/views/details/gcpDetails/detailsTable.tsx
@@ -111,7 +111,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           },
           {
             orderBy: 'cost',
-            title: t('gcp_details.cost_column_title', { total }),
+            title: t('chart.cost', { total }),
             transforms: [sortable],
           },
           {
@@ -129,7 +129,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           },
           {
             orderBy: 'cost',
-            title: t('gcp_details.cost_column_title'),
+            title: t('chart.cost'),
             transforms: [sortable],
           },
           {

--- a/src/pages/views/details/ocpDetails/detailsHeader.tsx
+++ b/src/pages/views/details/ocpDetails/detailsHeader.tsx
@@ -117,7 +117,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             </Title>
             <div style={styles.costLabel}>
               <div style={styles.costLabelUnit}>
-                {t('chart.cost')}
+                {t('cost')}
                 <span style={styles.infoIcon}>
                   <Popover
                     aria-label={t('ocp_details.supplementary_aria_label')}

--- a/src/pages/views/details/ocpDetails/detailsHeader.tsx
+++ b/src/pages/views/details/ocpDetails/detailsHeader.tsx
@@ -117,7 +117,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             </Title>
             <div style={styles.costLabel}>
               <div style={styles.costLabelUnit}>
-                {t('ocp_details.total_cost')}
+                {t('chart.cost')}
                 <span style={styles.infoIcon}>
                   <Popover
                     aria-label={t('ocp_details.supplementary_aria_label')}

--- a/src/pages/views/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/views/details/ocpDetails/detailsTable.tsx
@@ -118,7 +118,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           },
           {
             orderBy: 'cost',
-            title: t('chart.cost', { total }),
+            title: t('cost', { total }),
             transforms: [sortable],
           },
           {
@@ -150,7 +150,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           },
           {
             orderBy: 'cost',
-            title: t('chart.cost'),
+            title: t('cost'),
             transforms: [sortable],
           },
           {

--- a/src/pages/views/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/views/details/ocpDetails/detailsTable.tsx
@@ -118,7 +118,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           },
           {
             orderBy: 'cost',
-            title: t('ocp_details.cost_column_title', { total }),
+            title: t('chart.cost', { total }),
             transforms: [sortable],
           },
           {
@@ -150,7 +150,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           },
           {
             orderBy: 'cost',
-            title: t('ocp_details.cost_column_title'),
+            title: t('chart.cost'),
             transforms: [sortable],
           },
           {

--- a/src/store/dashboard/awsCloudDashboard/awsCloudDashboardWidgets.ts
+++ b/src/store/dashboard/awsCloudDashboard/awsCloudDashboardWidgets.ts
@@ -19,7 +19,7 @@ export const computeWidget: AwsCloudDashboardWidget = {
   reportPathsType: ReportPathsType.awsCloud,
   reportType: ReportType.instanceType,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -66,7 +66,7 @@ export const costSummaryWidget: AwsCloudDashboardWidget = {
   reportPathsType: ReportPathsType.awsCloud,
   reportType: ReportType.cost,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -98,7 +98,7 @@ export const databaseWidget: AwsCloudDashboardWidget = {
   reportPathsType: ReportPathsType.awsCloud,
   reportType: ReportType.database,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -135,7 +135,7 @@ export const networkWidget: AwsCloudDashboardWidget = {
   reportPathsType: ReportPathsType.awsCloud,
   reportType: ReportType.network,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -172,7 +172,7 @@ export const storageWidget: AwsCloudDashboardWidget = {
   reportPathsType: ReportPathsType.awsCloud,
   reportType: ReportType.storage,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/awsCloudDashboard/awsCloudDashboardWidgets.ts
+++ b/src/store/dashboard/awsCloudDashboard/awsCloudDashboardWidgets.ts
@@ -19,7 +19,7 @@ export const computeWidget: AwsCloudDashboardWidget = {
   reportPathsType: ReportPathsType.awsCloud,
   reportType: ReportType.instanceType,
   details: {
-    costKey: 'aws_cloud_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -66,7 +66,7 @@ export const costSummaryWidget: AwsCloudDashboardWidget = {
   reportPathsType: ReportPathsType.awsCloud,
   reportType: ReportType.cost,
   details: {
-    costKey: 'aws_cloud_dashboard.cumulative_cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -98,7 +98,7 @@ export const databaseWidget: AwsCloudDashboardWidget = {
   reportPathsType: ReportPathsType.awsCloud,
   reportType: ReportType.database,
   details: {
-    costKey: 'aws_cloud_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -135,7 +135,7 @@ export const networkWidget: AwsCloudDashboardWidget = {
   reportPathsType: ReportPathsType.awsCloud,
   reportType: ReportType.network,
   details: {
-    costKey: 'aws_cloud_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -172,7 +172,7 @@ export const storageWidget: AwsCloudDashboardWidget = {
   reportPathsType: ReportPathsType.awsCloud,
   reportType: ReportType.storage,
   details: {
-    costKey: 'aws_cloud_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -20,7 +20,7 @@ export const computeWidget: AwsDashboardWidget = {
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.instanceType,
   details: {
-    costKey: 'aws_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -102,7 +102,7 @@ export const databaseWidget: AwsDashboardWidget = {
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.database,
   details: {
-    costKey: 'aws_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -139,7 +139,7 @@ export const networkWidget: AwsDashboardWidget = {
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.network,
   details: {
-    costKey: 'aws_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -176,7 +176,7 @@ export const storageWidget: AwsDashboardWidget = {
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.storage,
   details: {
-    costKey: 'aws_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -20,7 +20,7 @@ export const computeWidget: AwsDashboardWidget = {
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.instanceType,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -102,7 +102,7 @@ export const databaseWidget: AwsDashboardWidget = {
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.database,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -139,7 +139,7 @@ export const networkWidget: AwsDashboardWidget = {
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.network,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -176,7 +176,7 @@ export const storageWidget: AwsDashboardWidget = {
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.storage,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
+++ b/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
@@ -57,7 +57,7 @@ export const databaseWidget: AzureCloudDashboardWidget = {
   reportPathsType: ReportPathsType.azureCloud,
   reportType: ReportType.database,
   details: {
-    costKey: 'azure_cloud_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -94,7 +94,7 @@ export const networkWidget: AzureCloudDashboardWidget = {
   reportPathsType: ReportPathsType.azureCloud,
   reportType: ReportType.network,
   details: {
-    costKey: 'azure_cloud_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -131,7 +131,7 @@ export const storageWidget: AzureCloudDashboardWidget = {
   reportPathsType: ReportPathsType.azureCloud,
   reportType: ReportType.storage,
   details: {
-    costKey: 'azure_cloud_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -177,7 +177,7 @@ export const virtualMachineWidget: AzureCloudDashboardWidget = {
   reportPathsType: ReportPathsType.azureCloud,
   reportType: ReportType.instanceType,
   details: {
-    costKey: 'azure_cloud_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
+++ b/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
@@ -57,7 +57,7 @@ export const databaseWidget: AzureCloudDashboardWidget = {
   reportPathsType: ReportPathsType.azureCloud,
   reportType: ReportType.database,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -94,7 +94,7 @@ export const networkWidget: AzureCloudDashboardWidget = {
   reportPathsType: ReportPathsType.azureCloud,
   reportType: ReportType.network,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -131,7 +131,7 @@ export const storageWidget: AzureCloudDashboardWidget = {
   reportPathsType: ReportPathsType.azureCloud,
   reportType: ReportType.storage,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -177,7 +177,7 @@ export const virtualMachineWidget: AzureCloudDashboardWidget = {
   reportPathsType: ReportPathsType.azureCloud,
   reportType: ReportType.instanceType,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -61,7 +61,7 @@ export const databaseWidget: AzureDashboardWidget = {
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.database,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -98,7 +98,7 @@ export const networkWidget: AzureDashboardWidget = {
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.network,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -135,7 +135,7 @@ export const storageWidget: AzureDashboardWidget = {
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.storage,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -181,7 +181,7 @@ export const virtualMachineWidget: AzureDashboardWidget = {
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.instanceType,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -61,7 +61,7 @@ export const databaseWidget: AzureDashboardWidget = {
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.database,
   details: {
-    costKey: 'azure_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -98,7 +98,7 @@ export const networkWidget: AzureDashboardWidget = {
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.network,
   details: {
-    costKey: 'azure_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -135,7 +135,7 @@ export const storageWidget: AzureDashboardWidget = {
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.storage,
   details: {
-    costKey: 'azure_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -181,7 +181,7 @@ export const virtualMachineWidget: AzureDashboardWidget = {
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.instanceType,
   details: {
-    costKey: 'azure_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
@@ -21,7 +21,7 @@ export const computeWidget: GcpDashboardWidget = {
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.instanceType,
   details: {
-    costKey: 'gcp_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -103,7 +103,7 @@ export const databaseWidget: GcpDashboardWidget = {
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.database,
   details: {
-    costKey: 'gcp_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -140,7 +140,7 @@ export const networkWidget: GcpDashboardWidget = {
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.network,
   details: {
-    costKey: 'gcp_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -179,7 +179,7 @@ export const storageWidget: GcpDashboardWidget = {
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.storage,
   details: {
-    costKey: 'gcp_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
@@ -21,7 +21,7 @@ export const computeWidget: GcpDashboardWidget = {
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.instanceType,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -103,7 +103,7 @@ export const databaseWidget: GcpDashboardWidget = {
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.database,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -140,7 +140,7 @@ export const networkWidget: GcpDashboardWidget = {
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.network,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -179,7 +179,7 @@ export const storageWidget: GcpDashboardWidget = {
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.storage,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
@@ -55,7 +55,7 @@ export const computeWidget: OcpCloudDashboardWidget = {
   reportPathsType: ReportPathsType.ocpCloud,
   reportType: ReportType.instanceType,
   details: {
-    costKey: 'ocp_cloud_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -88,7 +88,7 @@ export const databaseWidget: OcpCloudDashboardWidget = {
   reportPathsType: ReportPathsType.ocpCloud,
   reportType: ReportType.database,
   details: {
-    costKey: 'ocp_cloud_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -115,7 +115,7 @@ export const networkWidget: OcpCloudDashboardWidget = {
   reportPathsType: ReportPathsType.ocpCloud,
   reportType: ReportType.network,
   details: {
-    costKey: 'ocp_cloud_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -142,7 +142,7 @@ export const storageWidget: OcpCloudDashboardWidget = {
   reportPathsType: ReportPathsType.ocpCloud,
   reportType: ReportType.storage,
   details: {
-    costKey: 'ocp_cloud_dashboard.cost_label',
+    costKey: 'chart.cost',
     formatOptions: {
       fractionDigits: 2,
     },

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
@@ -55,7 +55,7 @@ export const computeWidget: OcpCloudDashboardWidget = {
   reportPathsType: ReportPathsType.ocpCloud,
   reportType: ReportType.instanceType,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -88,7 +88,7 @@ export const databaseWidget: OcpCloudDashboardWidget = {
   reportPathsType: ReportPathsType.ocpCloud,
   reportType: ReportType.database,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -115,7 +115,7 @@ export const networkWidget: OcpCloudDashboardWidget = {
   reportPathsType: ReportPathsType.ocpCloud,
   reportType: ReportType.network,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },
@@ -142,7 +142,7 @@ export const storageWidget: OcpCloudDashboardWidget = {
   reportPathsType: ReportPathsType.ocpCloud,
   reportType: ReportType.storage,
   details: {
-    costKey: 'chart.cost',
+    costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,
     },


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/COST-727

Merge duplicate i18n keys into one key,value ("chart.cost": "Cost")

"Cost"                                                                     [Found: 11]
	FOUND IN KEY: gcp_details.cost_column_title
	FOUND IN KEY: aws_dashboard.cost_label
	FOUND IN KEY: azure_details.cost_column_title
	FOUND IN KEY: azure_dashboard.cost_label
	FOUND IN KEY: gcp_dashboard.cost_label
	FOUND IN KEY: ocp_cloud_dashboard.cost_label
	FOUND IN KEY: azure_cloud_dashboard.cost_label
	FOUND IN KEY: aws_cloud_dashboard.cost_label
	FOUND IN KEY: ocp_details.cost_column_title
	FOUND IN KEY: aws_details.cost_column_title
	FOUND IN KEY: ocp_details.total_cost


