### PR TITLE
No data states should check new previous_month_data and has_data flags

### DIFF
--- a/src/api/providers.ts
+++ b/src/api/providers.ts
@@ -39,7 +39,9 @@ export interface Provider {
   cost_models?: ProviderCostModel[];
   current_month_data?: boolean;
   customer?: ProviderCustomer;
+  has_data?: boolean;
   name?: string;
+  previous_month_data?: boolean;
   type?: string;
   uuid?: string;
 }

--- a/src/pages/views/details/awsDetails/awsDetails.tsx
+++ b/src/pages/views/details/awsDetails/awsDetails.tsx
@@ -12,6 +12,7 @@ import NoProviders from 'pages/state/noProviders';
 import NotAvailable from 'pages/state/notAvailable';
 import { ExportModal } from 'pages/views/components/export/exportModal';
 import { getGroupByTagKey } from 'pages/views/utils/groupBy';
+import { hasCurrentMonthData } from 'pages/views/utils/providers';
 import { addQueryFilter, removeQueryFilter } from 'pages/views/utils/query';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
@@ -354,22 +355,6 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     history.replace(filteredQuery);
   };
 
-  // Ensure at least one source provider has data available
-  private hasCurrentMonthData = () => {
-    const { providers } = this.props;
-    let result = false;
-
-    if (providers && providers.data) {
-      for (const provider of providers.data) {
-        if (provider.current_month_data) {
-          result = true;
-          break;
-        }
-      }
-    }
-    return result;
-  };
-
   private updateReport = () => {
     const { query, location, fetchReport, history, queryString } = this.props;
     if (!location.search) {
@@ -405,7 +390,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
       if (noProviders) {
         return <NoProviders providerType={ProviderType.aws} title={title} />;
       }
-      if (!this.hasCurrentMonthData()) {
+      if (!hasCurrentMonthData(providers)) {
         return <NoData title={title} />;
       }
     }

--- a/src/pages/views/details/azureDetails/azureDetails.tsx
+++ b/src/pages/views/details/azureDetails/azureDetails.tsx
@@ -12,6 +12,7 @@ import NoProviders from 'pages/state/noProviders';
 import NotAvailable from 'pages/state/notAvailable';
 import { ExportModal } from 'pages/views/components/export/exportModal';
 import { getGroupByTagKey } from 'pages/views/utils/groupBy';
+import { hasCurrentMonthData } from 'pages/views/utils/providers';
 import { addQueryFilter, removeQueryFilter } from 'pages/views/utils/query';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
@@ -344,22 +345,6 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     history.replace(filteredQuery);
   };
 
-  // Ensure at least one source provider has data available
-  private hasCurrentMonthData = () => {
-    const { providers } = this.props;
-    let result = false;
-
-    if (providers && providers.data) {
-      for (const provider of providers.data) {
-        if (provider.current_month_data) {
-          result = true;
-          break;
-        }
-      }
-    }
-    return result;
-  };
-
   private updateReport = () => {
     const { query, location, fetchReport, history, queryString } = this.props;
     if (!location.search) {
@@ -395,7 +380,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
       if (noProviders) {
         return <NoProviders providerType={ProviderType.azure} title={title} />;
       }
-      if (!this.hasCurrentMonthData()) {
+      if (!hasCurrentMonthData(providers)) {
         return <NoData title={title} />;
       }
     }

--- a/src/pages/views/details/components/breakdown/breakdownBase.tsx
+++ b/src/pages/views/details/components/breakdown/breakdownBase.tsx
@@ -8,6 +8,7 @@ import Loading from 'pages/state/loading';
 import NoData from 'pages/state/noData';
 import NoProviders from 'pages/state/noProviders';
 import NotAvailable from 'pages/state/notAvailable';
+import { hasCurrentMonthData } from 'pages/views/utils/providers';
 import React from 'react';
 import { WithTranslation } from 'react-i18next';
 import { RouteComponentProps } from 'react-router-dom';
@@ -181,22 +182,6 @@ class BreakdownBase extends React.Component<BreakdownProps> {
     }
   };
 
-  // Ensure at least one source provider has data available
-  private hasCurrentMonthData = () => {
-    const { providers } = this.props;
-    let result = false;
-
-    if (providers && providers.data) {
-      for (const provider of providers.data) {
-        if (provider.current_month_data) {
-          result = true;
-          break;
-        }
-      }
-    }
-    return result;
-  };
-
   private updateReport = () => {
     const { location, fetchReport, queryString, reportPathsType, reportType } = this.props;
     if (location.search) {
@@ -236,7 +221,7 @@ class BreakdownBase extends React.Component<BreakdownProps> {
       if (noProviders) {
         return <NoProviders providerType={providerType} title={emptyStateTitle} />;
       }
-      if (!this.hasCurrentMonthData()) {
+      if (!hasCurrentMonthData(providers)) {
         return <NoData title={title} />;
       }
     }

--- a/src/pages/views/details/gcpDetails/gcpDetails.tsx
+++ b/src/pages/views/details/gcpDetails/gcpDetails.tsx
@@ -12,6 +12,7 @@ import NoProviders from 'pages/state/noProviders';
 import NotAvailable from 'pages/state/notAvailable';
 import { ExportModal } from 'pages/views/components/export/exportModal';
 import { getGroupByTagKey } from 'pages/views/utils/groupBy';
+import { hasCurrentMonthData } from 'pages/views/utils/providers';
 import { addQueryFilter, removeQueryFilter } from 'pages/views/utils/query';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
@@ -343,22 +344,6 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
     history.replace(filteredQuery);
   };
 
-  // Ensure at least one source provider has data available
-  private hasCurrentMonthData = () => {
-    const { providers } = this.props;
-    let result = false;
-
-    if (providers && providers.data) {
-      for (const provider of providers.data) {
-        if (provider.current_month_data) {
-          result = true;
-          break;
-        }
-      }
-    }
-    return result;
-  };
-
   private updateReport = () => {
     const { query, location, fetchReport, history, queryString } = this.props;
     if (!location.search) {
@@ -394,7 +379,7 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
       if (noProviders) {
         return <NoProviders providerType={ProviderType.gcp} title={title} />;
       }
-      if (!this.hasCurrentMonthData()) {
+      if (!hasCurrentMonthData(providers)) {
         return <NoData title={title} />;
       }
     }

--- a/src/pages/views/details/ibmDetails/ibmDetails.tsx
+++ b/src/pages/views/details/ibmDetails/ibmDetails.tsx
@@ -12,6 +12,7 @@ import NoProviders from 'pages/state/noProviders';
 import NotAvailable from 'pages/state/notAvailable';
 import { ExportModal } from 'pages/views/components/export/exportModal';
 import { getGroupByTagKey } from 'pages/views/utils/groupBy';
+import { hasCurrentMonthData } from 'pages/views/utils/providers';
 import { addQueryFilter, removeQueryFilter } from 'pages/views/utils/query';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
@@ -343,22 +344,6 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
     history.replace(filteredQuery);
   };
 
-  // Ensure at least one source provider has data available
-  private hasCurrentMonthData = () => {
-    const { providers } = this.props;
-    let result = false;
-
-    if (providers && providers.data) {
-      for (const provider of providers.data) {
-        if (provider.current_month_data) {
-          result = true;
-          break;
-        }
-      }
-    }
-    return result;
-  };
-
   private updateReport = () => {
     const { query, location, fetchReport, history, queryString } = this.props;
     if (!location.search) {
@@ -394,7 +379,7 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
       if (noProviders) {
         return <NoProviders providerType={ProviderType.ibm} title={title} />;
       }
-      if (!this.hasCurrentMonthData()) {
+      if (!hasCurrentMonthData(providers)) {
         return <NoData title={title} />;
       }
     }

--- a/src/pages/views/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/views/details/ocpDetails/ocpDetails.tsx
@@ -12,6 +12,7 @@ import NoProviders from 'pages/state/noProviders';
 import NotAvailable from 'pages/state/notAvailable';
 import { ExportModal } from 'pages/views/components/export/exportModal';
 import { getGroupByTagKey } from 'pages/views/utils/groupBy';
+import { hasCurrentMonthData } from 'pages/views/utils/providers';
 import { addQueryFilter, removeQueryFilter } from 'pages/views/utils/query';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
@@ -344,22 +345,6 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     history.replace(filteredQuery);
   };
 
-  // Ensure at least one source provider has data available
-  private hasCurrentMonthData = () => {
-    const { providers } = this.props;
-    let result = false;
-
-    if (providers && providers.data) {
-      for (const provider of providers.data) {
-        if (provider.current_month_data) {
-          result = true;
-          break;
-        }
-      }
-    }
-    return result;
-  };
-
   private updateReport = () => {
     const { query, location, fetchReport, history, queryString } = this.props;
     if (!location.search) {
@@ -395,7 +380,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
       if (noProviders) {
         return <NoProviders providerType={ProviderType.ocp} title={title} />;
       }
-      if (!this.hasCurrentMonthData()) {
+      if (!hasCurrentMonthData(providers)) {
         return <NoData title={title} />;
       }
     }

--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -13,6 +13,7 @@ import NoProviders from 'pages/state/noProviders';
 import NotAvailable from 'pages/state/notAvailable';
 import { ExportModal } from 'pages/views/components/export/exportModal';
 import { getGroupByOrg, getGroupByTagKey } from 'pages/views/utils/groupBy';
+import { hasData } from 'pages/views/utils/providers';
 import { addQueryFilter, removeQueryFilter } from 'pages/views/utils/query';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
@@ -370,21 +371,6 @@ class Explorer extends React.Component<ExplorerProps> {
     history.replace(filteredQuery);
   };
 
-  // Ensure at least one source provider has data available
-  private hasCurrentMonthData = (providers: Providers) => {
-    let result = false;
-
-    if (providers && providers.data) {
-      for (const provider of providers.data) {
-        if (provider.current_month_data) {
-          result = true;
-          break;
-        }
-      }
-    }
-    return result;
-  };
-
   private updateReport = () => {
     const { dateRange, fetchReport, history, location, perspective, query, queryString } = this.props;
     if (!location.search) {
@@ -455,11 +441,11 @@ class Explorer extends React.Component<ExplorerProps> {
       return <NoProviders title={title} />;
     } else if (
       !(
-        this.hasCurrentMonthData(awsProviders) ||
-        this.hasCurrentMonthData(azureProviders) ||
-        this.hasCurrentMonthData(gcpProviders) ||
-        this.hasCurrentMonthData(ibmProviders) ||
-        this.hasCurrentMonthData(ocpProviders)
+        hasData(awsProviders) ||
+        hasData(azureProviders) ||
+        hasData(gcpProviders) ||
+        hasData(ibmProviders) ||
+        hasData(ocpProviders)
       )
     ) {
       return <NoData title={title} />;

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -21,6 +21,7 @@ import OcpCloudDashboard from 'pages/views/overview/ocpCloudDashboard';
 import OcpDashboard from 'pages/views/overview/ocpDashboard';
 import OcpSupplementaryDashboard from 'pages/views/overview/ocpSupplementaryDashboard';
 import OcpUsageDashboard from 'pages/views/overview/ocpUsageDashboard';
+import { hasCurrentMonthData, hasPreviousMonthData } from 'pages/views/utils/providers';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -337,21 +338,6 @@ class OverviewBase extends React.Component<OverviewProps> {
     });
   };
 
-  // Ensure at least one source provider has data available
-  private hasCurrentMonthData = (providers: Providers) => {
-    let result = false;
-
-    if (providers && providers.data) {
-      for (const provider of providers.data) {
-        if (provider.current_month_data) {
-          result = true;
-          break;
-        }
-      }
-    }
-    return result;
-  };
-
   private getTabItem = (tab: OverviewTab, index: number) => {
     const { awsProviders, azureProviders, gcpProviders, ibmProviders, ocpProviders } = this.props;
     const { activeTabKey, currentInfrastructurePerspective, currentOcpPerspective } = this.state;
@@ -364,31 +350,41 @@ class OverviewBase extends React.Component<OverviewProps> {
     const currentTab = getIdKeyForTab(tab);
     if (currentTab === OverviewTab.infrastructure) {
       if (currentInfrastructurePerspective === InfrastructurePerspective.allCloud) {
-        return this.hasCurrentMonthData(ocpProviders) ? <OcpCloudDashboard /> : noData;
+        const hasData = hasCurrentMonthData(ocpProviders) || hasPreviousMonthData(ocpProviders);
+        return hasData ? <OcpCloudDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.aws) {
-        return this.hasCurrentMonthData(awsProviders) ? <AwsDashboard /> : noData;
+        const hasData = hasCurrentMonthData(awsProviders) || hasPreviousMonthData(awsProviders);
+        return hasData ? <AwsDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.awsCloud) {
-        return this.hasCurrentMonthData(awsProviders) ? <AwsCloudDashboard /> : noData;
+        const hasData = hasCurrentMonthData(awsProviders) || hasPreviousMonthData(awsProviders);
+        return hasData ? <AwsCloudDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.gcp) {
-        return this.hasCurrentMonthData(gcpProviders) ? <GcpDashboard /> : noData;
+        const hasData = hasCurrentMonthData(gcpProviders) || hasPreviousMonthData(gcpProviders);
+        return hasData ? <GcpDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.ibm) {
-        return this.hasCurrentMonthData(ibmProviders) ? <IbmDashboard /> : noData;
+        const hasData = hasCurrentMonthData(ibmProviders) || hasPreviousMonthData(ibmProviders);
+        return hasData ? <IbmDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.azure) {
-        return this.hasCurrentMonthData(azureProviders) ? <AzureDashboard /> : noData;
+        const hasData = hasCurrentMonthData(azureProviders) || hasPreviousMonthData(azureProviders);
+        return hasData ? <AzureDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.azureCloud) {
-        return this.hasCurrentMonthData(azureProviders) ? <AzureCloudDashboard /> : noData;
+        const hasData = hasCurrentMonthData(azureProviders) || hasPreviousMonthData(azureProviders);
+        return hasData ? <AzureCloudDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.ocpUsage) {
-        return this.hasCurrentMonthData(ocpProviders) ? <OcpUsageDashboard /> : noData;
+        const hasData = hasCurrentMonthData(ocpProviders) || hasPreviousMonthData(ocpProviders);
+        return hasData ? <OcpUsageDashboard /> : noData;
       } else {
-        return this.hasCurrentMonthData(ocpProviders) ? <OcpCloudDashboard /> : noData; // default
+        const hasData = hasCurrentMonthData(ocpProviders) || hasPreviousMonthData(ocpProviders);
+        return hasData ? <OcpCloudDashboard /> : noData; // default
       }
     } else if (currentTab === OverviewTab.ocp) {
+      const hasData = hasCurrentMonthData(ocpProviders) || hasPreviousMonthData(ocpProviders);
       if (currentOcpPerspective === OcpPerspective.all) {
-        return this.hasCurrentMonthData(ocpProviders) ? <OcpDashboard /> : noData;
+        return hasData ? <OcpDashboard /> : noData;
       } else if (currentOcpPerspective === OcpPerspective.supplementary) {
-        return this.hasCurrentMonthData(ocpProviders) ? <OcpSupplementaryDashboard /> : noData;
+        return hasData ? <OcpSupplementaryDashboard /> : noData;
       } else {
-        return this.hasCurrentMonthData(ocpProviders) ? <OcpDashboard /> : noData; // default
+        return hasData ? <OcpDashboard /> : noData; // default
       }
     } else {
       return emptyTab;

--- a/src/pages/views/utils/providers.ts
+++ b/src/pages/views/utils/providers.ts
@@ -1,0 +1,46 @@
+import { Providers } from 'api/providers';
+
+// Ensure at least one source provider has data available for the current month
+export const hasCurrentMonthData = (providers: Providers) => {
+  let result = false;
+
+  if (providers && providers.data) {
+    for (const provider of providers.data) {
+      if (provider.current_month_data) {
+        result = true;
+        break;
+      }
+    }
+  }
+  return result;
+};
+
+// Ensure at least one source provider has data available
+export const hasData = (providers: Providers) => {
+  let result = false;
+
+  if (providers && providers.data) {
+    for (const provider of providers.data) {
+      if (provider.has_data) {
+        result = true;
+        break;
+      }
+    }
+  }
+  return result;
+};
+
+// Ensure at least one source provider has data available for the previous month
+export const hasPreviousMonthData = (providers: Providers) => {
+  let result = false;
+
+  if (providers && providers.data) {
+    for (const provider of providers.data) {
+      if (provider.previous_month_data) {
+        result = true;
+        break;
+      }
+    }
+  }
+  return result;
+};


### PR DESCRIPTION
When displaying the "no data" state, we currently only check the `current_month_data` flag of the sources API. However, we can still show the overview page if there is data for the previous month. If there is no data for either month, then we should display an empty state.

- For the overview page, check the new `previous_month_data` flag; as well as, `current_month_data`.
- For the details pages, we only need to check the `current_month_data` flag.
- For the cost explorer, we shall check the `has_data` flag, since the date range may cover more than just the current and previous month.