### PR TITLE
consolidate duplicate i18n keys for dashboards.

### DIFF
--- a/scripts/utils/i18n_excludes
+++ b/scripts/utils/i18n_excludes
@@ -11,6 +11,7 @@ breakdown.historical_chart.view_data
 breakdown.navigation.aws
 breakdown.navigation.azure
 breakdown.navigation.gcp
+breakdown.navigation.ibm
 breakdown.navigation.ocp
 breakdown.navigation.ocpunit_tooltips.core-hours
 chart.cost_forecast_cone_legend_label_no_data

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -3,21 +3,13 @@
     "compute_title": "Compute (EC2) instances usage",
     "cost_title": "Amazon Web Services filtered by OpenShift cost",
     "cost_trend_title": "Amazon Web Services cumulative cost comparison ({{units}})",
-    "daily_cost_trend_title": "Amazon Web Services daily cost comparison ({{units}})",
-    "database_title": "Database services cost",
-    "network_title": "Network services cost",
-    "storage_title": "Storage services usage",
-    "usage_label": "Usage"
+    "daily_cost_trend_title": "Amazon Web Services daily cost comparison ({{units}})"
   },
   "aws_dashboard": {
     "compute_title": "Compute (EC2) instances usage",
     "cost_title": "Amazon Web Services cost",
     "cost_trend_title": "Amazon Web Services cumulative cost comparison ({{units}})",
-    "daily_cost_trend_title": "Amazon Web Services daily cost comparison ({{units}})",
-    "database_title": "Database services cost",
-    "network_title": "Network services cost",
-    "storage_title": "Storage services usage",
-    "usage_label": "Usage"
+    "daily_cost_trend_title": "Amazon Web Services daily cost comparison ({{units}})"
   },
   "aws_details": {
     "change_column_title": "Month over month change",
@@ -31,21 +23,13 @@
     "compute_title": "Virtual machines usage",
     "cost_title": "Microsoft Azure filtered by OpenShift cost",
     "cost_trend_title": "Microsoft Azure cumulative cost comparison ({{units}})",
-    "daily_cost_trend_title": "Microsoft Azure daily cost comparison ({{units}})",
-    "database_title": "Database services cost",
-    "network_title": "Network services cost",
-    "storage_title": "Storage services usage",
-    "usage_label": "Usage"
+    "daily_cost_trend_title": "Microsoft Azure daily cost comparison ({{units}})"
   },
   "azure_dashboard": {
     "compute_title": "Virtual machines usage",
     "cost_title": "Microsoft Azure cost",
     "cost_trend_title": "Microsoft Azure cumulative cost comparison ({{units}})",
-    "daily_cost_trend_title": "Microsoft Azure daily cost comparison ({{units}})",
-    "database_title": "Database services cost",
-    "network_title": "Network services cost",
-    "storage_title": "Storage services usage",
-    "usage_label": "Usage"
+    "daily_cost_trend_title": "Microsoft Azure daily cost comparison ({{units}})"
   },
   "azure_details": {
     "change_column_title": "Month over month change",
@@ -367,8 +351,12 @@
   },
   "dashboard": {
     "cumulative_cost_comparison": "Cumulative cost comparison ({{units}})",
+    "database_title": "Database services cost",
     "daily_usage_comparison": "Daily usage comparison ({{units}})",
+    "network_title": "Network services cost",
+    "storage_title": "Storage services usage",
     "total_cost_tooltip": "This total cost is the sum of the infrastructure cost {{infrastructureCost}} and supplementary cost {{supplementaryCost}}",
+    "usage": "Usage",
     "widget_subtitle": "{{startDate}} $t(months.{{month}})",
     "widget_subtitle_plural": "{{startDate}}-{{endDate}} $t(months.{{month}})"
   },
@@ -610,11 +598,7 @@
     "compute_title": "Compute instances usage",
     "cost_title": "Google Cloud Platform Services cost",
     "cost_trend_title": "Google Cloud Platform Services cumulative cost comparison ({{units}})",
-    "daily_cost_trend_title": "Google Cloud Platform Services daily cost comparison ({{units}})",
-    "database_title": "Database services cost",
-    "network_title": "Network services cost",
-    "storage_title": "Storage services usage",
-    "usage_label": "Usage"
+    "daily_cost_trend_title": "Google Cloud Platform Services daily cost comparison ({{units}})"
   },
   "gcp_details": {
     "change_column_title": "Month over month change",
@@ -692,11 +676,7 @@
     "compute_title": "Compute instances usage",
     "cost_title": "IBM Cloud Services cost",
     "cost_trend_title": "IBM Cloud Services cumulative cost comparison ({{units}})",
-    "daily_cost_trend_title": "IBM Cloud Services daily cost comparison ({{units}})",
-    "database_title": "Database services cost",
-    "network_title": "Network services cost",
-    "storage_title": "Storage services usage",
-    "usage_label": "Usage"
+    "daily_cost_trend_title": "IBM Cloud Services daily cost comparison ({{units}})"
   },
   "ibm_details": {
     "change_column_title": "Month over month change",
@@ -813,17 +793,12 @@
     "compute_title": "Compute services usage",
     "cost_title": "All cloud filtered by OpenShift cost",
     "cost_trend_title": "All cloud filtered by OpenShift cumulative cost comparison ({{units}})",
-    "daily_cost_trend_title": "All cloud filtered by OpenShift daily cost comparison ({{units}})",
-    "database_title": "Database services cost",
-    "network_title": "Network services cost",
-    "storage_title": "Storage services usage",
-    "usage_label": "Usage"
+    "daily_cost_trend_title": "All cloud filtered by OpenShift daily cost comparison ({{units}})"
   },
   "ocp_dashboard": {
     "cost_title": "All OpenShift cost",
     "cost_trend_title": "All OpenShift cumulative cost comparison ({{units}})",
-    "daily_cost_trend_title": "All OpenShift daily cost comparison ({{units}})",
-    "usage_label": "Usage"
+    "daily_cost_trend_title": "All OpenShift daily cost comparison ({{units}})"
   },
   "ocp_details": {
     "change_column_title": "Month over month change",
@@ -841,15 +816,13 @@
   "ocp_supplementary_dashboard": {
     "cost_title": "OpenShift supplementary cost",
     "cost_trend_title": "OpenShift cumulative supplementary cost comparison ({{units}})",
-    "daily_cost_trend_title": "OpenShift daily supplementary cost comparison ({{units}})",
-    "usage_label": "Usage"
+    "daily_cost_trend_title": "OpenShift daily supplementary cost comparison ({{units}})"
   },
   "ocp_usage_dashboard": {
     "cost_title": "OpenShift usage cost",
     "cost_trend_title": "Metering cumulative cost comparison ({{units}})",
     "cpu_title": "OpenShift CPU usage and requests",
     "memory_title": "OpenShift memory usage and requests",
-    "usage_label": "Usage",
     "volume_title": "OpenShift volume usage and requests"
   },
   "onboarding": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -351,8 +351,8 @@
   },
   "dashboard": {
     "cumulative_cost_comparison": "Cumulative cost comparison ({{units}})",
-    "database_title": "Database services cost",
     "daily_usage_comparison": "Daily usage comparison ({{units}})",
+    "database_title": "Database services cost",
     "network_title": "Network services cost",
     "storage_title": "Storage services usage",
     "total_cost_tooltip": "This total cost is the sum of the infrastructure cost {{infrastructureCost}} and supplementary cost {{supplementaryCost}}",

--- a/src/store/dashboard/awsCloudDashboard/awsCloudDashboardWidgets.ts
+++ b/src/store/dashboard/awsCloudDashboard/awsCloudDashboardWidgets.ts
@@ -29,7 +29,7 @@ export const computeWidget: AwsCloudDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'aws_cloud_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   filter: {
     service: 'AmazonEC2',
@@ -94,7 +94,7 @@ export const costSummaryWidget: AwsCloudDashboardWidget = {
 
 export const databaseWidget: AwsCloudDashboardWidget = {
   id: getId(),
-  titleKey: 'aws_cloud_dashboard.database_title',
+  titleKey: 'dashboard.database_title',
   reportPathsType: ReportPathsType.awsCloud,
   reportType: ReportType.database,
   details: {
@@ -131,7 +131,7 @@ export const databaseWidget: AwsCloudDashboardWidget = {
 
 export const networkWidget: AwsCloudDashboardWidget = {
   id: getId(),
-  titleKey: 'aws_cloud_dashboard.network_title',
+  titleKey: 'dashboard.network_title',
   reportPathsType: ReportPathsType.awsCloud,
   reportType: ReportType.network,
   details: {
@@ -168,7 +168,7 @@ export const networkWidget: AwsCloudDashboardWidget = {
 
 export const storageWidget: AwsCloudDashboardWidget = {
   id: getId(),
-  titleKey: 'aws_cloud_dashboard.storage_title',
+  titleKey: 'dashboard.storage_title',
   reportPathsType: ReportPathsType.awsCloud,
   reportType: ReportType.storage,
   details: {
@@ -182,7 +182,7 @@ export const storageWidget: AwsCloudDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'aws_cloud_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -30,7 +30,7 @@ export const computeWidget: AwsDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'aws_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   filter: {
     service: 'AmazonEC2',
@@ -98,7 +98,7 @@ export const costSummaryWidget: AwsDashboardWidget = {
 
 export const databaseWidget: AwsDashboardWidget = {
   id: getId(),
-  titleKey: 'aws_dashboard.database_title',
+  titleKey: 'dashboard.database_title',
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.database,
   details: {
@@ -135,7 +135,7 @@ export const databaseWidget: AwsDashboardWidget = {
 
 export const networkWidget: AwsDashboardWidget = {
   id: getId(),
-  titleKey: 'aws_dashboard.network_title',
+  titleKey: 'dashboard.network_title',
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.network,
   details: {
@@ -172,7 +172,7 @@ export const networkWidget: AwsDashboardWidget = {
 
 export const storageWidget: AwsDashboardWidget = {
   id: getId(),
-  titleKey: 'aws_dashboard.storage_title',
+  titleKey: 'dashboard.storage_title',
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.storage,
   details: {
@@ -186,7 +186,7 @@ export const storageWidget: AwsDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'aws_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,

--- a/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
+++ b/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
@@ -53,7 +53,7 @@ export const costSummaryWidget: AzureCloudDashboardWidget = {
 
 export const databaseWidget: AzureCloudDashboardWidget = {
   id: getId(),
-  titleKey: 'azure_cloud_dashboard.database_title',
+  titleKey: 'dashboard.database_title',
   reportPathsType: ReportPathsType.azureCloud,
   reportType: ReportType.database,
   details: {
@@ -90,7 +90,7 @@ export const databaseWidget: AzureCloudDashboardWidget = {
 
 export const networkWidget: AzureCloudDashboardWidget = {
   id: getId(),
-  titleKey: 'azure_cloud_dashboard.network_title',
+  titleKey: 'dashboard.network_title',
   reportPathsType: ReportPathsType.azureCloud,
   reportType: ReportType.network,
   details: {
@@ -127,7 +127,7 @@ export const networkWidget: AzureCloudDashboardWidget = {
 
 export const storageWidget: AzureCloudDashboardWidget = {
   id: getId(),
-  titleKey: 'azure_cloud_dashboard.storage_title',
+  titleKey: 'dashboard.storage_title',
   reportPathsType: ReportPathsType.azureCloud,
   reportType: ReportType.storage,
   details: {
@@ -142,7 +142,7 @@ export const storageWidget: AzureCloudDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'azure_cloud_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   filter: {
     service_name: 'Storage',
@@ -188,7 +188,7 @@ export const virtualMachineWidget: AzureCloudDashboardWidget = {
       fractionDigits: 0,
     },
     units: 'vm-hours',
-    usageKey: 'azure_cloud_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   filter: {
     service_name: 'Virtual Machines',

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -57,7 +57,7 @@ export const costSummaryWidget: AzureDashboardWidget = {
 
 export const databaseWidget: AzureDashboardWidget = {
   id: getId(),
-  titleKey: 'azure_dashboard.database_title',
+  titleKey: 'dashboard.database_title',
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.database,
   details: {
@@ -94,7 +94,7 @@ export const databaseWidget: AzureDashboardWidget = {
 
 export const networkWidget: AzureDashboardWidget = {
   id: getId(),
-  titleKey: 'azure_dashboard.network_title',
+  titleKey: 'dashboard.network_title',
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.network,
   details: {
@@ -131,7 +131,7 @@ export const networkWidget: AzureDashboardWidget = {
 
 export const storageWidget: AzureDashboardWidget = {
   id: getId(),
-  titleKey: 'azure_dashboard.storage_title',
+  titleKey: 'dashboard.storage_title',
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.storage,
   details: {
@@ -146,7 +146,7 @@ export const storageWidget: AzureDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'azure_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   filter: {
     service_name: 'Storage',
@@ -192,7 +192,7 @@ export const virtualMachineWidget: AzureDashboardWidget = {
       fractionDigits: 0,
     },
     units: 'vm-hours',
-    usageKey: 'azure_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   filter: {
     service_name: 'Virtual Machines',

--- a/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
@@ -31,7 +31,7 @@ export const computeWidget: GcpDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'gcp_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   filter: {
     service: 'Compute Engine',
@@ -99,7 +99,7 @@ export const costSummaryWidget: GcpDashboardWidget = {
 
 export const databaseWidget: GcpDashboardWidget = {
   id: getId(),
-  titleKey: 'gcp_dashboard.database_title',
+  titleKey: 'dashboard.database_title',
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.database,
   details: {
@@ -136,7 +136,7 @@ export const databaseWidget: GcpDashboardWidget = {
 
 export const networkWidget: GcpDashboardWidget = {
   id: getId(),
-  titleKey: 'gcp_dashboard.network_title',
+  titleKey: 'dashboard.network_title',
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.network,
   details: {
@@ -175,7 +175,7 @@ export const networkWidget: GcpDashboardWidget = {
 
 export const storageWidget: GcpDashboardWidget = {
   id: getId(),
-  titleKey: 'gcp_dashboard.storage_title',
+  titleKey: 'dashboard.storage_title',
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.storage,
   details: {
@@ -189,7 +189,7 @@ export const storageWidget: GcpDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'gcp_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,

--- a/src/store/dashboard/ibmDashboard/ibmDashboardWidgets.ts
+++ b/src/store/dashboard/ibmDashboard/ibmDashboardWidgets.ts
@@ -31,7 +31,7 @@ export const computeWidget: IbmDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'ibm_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   filter: {
     service: 'Compute Engine',
@@ -99,7 +99,7 @@ export const costSummaryWidget: IbmDashboardWidget = {
 
 export const databaseWidget: IbmDashboardWidget = {
   id: getId(),
-  titleKey: 'ibm_dashboard.database_title',
+  titleKey: 'dashboard.database_title',
   reportPathsType: ReportPathsType.ibm,
   reportType: ReportType.database,
   details: {
@@ -136,7 +136,7 @@ export const databaseWidget: IbmDashboardWidget = {
 
 export const networkWidget: IbmDashboardWidget = {
   id: getId(),
-  titleKey: 'ibm_dashboard.network_title',
+  titleKey: 'dashboard.network_title',
   reportPathsType: ReportPathsType.ibm,
   reportType: ReportType.network,
   details: {
@@ -175,7 +175,7 @@ export const networkWidget: IbmDashboardWidget = {
 
 export const storageWidget: IbmDashboardWidget = {
   id: getId(),
-  titleKey: 'ibm_dashboard.storage_title',
+  titleKey: 'dashboard.storage_title',
   reportPathsType: ReportPathsType.ibm,
   reportType: ReportType.storage,
   details: {
@@ -189,7 +189,7 @@ export const storageWidget: IbmDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'ibm_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
@@ -65,7 +65,7 @@ export const computeWidget: OcpCloudDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'ocp_cloud_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   filter: {
     service: 'AmazonEC2',
@@ -84,7 +84,7 @@ export const computeWidget: OcpCloudDashboardWidget = {
 
 export const databaseWidget: OcpCloudDashboardWidget = {
   id: getId(),
-  titleKey: 'ocp_cloud_dashboard.database_title',
+  titleKey: 'dashboard.database_title',
   reportPathsType: ReportPathsType.ocpCloud,
   reportType: ReportType.database,
   details: {
@@ -111,7 +111,7 @@ export const databaseWidget: OcpCloudDashboardWidget = {
 
 export const networkWidget: OcpCloudDashboardWidget = {
   id: getId(),
-  titleKey: 'ocp_cloud_dashboard.network_title',
+  titleKey: 'dashboard.network_title',
   reportPathsType: ReportPathsType.ocpCloud,
   reportType: ReportType.network,
   details: {
@@ -138,7 +138,7 @@ export const networkWidget: OcpCloudDashboardWidget = {
 
 export const storageWidget: OcpCloudDashboardWidget = {
   id: getId(),
-  titleKey: 'ocp_cloud_dashboard.storage_title',
+  titleKey: 'dashboard.storage_title',
   reportPathsType: ReportPathsType.ocpCloud,
   reportType: ReportType.storage,
   details: {

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -71,7 +71,7 @@ export const cpuWidget: OcpDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'ocp_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
@@ -108,7 +108,7 @@ export const memoryWidget: OcpDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'ocp_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
@@ -145,7 +145,7 @@ export const volumeWidget: OcpDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'ocp_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,

--- a/src/store/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidgets.ts
+++ b/src/store/dashboard/ocpSupplementaryDashboard/ocpSupplementaryDashboardWidgets.ts
@@ -66,7 +66,7 @@ export const cpuWidget: OcpSupplementaryDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'ocp_supplementary_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
@@ -106,7 +106,7 @@ export const memoryWidget: OcpSupplementaryDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'ocp_supplementary_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
@@ -146,7 +146,7 @@ export const volumeWidget: OcpSupplementaryDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'ocp_supplementary_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,

--- a/src/store/dashboard/ocpUsageDashboard/ocpUsageDashboardWidgets.ts
+++ b/src/store/dashboard/ocpUsageDashboard/ocpUsageDashboardWidgets.ts
@@ -56,7 +56,7 @@ export const cpuWidget: OcpUsageDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'ocp_usage_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
 
   trend: {
@@ -89,7 +89,7 @@ export const memoryWidget: OcpUsageDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'ocp_usage_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
@@ -121,7 +121,7 @@ export const volumeWidget: OcpUsageDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    usageKey: 'ocp_usage_dashboard.usage_label',
+    usageKey: 'dashboard.usage_label',
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/COST-727

The below keys have all been consolidated and moved under "dashboard" in the i18n json file

Original key values:
**"Database services cost"                                                   [Found: 7]**
- 	FOUND IN KEY: aws_cloud_dashboard.database_title
- 	FOUND IN KEY: aws_dashboard.database_title
- 	FOUND IN KEY: ibm_dashboard.database_title
- 	FOUND IN KEY: ocp_cloud_dashboard.database_title
- 	FOUND IN KEY: azure_cloud_dashboard.database_title
- 	FOUND IN KEY: azure_dashboard.database_title
- 	FOUND IN KEY: gcp_dashboard.database_title

**"Network services cost"                                                    [Found: 7]**
- 	FOUND IN KEY: azure_cloud_dashboard.network_title
- 	FOUND IN KEY: aws_dashboard.network_title
- 	FOUND IN KEY: ocp_cloud_dashboard.network_title
- 	FOUND IN KEY: ibm_dashboard.network_title
- 	FOUND IN KEY: gcp_dashboard.network_title
- 	FOUND IN KEY: aws_cloud_dashboard.network_title
- 	FOUND IN KEY: azure_dashboard.network_title

**"Storage services usage"                                                   [Found: 7]**
- 	FOUND IN KEY: azure_cloud_dashboard.storage_title
- 	FOUND IN KEY: gcp_dashboard.storage_title
- 	FOUND IN KEY: aws_dashboard.storage_title
- 	FOUND IN KEY: ibm_dashboard.storage_title
- 	FOUND IN KEY: aws_cloud_dashboard.storage_title
- 	FOUND IN KEY: azure_dashboard.storage_title
- 	FOUND IN KEY: ocp_cloud_dashboard.storage_title

**"Usage"                                                                    [Found: 10]**
- 	FOUND IN KEY: ocp_cloud_dashboard.usage_label
- 	FOUND IN KEY: ocp_dashboard.usage_label
- 	FOUND IN KEY: aws_dashboard.usage_label
- 	FOUND IN KEY: ibm_dashboard.usage_label
- 	FOUND IN KEY: gcp_dashboard.usage_label
- 	FOUND IN KEY: aws_cloud_dashboard.usage_label
- 	FOUND IN KEY: azure_cloud_dashboard.usage_label
- 	FOUND IN KEY: ocp_supplementary_dashboard.usage_label
- 	FOUND IN KEY: azure_dashboard.usage_label
- 	FOUND IN KEY: ocp_usage_dashboard.usage_label
