### PR TITLE
Preserve applied filter

### DIFF
--- a/src/pages/views/details/awsDetails/awsDetails.tsx
+++ b/src/pages/views/details/awsDetails/awsDetails.tsx
@@ -290,7 +290,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 
     const newQuery = {
       ...JSON.parse(JSON.stringify(query)),
-      filter_by: undefined,
+      // filter_by: undefined, // See https://issues.redhat.com/browse/COST-1090
       group_by: {
         [groupByKey]: value,
       },

--- a/src/pages/views/details/awsDetails/awsDetails.tsx
+++ b/src/pages/views/details/awsDetails/awsDetails.tsx
@@ -290,7 +290,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 
     const newQuery = {
       ...JSON.parse(JSON.stringify(query)),
-      // filter_by: undefined, // See https://issues.redhat.com/browse/COST-1090
+      // filter_by: undefined, // Preserve filter -- see https://issues.redhat.com/browse/COST-1090
       group_by: {
         [groupByKey]: value,
       },

--- a/src/pages/views/details/azureDetails/azureDetails.tsx
+++ b/src/pages/views/details/azureDetails/azureDetails.tsx
@@ -280,7 +280,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     const groupByKey: keyof AzureQuery['group_by'] = groupBy as any;
     const newQuery = {
       ...JSON.parse(JSON.stringify(query)),
-      filter_by: undefined,
+      // filter_by: undefined, // See https://issues.redhat.com/browse/COST-1090
       group_by: {
         [groupByKey]: '*',
       },

--- a/src/pages/views/details/azureDetails/azureDetails.tsx
+++ b/src/pages/views/details/azureDetails/azureDetails.tsx
@@ -280,7 +280,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     const groupByKey: keyof AzureQuery['group_by'] = groupBy as any;
     const newQuery = {
       ...JSON.parse(JSON.stringify(query)),
-      // filter_by: undefined, // See https://issues.redhat.com/browse/COST-1090
+      // filter_by: undefined, // Preserve filter -- see https://issues.redhat.com/browse/COST-1090
       group_by: {
         [groupByKey]: '*',
       },

--- a/src/pages/views/details/gcpDetails/gcpDetails.tsx
+++ b/src/pages/views/details/gcpDetails/gcpDetails.tsx
@@ -279,7 +279,7 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
     const groupByKey: keyof GcpQuery['group_by'] = groupBy as any;
     const newQuery = {
       ...JSON.parse(JSON.stringify(query)),
-      // filter_by: undefined, // See https://issues.redhat.com/browse/COST-1090
+      // filter_by: undefined, // Preserve filter -- see https://issues.redhat.com/browse/COST-1090
       group_by: {
         [groupByKey]: '*',
       },

--- a/src/pages/views/details/gcpDetails/gcpDetails.tsx
+++ b/src/pages/views/details/gcpDetails/gcpDetails.tsx
@@ -279,7 +279,7 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
     const groupByKey: keyof GcpQuery['group_by'] = groupBy as any;
     const newQuery = {
       ...JSON.parse(JSON.stringify(query)),
-      filter_by: undefined,
+      // filter_by: undefined, // See https://issues.redhat.com/browse/COST-1090
       group_by: {
         [groupByKey]: '*',
       },

--- a/src/pages/views/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/views/details/ocpDetails/ocpDetails.tsx
@@ -280,7 +280,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     const groupByKey: keyof OcpQuery['group_by'] = groupBy as any;
     const newQuery = {
       ...JSON.parse(JSON.stringify(query)),
-      // filter_by: undefined, // See https://issues.redhat.com/browse/COST-1090
+      // filter_by: undefined, // Preserve filter -- see https://issues.redhat.com/browse/COST-1090
       group_by: {
         [groupByKey]: '*',
       },

--- a/src/pages/views/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/views/details/ocpDetails/ocpDetails.tsx
@@ -280,7 +280,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     const groupByKey: keyof OcpQuery['group_by'] = groupBy as any;
     const newQuery = {
       ...JSON.parse(JSON.stringify(query)),
-      filter_by: undefined,
+      // filter_by: undefined, // See https://issues.redhat.com/browse/COST-1090
       group_by: {
         [groupByKey]: '*',
       },

--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -297,7 +297,7 @@ class Explorer extends React.Component<ExplorerProps> {
 
     const newQuery = {
       ...JSON.parse(JSON.stringify(query)),
-      // filter_by: undefined, // See https://issues.redhat.com/browse/COST-1090
+      // filter_by: undefined, // Preserve filter -- see https://issues.redhat.com/browse/COST-1090
       group_by: {
         [groupByKey]: value,
       },
@@ -381,13 +381,14 @@ class Explorer extends React.Component<ExplorerProps> {
   };
 
   private updateReport = () => {
-    const { perspective, fetchReport, history, location, query, queryString } = this.props;
+    const { dateRange, fetchReport, history, location, perspective, query, queryString } = this.props;
     if (!location.search) {
       history.replace(
         getRouteForQuery(history, {
           filter_by: query ? query.filter_by : undefined,
           group_by: query ? query.group_by : undefined,
           order_by: { cost: 'desc' },
+          dateRange, // Preserve date range
         })
       );
     } else {

--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -297,7 +297,7 @@ class Explorer extends React.Component<ExplorerProps> {
 
     const newQuery = {
       ...JSON.parse(JSON.stringify(query)),
-      filter_by: undefined,
+      // filter_by: undefined, // See https://issues.redhat.com/browse/COST-1090
       group_by: {
         [groupByKey]: value,
       },

--- a/src/pages/views/explorer/explorerFilter.tsx
+++ b/src/pages/views/explorer/explorerFilter.tsx
@@ -89,7 +89,6 @@ export class ExplorerFilterBase extends React.Component<ExplorerFilterProps> {
     const {
       fetchOrg,
       fetchTag,
-      groupBy,
       orgReport,
       orgReportPathsType,
       perspective,
@@ -112,7 +111,8 @@ export class ExplorerFilterBase extends React.Component<ExplorerFilterProps> {
         categoryOptions: this.getCategoryOptions(),
       });
     }
-    if (prevProps.groupBy !== groupBy || prevProps.perspective !== perspective) {
+    // Preserve filter -- see https://issues.redhat.com/browse/COST-1090
+    if (prevProps.perspective !== perspective) {
       this.handleDateRangeClick(dateRangeOptions[0].value);
     }
   }


### PR DESCRIPTION
This preserves the applied filter when the "Group by" dropdown is changed. This includes the details pages as well as the cost explorer.

https://issues.redhat.com/browse/COST-1090

![chrome-capture](https://user-images.githubusercontent.com/17481322/109692253-4cc03180-7b56-11eb-8481-8b9a4614be7f.gif)
