### PR TITLE
Omit negative chart data

### DIFF
--- a/src/components/charts/common/chartDatumUtils.ts
+++ b/src/components/charts/common/chartDatumUtils.ts
@@ -477,11 +477,11 @@ export function getUsageRangeString(
 // Returns true if non negative integer
 export function isInt(n) {
   const result = Number(n) === n && n % 1 === 0;
-  return result && n > 0;
+  return result && n >= 0;
 }
 
 // Returns true if non negative float
 export function isFloat(n) {
   const result = Number(n) === n && n % 1 !== 0;
-  return result && n > 0;
+  return result && n >= 0;
 }

--- a/src/components/charts/common/chartDatumUtils.ts
+++ b/src/components/charts/common/chartDatumUtils.ts
@@ -474,10 +474,14 @@ export function getUsageRangeString(
   return getCostRangeString(datums, key, firstOfMonth, lastOfMonth, offset);
 }
 
+// Returns true if non negative integer
 export function isInt(n) {
-  return Number(n) === n && n % 1 === 0;
+  const result = Number(n) === n && n % 1 === 0;
+  return result && n > 0;
 }
 
+// Returns true if non negative float
 export function isFloat(n) {
-  return Number(n) === n && n % 1 !== 0;
+  const result = Number(n) === n && n % 1 !== 0;
+  return result && n > 0;
 }


### PR DESCRIPTION
The cost-demo user in production is retrieving negative forecast values. As a result, data is being shown outside the chart's y-domain.

Although the forecast API is not expected to return negative values, we can ensure data is shown only for the chart's valid domain. That is, if we encounter negative values, our ChartDatumUtils can replace that with zero instead.

https://issues.redhat.com/browse/COST-1109

**Before**
<img width="1157" alt="before" src="https://user-images.githubusercontent.com/17481322/109855280-118d3380-7c26-11eb-9001-464b25750c76.png">

**After**
<img width="1145" alt="after" src="https://user-images.githubusercontent.com/17481322/109855272-0e924300-7c26-11eb-8fcf-256008f956b1.png">
