### PR TITLE
Historical Cost Explorer y-axis labels

### DIFF
--- a/src/components/charts/common/chartUtils.ts
+++ b/src/components/charts/common/chartUtils.ts
@@ -7,6 +7,7 @@ import { getMaxMinValues, getTooltipContent } from './chartDatumUtils';
 
 export interface ChartData {
   childName?: string;
+  units?: string;
 }
 
 export interface ChartLegendItem {

--- a/src/components/charts/historicalExplorerChart/historicalExplorerChart.tsx
+++ b/src/components/charts/historicalExplorerChart/historicalExplorerChart.tsx
@@ -25,7 +25,7 @@ import {
 } from 'components/charts/common/chartUtils';
 import i18next from 'i18next';
 import React from 'react';
-import { FormatOptions, ValueFormatter } from 'utils/formatValue';
+import { formatCurrencyAbbreviation, FormatOptions, ValueFormatter } from 'utils/formatValue';
 import { noop } from 'utils/noop';
 
 import { chartStyles } from './historicalExplorerChart.styles';
@@ -51,6 +51,7 @@ interface State {
   hiddenSeries: Set<number>;
   series?: ChartSeries[];
   width: number;
+  units?: string;
 }
 
 class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartProps, State> {
@@ -208,7 +209,8 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
       });
     }
     const cursorVoronoiContainer = this.getCursorVoronoiContainer();
-    this.setState({ cursorVoronoiContainer, series });
+    const units = this.getUnits(series);
+    this.setState({ cursorVoronoiContainer, series, units });
   };
 
   // Adds a child name to help identify hidden data series
@@ -292,7 +294,7 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
   };
 
   // Returns domain only if max y values are zero
-  private getDomain(series: ChartSeries[], hiddenSeries: Set<number>) {
+  private getDomain = (series: ChartSeries[], hiddenSeries: Set<number>) => {
     let maxValue = -1;
     let domain;
 
@@ -309,10 +311,10 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
       domain = { y: [0, 1] };
     }
     return domain;
-  }
+  };
 
   // Returns onMouseOver, onMouseOut, and onClick events for the interactive legend
-  private getEvents() {
+  private getEvents = () => {
     const { hiddenSeries, series } = this.state;
 
     const result = getInteractiveLegendEvents({
@@ -323,7 +325,7 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
       onLegendClick: props => this.handleLegendClick(props.index),
     });
     return result;
-  }
+  };
 
   private getLegend = () => {
     const { hiddenSeries, series } = this.state;
@@ -342,7 +344,7 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
   // This ensures we show every 3rd tick value, including the first and last value
   //
   // Note: We're not using Victory's tickCount because it won't always include the last tick value.
-  private getTickValues() {
+  private getTickValues = () => {
     const { top1stData, top2ndData, top3rdData, top4thData, top5thData, top6thData } = this.props;
 
     // Find the datum with the greatest number of values
@@ -368,12 +370,31 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
     }
     tickValues.push(values[values.length - 1]);
     return tickValues;
-  }
+  };
 
-  private getTruncatedString(str: string) {
+  private getTruncatedString = (str: string) => {
     const maxChars = 20;
     return str.length > maxChars ? str.substr(0, maxChars - 1) + '...' : str;
-  }
+  };
+
+  private getTickValue = (t: number) => {
+    const { units } = this.state;
+
+    return formatCurrencyAbbreviation(t, units);
+  };
+
+  private getUnits = (series: ChartSeries[]) => {
+    if (series) {
+      for (const s of series) {
+        for (const datum of s.data) {
+          if (datum.units) {
+            return datum.units;
+          }
+        }
+      }
+    }
+    return 'USD';
+  };
 
   // Hide each data series individually
   private handleLegendClick = (index: number) => {
@@ -399,7 +420,7 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
       height,
       padding = {
         bottom: 50,
-        left: 8,
+        left: 20,
         right: 8,
         top: 8,
       },
@@ -441,7 +462,7 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
               <ChartStack>{series.map((s, index) => this.getChart(s, index))}</ChartStack>
             )}
             <ChartAxis style={chartStyles.xAxis} tickValues={this.getTickValues()} />
-            <ChartAxis dependentAxis style={chartStyles.yAxis} />
+            <ChartAxis dependentAxis style={chartStyles.yAxis} tickFormat={this.getTickValue} />
           </Chart>
         </div>
       </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -971,6 +971,12 @@
       }
     }
   },
+  "unit_currency": {
+    "billion": "B",
+    "million": "M",
+    "thousand": "K",
+    "trillion": "T"
+  },
   "unit_tooltips": {
     "core-hours": "{{value}} core-hours",
     "gb": "{{value}} GB",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -367,6 +367,12 @@
     "warning_sources": "Cannot assign cost model to a source that is already assigned to another one"
   },
   "cumulative_cost": "Cumulative cost",
+  "currency_abbreviations": {
+    "billion": "B",
+    "million": "M",
+    "thousand": "K",
+    "trillion": "T"
+  },
   "dashboard": {
     "total_cost_tooltip": "This total cost is the sum of the infrastructure cost {{infrastructureCost}} and supplementary cost {{supplementaryCost}}",
     "widget_subtitle": "{{startDate}} $t(months.{{month}})",
@@ -970,12 +976,6 @@
         "ocp": "Red Hat OpenShift Container Platform"
       }
     }
-  },
-  "unit_currency": {
-    "billion": "B",
-    "million": "M",
-    "thousand": "K",
-    "trillion": "T"
   },
   "unit_tooltips": {
     "core-hours": "{{value}} core-hours",

--- a/src/utils/formatValue.ts
+++ b/src/utils/formatValue.ts
@@ -1,3 +1,5 @@
+import i18next from 'i18next';
+
 export interface FormatOptions {
   fractionDigits?: number;
 }
@@ -62,6 +64,48 @@ export const formatCurrency: ValueFormatter = (value, unit, { fractionDigits = 2
     style: 'currency',
     currency: unit || 'USD',
     minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  });
+};
+
+export const formatCurrencyAbbreviation: ValueFormatter = (value, unit, { fractionDigits = 2 } = {}) => {
+  let fValue = value;
+  if (!value) {
+    fValue = 0;
+  }
+
+  // Derived from https://stackoverflow.com/questions/37799955/how-can-i-format-big-numbers-with-tolocalestring
+  const abbreviationFormats = [
+    { val: 1e12, symbol: 'unit_currency.trillion' },
+    { val: 1e9, symbol: 'unit_currency.billion' },
+    { val: 1e6, symbol: 'unit_currency.million' },
+    { val: 1e3, symbol: 'unit_currency.thousand' },
+  ];
+
+  // Find the proper format to use
+  let format;
+  if (abbreviationFormats != null) {
+    format = abbreviationFormats.find(f => fValue >= f.val);
+  }
+
+  // Apply format and insert symbol next to the numeric portion of the formatted string
+  if (format != null) {
+    const { val, symbol } = format;
+    const formatted = (fValue / val).toLocaleString('en', {
+      style: 'currency',
+      currency: unit || 'USD',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: fractionDigits,
+    });
+    const parts = formatted.match(/([\D]*)([\d.,]+)([\D]*)/);
+    return `${parts[1]}${parts[2]}${i18next.t(symbol)}${parts[3]}`;
+  }
+
+  // If no format was found, format value without abbreviation
+  return fValue.toLocaleString('en', {
+    style: 'currency',
+    currency: unit || 'USD',
+    minimumFractionDigits: 0,
     maximumFractionDigits: fractionDigits,
   });
 };

--- a/src/utils/formatValue.ts
+++ b/src/utils/formatValue.ts
@@ -76,10 +76,10 @@ export const formatCurrencyAbbreviation: ValueFormatter = (value, unit, { fracti
 
   // Derived from https://stackoverflow.com/questions/37799955/how-can-i-format-big-numbers-with-tolocalestring
   const abbreviationFormats = [
-    { val: 1e12, symbol: 'unit_currency.trillion' },
-    { val: 1e9, symbol: 'unit_currency.billion' },
-    { val: 1e6, symbol: 'unit_currency.million' },
-    { val: 1e3, symbol: 'unit_currency.thousand' },
+    { val: 1e12, symbol: 'currency_abbreviations.trillion' },
+    { val: 1e9, symbol: 'currency_abbreviations.billion' },
+    { val: 1e6, symbol: 'currency_abbreviations.million' },
+    { val: 1e3, symbol: 'currency_abbreviations.thousand' },
   ];
 
   // Find the proper format to use


### PR DESCRIPTION
This formats the chart's y-axis labels using big number abbreviations.

- K for Thousands
- M for Millions
- B for Billions
- T for Trillion

https://issues.redhat.com/browse/COST-1087

**Before:**
<img width="388" alt="y-axis labels" src="https://user-images.githubusercontent.com/17481322/108920213-471c9600-7602-11eb-9aaa-52c8fea22b28.png">

**After:**
<img width="359" alt="Screen Shot 2021-02-23 at 6 09 42 PM" src="https://user-images.githubusercontent.com/17481322/108920434-a37fb580-7602-11eb-98da-b8dbb7d7f607.png">

