### PR TITLE
Cost Explorer shows 31 and 61 days

### DIFF
--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -156,13 +156,13 @@ export const getDateRange = queryFromRoute => {
       start_date = format(startOfMonth(today), 'yyyy-MM-dd');
       break;
     case DateRangeType.lastSixtyDays:
-      // 60 days, including today's date
-      today.setDate(today.getDate() - 59);
+      // 61 days, including today's date. See https://issues.redhat.com/browse/COST-1117
+      today.setDate(today.getDate() - 60);
       start_date = format(today, 'yyyy-MM-dd');
       break;
     case DateRangeType.lastThirtyDays:
-      // 30 days, including today's date
-      today.setDate(today.getDate() - 29);
+      // 31 days, including today's date. See https://issues.redhat.com/browse/COST-1117
+      today.setDate(today.getDate() - 30);
       start_date = format(today, 'yyyy-MM-dd');
       break;
     case DateRangeType.currentMonthToDate:

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -156,11 +156,13 @@ export const getDateRange = queryFromRoute => {
       start_date = format(startOfMonth(today), 'yyyy-MM-dd');
       break;
     case DateRangeType.lastSixtyDays:
-      today.setDate(today.getDate() - 60);
+      // 60 days, including today's date
+      today.setDate(today.getDate() - 59);
       start_date = format(today, 'yyyy-MM-dd');
       break;
     case DateRangeType.lastThirtyDays:
-      today.setDate(today.getDate() - 30);
+      // 30 days, including today's date
+      today.setDate(today.getDate() - 29);
       start_date = format(today, 'yyyy-MM-dd');
       break;
     case DateRangeType.currentMonthToDate:


### PR DESCRIPTION
~~The explorer's "Last 30 days" and "Last 60 days" features are showing 31 and 61 days. If we include today's date, then we need to subtract 29 and 59 days from today, instead.~~

After looking at more examples, I believe the current calculations are correct. I'm going to revert the change an update comments instead.

https://issues.redhat.com/browse/COST-1117