### PR TITLE
Fix no data state for explorer

### DIFF
--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -445,9 +445,9 @@ class Explorer extends React.Component<ExplorerProps> {
       return <NoProviders title={title} />;
     } else if (
       !(
-        this.hasCurrentMonthData(awsProviders) &&
-        this.hasCurrentMonthData(azureProviders) &&
-        this.hasCurrentMonthData(gcpProviders) &&
+        this.hasCurrentMonthData(awsProviders) ||
+        this.hasCurrentMonthData(azureProviders) ||
+        this.hasCurrentMonthData(gcpProviders) ||
         this.hasCurrentMonthData(ocpProviders)
       )
     ) {


### PR DESCRIPTION
The Historical Cost Explorer is showing the no data state incorrectly. If there is at least one source provider, then we can show the explorer

<img width="1748" alt="Screen Shot 2021-03-01 at 9 46 13 AM" src="https://user-images.githubusercontent.com/17481322/109523984-f7b0ec80-7a7d-11eb-9ccd-8c7f00a9d634.png">
