### PR TITLE
Reset export modal's default state upon close

### DIFF
--- a/src/pages/views/components/export/exportModal.tsx
+++ b/src/pages/views/components/export/exportModal.tsx
@@ -70,19 +70,15 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
 
   constructor(stateProps, dispatchProps) {
     super(stateProps, dispatchProps);
+    this.handleMonthChange = this.handleMonthChange.bind(this);
     this.handleResolutionChange = this.handleResolutionChange.bind(this);
   }
 
-  public componentDidUpdate(prevProps: ExportModalProps) {
-    const { isOpen } = this.props;
-
-    if (isOpen && !prevProps.isOpen) {
-      this.setState({ ...this.defaultState });
-    }
-  }
-
+  // Reset defult state upon close -- see https://issues.redhat.com/browse/COST-1134
   private handleClose = () => {
-    this.props.onClose(false);
+    this.setState({ ...this.defaultState }, () => {
+      this.props.onClose(false);
+    });
   };
 
   public handleMonthChange = (_, event) => {

--- a/src/pages/views/components/export/exportSubmit.tsx
+++ b/src/pages/views/components/export/exportSubmit.tsx
@@ -55,7 +55,6 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
 
   constructor(stateProps, dispatchProps) {
     super(stateProps, dispatchProps);
-    this.handleResolutionChange = this.handleResolutionChange.bind(this);
   }
 
   public componentDidUpdate(prevProps: ExportSubmitProps) {
@@ -105,10 +104,6 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
         this.getExport();
       }
     );
-  };
-
-  public handleResolutionChange = (_, event) => {
-    this.setState({ resolution: event.currentTarget.value });
   };
 
   public render() {


### PR DESCRIPTION
When the modal is opened, we're setting a default state. However, if the modal is opened a second time, it appears to lose its event handlers for `resolution` and `timeScope`.

This change resets the default state only when the modal is closed.

https://issues.redhat.com/browse/COST-1134