### PR TITLE
Incorrect data with multiple filters

### DIFF
--- a/src/pages/views/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/pages/views/details/awsBreakdown/awsBreakdown.tsx
@@ -45,23 +45,20 @@ const reportPathsType = ReportPathsType.aws;
 const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdownStateProps>((state, props) => {
   const queryFromRoute = parseQuery<AwsQuery>(location.search);
   const query = queryFromRoute;
-  const filterBy = getGroupByValue(query);
   const groupBy = getGroupById(query);
+  const groupByValue = getGroupByValue(query);
   const groupByOrg = query && query.group_by && query.group_by[orgUnitIdKey] ? query.group_by[orgUnitIdKey] : undefined;
 
   const newQuery: Query = {
     filter: {
+      resolution: 'monthly',
       time_scope_units: 'month',
       time_scope_value: -1,
-      resolution: 'monthly',
-      limit: 3,
       ...(query && query.filter && query.filter.account && { ['account']: query.filter.account }),
-    },
-    filter_by: query ? query.filter_by : undefined,
-    group_by: {
+      ...(groupBy && { [groupBy]: groupByValue }), // details page "group_by" must be applied here
       ...(groupByOrg && ({ [orgUnitIdKey]: groupByOrg } as any)),
-      ...(groupBy && { [groupBy]: filterBy }),
     },
+    ...(query && query.filter_by && { filter_by: query.filter_by }),
   };
   const queryString = getQuery(newQuery);
 
@@ -78,13 +75,13 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
   );
 
   return {
-    costOverviewComponent: <CostOverview filterBy={filterBy} groupBy={groupBy} query={query} report={report} />,
+    costOverviewComponent: <CostOverview groupBy={groupBy} groupByValue={groupByValue} query={query} report={report} />,
     description: query[breakdownDescKey],
     detailsURL,
     emptyStateTitle: props.t('navigation.aws_details'),
-    filterBy,
     groupBy,
-    historicalDataComponent: <HistoricalData filterBy={filterBy} groupBy={groupBy} query={query} />,
+    groupByValue,
+    historicalDataComponent: <HistoricalData groupBy={groupBy} groupByValue={groupByValue} query={query} />,
     providers,
     providersFetchStatus,
     providerType: ProviderType.aws,
@@ -96,7 +93,7 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
     reportType,
     reportPathsType,
     tagReportPathsType: TagPathsType.aws,
-    title: query[breakdownTitleKey] ? query[breakdownTitleKey] : filterBy,
+    title: query[breakdownTitleKey] ? query[breakdownTitleKey] : groupByValue,
   };
 });
 

--- a/src/pages/views/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/pages/views/details/awsBreakdown/awsBreakdown.tsx
@@ -56,7 +56,7 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
       time_scope_value: -1,
       ...(query && query.filter && query.filter.account && { ['account']: query.filter.account }),
       ...(groupBy && { [groupBy]: groupByValue }), // details page "group_by" must be applied here
-      ...(groupByOrg && ({ [orgUnitIdKey]: groupByOrg } as any)),
+      ...(groupByOrg && ({ [orgUnitIdKey]: groupByOrg } as any)), // instance-types and storage APIs must filter org units
     },
     ...(query && query.filter_by && { filter_by: query.filter_by }),
   };
@@ -81,7 +81,7 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
     emptyStateTitle: props.t('navigation.aws_details'),
     groupBy,
     groupByValue,
-    historicalDataComponent: <HistoricalData groupBy={groupBy} groupByValue={groupByValue} query={query} />,
+    historicalDataComponent: <HistoricalData />,
     providers,
     providersFetchStatus,
     providerType: ProviderType.aws,

--- a/src/pages/views/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/pages/views/details/azureBreakdown/azureBreakdown.tsx
@@ -78,7 +78,7 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateP
     emptyStateTitle: props.t('navigation.azure_details'),
     groupBy,
     groupByValue,
-    historicalDataComponent: <HistoricalData groupBy={groupBy} groupByValue={groupByValue} />,
+    historicalDataComponent: <HistoricalData />,
     providers,
     providersFetchStatus,
     providerType: ProviderType.azure,

--- a/src/pages/views/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/pages/views/details/azureBreakdown/azureBreakdown.tsx
@@ -45,12 +45,17 @@ const reportPathsType = ReportPathsType.azure;
 const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateProps>((state, props) => {
   const queryFromRoute = parseQuery<OcpQuery>(location.search);
   const query = queryFromRoute;
-  const filterBy = getGroupByValue(query);
   const groupBy = getGroupById(query);
+  const groupByValue = getGroupByValue(query);
 
   const newQuery: Query = {
-    ...query,
-    ...{ [breakdownDescKey]: undefined },
+    filter: {
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
+      ...(groupBy && { [groupBy]: groupByValue }), // details page "group_by" must be applied here
+    },
+    ...(query && query.filter_by && { filter_by: query.filter_by }),
   };
   const queryString = getQuery(newQuery);
 
@@ -67,13 +72,13 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateP
   );
 
   return {
-    costOverviewComponent: <CostOverview filterBy={filterBy} groupBy={groupBy} report={report} />,
+    costOverviewComponent: <CostOverview groupBy={groupBy} groupByValue={groupByValue} report={report} />,
     description: query[breakdownDescKey],
     detailsURL,
     emptyStateTitle: props.t('navigation.azure_details'),
-    filterBy,
     groupBy,
-    historicalDataComponent: <HistoricalData filterBy={filterBy} groupBy={groupBy} />,
+    groupByValue,
+    historicalDataComponent: <HistoricalData groupBy={groupBy} groupByValue={groupByValue} />,
     providers,
     providersFetchStatus,
     providerType: ProviderType.azure,
@@ -85,7 +90,7 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateP
     reportType,
     reportPathsType,
     tagReportPathsType: TagPathsType.azure,
-    title: filterBy,
+    title: groupByValue,
   };
 });
 

--- a/src/pages/views/details/components/costOverview/costOverviewBase.tsx
+++ b/src/pages/views/details/components/costOverview/costOverviewBase.tsx
@@ -22,8 +22,8 @@ import { WithTranslation } from 'react-i18next';
 import { CostOverviewWidget, CostOverviewWidgetType } from 'store/breakdown/costOverview/common/costOverviewCommon';
 
 interface CostOverviewOwnProps {
-  filterBy: string | number;
   groupBy: string;
+  groupByValue: string | number;
   query?: Query;
   report: Report;
 }
@@ -146,7 +146,7 @@ class CostOverviewBase extends React.Component<CostOverviewProps> {
 
   // Returns summary card widget
   private getSummaryCard = (widget: CostOverviewWidget) => {
-    const { filterBy, groupBy, query } = this.props;
+    const { groupBy, groupByValue, query } = this.props;
 
     let showWidget = false;
     for (const groupById of widget.reportSummary.showWidgetOnGroupBy) {
@@ -162,8 +162,8 @@ class CostOverviewBase extends React.Component<CostOverviewProps> {
     if (showWidget) {
       return (
         <SummaryCard
-          filterBy={filterBy}
           groupBy={groupBy}
+          groupByValue={groupByValue}
           query={query}
           reportGroupBy={widget.reportSummary.reportGroupBy}
           reportPathsType={widget.reportPathsType}

--- a/src/pages/views/details/components/historicalData/historicalDataBase.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataBase.tsx
@@ -12,8 +12,8 @@ import { HistoricalDataTrendChart } from './historicalDataTrendChart';
 import { HistoricalDataUsageChart } from './historicalDataUsageChart';
 
 interface HistoricalDataOwnProps {
-  filterBy: string | number;
   groupBy: string;
+  groupByValue: string | number;
   query?: Query;
 }
 
@@ -27,7 +27,7 @@ type HistoricalDataProps = HistoricalDataOwnProps & HistoricalDataStateProps & W
 class HistoricalDataBase extends React.Component<HistoricalDataProps> {
   // Returns cost chart
   private getCostChart = (widget: HistoricalDataWidget) => {
-    const { filterBy, groupBy, t } = this.props;
+    const { groupBy, groupByValue, t } = this.props;
 
     return (
       <Card>
@@ -38,8 +38,8 @@ class HistoricalDataBase extends React.Component<HistoricalDataProps> {
         </CardTitle>
         <CardBody>
           <HistoricalDataCostChart
-            filterBy={filterBy}
             groupBy={groupBy}
+            groupByValue={groupByValue}
             reportPathsType={widget.reportPathsType}
             reportType={widget.reportType}
           />
@@ -50,7 +50,7 @@ class HistoricalDataBase extends React.Component<HistoricalDataProps> {
 
   // Returns trend chart
   private getTrendChart = (widget: HistoricalDataWidget) => {
-    const { filterBy, groupBy, query, t } = this.props;
+    const { groupBy, groupByValue, query, t } = this.props;
 
     return (
       <Card>
@@ -61,8 +61,8 @@ class HistoricalDataBase extends React.Component<HistoricalDataProps> {
         </CardTitle>
         <CardBody>
           <HistoricalDataTrendChart
-            filterBy={filterBy}
             groupBy={groupBy}
+            groupByValue={groupByValue}
             query={query}
             reportPathsType={widget.reportPathsType}
             reportType={widget.reportType}
@@ -74,7 +74,7 @@ class HistoricalDataBase extends React.Component<HistoricalDataProps> {
 
   // Returns usage chart
   private getUsageChart = (widget: HistoricalDataWidget) => {
-    const { filterBy, groupBy, t } = this.props;
+    const { groupBy, groupByValue, t } = this.props;
 
     return (
       <Card>
@@ -85,8 +85,8 @@ class HistoricalDataBase extends React.Component<HistoricalDataProps> {
         </CardTitle>
         <CardBody>
           <HistoricalDataUsageChart
-            filterBy={filterBy}
             groupBy={groupBy}
+            groupByValue={groupByValue}
             reportPathsType={widget.reportPathsType}
             reportType={widget.reportType}
           />

--- a/src/pages/views/details/components/historicalData/historicalDataBase.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataBase.tsx
@@ -1,5 +1,4 @@
 import { Card, CardBody, CardTitle, Grid, GridItem, Title } from '@patternfly/react-core';
-import { Query } from 'api/queries/query';
 import React from 'react';
 import { WithTranslation } from 'react-i18next';
 import {
@@ -12,9 +11,7 @@ import { HistoricalDataTrendChart } from './historicalDataTrendChart';
 import { HistoricalDataUsageChart } from './historicalDataUsageChart';
 
 interface HistoricalDataOwnProps {
-  groupBy: string;
-  groupByValue: string | number;
-  query?: Query;
+  // TBD...
 }
 
 interface HistoricalDataStateProps {
@@ -27,7 +24,7 @@ type HistoricalDataProps = HistoricalDataOwnProps & HistoricalDataStateProps & W
 class HistoricalDataBase extends React.Component<HistoricalDataProps> {
   // Returns cost chart
   private getCostChart = (widget: HistoricalDataWidget) => {
-    const { groupBy, groupByValue, t } = this.props;
+    const { t } = this.props;
 
     return (
       <Card>
@@ -37,12 +34,7 @@ class HistoricalDataBase extends React.Component<HistoricalDataProps> {
           </Title>
         </CardTitle>
         <CardBody>
-          <HistoricalDataCostChart
-            groupBy={groupBy}
-            groupByValue={groupByValue}
-            reportPathsType={widget.reportPathsType}
-            reportType={widget.reportType}
-          />
+          <HistoricalDataCostChart reportPathsType={widget.reportPathsType} reportType={widget.reportType} />
         </CardBody>
       </Card>
     );
@@ -50,7 +42,7 @@ class HistoricalDataBase extends React.Component<HistoricalDataProps> {
 
   // Returns trend chart
   private getTrendChart = (widget: HistoricalDataWidget) => {
-    const { groupBy, groupByValue, query, t } = this.props;
+    const { t } = this.props;
 
     return (
       <Card>
@@ -60,13 +52,7 @@ class HistoricalDataBase extends React.Component<HistoricalDataProps> {
           </Title>
         </CardTitle>
         <CardBody>
-          <HistoricalDataTrendChart
-            groupBy={groupBy}
-            groupByValue={groupByValue}
-            query={query}
-            reportPathsType={widget.reportPathsType}
-            reportType={widget.reportType}
-          />
+          <HistoricalDataTrendChart reportPathsType={widget.reportPathsType} reportType={widget.reportType} />
         </CardBody>
       </Card>
     );
@@ -74,7 +60,7 @@ class HistoricalDataBase extends React.Component<HistoricalDataProps> {
 
   // Returns usage chart
   private getUsageChart = (widget: HistoricalDataWidget) => {
-    const { groupBy, groupByValue, t } = this.props;
+    const { t } = this.props;
 
     return (
       <Card>
@@ -84,12 +70,7 @@ class HistoricalDataBase extends React.Component<HistoricalDataProps> {
           </Title>
         </CardTitle>
         <CardBody>
-          <HistoricalDataUsageChart
-            groupBy={groupBy}
-            groupByValue={groupByValue}
-            reportPathsType={widget.reportPathsType}
-            reportType={widget.reportType}
-          />
+          <HistoricalDataUsageChart reportPathsType={widget.reportPathsType} reportType={widget.reportType} />
         </CardBody>
       </Card>
     );

--- a/src/pages/views/details/components/historicalData/historicalDataCostChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataCostChart.tsx
@@ -13,8 +13,8 @@ import { formatValue, unitLookupKey } from 'utils/formatValue';
 import { chartStyles, styles } from './historicalChart.styles';
 
 interface HistoricalDataCostChartOwnProps {
-  filterBy: string | number;
   groupBy: string;
+  groupByValue: string | number;
   reportPathsType: ReportPathsType;
   reportType: ReportType;
 }
@@ -120,7 +120,7 @@ class HistoricalDataCostChartBase extends React.Component<HistoricalDataCostChar
 }
 
 const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, HistoricalDataCostChartStateProps>(
-  (state, { filterBy, groupBy, reportPathsType, reportType }) => {
+  (state, { groupBy, groupByValue, reportPathsType, reportType }) => {
     const currentQuery: Query = {
       filter: {
         time_scope_units: 'month',
@@ -129,7 +129,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
         limit: 3,
       },
       group_by: {
-        [groupBy]: filterBy,
+        [groupBy]: groupByValue,
       },
     };
     const currentQueryString = getQuery(currentQuery);
@@ -141,7 +141,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
         limit: 3,
       },
       group_by: {
-        [groupBy]: filterBy,
+        [groupBy]: groupByValue,
       },
     };
     const previousQueryString = getQuery(previousQuery);

--- a/src/pages/views/details/components/historicalData/historicalDataTrendChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataTrendChart.tsx
@@ -1,8 +1,9 @@
 import Skeleton from '@redhat-cloud-services/frontend-components/Skeleton';
-import { getQuery, orgUnitIdKey, Query } from 'api/queries/query';
+import { getQuery, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import { ChartType, transformReport } from 'components/charts/common/chartDatumUtils';
 import { HistoricalTrendChart } from 'components/charts/historicalTrendChart';
+import { getGroupById, getGroupByValue } from 'pages/views/utils/groupBy';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -13,9 +14,6 @@ import { formatValue, unitLookupKey } from 'utils/formatValue';
 import { chartStyles, styles } from './historicalChart.styles';
 
 interface HistoricalDataTrendChartOwnProps {
-  groupBy: string;
-  groupByValue: string | number;
-  query?: Query;
   reportPathsType: ReportPathsType;
   reportType: ReportType;
 }
@@ -146,11 +144,12 @@ class HistoricalDataTrendChartBase extends React.Component<HistoricalDataTrendCh
 }
 
 const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, HistoricalDataTrendChartStateProps>(
-  (state, { groupBy, groupByValue, query, reportPathsType, reportType }) => {
+  (state, { reportPathsType, reportType }) => {
+    const queryFromRoute = parseQuery<Query>(location.search);
+    const query = queryFromRoute;
+    const groupBy = getGroupById(query);
+    const groupByValue = getGroupByValue(query);
     const groupByOrg = query && query.group_by[orgUnitIdKey] ? query.group_by[orgUnitIdKey] : undefined;
-
-    // instance-types and storage APIs must filter org units
-    const useFilter = reportType === ReportType.instanceType || reportType === ReportType.storage;
 
     const currentQuery: Query = {
       filter: {
@@ -159,13 +158,10 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
         resolution: 'daily',
         limit: 3,
         ...(query && query.filter && query.filter.account && { account: query.filter.account }),
-        ...(groupByOrg && useFilter && { [orgUnitIdKey]: groupByOrg }),
+        ...(groupBy && { [groupBy]: groupByValue }), // details page "group_by" must be applied here
+        ...(groupByOrg && ({ [orgUnitIdKey]: groupByOrg } as any)), // instance-types and storage APIs must filter org units
       },
-      filter_by: query ? query.filter_by : undefined,
-      group_by: {
-        ...(groupByOrg && !useFilter && ({ [orgUnitIdKey]: groupByOrg } as any)),
-        [groupBy]: groupByValue,
-      },
+      ...(query && query.filter_by && { filter_by: query.filter_by }),
     };
     const currentQueryString = getQuery(currentQuery);
     const previousQuery: Query = {
@@ -175,13 +171,10 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
         resolution: 'daily',
         limit: 3,
         ...(query && query.filter && query.filter.account && { account: query.filter.account }),
-        ...(groupByOrg && useFilter && { [orgUnitIdKey]: groupByOrg }),
+        ...(groupBy && { [groupBy]: groupByValue }), // details page "group_by" must be applied here
+        ...(groupByOrg && ({ [orgUnitIdKey]: groupByOrg } as any)), // instance-types and storage APIs must filter org units
       },
-      filter_by: query ? query.filter_by : undefined,
-      group_by: {
-        ...(groupByOrg && !useFilter && ({ [orgUnitIdKey]: groupByOrg } as any)),
-        [groupBy]: groupByValue,
-      },
+      ...(query && query.filter_by && { filter_by: query.filter_by }),
     };
     const previousQueryString = getQuery(previousQuery);
 

--- a/src/pages/views/details/components/historicalData/historicalDataTrendChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataTrendChart.tsx
@@ -13,8 +13,8 @@ import { formatValue, unitLookupKey } from 'utils/formatValue';
 import { chartStyles, styles } from './historicalChart.styles';
 
 interface HistoricalDataTrendChartOwnProps {
-  filterBy: string | number;
   groupBy: string;
+  groupByValue: string | number;
   query?: Query;
   reportPathsType: ReportPathsType;
   reportType: ReportType;
@@ -146,7 +146,7 @@ class HistoricalDataTrendChartBase extends React.Component<HistoricalDataTrendCh
 }
 
 const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, HistoricalDataTrendChartStateProps>(
-  (state, { filterBy, groupBy, query, reportPathsType, reportType }) => {
+  (state, { groupBy, groupByValue, query, reportPathsType, reportType }) => {
     const groupByOrg = query && query.group_by[orgUnitIdKey] ? query.group_by[orgUnitIdKey] : undefined;
 
     // instance-types and storage APIs must filter org units
@@ -164,7 +164,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
       filter_by: query ? query.filter_by : undefined,
       group_by: {
         ...(groupByOrg && !useFilter && ({ [orgUnitIdKey]: groupByOrg } as any)),
-        [groupBy]: filterBy,
+        [groupBy]: groupByValue,
       },
     };
     const currentQueryString = getQuery(currentQuery);
@@ -180,7 +180,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
       filter_by: query ? query.filter_by : undefined,
       group_by: {
         ...(groupByOrg && !useFilter && ({ [orgUnitIdKey]: groupByOrg } as any)),
-        [groupBy]: filterBy,
+        [groupBy]: groupByValue,
       },
     };
     const previousQueryString = getQuery(previousQuery);

--- a/src/pages/views/details/components/historicalData/historicalDataUsageChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataUsageChart.tsx
@@ -1,8 +1,9 @@
 import Skeleton from '@redhat-cloud-services/frontend-components/Skeleton';
-import { getQuery, Query } from 'api/queries/query';
+import { getQuery, parseQuery, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import { ChartType, transformReport } from 'components/charts/common/chartDatumUtils';
 import { HistoricalUsageChart } from 'components/charts/historicalUsageChart';
+import { getGroupById, getGroupByValue } from 'pages/views/utils/groupBy';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -13,8 +14,6 @@ import { formatValue, unitLookupKey } from 'utils/formatValue';
 import { chartStyles, styles } from './historicalChart.styles';
 
 interface HistoricalDataUsageChartOwnProps {
-  groupBy: string;
-  groupByValue: string | number;
   reportPathsType: ReportPathsType;
   reportType: ReportType;
 }
@@ -117,17 +116,21 @@ class HistoricalDataUsageChartBase extends React.Component<HistoricalDataUsageCh
 }
 
 const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, HistoricalDataUsageChartStateProps>(
-  (state, { groupBy, groupByValue, reportPathsType, reportType }) => {
+  (state, { reportPathsType, reportType }) => {
+    const queryFromRoute = parseQuery<Query>(location.search);
+    const query = queryFromRoute;
+    const groupBy = getGroupById(query);
+    const groupByValue = getGroupByValue(query);
+
     const currentQuery: Query = {
       filter: {
         time_scope_units: 'month',
         time_scope_value: -1,
         resolution: 'daily',
         limit: 3,
+        ...(groupBy && { [groupBy]: groupByValue }), // details page "group_by" must be applied here
       },
-      group_by: {
-        [groupBy]: groupByValue,
-      },
+      ...(query && query.filter_by && { filter_by: query.filter_by }),
     };
     const currentQueryString = getQuery(currentQuery);
     const previousQuery: Query = {
@@ -136,10 +139,9 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
         time_scope_value: -2,
         resolution: 'daily',
         limit: 3,
+        ...(groupBy && { [groupBy]: groupByValue }), // details page "group_by" must be applied here
       },
-      group_by: {
-        [groupBy]: groupByValue,
-      },
+      ...(query && query.filter_by && { filter_by: query.filter_by }),
     };
     const previousQueryString = getQuery(previousQuery);
 

--- a/src/pages/views/details/components/historicalData/historicalDataUsageChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataUsageChart.tsx
@@ -13,8 +13,8 @@ import { formatValue, unitLookupKey } from 'utils/formatValue';
 import { chartStyles, styles } from './historicalChart.styles';
 
 interface HistoricalDataUsageChartOwnProps {
-  filterBy: string | number;
   groupBy: string;
+  groupByValue: string | number;
   reportPathsType: ReportPathsType;
   reportType: ReportType;
 }
@@ -117,7 +117,7 @@ class HistoricalDataUsageChartBase extends React.Component<HistoricalDataUsageCh
 }
 
 const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, HistoricalDataUsageChartStateProps>(
-  (state, { filterBy, groupBy, reportPathsType, reportType }) => {
+  (state, { groupBy, groupByValue, reportPathsType, reportType }) => {
     const currentQuery: Query = {
       filter: {
         time_scope_units: 'month',
@@ -126,7 +126,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
         limit: 3,
       },
       group_by: {
-        [groupBy]: filterBy,
+        [groupBy]: groupByValue,
       },
     };
     const currentQueryString = getQuery(currentQuery);
@@ -138,7 +138,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
         limit: 3,
       },
       group_by: {
-        [groupBy]: filterBy,
+        [groupBy]: groupByValue,
       },
     };
     const previousQueryString = getQuery(previousQuery);

--- a/src/pages/views/details/components/summary/summaryCard.tsx
+++ b/src/pages/views/details/components/summary/summaryCard.tsx
@@ -185,10 +185,10 @@ const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps
         resolution: 'monthly',
         ...(query && query.filter && query.filter.account && { account: query.filter.account }),
         ...(groupBy && { [groupBy]: groupByValue }), // details page "group_by" must be applied here
+        ...(groupByOrg && ({ [orgUnitIdKey]: groupByOrg } as any)), // instance-types and storage APIs must filter org units
       },
       ...(query && query.filter_by && { filter_by: query.filter_by }),
       group_by: {
-        ...(groupByOrg && ({ [orgUnitIdKey]: groupByOrg } as any)),
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.
       },
     };

--- a/src/pages/views/details/components/summary/summaryCard.tsx
+++ b/src/pages/views/details/components/summary/summaryCard.tsx
@@ -26,8 +26,8 @@ import { formatValue } from 'utils/formatValue';
 import { styles } from './summaryCard.styles';
 
 interface SummaryOwnProps {
-  filterBy: string | number;
   groupBy: string;
+  groupByValue: string | number;
   query?: Query;
   reportGroupBy?: string;
   reportPathsType: ReportPathsType;
@@ -99,7 +99,7 @@ class SummaryBase extends React.Component<SummaryProps> {
   };
 
   private getViewAll = () => {
-    const { filterBy, groupBy, query, reportGroupBy, reportPathsType, t } = this.props;
+    const { groupBy, groupByValue, query, reportGroupBy, reportPathsType, t } = this.props;
     const { isBulletChartModalOpen } = this.state;
 
     const computedItems = this.getItems();
@@ -122,8 +122,8 @@ class SummaryBase extends React.Component<SummaryProps> {
             {t('details.view_all', { groupBy: reportGroupBy })}
           </Button>
           <SummaryModal
-            filterBy={filterBy}
             groupBy={groupBy}
+            groupByValue={groupByValue}
             isOpen={isBulletChartModalOpen}
             onClose={this.handleBulletChartModalClose}
             query={query}
@@ -175,7 +175,7 @@ class SummaryBase extends React.Component<SummaryProps> {
 }
 
 const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps>(
-  (state, { filterBy, groupBy, query, reportGroupBy, reportPathsType, reportType }) => {
+  (state, { groupBy, groupByValue, query, reportGroupBy, reportPathsType, reportType }) => {
     const groupByOrg = query && query.group_by[orgUnitIdKey] ? query.group_by[orgUnitIdKey] : undefined;
     const newQuery: Query = {
       filter: {
@@ -183,10 +183,10 @@ const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps
         time_scope_units: 'month',
         time_scope_value: -1,
         resolution: 'monthly',
-        [groupBy]: filterBy, // Other "filter_by"s must be applied here
         ...(query && query.filter && query.filter.account && { account: query.filter.account }),
+        ...(groupBy && { [groupBy]: groupByValue }), // details page "group_by" must be applied here
       },
-      filter_by: query ? query.filter_by : undefined,
+      ...(query && query.filter_by && { filter_by: query.filter_by }),
       group_by: {
         ...(groupByOrg && ({ [orgUnitIdKey]: groupByOrg } as any)),
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.

--- a/src/pages/views/details/components/summary/summaryModal.tsx
+++ b/src/pages/views/details/components/summary/summaryModal.tsx
@@ -9,8 +9,8 @@ import { WithTranslation, withTranslation } from 'react-i18next';
 import { SummaryModalView } from './summaryModalView';
 
 interface SummaryModalOwnProps {
-  filterBy: string | number;
   groupBy: string;
+  groupByValue: string | number;
   isOpen: boolean;
   onClose(isOpen: boolean);
   query?: Query;
@@ -27,8 +27,8 @@ class SummaryModalBase extends React.Component<SummaryModalProps> {
   }
 
   public shouldComponentUpdate(nextProps: SummaryModalProps) {
-    const { filterBy, isOpen } = this.props;
-    return nextProps.filterBy !== filterBy || nextProps.isOpen !== isOpen;
+    const { groupByValue, isOpen } = this.props;
+    return nextProps.groupByValue !== groupByValue || nextProps.isOpen !== isOpen;
   }
 
   private handleClose = () => {
@@ -36,7 +36,7 @@ class SummaryModalBase extends React.Component<SummaryModalProps> {
   };
 
   public render() {
-    const { filterBy, groupBy, isOpen, query, reportGroupBy, reportPathsType, t } = this.props;
+    const { groupBy, groupByValue, isOpen, query, reportGroupBy, reportPathsType, t } = this.props;
 
     return (
       <Modal
@@ -45,13 +45,13 @@ class SummaryModalBase extends React.Component<SummaryModalProps> {
         onClose={this.handleClose}
         title={t('details.summary_modal_title', {
           groupBy: reportGroupBy,
-          name: filterBy,
+          name: groupByValue,
         })}
         variant="large"
       >
         <SummaryModalView
-          filterBy={filterBy}
           groupBy={groupBy}
+          groupByValue={groupByValue}
           query={query}
           reportGroupBy={reportGroupBy}
           reportPathsType={reportPathsType}

--- a/src/pages/views/details/components/summary/summaryModalView.tsx
+++ b/src/pages/views/details/components/summary/summaryModalView.tsx
@@ -13,8 +13,8 @@ import { formatCurrency } from 'utils/formatValue';
 import { styles } from './summaryModal.styles';
 
 interface SummaryModalViewOwnProps {
-  filterBy: string | number;
   groupBy: string;
+  groupByValue: string | number;
   query?: Query;
   reportGroupBy?: string;
   reportPathsType: ReportPathsType;
@@ -89,17 +89,17 @@ class SummaryModalViewBase extends React.Component<SummaryModalViewProps> {
 }
 
 const mapStateToProps = createMapStateToProps<SummaryModalViewOwnProps, SummaryModalViewStateProps>(
-  (state, { filterBy, groupBy, query, reportGroupBy, reportPathsType }) => {
+  (state, { groupBy, groupByValue, query, reportGroupBy, reportPathsType }) => {
     const groupByOrg = query && query.group_by[orgUnitIdKey] ? query.group_by[orgUnitIdKey] : undefined;
     const newQuery: Query = {
       filter: {
         time_scope_units: 'month',
         time_scope_value: -1,
         resolution: 'monthly',
-        [groupBy]: filterBy, // Other "filter_by"s must be applied here
         ...(query && query.filter && query.filter.account && { account: query.filter.account }),
+        ...(groupBy && { [groupBy]: groupByValue }), // details page "group_by" must be applied here
       },
-      filter_by: query ? query.filter_by : undefined,
+      ...(query && query.filter_by && { filter_by: query.filter_by }),
       group_by: {
         ...(groupByOrg && ({ [orgUnitIdKey]: groupByOrg } as any)),
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.

--- a/src/pages/views/details/components/summary/summaryModalView.tsx
+++ b/src/pages/views/details/components/summary/summaryModalView.tsx
@@ -98,10 +98,10 @@ const mapStateToProps = createMapStateToProps<SummaryModalViewOwnProps, SummaryM
         resolution: 'monthly',
         ...(query && query.filter && query.filter.account && { account: query.filter.account }),
         ...(groupBy && { [groupBy]: groupByValue }), // details page "group_by" must be applied here
+        ...(groupByOrg && ({ [orgUnitIdKey]: groupByOrg } as any)), // instance-types and storage APIs must filter org units
       },
       ...(query && query.filter_by && { filter_by: query.filter_by }),
       group_by: {
-        ...(groupByOrg && ({ [orgUnitIdKey]: groupByOrg } as any)),
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.
       },
     };

--- a/src/pages/views/details/components/usageChart/usageChart.tsx
+++ b/src/pages/views/details/components/usageChart/usageChart.tsx
@@ -7,7 +7,7 @@ import { OcpQuery, parseQuery } from 'api/queries/ocpQuery';
 import { getQuery, Query } from 'api/queries/query';
 import { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
-import { getGroupById } from 'pages/views/utils/groupBy';
+import { getGroupById, getGroupByValue } from 'pages/views/utils/groupBy';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -402,15 +402,16 @@ const mapStateToProps = createMapStateToProps<UsageChartOwnProps, UsageChartStat
     const queryFromRoute = parseQuery<OcpQuery>(location.search);
     const query = queryFromRoute;
     const groupBy = getGroupById(query);
+    const groupByValue = getGroupByValue(query);
 
     const newQuery: Query = {
       filter: {
         time_scope_units: 'month',
         time_scope_value: -1,
         resolution: 'monthly',
+        ...(groupBy && { [groupBy]: groupByValue }), // details page "group_by" must be applied here
       },
-      filter_by: query ? query.filter_by : undefined,
-      group_by: query ? query.group_by : undefined,
+      ...(query && query.filter_by && { filter_by: query.filter_by }),
     };
     const queryString = getQuery(newQuery);
     const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);

--- a/src/pages/views/details/gcpBreakdown/gcpBreakdown.tsx
+++ b/src/pages/views/details/gcpBreakdown/gcpBreakdown.tsx
@@ -45,21 +45,18 @@ const reportPathsType = ReportPathsType.gcp;
 const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, GcpBreakdownStateProps>((state, props) => {
   const queryFromRoute = parseQuery<GcpQuery>(location.search);
   const query = queryFromRoute;
-  const filterBy = getGroupByValue(query);
   const groupBy = getGroupById(query);
+  const groupByValue = getGroupByValue(query);
 
   const newQuery: Query = {
     filter: {
+      resolution: 'monthly',
       time_scope_units: 'month',
       time_scope_value: -1,
-      resolution: 'monthly',
-      limit: 3,
       ...(query && query.filter && query.filter.account && { ['account']: query.filter.account }),
+      ...(groupBy && { [groupBy]: groupByValue }), // details page "group_by" must be applied here
     },
-    filter_by: query ? query.filter_by : undefined,
-    group_by: {
-      ...(groupBy && { [groupBy]: filterBy }),
-    },
+    ...(query && query.filter_by && { filter_by: query.filter_by }),
   };
   const queryString = getQuery(newQuery);
 
@@ -76,13 +73,13 @@ const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, GcpBreakdown
   );
 
   return {
-    costOverviewComponent: <CostOverview filterBy={filterBy} groupBy={groupBy} query={query} report={report} />,
+    costOverviewComponent: <CostOverview groupBy={groupBy} groupByValue={groupByValue} query={query} report={report} />,
     description: query[breakdownDescKey],
     detailsURL,
     emptyStateTitle: props.t('navigation.gcp_details'),
-    filterBy,
     groupBy,
-    historicalDataComponent: <HistoricalData filterBy={filterBy} groupBy={groupBy} query={query} />,
+    groupByValue,
+    historicalDataComponent: <HistoricalData groupBy={groupBy} groupByValue={groupByValue} query={query} />,
     providers,
     providersFetchStatus,
     providerType: ProviderType.gcp,
@@ -94,7 +91,7 @@ const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, GcpBreakdown
     reportType,
     reportPathsType,
     tagReportPathsType: TagPathsType.gcp,
-    title: query[breakdownTitleKey] ? query[breakdownTitleKey] : filterBy,
+    title: query[breakdownTitleKey] ? query[breakdownTitleKey] : groupByValue,
   };
 });
 
@@ -105,3 +102,18 @@ const mapDispatchToProps: BreakdownDispatchProps = {
 const GcpBreakdown = withTranslation()(connect(mapStateToProps, mapDispatchToProps)(BreakdownBase));
 
 export default GcpBreakdown;
+
+/*
+https://ci.foo.redhat.com:1337/api/cost-management/v1/reports/gcp/costs/?filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&group_by[and:project]=openshift-gce-devel-ci&group_by[or:project]=openshift&group_by[or:region]=us
+filter[resolution]=monthly
+filter[time_scope_units]=month
+filter[time_scope_value]=-1
+group_by[and:project]=openshift-gce-devel-ci
+group_by[or:project]=openshift
+group_by[or:region]=us
+$20,730.30
+
+
+
+
+ */

--- a/src/pages/views/details/gcpBreakdown/gcpBreakdown.tsx
+++ b/src/pages/views/details/gcpBreakdown/gcpBreakdown.tsx
@@ -102,18 +102,3 @@ const mapDispatchToProps: BreakdownDispatchProps = {
 const GcpBreakdown = withTranslation()(connect(mapStateToProps, mapDispatchToProps)(BreakdownBase));
 
 export default GcpBreakdown;
-
-/*
-https://ci.foo.redhat.com:1337/api/cost-management/v1/reports/gcp/costs/?filter[resolution]=monthly&filter[time_scope_units]=month&filter[time_scope_value]=-1&group_by[and:project]=openshift-gce-devel-ci&group_by[or:project]=openshift&group_by[or:region]=us
-filter[resolution]=monthly
-filter[time_scope_units]=month
-filter[time_scope_value]=-1
-group_by[and:project]=openshift-gce-devel-ci
-group_by[or:project]=openshift
-group_by[or:region]=us
-$20,730.30
-
-
-
-
- */

--- a/src/pages/views/details/gcpBreakdown/gcpBreakdown.tsx
+++ b/src/pages/views/details/gcpBreakdown/gcpBreakdown.tsx
@@ -79,7 +79,7 @@ const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, GcpBreakdown
     emptyStateTitle: props.t('navigation.gcp_details'),
     groupBy,
     groupByValue,
-    historicalDataComponent: <HistoricalData groupBy={groupBy} groupByValue={groupByValue} query={query} />,
+    historicalDataComponent: <HistoricalData />,
     providers,
     providersFetchStatus,
     providerType: ProviderType.gcp,

--- a/src/pages/views/details/ibmBreakdown/ibmBreakdown.tsx
+++ b/src/pages/views/details/ibmBreakdown/ibmBreakdown.tsx
@@ -79,7 +79,7 @@ const mapStateToProps = createMapStateToProps<IbmBreakdownOwnProps, IbmBreakdown
     emptyStateTitle: props.t('navigation.ibm_details'),
     groupBy,
     groupByValue,
-    historicalDataComponent: <HistoricalData groupBy={groupBy} groupByValue={groupByValue} query={query} />,
+    historicalDataComponent: <HistoricalData />,
     providers,
     providersFetchStatus,
     providerType: ProviderType.ibm,

--- a/src/pages/views/details/ibmBreakdown/ibmBreakdown.tsx
+++ b/src/pages/views/details/ibmBreakdown/ibmBreakdown.tsx
@@ -45,21 +45,18 @@ const reportPathsType = ReportPathsType.ibm;
 const mapStateToProps = createMapStateToProps<IbmBreakdownOwnProps, IbmBreakdownStateProps>((state, props) => {
   const queryFromRoute = parseQuery<IbmQuery>(location.search);
   const query = queryFromRoute;
-  const filterBy = getGroupByValue(query);
   const groupBy = getGroupById(query);
+  const groupByValue = getGroupByValue(query);
 
   const newQuery: Query = {
     filter: {
+      resolution: 'monthly',
       time_scope_units: 'month',
       time_scope_value: -1,
-      resolution: 'monthly',
-      limit: 3,
       ...(query && query.filter && query.filter.account && { ['account']: query.filter.account }),
+      ...(groupBy && { [groupBy]: groupByValue }), // details page "group_by" must be applied here
     },
-    filter_by: query ? query.filter_by : undefined,
-    group_by: {
-      ...(groupBy && { [groupBy]: filterBy }),
-    },
+    ...(query && query.filter_by && { filter_by: query.filter_by }),
   };
   const queryString = getQuery(newQuery);
 
@@ -76,13 +73,13 @@ const mapStateToProps = createMapStateToProps<IbmBreakdownOwnProps, IbmBreakdown
   );
 
   return {
-    costOverviewComponent: <CostOverview filterBy={filterBy} groupBy={groupBy} query={query} report={report} />,
+    costOverviewComponent: <CostOverview groupBy={groupBy} groupByValue={groupByValue} query={query} report={report} />,
     description: query[breakdownDescKey],
     detailsURL,
     emptyStateTitle: props.t('navigation.ibm_details'),
-    filterBy,
     groupBy,
-    historicalDataComponent: <HistoricalData filterBy={filterBy} groupBy={groupBy} query={query} />,
+    groupByValue,
+    historicalDataComponent: <HistoricalData groupBy={groupBy} groupByValue={groupByValue} query={query} />,
     providers,
     providersFetchStatus,
     providerType: ProviderType.ibm,
@@ -94,7 +91,7 @@ const mapStateToProps = createMapStateToProps<IbmBreakdownOwnProps, IbmBreakdown
     reportType,
     reportPathsType,
     tagReportPathsType: TagPathsType.ibm,
-    title: query[breakdownTitleKey] ? query[breakdownTitleKey] : filterBy,
+    title: query[breakdownTitleKey] ? query[breakdownTitleKey] : groupByValue,
   };
 });
 

--- a/src/pages/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/pages/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -78,7 +78,7 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
     emptyStateTitle: props.t('navigation.ocp_details'),
     groupBy,
     groupByValue,
-    historicalDataComponent: <HistoricalData groupBy={groupBy} groupByValue={groupByValue} />,
+    historicalDataComponent: <HistoricalData />,
     providers,
     providersFetchStatus,
     providerType: ProviderType.ocp,

--- a/src/pages/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/pages/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -45,17 +45,17 @@ const reportPathsType = ReportPathsType.ocp;
 const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdownStateProps>((state, props) => {
   const queryFromRoute = parseQuery<OcpQuery>(location.search);
   const query = queryFromRoute;
-  const filterBy = getGroupByValue(query);
   const groupBy = getGroupById(query);
+  const groupByValue = getGroupByValue(query);
 
   const newQuery: Query = {
-    ...query,
-    ...{ [breakdownDescKey]: undefined },
     filter: {
-      ...query.filter,
-      limit: undefined, // Not necessary
-      offset: undefined, // Not necessary
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
+      ...(groupBy && { [groupBy]: groupByValue }), // details page "group_by" must be applied here
     },
+    ...(query && query.filter_by && { filter_by: query.filter_by }),
   };
   const queryString = getQuery(newQuery);
 
@@ -72,13 +72,13 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
   );
 
   return {
-    costOverviewComponent: <CostOverview filterBy={filterBy} groupBy={groupBy} report={report} />,
+    costOverviewComponent: <CostOverview groupBy={groupBy} groupByValue={groupByValue} report={report} />,
     description: query[breakdownDescKey],
     detailsURL,
     emptyStateTitle: props.t('navigation.ocp_details'),
-    filterBy,
     groupBy,
-    historicalDataComponent: <HistoricalData filterBy={filterBy} groupBy={groupBy} />,
+    groupByValue,
+    historicalDataComponent: <HistoricalData groupBy={groupBy} groupByValue={groupByValue} />,
     providers,
     providersFetchStatus,
     providerType: ProviderType.ocp,
@@ -90,7 +90,7 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
     reportType,
     reportPathsType,
     tagReportPathsType: TagPathsType.ocp,
-    title: filterBy,
+    title: groupByValue,
   };
 });
 

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -210,7 +210,7 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
         } else {
           const item = itemMap.get(mapId);
           if (item) {
-            // When filtering, project costs may be split between regions. We need to sum those costs
+            // When applying multiple filters, project costs may be split between regions. We need to sum those costs
             // See https://issues.redhat.com/browse/COST-1131
             itemMap.set(mapId, {
               ...item,

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -73,20 +73,28 @@ export function getComputedReportItems<R extends Report, T extends ReportItem>({
 function getCostData(val, key, item?: any) {
   return {
     markup: {
-      value: (item ? item[key].markup.value : 0) + val[key] && val[key].markup ? val[key].markup.value : 0,
-      units: val[key] && val[key].markup ? val[key].markup.units : 'USD',
+      value:
+        (item && item[key] && item[key].markup ? item[key].markup.value : 0) +
+        (val[key] && val[key].markup ? val[key].markup.value : 0),
+      units: val && val[key] && val[key].markup ? val[key].markup.units : 'USD',
     },
     raw: {
-      value: (item ? item[key].raw.value : 0) + val[key] && val[key].raw ? val[key].raw.value : 0,
-      units: val[key] && val[key].raw ? val[key].raw.units : 'USD',
+      value:
+        (item && item[key] && item[key].raw ? item[key].raw.value : 0) +
+        (val[key] && val[key].raw ? val[key].raw.value : 0),
+      units: val && val[key] && val[key].raw ? val[key].raw.units : 'USD',
     },
     total: {
-      value: (item ? item[key].total.value : 0) + val[key] && val[key].total ? Number(val[key].total.value) : 0,
-      units: val[key] && val[key].total ? val[key].total.units : null,
+      value:
+        (item && item[key] && item[key].total ? item[key].total.value : 0) +
+        (val[key] && val[key].total ? Number(val[key].total.value) : 0),
+      units: val && val[key] && val[key].total ? val[key].total.units : null,
     },
     usage: {
-      value: (item ? item[key].usage.value : 0) + val[key] && val[key].usage ? Number(val[key].usage.value) : 0,
-      units: val[key] && val[key].usage ? val[key].usage.units : null,
+      value:
+        (item && item[key] && item[key].usage ? item[key].usage.value : 0) +
+        (val[key] && val[key].usage ? Number(val[key].usage.value) : 0),
+      units: val && val[key] && val[key].usage ? val[key].usage.units : null,
     },
   };
 }
@@ -94,20 +102,20 @@ function getCostData(val, key, item?: any) {
 function getUsageData(val, item?: any) {
   return {
     capacity: {
-      value: (item ? item.capacity.value : 0) + val.capacity ? val.capacity.value : 0,
-      units: val.capacity ? val.capacity.units : 'Core-Hours',
+      value: (item && item.capacity ? item.capacity.value : 0) + (val.capacity ? val.capacity.value : 0),
+      units: val && val.capacity ? val.capacity.units : 'Core-Hours',
     },
     limit: {
-      value: (item ? item.limit.value : 0) + val.limit ? val.limit.value : 0,
-      units: val.limit ? val.limit.units : 'Core-Hours',
+      value: (item && item.limit ? item.limit.value : 0) + (val.limit ? val.limit.value : 0),
+      units: val && val.limit ? val.limit.units : 'Core-Hours',
     },
     request: {
-      value: (item ? item.request.value : 0) + val.request ? val.request.value : 0,
-      units: val.request ? val.request.units : 'Core-Hours',
+      value: (item && item.request ? item.request.value : 0) + (val.request ? val.request.value : 0),
+      units: val && val.request ? val.request.units : 'Core-Hours',
     },
     usage: {
-      value: (item ? item.usage.value : 0) + val.usage ? val.usage.value : 0,
-      units: val.usage ? val.usage.units : 'Core-Hours',
+      value: (item && item.usage ? item.usage.value : 0) + (val.usage ? val.usage.value : 0),
+      units: val && val.usage ? val.usage.units : 'Core-Hours',
     },
   };
 }
@@ -202,6 +210,8 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
         } else {
           const item = itemMap.get(mapId);
           if (item) {
+            // When filtering, project costs may be split between regions. We need to sum those costs
+            // See https://issues.redhat.com/browse/COST-1131
             itemMap.set(mapId, {
               ...item,
               ...getUsageData(val, item), // capacity, limit, request, & usage


### PR DESCRIPTION
This ensures that the details and breakdown pages represent the correct cost when multiple filters are applied.

- Updated query functions to use either logical AND or logical OR
- Fixed sum calculation of costs in getComuptedReportItem
- Renamed filterBy props as groupByValue
- Added filter_by params to summary cards
- Modified breakdown querys to include group_by from previous page as a filter

https://issues.redhat.com/browse/COST-1131

**Details page with filters**
<img width="1838" alt="Screen Shot 2021-03-09 at 12 39 15 AM" src="https://user-images.githubusercontent.com/17481322/110426218-b5863d00-8073-11eb-8c84-121a097b1982.png">

**Breakdown page**
<img width="1835" alt="Screen Shot 2021-03-09 at 12 38 30 AM" src="https://user-images.githubusercontent.com/17481322/110426232-bb7c1e00-8073-11eb-8ea3-ae86a1426920.png">
