### PR TITLE
Add filter to OCP breakdown compute & memory charts

### DIFF
--- a/src/pages/views/details/components/costOverview/costOverviewBase.tsx
+++ b/src/pages/views/details/components/costOverview/costOverviewBase.tsx
@@ -110,7 +110,7 @@ class CostOverviewBase extends React.Component<CostOverviewProps> {
 
   // Returns CPU usage chart
   private getCpuUsageChart = (widget: CostOverviewWidget) => {
-    const { filterBy, groupBy, t } = this.props;
+    const { t } = this.props;
 
     return (
       <Card>
@@ -120,12 +120,7 @@ class CostOverviewBase extends React.Component<CostOverviewProps> {
           </Title>
         </CardTitle>
         <CardBody>
-          <UsageChart
-            groupBy={filterBy}
-            parentGroupBy={groupBy}
-            reportPathsType={widget.reportPathsType}
-            reportType={widget.reportType}
-          />
+          <UsageChart reportPathsType={widget.reportPathsType} reportType={widget.reportType} />
         </CardBody>
       </Card>
     );
@@ -133,7 +128,7 @@ class CostOverviewBase extends React.Component<CostOverviewProps> {
 
   // Returns memory usage chart
   private getMemoryUsageChart = (widget: CostOverviewWidget) => {
-    const { filterBy, groupBy, t } = this.props;
+    const { t } = this.props;
 
     return (
       <Card>
@@ -143,12 +138,7 @@ class CostOverviewBase extends React.Component<CostOverviewProps> {
           </Title>
         </CardTitle>
         <CardBody>
-          <UsageChart
-            groupBy={filterBy}
-            parentGroupBy={groupBy}
-            reportPathsType={widget.reportPathsType}
-            reportType={widget.reportType}
-          />
+          <UsageChart reportPathsType={widget.reportPathsType} reportType={widget.reportType} />
         </CardBody>
       </Card>
     );
@@ -173,9 +163,9 @@ class CostOverviewBase extends React.Component<CostOverviewProps> {
       return (
         <SummaryCard
           filterBy={filterBy}
-          groupBy={widget.reportSummary.reportGroupBy}
-          parentGroupBy={groupBy}
+          groupBy={groupBy}
           query={query}
+          reportGroupBy={widget.reportSummary.reportGroupBy}
           reportPathsType={widget.reportPathsType}
           reportType={widget.reportType}
         />

--- a/src/pages/views/details/components/summary/summaryCard.tsx
+++ b/src/pages/views/details/components/summary/summaryCard.tsx
@@ -183,13 +183,13 @@ const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps
         time_scope_units: 'month',
         time_scope_value: -1,
         resolution: 'monthly',
-        [groupBy]: filterBy,
+        [groupBy]: filterBy, // Other "filter_by"s must be applied here
         ...(query && query.filter && query.filter.account && { account: query.filter.account }),
       },
       filter_by: query ? query.filter_by : undefined,
       group_by: {
         ...(groupByOrg && ({ [orgUnitIdKey]: groupByOrg } as any)),
-        ...(reportGroupBy && { [reportGroupBy]: '*' }), // For specific summary cards; account, project, etc.
+        ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.
       },
     };
     const queryString = getQuery(newQuery);

--- a/src/pages/views/details/components/summary/summaryCard.tsx
+++ b/src/pages/views/details/components/summary/summaryCard.tsx
@@ -28,8 +28,8 @@ import { styles } from './summaryCard.styles';
 interface SummaryOwnProps {
   filterBy: string | number;
   groupBy: string;
-  parentGroupBy: string;
   query?: Query;
+  reportGroupBy?: string;
   reportPathsType: ReportPathsType;
   reportType: ReportType;
 }
@@ -68,19 +68,19 @@ class SummaryBase extends React.Component<SummaryProps> {
   }
 
   private getItems = () => {
-    const { groupBy, report } = this.props;
+    const { report, reportGroupBy } = this.props;
 
     const computedItems = getComputedReportItems({
       report,
-      idKey: groupBy as any,
+      idKey: reportGroupBy as any,
     });
     return computedItems;
   };
 
   private getSummary = () => {
-    const { groupBy, report, reportFetchStatus } = this.props;
+    const { report, reportGroupBy, reportFetchStatus } = this.props;
     return (
-      <ReportSummaryItems idKey={groupBy as any} report={report} status={reportFetchStatus}>
+      <ReportSummaryItems idKey={reportGroupBy as any} report={report} status={reportFetchStatus}>
         {({ items }) =>
           items.map(reportItem => (
             <ReportSummaryItem
@@ -99,7 +99,7 @@ class SummaryBase extends React.Component<SummaryProps> {
   };
 
   private getViewAll = () => {
-    const { filterBy, groupBy, parentGroupBy, query, reportPathsType, t } = this.props;
+    const { filterBy, groupBy, query, reportGroupBy, reportPathsType, t } = this.props;
     const { isBulletChartModalOpen } = this.state;
 
     const computedItems = this.getItems();
@@ -119,15 +119,15 @@ class SummaryBase extends React.Component<SummaryProps> {
             type={ButtonType.button}
             variant={ButtonVariant.link}
           >
-            {t('details.view_all', { groupBy })}
+            {t('details.view_all', { groupBy: reportGroupBy })}
           </Button>
           <SummaryModal
             filterBy={filterBy}
             groupBy={groupBy}
             isOpen={isBulletChartModalOpen}
             onClose={this.handleBulletChartModalClose}
-            parentGroupBy={parentGroupBy}
             query={query}
+            reportGroupBy={reportGroupBy}
             reportPathsType={reportPathsType}
           />
         </div>
@@ -147,13 +147,13 @@ class SummaryBase extends React.Component<SummaryProps> {
   };
 
   public render() {
-    const { groupBy, reportFetchStatus, t } = this.props;
+    const { reportGroupBy, reportFetchStatus, t } = this.props;
 
     return (
       <Card style={styles.card}>
         <CardTitle>
           <Title headingLevel="h2" size="lg">
-            {t('breakdown.summary_title', { groupBy })}
+            {t('breakdown.summary_title', { groupBy: reportGroupBy })}
           </Title>
         </CardTitle>
         <CardBody>
@@ -175,7 +175,7 @@ class SummaryBase extends React.Component<SummaryProps> {
 }
 
 const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps>(
-  (state, { filterBy, groupBy, parentGroupBy, query, reportPathsType, reportType }) => {
+  (state, { filterBy, groupBy, query, reportGroupBy, reportPathsType, reportType }) => {
     const groupByOrg = query && query.group_by[orgUnitIdKey] ? query.group_by[orgUnitIdKey] : undefined;
     const newQuery: Query = {
       filter: {
@@ -183,13 +183,13 @@ const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps
         time_scope_units: 'month',
         time_scope_value: -1,
         resolution: 'monthly',
-        [parentGroupBy]: filterBy,
+        [groupBy]: filterBy,
         ...(query && query.filter && query.filter.account && { account: query.filter.account }),
       },
       filter_by: query ? query.filter_by : undefined,
       group_by: {
         ...(groupByOrg && ({ [orgUnitIdKey]: groupByOrg } as any)),
-        ...(groupBy && { [groupBy]: '*' }),
+        ...(reportGroupBy && { [reportGroupBy]: '*' }), // For specific summary cards; account, project, etc.
       },
     };
     const queryString = getQuery(newQuery);

--- a/src/pages/views/details/components/summary/summaryModal.tsx
+++ b/src/pages/views/details/components/summary/summaryModal.tsx
@@ -13,8 +13,8 @@ interface SummaryModalOwnProps {
   groupBy: string;
   isOpen: boolean;
   onClose(isOpen: boolean);
-  parentGroupBy: string;
   query?: Query;
+  reportGroupBy?: string;
   reportPathsType: ReportPathsType;
 }
 
@@ -36,7 +36,7 @@ class SummaryModalBase extends React.Component<SummaryModalProps> {
   };
 
   public render() {
-    const { filterBy, groupBy, isOpen, parentGroupBy, query, reportPathsType, t } = this.props;
+    const { filterBy, groupBy, isOpen, query, reportGroupBy, reportPathsType, t } = this.props;
 
     return (
       <Modal
@@ -44,7 +44,7 @@ class SummaryModalBase extends React.Component<SummaryModalProps> {
         isOpen={isOpen}
         onClose={this.handleClose}
         title={t('details.summary_modal_title', {
-          groupBy,
+          groupBy: reportGroupBy,
           name: filterBy,
         })}
         variant="large"
@@ -52,8 +52,8 @@ class SummaryModalBase extends React.Component<SummaryModalProps> {
         <SummaryModalView
           filterBy={filterBy}
           groupBy={groupBy}
-          parentGroupBy={parentGroupBy}
           query={query}
+          reportGroupBy={reportGroupBy}
           reportPathsType={reportPathsType}
         />
       </Modal>

--- a/src/pages/views/details/components/summary/summaryModalView.tsx
+++ b/src/pages/views/details/components/summary/summaryModalView.tsx
@@ -96,13 +96,13 @@ const mapStateToProps = createMapStateToProps<SummaryModalViewOwnProps, SummaryM
         time_scope_units: 'month',
         time_scope_value: -1,
         resolution: 'monthly',
-        [groupBy]: filterBy,
+        [groupBy]: filterBy, // Other "filter_by"s must be applied here
         ...(query && query.filter && query.filter.account && { account: query.filter.account }),
       },
       filter_by: query ? query.filter_by : undefined,
       group_by: {
         ...(groupByOrg && ({ [orgUnitIdKey]: groupByOrg } as any)),
-        ...(reportGroupBy && { [reportGroupBy]: '*' }), // For specific summary cards; account, project, etc.
+        ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.
       },
     };
     const queryString = getQuery(newQuery);

--- a/src/pages/views/details/components/summary/summaryModalView.tsx
+++ b/src/pages/views/details/components/summary/summaryModalView.tsx
@@ -15,8 +15,8 @@ import { styles } from './summaryModal.styles';
 interface SummaryModalViewOwnProps {
   filterBy: string | number;
   groupBy: string;
-  parentGroupBy: string;
   query?: Query;
+  reportGroupBy?: string;
   reportPathsType: ReportPathsType;
 }
 
@@ -55,7 +55,7 @@ class SummaryModalViewBase extends React.Component<SummaryModalViewProps> {
   }
 
   public render() {
-    const { groupBy, report, reportFetchStatus, t } = this.props;
+    const { report, reportGroupBy, reportFetchStatus, t } = this.props;
 
     const cost = formatCurrency(report && report.meta && report.meta.total ? report.meta.total.cost.total.value : 0);
 
@@ -67,7 +67,7 @@ class SummaryModalViewBase extends React.Component<SummaryModalViewProps> {
           </Title>
         </div>
         <div style={styles.mainContent}>
-          <ReportSummaryItems idKey={groupBy as any} report={report} status={reportFetchStatus}>
+          <ReportSummaryItems idKey={reportGroupBy as any} report={report} status={reportFetchStatus}>
             {({ items }) =>
               items.map(_item => (
                 <ReportSummaryItem
@@ -89,20 +89,20 @@ class SummaryModalViewBase extends React.Component<SummaryModalViewProps> {
 }
 
 const mapStateToProps = createMapStateToProps<SummaryModalViewOwnProps, SummaryModalViewStateProps>(
-  (state, { filterBy, groupBy, parentGroupBy, query, reportPathsType }) => {
+  (state, { filterBy, groupBy, query, reportGroupBy, reportPathsType }) => {
     const groupByOrg = query && query.group_by[orgUnitIdKey] ? query.group_by[orgUnitIdKey] : undefined;
     const newQuery: Query = {
       filter: {
         time_scope_units: 'month',
         time_scope_value: -1,
         resolution: 'monthly',
-        [parentGroupBy]: filterBy,
+        [groupBy]: filterBy,
         ...(query && query.filter && query.filter.account && { account: query.filter.account }),
       },
       filter_by: query ? query.filter_by : undefined,
       group_by: {
         ...(groupByOrg && ({ [orgUnitIdKey]: groupByOrg } as any)),
-        ...(groupBy && { [groupBy]: '*' }),
+        ...(reportGroupBy && { [reportGroupBy]: '*' }), // For specific summary cards; account, project, etc.
       },
     };
     const queryString = getQuery(newQuery);

--- a/src/pages/views/details/components/summary/summaryView.tsx
+++ b/src/pages/views/details/components/summary/summaryView.tsx
@@ -20,7 +20,7 @@ import { SummaryModalViewProps } from './summaryModalView';
 interface SummaryViewOwnProps {
   filterBy: string | number;
   groupBy: string;
-  parentGroupBy: string;
+  reportGroupBy: string;
   reportPathsType: ReportPathsType;
 }
 
@@ -61,11 +61,11 @@ class SummaryViewBase extends React.Component<SummaryViewProps> {
   }
 
   private getItems = () => {
-    const { groupBy, report } = this.props;
+    const { report, reportGroupBy } = this.props;
 
     const computedItems = getComputedReportItems({
       report,
-      idKey: groupBy as any,
+      idKey: reportGroupBy as any,
     });
     return computedItems;
   };
@@ -87,7 +87,7 @@ class SummaryViewBase extends React.Component<SummaryViewProps> {
   };
 
   private getViewAll = () => {
-    const { filterBy, groupBy, parentGroupBy, reportPathsType, t } = this.props;
+    const { filterBy, groupBy, reportGroupBy, reportPathsType, t } = this.props;
     const { isSummaryModalOpen } = this.state;
     const computedItems = this.getItems();
 
@@ -107,14 +107,14 @@ class SummaryViewBase extends React.Component<SummaryViewProps> {
             type={ButtonType.button}
             variant={ButtonVariant.link}
           >
-            {t('details.view_all', { groupBy })}
+            {t('details.view_all', { groupBy: reportGroupBy })}
           </Button>
           <SummaryModal
             filterBy={filterBy}
             groupBy={groupBy}
             isOpen={isSummaryModalOpen}
             onClose={this.handleSummaryModalClose}
-            parentGroupBy={parentGroupBy}
+            reportGroupBy={reportGroupBy}
             reportPathsType={reportPathsType}
           />
         </div>
@@ -134,7 +134,7 @@ class SummaryViewBase extends React.Component<SummaryViewProps> {
   };
 
   public render() {
-    const { groupBy, report, reportFetchStatus } = this.props;
+    const { report, reportGroupBy, reportFetchStatus } = this.props;
 
     return (
       <>
@@ -149,8 +149,8 @@ class SummaryViewBase extends React.Component<SummaryViewProps> {
           <>
             <div style={styles.tabs}>
               <ReportSummaryItems
-                idKey={groupBy as any}
-                key={`${groupBy}-items`}
+                idKey={reportGroupBy as any}
+                key={`${reportGroupBy}-items`}
                 report={report}
                 status={reportFetchStatus}
               >
@@ -166,16 +166,16 @@ class SummaryViewBase extends React.Component<SummaryViewProps> {
 }
 
 const mapStateToProps = createMapStateToProps<SummaryViewOwnProps, SummaryViewStateProps>(
-  (state, { filterBy, groupBy, parentGroupBy, reportPathsType }) => {
+  (state, { filterBy, groupBy, reportGroupBy, reportPathsType }) => {
     const query: Query = {
       filter: {
         limit: 3,
         time_scope_units: 'month',
         time_scope_value: -1,
         resolution: 'monthly',
-        [parentGroupBy]: filterBy,
+        [groupBy]: filterBy,
       },
-      group_by: { [groupBy]: '*' },
+      group_by: { [reportGroupBy]: '*' }, // For specific summary cards; account, project, etc.
     };
     const queryString = getQuery(query);
     const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);

--- a/src/pages/views/details/components/summary/summaryView.tsx
+++ b/src/pages/views/details/components/summary/summaryView.tsx
@@ -173,9 +173,9 @@ const mapStateToProps = createMapStateToProps<SummaryViewOwnProps, SummaryViewSt
         time_scope_units: 'month',
         time_scope_value: -1,
         resolution: 'monthly',
-        [groupBy]: filterBy,
+        [groupBy]: filterBy, // Other "filter_by"s must be applied here
       },
-      group_by: { [reportGroupBy]: '*' }, // For specific summary cards; account, project, etc.
+      group_by: { [reportGroupBy]: '*' }, // Group by specific account, project, etc.
     };
     const queryString = getQuery(query);
     const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);

--- a/src/pages/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/pages/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -51,6 +51,11 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
   const newQuery: Query = {
     ...query,
     ...{ [breakdownDescKey]: undefined },
+    filter: {
+      ...query.filter,
+      limit: undefined, // Not necessary
+      offset: undefined, // Not necessary
+    },
   };
   const queryString = getQuery(newQuery);
 


### PR DESCRIPTION
This ensures that bullet chart ,shown on the details breakdown page, includes the filter applied via the previous page.

https://issues.redhat.com/browse/COST-1128

<img width="1628" alt="Screen Shot 2021-03-08 at 1 47 27 AM" src="https://user-images.githubusercontent.com/17481322/110284789-47c50d00-7fb0-11eb-9bb6-84386091566e.png">


