### PR TITLE
combined duplicates keys to one key value pair

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -777,6 +777,9 @@
     "desc": "Sorry, no rates related to cluster {{cluster}} were set.",
     "title": "No rates found"
   },
+  "ocp": {
+    "daily_usage_request_comparison": "Daily usage and requests comparison ({{units}})"
+  },
   "ocp_cloud_dashboard": {
     "compute_title": "Compute services usage",
     "cost_title": "All cloud filtered by OpenShift cost",
@@ -792,14 +795,11 @@
     "cost_title": "All OpenShift cost",
     "cost_trend_title": "All OpenShift cumulative cost comparison ({{units}})",
     "cpu_title": "CPU usage and requests",
-    "cpu_trend_title": "Daily usage and requests comparison ({{units}})",
     "daily_cost_trend_title": "All OpenShift daily cost comparison ({{units}})",
     "memory_title": "Memory usage and requests",
-    "memory_trend_title": "Daily usage and requests comparison ({{units}})",
     "requests_label": "Requests",
     "usage_label": "Usage",
-    "volume_title": "Volume usage and requests",
-    "volume_trend_title": "Daily usage and requests comparison ({{units}})"
+    "volume_title": "Volume usage and requests"
   },
   "ocp_details": {
     "change_column_title": "Month over month change",
@@ -820,26 +820,20 @@
     "cost_title": "OpenShift supplementary cost",
     "cost_trend_title": "OpenShift cumulative supplementary cost comparison ({{units}})",
     "cpu_title": "CPU usage and requests",
-    "cpu_trend_title": "Daily usage and requests comparison ({{units}})",
     "daily_cost_trend_title": "OpenShift daily supplementary cost comparison ({{units}})",
     "memory_title": "Memory usage and requests",
-    "memory_trend_title": "Daily usage and requests comparison ({{units}})",
     "requests_label": "Requests",
     "usage_label": "Usage",
-    "volume_title": "Volume usage and requests",
-    "volume_trend_title": "Daily usage and requests comparison ({{units}})"
+    "volume_title": "Volume usage and requests"
   },
   "ocp_usage_dashboard": {
     "cost_title": "OpenShift usage cost",
     "cost_trend_title": "Metering cumulative cost comparison ({{units}})",
     "cpu_title": "OpenShift CPU usage and requests",
-    "cpu_trend_title": "Daily usage and requests comparison ({{units}})",
     "memory_title": "OpenShift memory usage and requests",
-    "memory_trend_title": "Daily usage and requests comparison ({{units}})",
     "requests_label": "Requests",
     "usage_label": "Usage",
-    "volume_title": "OpenShift volume usage and requests",
-    "volume_trend_title": "Daily usage and requests comparison ({{units}})"
+    "volume_title": "OpenShift volume usage and requests"
   },
   "onboarding": {
     "type_label": "Type",

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -79,7 +79,7 @@ export const cpuWidget: OcpDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'ocp_dashboard.cpu_trend_title',
+    titleKey: 'daily_usage_request_comparison',
     type: ChartType.daily,
   },
   topItems: {
@@ -116,7 +116,7 @@ export const memoryWidget: OcpDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'ocp_dashboard.memory_trend_title',
+    titleKey: 'ocp.daily_usage_request_comparison',
     type: ChartType.daily,
   },
   topItems: {
@@ -153,7 +153,7 @@ export const volumeWidget: OcpDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'ocp_dashboard.volume_trend_title',
+    titleKey: 'ocp.daily_usage_request_comparison',
     type: ChartType.daily,
   },
   topItems: {

--- a/src/store/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidgets.ts
+++ b/src/store/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidgets.ts
@@ -74,7 +74,7 @@ export const cpuWidget: OcpSupplementaryDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'ocp_supplementary_dashboard.cpu_trend_title',
+    titleKey: 'ocp.daily_usage_request_comparison',
     type: ChartType.daily,
   },
   topItems: {
@@ -114,7 +114,7 @@ export const memoryWidget: OcpSupplementaryDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'ocp_supplementary_dashboard.memory_trend_title',
+    titleKey: 'ocp.daily_usage_request_comparison',
     type: ChartType.daily,
   },
   topItems: {
@@ -154,7 +154,7 @@ export const volumeWidget: OcpSupplementaryDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'ocp_supplementary_dashboard.volume_trend_title',
+    titleKey: 'ocp.daily_usage_request_comparison',
     type: ChartType.daily,
   },
   topItems: {

--- a/src/store/dashboard/ocpUsageDashboard/ocpUsageDashboardWidgets.ts
+++ b/src/store/dashboard/ocpUsageDashboard/ocpUsageDashboardWidgets.ts
@@ -65,7 +65,7 @@ export const cpuWidget: OcpUsageDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'ocp_usage_dashboard.cpu_trend_title',
+    titleKey: 'ocp.daily_usage_request_comparison',
     type: ChartType.daily,
   },
   chartType: DashboardChartType.usage,
@@ -97,7 +97,7 @@ export const memoryWidget: OcpUsageDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'ocp_usage_dashboard.memory_trend_title',
+    titleKey: 'ocp.daily_usage_request_comparison',
     type: ChartType.daily,
   },
   chartType: DashboardChartType.usage,
@@ -129,7 +129,7 @@ export const volumeWidget: OcpUsageDashboardWidget = {
     formatOptions: {
       fractionDigits: 2,
     },
-    titleKey: 'ocp_usage_dashboard.volume_trend_title',
+    titleKey: 'ocp.daily_usage_request_comparison',
     type: ChartType.daily,
   },
   chartType: DashboardChartType.usage,


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/COST-727

Old Keys:
"Daily usage and requests comparison ({{units}})"                          [Found: 9]
- 	FOUND IN KEY: ocp_usage_dashboard.cpu_trend_title
- 	FOUND IN KEY: ocp_supplementary_dashboard.cpu_trend_title
- 	FOUND IN KEY: ocp_dashboard.memory_trend_title
- 	FOUND IN KEY: ocp_supplementary_dashboard.volume_trend_title
- 	FOUND IN KEY: ocp_supplementary_dashboard.memory_trend_title
- 	FOUND IN KEY: ocp_usage_dashboard.memory_trend_title
- 	FOUND IN KEY: ocp_dashboard.cpu_trend_title
- 	FOUND IN KEY: ocp_dashboard.volume_trend_title
- 	FOUND IN KEY: ocp_usage_dashboard.volume_trend_title

New Key:
- ocp.daily_usage_request_comparison