### PR TITLE
Historical Cost Explorer domain

### DIFF
--- a/src/components/charts/historicalExplorerChart/historicalExplorerChart.tsx
+++ b/src/components/charts/historicalExplorerChart/historicalExplorerChart.tsx
@@ -308,7 +308,7 @@ class HistoricalExplorerChart extends React.Component<HistoricalExplorerChartPro
     }
 
     if (maxValue <= 0) {
-      domain = { y: [0, 1] };
+      domain = { y: [0, 100] };
     }
     return domain;
   };


### PR DESCRIPTION
Modified the explorer chart's default domain range. The previous y-axis labels appear odd when all data series are hidden via the interactive legend.

Before
<img width="715" alt="before" src="https://user-images.githubusercontent.com/17481322/108944077-0d5e8600-7628-11eb-94eb-29c5208e68e3.png">

After
<img width="695" alt="Screen Shot 2021-02-23 at 10 37 16 PM" src="https://user-images.githubusercontent.com/17481322/108944084-12233a00-7628-11eb-8938-512acf32d3d6.png">
