### PR TITLE
Fixed SourceMap warnings in dev mode

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -74,7 +74,7 @@ module.exports = (_env, argv) => {
   return {
     stats: stats,
     mode: isProduction ? 'production' : 'development',
-    devtool: isProduction ? 'source-map' : 'eval',
+    devtool: 'source-map', // isProduction ? 'source-map' : 'eval',
     entry,
     output: {
       path: distDir,


### PR DESCRIPTION
Not sure why we were using `eval` for dev mode and `source-map` for production -- seems backwads? We may ultimately want `eval` in production, but this will allow debugging in both cases.

<img width="1612" alt="Screen Shot 2021-02-22 at 8 35 14 PM" src="https://user-images.githubusercontent.com/17481322/108866097-e1a8b500-75c1-11eb-9d5d-f6c0217a21d6.png">
