### PR TITLE
Fix chart null (no data) padding

### DIFF
--- a/src/components/charts/common/chartDatumUtils.ts
+++ b/src/components/charts/common/chartDatumUtils.ts
@@ -157,7 +157,7 @@ export function createForecastDatum<T extends ComputedForecastItem>(
   forecastItem: string = 'cost',
   forecastItemValue: string = 'total'
 ): ChartDatum {
-  const xVal = getDate(new Date(computedItem.date));
+  const xVal = getDate(new Date(computedItem.date + 'T00:00:00'));
   const yVal = isFloat(value) ? parseFloat(value.toFixed(2)) : isInt(value) ? value : 0;
   return {
     x: xVal,
@@ -177,7 +177,7 @@ export function createForecastConeDatum<T extends ComputedForecastItem>(
   forecastItem: string = 'cost',
   forecastItemValue: string = 'total'
 ): ChartDatum {
-  const xVal = getDate(new Date(computedItem.date));
+  const xVal = getDate(new Date(computedItem.date + 'T00:00:00'));
   const yVal = isFloat(maxValue) ? parseFloat(maxValue.toFixed(2)) : isInt(maxValue) ? maxValue : 0;
   const y0Val = isFloat(minValue) ? parseFloat(minValue.toFixed(2)) : isInt(minValue) ? minValue : 0;
   return {
@@ -199,7 +199,7 @@ export function createReportDatum<T extends ComputedReportItem>(
   reportItem: string = 'cost',
   reportItemValue: string = 'total' // useful for infrastructure.usage values
 ): ChartDatum {
-  const xVal = idKey === 'date' ? getDate(new Date(computedItem.id)) : computedItem.label;
+  const xVal = idKey === 'date' ? getDate(new Date(computedItem.id + 'T00:00:00')) : computedItem.label;
   const yVal = isFloat(value) ? parseFloat(value.toFixed(2)) : isInt(value) ? value : 0;
   return {
     x: xVal,
@@ -234,7 +234,7 @@ export function fillChartDatums(datums: ChartDatum[], type: ChartType = ChartTyp
       result.push({
         ...prevChartDatum,
         key: id,
-        x: getDate(new Date(id)),
+        x: getDate(new Date(id + 'T00:00:00')),
       });
     }
     if (chartDatum) {
@@ -244,7 +244,7 @@ export function fillChartDatums(datums: ChartDatum[], type: ChartType = ChartTyp
       if (type === ChartType.daily) {
         prevChartDatum = {
           key: id,
-          x: getDate(new Date(id)),
+          x: getDate(new Date(id + 'T00:00:00')),
           y: null,
         };
       } else {


### PR DESCRIPTION
Charts are not padding missing data correctly. It appears that some dates don't use 'T00:00:00', so the chart's null ("no data") values are off by a day.

https://issues.redhat.com/browse/COST-1106

Before
<img width="1154" alt="before" src="https://user-images.githubusercontent.com/17481322/109827203-8736d680-7c09-11eb-88bb-2d7862e775c4.png">

After
<img width="1160" alt="Screen Shot 2021-03-03 at 10 16 42 AM" src="https://user-images.githubusercontent.com/17481322/109827280-94ec5c00-7c09-11eb-8518-42d6290b91ea.png">
