### PR TITLE
Incorrect data with multiple filters

### DIFF
--- a/src/api/queries/awsQuery.ts
+++ b/src/api/queries/awsQuery.ts
@@ -29,23 +29,14 @@ export interface AwsQuery extends utils.Query {
   order_by?: AwsOrderBys;
 }
 
-// Filters are returned with logical AND
-export function getLogicalAndQuery(query: AwsQuery) {
-  return utils.getLogicalAndQuery(query);
-}
-
-// Filters are returned with logical OR
-export function getLogicalOrQuery(query: AwsQuery) {
-  return utils.getLogicalOrQuery(query);
-}
-
-export function getQueryRoute(query: AwsQuery) {
-  return utils.getQueryRoute(query);
-}
-
-// Filters are returned without logical OR/AND
+// filter_by props are converted and returned with logical OR/AND prefix
 export function getQuery(query: AwsQuery) {
   return utils.getQuery(query);
+}
+
+// filter_by props are not converted
+export function getQueryRoute(query: AwsQuery) {
+  return utils.getQueryRoute(query);
 }
 
 export function parseQuery<T = any>(query: string): T {

--- a/src/api/queries/awsQuery.ts
+++ b/src/api/queries/awsQuery.ts
@@ -29,10 +29,21 @@ export interface AwsQuery extends utils.Query {
   order_by?: AwsOrderBys;
 }
 
+// Filters are returned with logical AND
+export function getLogicalAndQuery(query: AwsQuery) {
+  return utils.getLogicalAndQuery(query);
+}
+
+// Filters are returned with logical OR
+export function getLogicalOrQuery(query: AwsQuery) {
+  return utils.getLogicalOrQuery(query);
+}
+
 export function getQueryRoute(query: AwsQuery) {
   return utils.getQueryRoute(query);
 }
 
+// Filters are returned without logical OR/AND
 export function getQuery(query: AwsQuery) {
   return utils.getQuery(query);
 }

--- a/src/api/queries/azureQuery.ts
+++ b/src/api/queries/azureQuery.ts
@@ -28,12 +28,14 @@ export interface AzureQuery extends utils.Query {
   order_by?: AzureOrderBys;
 }
 
-export function getQueryRoute(query: AzureQuery) {
-  return utils.getQueryRoute(query);
-}
-
+// filter_by props are converted and returned with logical OR/AND prefix
 export function getQuery(query: AzureQuery) {
   return utils.getQuery(query);
+}
+
+// filter_by props are not converted
+export function getQueryRoute(query: AzureQuery) {
+  return utils.getQueryRoute(query);
 }
 
 export function parseQuery<T = any>(query: string): T {

--- a/src/api/queries/gcpQuery.ts
+++ b/src/api/queries/gcpQuery.ts
@@ -30,23 +30,14 @@ export interface GcpQuery extends utils.Query {
   order_by?: GcpOrderBys;
 }
 
-// Filters are returned with logical AND
-export function getLogicalAndQuery(query: GcpQuery) {
-  return utils.getLogicalAndQuery(query);
-}
-
-// Filters are returned with logical OR
-export function getLogicalOrQuery(query: GcpQuery) {
-  return utils.getLogicalOrQuery(query);
-}
-
-export function getQueryRoute(query: GcpQuery) {
-  return utils.getQueryRoute(query);
-}
-
-// Filters are returned without logical OR/AND
+// filter_by props are converted and returned with logical OR/AND prefix
 export function getQuery(query: GcpQuery) {
   return utils.getQuery(query);
+}
+
+// filter_by props are not converted
+export function getQueryRoute(query: GcpQuery) {
+  return utils.getQueryRoute(query);
 }
 
 export function parseQuery<T = any>(query: string): T {

--- a/src/api/queries/gcpQuery.ts
+++ b/src/api/queries/gcpQuery.ts
@@ -30,10 +30,21 @@ export interface GcpQuery extends utils.Query {
   order_by?: GcpOrderBys;
 }
 
+// Filters are returned with logical AND
+export function getLogicalAndQuery(query: GcpQuery) {
+  return utils.getLogicalAndQuery(query);
+}
+
+// Filters are returned with logical OR
+export function getLogicalOrQuery(query: GcpQuery) {
+  return utils.getLogicalOrQuery(query);
+}
+
 export function getQueryRoute(query: GcpQuery) {
   return utils.getQueryRoute(query);
 }
 
+// Filters are returned without logical OR/AND
 export function getQuery(query: GcpQuery) {
   return utils.getQuery(query);
 }

--- a/src/api/queries/ibmQuery.ts
+++ b/src/api/queries/ibmQuery.ts
@@ -30,23 +30,14 @@ export interface IbmQuery extends utils.Query {
   order_by?: IbmOrderBys;
 }
 
-// Filters are returned with logical AND
-export function getLogicalAndQuery(query: IbmQuery) {
-  return utils.getLogicalAndQuery(query);
-}
-
-// Filters are returned with logical OR
-export function getLogicalOrQuery(query: IbmQuery) {
-  return utils.getLogicalOrQuery(query);
-}
-
-export function getQueryRoute(query: IbmQuery) {
-  return utils.getQueryRoute(query);
-}
-
-// Filters are returned without logical OR/AND
+// filter_by props are converted and returned with logical OR/AND prefix
 export function getQuery(query: IbmQuery) {
   return utils.getQuery(query);
+}
+
+// filter_by props are not converted
+export function getQueryRoute(query: IbmQuery) {
+  return utils.getQueryRoute(query);
 }
 
 export function parseQuery<T = any>(query: string): T {

--- a/src/api/queries/ibmQuery.ts
+++ b/src/api/queries/ibmQuery.ts
@@ -30,10 +30,21 @@ export interface IbmQuery extends utils.Query {
   order_by?: IbmOrderBys;
 }
 
+// Filters are returned with logical AND
+export function getLogicalAndQuery(query: IbmQuery) {
+  return utils.getLogicalAndQuery(query);
+}
+
+// Filters are returned with logical OR
+export function getLogicalOrQuery(query: IbmQuery) {
+  return utils.getLogicalOrQuery(query);
+}
+
 export function getQueryRoute(query: IbmQuery) {
   return utils.getQueryRoute(query);
 }
 
+// Filters are returned without logical OR/AND
 export function getQuery(query: IbmQuery) {
   return utils.getQuery(query);
 }

--- a/src/api/queries/ocpCloudQuery.ts
+++ b/src/api/queries/ocpCloudQuery.ts
@@ -29,12 +29,14 @@ export interface OcpCloudQuery extends utils.Query {
   order_by?: OcpCloudOrderBys;
 }
 
-export function getQueryRoute(query: OcpCloudQuery) {
-  return utils.getQueryRoute(query);
-}
-
+// filter_by props are converted and returned with logical OR/AND prefix
 export function getQuery(query: OcpCloudQuery) {
   return utils.getQuery(query);
+}
+
+// filter_by props are not converted
+export function getQueryRoute(query: OcpCloudQuery) {
+  return utils.getQueryRoute(query);
 }
 
 export function parseQuery<T = any>(query: string): T {

--- a/src/api/queries/ocpQuery.ts
+++ b/src/api/queries/ocpQuery.ts
@@ -26,10 +26,21 @@ export interface OcpQuery extends utils.Query {
   order_by?: OcpOrderBys;
 }
 
+// Filters are returned with logical AND
+export function getLogicalAndQuery(query: OcpQuery) {
+  return utils.getLogicalAndQuery(query);
+}
+
+// Filters are returned with logical OR
+export function getLogicalOrQuery(query: OcpQuery) {
+  return utils.getLogicalOrQuery(query);
+}
+
 export function getQueryRoute(query: OcpQuery) {
   return utils.getQueryRoute(query);
 }
 
+// Filters are returned without logical OR/AND
 export function getQuery(query: OcpQuery) {
   return utils.getQuery(query);
 }

--- a/src/api/queries/ocpQuery.ts
+++ b/src/api/queries/ocpQuery.ts
@@ -26,23 +26,14 @@ export interface OcpQuery extends utils.Query {
   order_by?: OcpOrderBys;
 }
 
-// Filters are returned with logical AND
-export function getLogicalAndQuery(query: OcpQuery) {
-  return utils.getLogicalAndQuery(query);
-}
-
-// Filters are returned with logical OR
-export function getLogicalOrQuery(query: OcpQuery) {
-  return utils.getLogicalOrQuery(query);
-}
-
-export function getQueryRoute(query: OcpQuery) {
-  return utils.getQueryRoute(query);
-}
-
-// Filters are returned without logical OR/AND
+// filter_by props are converted and returned with logical OR/AND prefix
 export function getQuery(query: OcpQuery) {
   return utils.getQuery(query);
+}
+
+// filter_by props are not converted
+export function getQueryRoute(query: OcpQuery) {
+  return utils.getQueryRoute(query);
 }
 
 export function parseQuery<T = any>(query: string): T {

--- a/src/pages/views/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/pages/views/details/awsBreakdown/awsBreakdown.tsx
@@ -1,5 +1,5 @@
 import { ProviderType } from 'api/providers';
-import { AwsQuery, getLogicalOrQuery, parseQuery } from 'api/queries/awsQuery';
+import { AwsQuery, getQuery, parseQuery } from 'api/queries/awsQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { breakdownDescKey, breakdownTitleKey, logicalAndPrefix, orgUnitIdKey, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
@@ -43,8 +43,7 @@ const reportPathsType = ReportPathsType.aws;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdownStateProps>((state, props) => {
-  const queryFromRoute = parseQuery<AwsQuery>(location.search);
-  const query = queryFromRoute;
+  const query = parseQuery<AwsQuery>(location.search);
   const groupByOrgValue = getGroupByOrgValue(query);
   const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
   const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
@@ -65,7 +64,7 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
       ...(groupBy && { [groupBy]: groupByValue }),
     },
   };
-  const queryString = getLogicalOrQuery(newQuery);
+  const queryString = getQuery(newQuery);
 
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);

--- a/src/pages/views/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/pages/views/details/awsBreakdown/awsBreakdown.tsx
@@ -1,5 +1,5 @@
 import { ProviderType } from 'api/providers';
-import { AwsQuery, getQuery, parseQuery } from 'api/queries/awsQuery';
+import { AwsQuery, getLogicalOrQuery, parseQuery } from 'api/queries/awsQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { breakdownDescKey, breakdownTitleKey, logicalAndPrefix, orgUnitIdKey, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
@@ -57,14 +57,15 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
     },
     filter_by: {
       // Add filters here to apply logical OR/AND
-      ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
       ...(query && query.filter_by && query.filter_by),
+      ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
+      ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
     },
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
   };
-  const queryString = getQuery(newQuery);
+  const queryString = getLogicalOrQuery(newQuery);
 
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);

--- a/src/pages/views/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/pages/views/details/azureBreakdown/azureBreakdown.tsx
@@ -1,5 +1,5 @@
 import { ProviderType } from 'api/providers';
-import { getLogicalOrQuery, OcpQuery, parseQuery } from 'api/queries/ocpQuery';
+import { getQuery, OcpQuery, parseQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { breakdownDescKey, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
@@ -43,8 +43,7 @@ const reportPathsType = ReportPathsType.azure;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateProps>((state, props) => {
-  const queryFromRoute = parseQuery<OcpQuery>(location.search);
-  const query = queryFromRoute;
+  const query = parseQuery<OcpQuery>(location.search);
   const groupBy = getGroupById(query);
   const groupByValue = getGroupByValue(query);
 
@@ -63,7 +62,7 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateP
       ...(groupBy && { [groupBy]: groupByValue }),
     },
   };
-  const queryString = getLogicalOrQuery(newQuery);
+  const queryString = getQuery(newQuery);
 
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);

--- a/src/pages/views/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/pages/views/details/azureBreakdown/azureBreakdown.tsx
@@ -1,5 +1,5 @@
 import { ProviderType } from 'api/providers';
-import { getQuery, OcpQuery, parseQuery } from 'api/queries/ocpQuery';
+import { getLogicalOrQuery, OcpQuery, parseQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { breakdownDescKey, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
@@ -54,12 +54,16 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateP
       time_scope_units: 'month',
       time_scope_value: -1,
     },
-    ...(query && query.filter_by && { filter_by: query.filter_by }),
+    filter_by: {
+      // Add filters here to apply logical OR/AND
+      ...(query && query.filter_by && query.filter_by),
+      ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
+    },
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
   };
-  const queryString = getQuery(newQuery);
+  const queryString = getLogicalOrQuery(newQuery);
 
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);

--- a/src/pages/views/details/azureDetails/detailsTable.tsx
+++ b/src/pages/views/details/azureDetails/detailsTable.tsx
@@ -3,14 +3,14 @@ import './azureDetailsTable.scss';
 import { Bullseye, EmptyState, EmptyStateBody, EmptyStateIcon, Spinner } from '@patternfly/react-core';
 import { CalculatorIcon } from '@patternfly/react-icons/dist/js/icons/calculator-icon';
 import { sortable, SortByDirection, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { getQueryRoute } from 'api/queries/azureQuery';
 import { AzureQuery, getQuery } from 'api/queries/azureQuery';
-import { breakdownDescKey, tagPrefix } from 'api/queries/query';
+import { tagPrefix } from 'api/queries/query';
 import { AzureReport } from 'api/reports/azureReports';
 import { ReportPathsType } from 'api/reports/report';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import { Actions } from 'pages/views/details/components/actions/actions';
+import { getBreakdownPath } from 'pages/views/utils/paths';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
@@ -72,19 +72,6 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       this.initDatum();
     }
   }
-
-  private buildCostLink = (label: string, description: string) => {
-    const { groupBy, query } = this.props;
-
-    const newQuery = {
-      ...query,
-      ...(description && description !== label && { [breakdownDescKey]: description }),
-      group_by: {
-        [groupBy]: label,
-      },
-    };
-    return `${paths.azureDetailsBreakdown}?${getQueryRoute(newQuery)}`;
-  };
 
   private initDatum = () => {
     const { isAllSelected, query, report, selectedItems, t } = this.props;
@@ -149,7 +136,19 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       const cost = this.getTotalCost(item, index);
       const actions = this.getActions(item);
 
-      let name = <Link to={this.buildCostLink(label.toString(), item.id)}>{label}</Link>;
+      let name = (
+        <Link
+          to={getBreakdownPath({
+            basePath: paths.azureDetailsBreakdown,
+            label: label.toString(),
+            description: item.id,
+            groupBy: groupById,
+            query,
+          })}
+        >
+          {label}
+        </Link>
+      );
       if (label === `no-${groupById}` || label === `no-${groupByTagKey}`) {
         name = label as any;
       }

--- a/src/pages/views/details/components/historicalData/historicalDataCostChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataCostChart.tsx
@@ -1,5 +1,5 @@
 import Skeleton from '@redhat-cloud-services/frontend-components/Skeleton';
-import { getLogicalOrQuery, parseQuery, Query } from 'api/queries/query';
+import { getQuery, parseQuery, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import { ChartType, transformReport } from 'components/charts/common/chartDatumUtils';
 import { HistoricalCostChart } from 'components/charts/historicalCostChart';
@@ -120,8 +120,7 @@ class HistoricalDataCostChartBase extends React.Component<HistoricalDataCostChar
 
 const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, HistoricalDataCostChartStateProps>(
   (state, { reportPathsType, reportType }) => {
-    const queryFromRoute = parseQuery<Query>(location.search);
-    const query = queryFromRoute;
+    const query = parseQuery<Query>(location.search);
     const groupBy = getGroupById(query);
     const groupByValue = getGroupByValue(query);
 
@@ -143,7 +142,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
         time_scope_value: -1,
       },
     };
-    const currentQueryString = getLogicalOrQuery(currentQuery);
+    const currentQueryString = getQuery(currentQuery);
     const previousQuery: Query = {
       ...baseQuery,
       filter: {
@@ -152,7 +151,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
         time_scope_value: -2,
       },
     };
-    const previousQueryString = getLogicalOrQuery(previousQuery);
+    const previousQueryString = getQuery(previousQuery);
 
     // Current report
     const currentReport = reportSelectors.selectReport(state, reportPathsType, reportType, currentQueryString);

--- a/src/pages/views/details/components/historicalData/historicalDataCostChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataCostChart.tsx
@@ -1,5 +1,5 @@
 import Skeleton from '@redhat-cloud-services/frontend-components/Skeleton';
-import { getQuery, parseQuery, Query } from 'api/queries/query';
+import { getLogicalOrQuery, parseQuery, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import { ChartType, transformReport } from 'components/charts/common/chartDatumUtils';
 import { HistoricalCostChart } from 'components/charts/historicalCostChart';
@@ -126,7 +126,11 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
     const groupByValue = getGroupByValue(query);
 
     const baseQuery: Query = {
-      ...(query && query.filter_by && { filter_by: query.filter_by }),
+      filter_by: {
+        // Add filters here to apply logical OR/AND
+        ...(query && query.filter_by && query.filter_by),
+        ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
+      },
       group_by: {
         ...(groupBy && { [groupBy]: groupByValue }),
       },
@@ -139,7 +143,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
         time_scope_value: -1,
       },
     };
-    const currentQueryString = getQuery(currentQuery);
+    const currentQueryString = getLogicalOrQuery(currentQuery);
     const previousQuery: Query = {
       ...baseQuery,
       filter: {
@@ -148,7 +152,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
         time_scope_value: -2,
       },
     };
-    const previousQueryString = getQuery(previousQuery);
+    const previousQueryString = getLogicalOrQuery(previousQuery);
 
     // Current report
     const currentReport = reportSelectors.selectReport(state, reportPathsType, reportType, currentQueryString);

--- a/src/pages/views/details/components/historicalData/historicalDataTrendChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataTrendChart.tsx
@@ -1,5 +1,5 @@
 import Skeleton from '@redhat-cloud-services/frontend-components/Skeleton';
-import { getLogicalOrQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
+import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import { ChartType, transformReport } from 'components/charts/common/chartDatumUtils';
 import { HistoricalTrendChart } from 'components/charts/historicalTrendChart';
@@ -145,8 +145,7 @@ class HistoricalDataTrendChartBase extends React.Component<HistoricalDataTrendCh
 
 const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, HistoricalDataTrendChartStateProps>(
   (state, { reportPathsType, reportType }) => {
-    const queryFromRoute = parseQuery<Query>(location.search);
-    const query = queryFromRoute;
+    const query = parseQuery<Query>(location.search);
     const groupByOrgValue = getGroupByOrgValue(query);
     const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
     const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
@@ -170,7 +169,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
         time_scope_value: -1,
       },
     };
-    const currentQueryString = getLogicalOrQuery(currentQuery);
+    const currentQueryString = getQuery(currentQuery);
     const previousQuery: Query = {
       ...baseQuery,
       filter: {
@@ -179,7 +178,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
         time_scope_value: -2,
       },
     };
-    const previousQueryString = getLogicalOrQuery(previousQuery);
+    const previousQueryString = getQuery(previousQuery);
 
     // Current report
     const currentReport = reportSelectors.selectReport(state, reportPathsType, reportType, currentQueryString);

--- a/src/pages/views/details/components/historicalData/historicalDataTrendChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataTrendChart.tsx
@@ -1,5 +1,5 @@
 import Skeleton from '@redhat-cloud-services/frontend-components/Skeleton';
-import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
+import { getLogicalOrQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import { ChartType, transformReport } from 'components/charts/common/chartDatumUtils';
 import { HistoricalTrendChart } from 'components/charts/historicalTrendChart';
@@ -154,8 +154,9 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
     const baseQuery: Query = {
       filter_by: {
         // Add filters here to apply logical OR/AND
-        ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
         ...(query && query.filter_by && query.filter_by),
+        ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
+        ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
       },
       group_by: {
         ...(groupBy && { [groupBy]: groupByValue }),
@@ -169,7 +170,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
         time_scope_value: -1,
       },
     };
-    const currentQueryString = getQuery(currentQuery);
+    const currentQueryString = getLogicalOrQuery(currentQuery);
     const previousQuery: Query = {
       ...baseQuery,
       filter: {
@@ -178,7 +179,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
         time_scope_value: -2,
       },
     };
-    const previousQueryString = getQuery(previousQuery);
+    const previousQueryString = getLogicalOrQuery(previousQuery);
 
     // Current report
     const currentReport = reportSelectors.selectReport(state, reportPathsType, reportType, currentQueryString);

--- a/src/pages/views/details/components/historicalData/historicalDataUsageChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataUsageChart.tsx
@@ -1,5 +1,5 @@
 import Skeleton from '@redhat-cloud-services/frontend-components/Skeleton';
-import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
+import { getLogicalOrQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import { ChartType, transformReport } from 'components/charts/common/chartDatumUtils';
 import { HistoricalUsageChart } from 'components/charts/historicalUsageChart';
@@ -129,9 +129,10 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
     const baseQuery: Query = {
       filter_by: {
         // Add filters here to apply logical OR/AND
-        ...(groupByOrgValue && useFilter && { [`${logicalAndPrefix}${orgUnitIdKey}`]: groupByOrgValue }),
-        ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
         ...(query && query.filter_by && query.filter_by),
+        ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
+        ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
+        ...(groupByOrgValue && useFilter && { [`${logicalAndPrefix}${orgUnitIdKey}`]: groupByOrgValue }),
       },
       group_by: {
         ...(groupByOrgValue && !useFilter && { [orgUnitIdKey]: groupByOrgValue }),
@@ -146,7 +147,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
         time_scope_value: -1,
       },
     };
-    const currentQueryString = getQuery(currentQuery);
+    const currentQueryString = getLogicalOrQuery(currentQuery);
     const previousQuery: Query = {
       ...baseQuery,
       filter: {
@@ -155,7 +156,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
         time_scope_value: -2,
       },
     };
-    const previousQueryString = getQuery(previousQuery);
+    const previousQueryString = getLogicalOrQuery(previousQuery);
 
     // Current report
     const currentReport = reportSelectors.selectReport(state, reportPathsType, reportType, currentQueryString);

--- a/src/pages/views/details/components/historicalData/historicalDataUsageChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataUsageChart.tsx
@@ -1,5 +1,5 @@
 import Skeleton from '@redhat-cloud-services/frontend-components/Skeleton';
-import { getLogicalOrQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
+import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import { ChartType, transformReport } from 'components/charts/common/chartDatumUtils';
 import { HistoricalUsageChart } from 'components/charts/historicalUsageChart';
@@ -117,8 +117,7 @@ class HistoricalDataUsageChartBase extends React.Component<HistoricalDataUsageCh
 
 const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, HistoricalDataUsageChartStateProps>(
   (state, { reportPathsType, reportType }) => {
-    const queryFromRoute = parseQuery<Query>(location.search);
-    const query = queryFromRoute;
+    const query = parseQuery<Query>(location.search);
     const groupByOrgValue = getGroupByOrgValue(query);
     const groupBy = getGroupById(query);
     const groupByValue = getGroupByValue(query);
@@ -147,7 +146,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
         time_scope_value: -1,
       },
     };
-    const currentQueryString = getLogicalOrQuery(currentQuery);
+    const currentQueryString = getQuery(currentQuery);
     const previousQuery: Query = {
       ...baseQuery,
       filter: {
@@ -156,7 +155,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
         time_scope_value: -2,
       },
     };
-    const previousQueryString = getLogicalOrQuery(previousQuery);
+    const previousQueryString = getQuery(previousQuery);
 
     // Current report
     const currentReport = reportSelectors.selectReport(state, reportPathsType, reportType, currentQueryString);

--- a/src/pages/views/details/components/summary/summaryCard.tsx
+++ b/src/pages/views/details/components/summary/summaryCard.tsx
@@ -9,7 +9,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import Skeleton from '@redhat-cloud-services/frontend-components/Skeleton';
-import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
+import { getLogicalOrQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
 import { OcpReport } from 'api/reports/ocpReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { ReportSummaryItem, ReportSummaryItems } from 'components/reports/reportSummary';
@@ -195,15 +195,17 @@ const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps
       },
       filter_by: {
         // Add filters here to apply logical OR/AND
-        ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
-        ...(groupBy && { [`${logicalAndPrefix}${groupBy}`]: groupByValue }), // group bys must appear in filter to show costs by regions, accounts, etc
         ...(query && query.filter_by && query.filter_by),
+        ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
+        ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
+        ...(groupBy && { [`${logicalAndPrefix}${groupBy}`]: groupByValue }), // group bys must appear in filter to show costs by regions, accounts, etc
       },
       group_by: {
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.
       },
     };
-    const queryString = getQuery(newQuery);
+    const queryString = getLogicalOrQuery(newQuery);
+
     const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
     const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
     return {

--- a/src/pages/views/details/components/summary/summaryCard.tsx
+++ b/src/pages/views/details/components/summary/summaryCard.tsx
@@ -9,7 +9,7 @@ import {
   Title,
 } from '@patternfly/react-core';
 import Skeleton from '@redhat-cloud-services/frontend-components/Skeleton';
-import { getLogicalOrQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
+import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
 import { OcpReport } from 'api/reports/ocpReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { ReportSummaryItem, ReportSummaryItems } from 'components/reports/reportSummary';
@@ -180,8 +180,7 @@ class SummaryBase extends React.Component<SummaryProps> {
 
 const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps>(
   (state, { reportGroupBy, reportPathsType, reportType }) => {
-    const queryFromRoute = parseQuery<Query>(location.search);
-    const query = queryFromRoute;
+    const query = parseQuery<Query>(location.search);
     const groupByOrgValue = getGroupByOrgValue(query);
     const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
     const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
@@ -204,7 +203,7 @@ const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.
       },
     };
-    const queryString = getLogicalOrQuery(newQuery);
+    const queryString = getQuery(newQuery);
 
     const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
     const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);

--- a/src/pages/views/details/components/summary/summaryModalView.tsx
+++ b/src/pages/views/details/components/summary/summaryModalView.tsx
@@ -1,5 +1,5 @@
 import { Title } from '@patternfly/react-core';
-import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
+import { getLogicalOrQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import { ReportSummaryItem, ReportSummaryItems } from 'components/reports/reportSummary';
 import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'pages/views/utils/groupBy';
@@ -102,15 +102,17 @@ const mapStateToProps = createMapStateToProps<SummaryModalViewOwnProps, SummaryM
       },
       filter_by: {
         // Add filters here to apply logical OR/AND
-        ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
-        ...(groupBy && { [`${logicalAndPrefix}${groupBy}`]: groupByValue }), // group bys must appear in filter to show costs by regions, accounts, etc
         ...(query && query.filter_by && query.filter_by),
+        ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
+        ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
+        ...(groupBy && { [`${logicalAndPrefix}${groupBy}`]: groupByValue }), // group bys must appear in filter to show costs by regions, accounts, etc
       },
       group_by: {
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.
       },
     };
-    const queryString = getQuery(newQuery);
+    const queryString = getLogicalOrQuery(newQuery);
+
     const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
     const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
     return {

--- a/src/pages/views/details/components/summary/summaryModalView.tsx
+++ b/src/pages/views/details/components/summary/summaryModalView.tsx
@@ -1,5 +1,5 @@
 import { Title } from '@patternfly/react-core';
-import { getLogicalOrQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
+import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import { ReportSummaryItem, ReportSummaryItems } from 'components/reports/reportSummary';
 import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'pages/views/utils/groupBy';
@@ -88,8 +88,7 @@ class SummaryModalViewBase extends React.Component<SummaryModalViewProps> {
 
 const mapStateToProps = createMapStateToProps<SummaryModalViewOwnProps, SummaryModalViewStateProps>(
   (state, { reportGroupBy, reportPathsType }) => {
-    const queryFromRoute = parseQuery<Query>(location.search);
-    const query = queryFromRoute;
+    const query = parseQuery<Query>(location.search);
     const groupByOrgValue = getGroupByOrgValue(query);
     const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
     const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
@@ -111,7 +110,7 @@ const mapStateToProps = createMapStateToProps<SummaryModalViewOwnProps, SummaryM
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.
       },
     };
-    const queryString = getLogicalOrQuery(newQuery);
+    const queryString = getQuery(newQuery);
 
     const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
     const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);

--- a/src/pages/views/details/components/tag/tagLink.tsx
+++ b/src/pages/views/details/components/tag/tagLink.tsx
@@ -1,5 +1,5 @@
 import { TagIcon } from '@patternfly/react-icons/dist/js/icons/tag-icon';
-import { getLogicalOrQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
+import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
 import { Tag, TagPathsType, TagType } from 'api/tags/tag';
 import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'pages/views/utils/groupBy';
 import React from 'react';
@@ -103,8 +103,7 @@ class TagLinkBase extends React.Component<TagLinkProps> {
 }
 
 const mapStateToProps = createMapStateToProps<TagLinkOwnProps, TagLinkStateProps>((state, { tagReportPathsType }) => {
-  const queryFromRoute = parseQuery<Query>(location.search);
-  const query = queryFromRoute;
+  const query = parseQuery<Query>(location.search);
   const groupByOrgValue = getGroupByOrgValue(query);
   const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
   const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
@@ -122,7 +121,7 @@ const mapStateToProps = createMapStateToProps<TagLinkOwnProps, TagLinkStateProps
       ...(groupBy && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
     },
   };
-  const queryString = getLogicalOrQuery(newQuery);
+  const queryString = getQuery(newQuery);
 
   const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
   const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);

--- a/src/pages/views/details/components/tag/tagLink.tsx
+++ b/src/pages/views/details/components/tag/tagLink.tsx
@@ -1,5 +1,5 @@
 import { TagIcon } from '@patternfly/react-icons/dist/js/icons/tag-icon';
-import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
+import { getLogicalOrQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
 import { Tag, TagPathsType, TagType } from 'api/tags/tag';
 import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'pages/views/utils/groupBy';
 import React from 'react';
@@ -117,12 +117,12 @@ const mapStateToProps = createMapStateToProps<TagLinkOwnProps, TagLinkStateProps
     },
     filter_by: {
       // Add filters here to apply logical OR/AND
-      ...(groupBy && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
-      ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
       ...(query && query.filter_by && query.filter_by),
+      ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
+      ...(groupBy && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
     },
   };
-  const queryString = getQuery(newQuery);
+  const queryString = getLogicalOrQuery(newQuery);
 
   const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
   const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);

--- a/src/pages/views/details/components/tag/tagModal.tsx
+++ b/src/pages/views/details/components/tag/tagModal.tsx
@@ -1,5 +1,5 @@
 import { Modal } from '@patternfly/react-core';
-import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
+import { getLogicalOrQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
 import { Tag, TagPathsType, TagType } from 'api/tags/tag';
 import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'pages/views/utils/groupBy';
 import React from 'react';
@@ -110,12 +110,12 @@ const mapStateToProps = createMapStateToProps<TagModalOwnProps, TagModalStatePro
     },
     filter_by: {
       // Add filters here to apply logical OR/AND
-      ...(groupBy && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
-      ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
       ...(query && query.filter_by && query.filter_by),
+      ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
+      ...(groupBy && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
     },
   };
-  const queryString = getQuery(newQuery);
+  const queryString = getLogicalOrQuery(newQuery);
 
   const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
   const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);

--- a/src/pages/views/details/components/tag/tagModal.tsx
+++ b/src/pages/views/details/components/tag/tagModal.tsx
@@ -1,5 +1,5 @@
 import { Modal } from '@patternfly/react-core';
-import { getLogicalOrQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
+import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
 import { Tag, TagPathsType, TagType } from 'api/tags/tag';
 import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'pages/views/utils/groupBy';
 import React from 'react';
@@ -96,8 +96,7 @@ class TagModalBase extends React.Component<TagModalProps> {
 }
 
 const mapStateToProps = createMapStateToProps<TagModalOwnProps, TagModalStateProps>((state, { tagReportPathsType }) => {
-  const queryFromRoute = parseQuery<Query>(location.search);
-  const query = queryFromRoute;
+  const query = parseQuery<Query>(location.search);
   const groupByOrgValue = getGroupByOrgValue(query);
   const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
   const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
@@ -115,7 +114,7 @@ const mapStateToProps = createMapStateToProps<TagModalOwnProps, TagModalStatePro
       ...(groupBy && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
     },
   };
-  const queryString = getLogicalOrQuery(newQuery);
+  const queryString = getQuery(newQuery);
 
   const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
   const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);

--- a/src/pages/views/details/components/usageChart/usageChart.tsx
+++ b/src/pages/views/details/components/usageChart/usageChart.tsx
@@ -4,7 +4,7 @@ import { ChartBullet } from '@patternfly/react-charts';
 import { Grid, GridItem } from '@patternfly/react-core';
 import Skeleton from '@redhat-cloud-services/frontend-components/Skeleton';
 import { OcpQuery, parseQuery } from 'api/queries/ocpQuery';
-import { getLogicalOrQuery, Query } from 'api/queries/query';
+import { getQuery, Query } from 'api/queries/query';
 import { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { getGroupById, getGroupByValue } from 'pages/views/utils/groupBy';
@@ -399,8 +399,7 @@ class UsageChartBase extends React.Component<UsageChartProps> {
 
 const mapStateToProps = createMapStateToProps<UsageChartOwnProps, UsageChartStateProps>(
   (state, { reportPathsType, reportType }) => {
-    const queryFromRoute = parseQuery<OcpQuery>(location.search);
-    const query = queryFromRoute;
+    const query = parseQuery<OcpQuery>(location.search);
     const groupBy = getGroupById(query);
     const groupByValue = getGroupByValue(query);
 
@@ -419,7 +418,7 @@ const mapStateToProps = createMapStateToProps<UsageChartOwnProps, UsageChartStat
         ...(groupBy && { [groupBy]: groupByValue }),
       },
     };
-    const queryString = getLogicalOrQuery(newQuery);
+    const queryString = getQuery(newQuery);
 
     const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
     const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);

--- a/src/pages/views/details/components/usageChart/usageChart.tsx
+++ b/src/pages/views/details/components/usageChart/usageChart.tsx
@@ -4,7 +4,7 @@ import { ChartBullet } from '@patternfly/react-charts';
 import { Grid, GridItem } from '@patternfly/react-core';
 import Skeleton from '@redhat-cloud-services/frontend-components/Skeleton';
 import { OcpQuery, parseQuery } from 'api/queries/ocpQuery';
-import { getQuery, Query } from 'api/queries/query';
+import { getLogicalOrQuery, Query } from 'api/queries/query';
 import { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { getGroupById, getGroupByValue } from 'pages/views/utils/groupBy';
@@ -410,14 +410,20 @@ const mapStateToProps = createMapStateToProps<UsageChartOwnProps, UsageChartStat
         time_scope_value: -1,
         resolution: 'monthly',
       },
-      ...(query && query.filter_by && { filter_by: query.filter_by }),
+      filter_by: {
+        // Add filters here to apply logical OR/AND
+        ...(query && query.filter_by && query.filter_by),
+        ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
+      },
       group_by: {
         ...(groupBy && { [groupBy]: groupByValue }),
       },
     };
-    const queryString = getQuery(newQuery);
+    const queryString = getLogicalOrQuery(newQuery);
+
     const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
     const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+
     return {
       groupBy,
       report,

--- a/src/pages/views/details/gcpBreakdown/gcpBreakdown.tsx
+++ b/src/pages/views/details/gcpBreakdown/gcpBreakdown.tsx
@@ -1,5 +1,5 @@
 import { ProviderType } from 'api/providers';
-import { GcpQuery, getQuery, parseQuery } from 'api/queries/gcpQuery';
+import { GcpQuery, getLogicalOrQuery, parseQuery } from 'api/queries/gcpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { breakdownDescKey, breakdownTitleKey, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
@@ -54,12 +54,16 @@ const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, GcpBreakdown
       time_scope_units: 'month',
       time_scope_value: -1,
     },
-    ...(query && query.filter_by && { filter_by: query.filter_by }),
+    filter_by: {
+      // Add filters here to apply logical OR/AND
+      ...(query && query.filter_by && query.filter_by),
+      ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
+    },
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
   };
-  const queryString = getQuery(newQuery);
+  const queryString = getLogicalOrQuery(newQuery);
 
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);

--- a/src/pages/views/details/gcpBreakdown/gcpBreakdown.tsx
+++ b/src/pages/views/details/gcpBreakdown/gcpBreakdown.tsx
@@ -1,5 +1,5 @@
 import { ProviderType } from 'api/providers';
-import { GcpQuery, getLogicalOrQuery, parseQuery } from 'api/queries/gcpQuery';
+import { GcpQuery, getQuery, parseQuery } from 'api/queries/gcpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { breakdownDescKey, breakdownTitleKey, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
@@ -43,8 +43,7 @@ const reportPathsType = ReportPathsType.gcp;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, GcpBreakdownStateProps>((state, props) => {
-  const queryFromRoute = parseQuery<GcpQuery>(location.search);
-  const query = queryFromRoute;
+  const query = parseQuery<GcpQuery>(location.search);
   const groupBy = getGroupById(query);
   const groupByValue = getGroupByValue(query);
 
@@ -63,7 +62,7 @@ const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, GcpBreakdown
       ...(groupBy && { [groupBy]: groupByValue }),
     },
   };
-  const queryString = getLogicalOrQuery(newQuery);
+  const queryString = getQuery(newQuery);
 
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);

--- a/src/pages/views/details/gcpDetails/detailsTable.tsx
+++ b/src/pages/views/details/gcpDetails/detailsTable.tsx
@@ -3,14 +3,14 @@ import './gcpDetailsTable.scss';
 import { Bullseye, EmptyState, EmptyStateBody, EmptyStateIcon, Spinner } from '@patternfly/react-core';
 import { CalculatorIcon } from '@patternfly/react-icons/dist/js/icons/calculator-icon';
 import { sortable, SortByDirection, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { getQueryRoute } from 'api/queries/azureQuery';
 import { GcpQuery, getQuery } from 'api/queries/gcpQuery';
-import { breakdownDescKey, tagPrefix } from 'api/queries/query';
+import { tagPrefix } from 'api/queries/query';
 import { GcpReport } from 'api/reports/gcpReports';
 import { ReportPathsType } from 'api/reports/report';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import { Actions } from 'pages/views/details/components/actions/actions';
+import { getBreakdownPath } from 'pages/views/utils/paths';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
@@ -72,19 +72,6 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       this.initDatum();
     }
   }
-
-  private buildCostLink = (label: string, description: string) => {
-    const { groupBy, query } = this.props;
-
-    const newQuery = {
-      ...query,
-      ...(description && description !== label && { [breakdownDescKey]: description }),
-      group_by: {
-        [groupBy]: label,
-      },
-    };
-    return `${paths.gcpDetailsBreakdown}?${getQueryRoute(newQuery)}`;
-  };
 
   private initDatum = () => {
     const { isAllSelected, query, report, selectedItems, t } = this.props;
@@ -149,7 +136,19 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       const cost = this.getTotalCost(item, index);
       const actions = this.getActions(item);
 
-      let name = <Link to={this.buildCostLink(label.toString(), item.id)}>{label}</Link>;
+      let name = (
+        <Link
+          to={getBreakdownPath({
+            basePath: paths.gcpDetailsBreakdown,
+            label: label.toString(),
+            description: item.id,
+            groupBy: groupById,
+            query,
+          })}
+        >
+          {label}
+        </Link>
+      );
       if (label === `no-${groupById}` || label === `no-${groupByTagKey}`) {
         name = label as any;
       }

--- a/src/pages/views/details/ibmBreakdown/ibmBreakdown.tsx
+++ b/src/pages/views/details/ibmBreakdown/ibmBreakdown.tsx
@@ -1,5 +1,5 @@
 import { ProviderType } from 'api/providers';
-import { getLogicalOrQuery, IbmQuery, parseQuery } from 'api/queries/ibmQuery';
+import { getQuery, IbmQuery, parseQuery } from 'api/queries/ibmQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { breakdownDescKey, breakdownTitleKey, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
@@ -43,8 +43,7 @@ const reportPathsType = ReportPathsType.ibm;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<IbmBreakdownOwnProps, IbmBreakdownStateProps>((state, props) => {
-  const queryFromRoute = parseQuery<IbmQuery>(location.search);
-  const query = queryFromRoute;
+  const query = parseQuery<IbmQuery>(location.search);
   const groupBy = getGroupById(query);
   const groupByValue = getGroupByValue(query);
 
@@ -63,7 +62,7 @@ const mapStateToProps = createMapStateToProps<IbmBreakdownOwnProps, IbmBreakdown
       ...(groupBy && { [groupBy]: groupByValue }),
     },
   };
-  const queryString = getLogicalOrQuery(newQuery);
+  const queryString = getQuery(newQuery);
 
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);

--- a/src/pages/views/details/ibmBreakdown/ibmBreakdown.tsx
+++ b/src/pages/views/details/ibmBreakdown/ibmBreakdown.tsx
@@ -1,5 +1,5 @@
 import { ProviderType } from 'api/providers';
-import { getQuery, IbmQuery, parseQuery } from 'api/queries/ibmQuery';
+import { getLogicalOrQuery, IbmQuery, parseQuery } from 'api/queries/ibmQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { breakdownDescKey, breakdownTitleKey, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
@@ -54,12 +54,16 @@ const mapStateToProps = createMapStateToProps<IbmBreakdownOwnProps, IbmBreakdown
       time_scope_units: 'month',
       time_scope_value: -1,
     },
-    ...(query && query.filter_by && { filter_by: query.filter_by }),
+    filter_by: {
+      // Add filters here to apply logical OR/AND
+      ...(query && query.filter_by && query.filter_by),
+      ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
+    },
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
   };
-  const queryString = getQuery(newQuery);
+  const queryString = getLogicalOrQuery(newQuery);
 
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);

--- a/src/pages/views/details/ibmDetails/detailsTable.tsx
+++ b/src/pages/views/details/ibmDetails/detailsTable.tsx
@@ -3,14 +3,14 @@ import './ibmDetailsTable.scss';
 import { Bullseye, EmptyState, EmptyStateBody, EmptyStateIcon, Spinner } from '@patternfly/react-core';
 import { CalculatorIcon } from '@patternfly/react-icons/dist/js/icons/calculator-icon';
 import { sortable, SortByDirection, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { getQueryRoute } from 'api/queries/azureQuery';
 import { getQuery, IbmQuery } from 'api/queries/ibmQuery';
-import { breakdownDescKey, tagPrefix } from 'api/queries/query';
+import { tagPrefix } from 'api/queries/query';
 import { IbmReport } from 'api/reports/ibmReports';
 import { ReportPathsType } from 'api/reports/report';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import { Actions } from 'pages/views/details/components/actions/actions';
+import { getBreakdownPath } from 'pages/views/utils/paths';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
@@ -72,19 +72,6 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       this.initDatum();
     }
   }
-
-  private buildCostLink = (label: string, description: string) => {
-    const { groupBy, query } = this.props;
-
-    const newQuery = {
-      ...query,
-      ...(description && description !== label && { [breakdownDescKey]: description }),
-      group_by: {
-        [groupBy]: label,
-      },
-    };
-    return `${paths.ibmDetailsBreakdown}?${getQueryRoute(newQuery)}`;
-  };
 
   private initDatum = () => {
     const { isAllSelected, query, report, selectedItems, t } = this.props;
@@ -149,7 +136,19 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       const cost = this.getTotalCost(item, index);
       const actions = this.getActions(item);
 
-      let name = <Link to={this.buildCostLink(label.toString(), item.id)}>{label}</Link>;
+      let name = (
+        <Link
+          to={getBreakdownPath({
+            basePath: paths.ibmDetailsBreakdown,
+            label: label.toString(),
+            description: item.id,
+            groupBy: groupById,
+            query,
+          })}
+        >
+          {label}
+        </Link>
+      );
       if (label === `no-${groupById}` || label === `no-${groupByTagKey}`) {
         name = label as any;
       }

--- a/src/pages/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/pages/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -1,5 +1,5 @@
 import { ProviderType } from 'api/providers';
-import { getQuery, OcpQuery, parseQuery } from 'api/queries/ocpQuery';
+import { getLogicalOrQuery, OcpQuery, parseQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { breakdownDescKey, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
@@ -54,12 +54,16 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
       time_scope_units: 'month',
       time_scope_value: -1,
     },
-    ...(query && query.filter_by && { filter_by: query.filter_by }),
+    filter_by: {
+      // Add filters here to apply logical OR/AND
+      ...(query && query.filter_by && query.filter_by),
+      ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
+    },
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
   };
-  const queryString = getQuery(newQuery);
+  const queryString = getLogicalOrQuery(newQuery);
 
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);

--- a/src/pages/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/pages/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -1,5 +1,5 @@
 import { ProviderType } from 'api/providers';
-import { getLogicalOrQuery, OcpQuery, parseQuery } from 'api/queries/ocpQuery';
+import { getQuery, OcpQuery, parseQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { breakdownDescKey, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
@@ -43,8 +43,7 @@ const reportPathsType = ReportPathsType.ocp;
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdownStateProps>((state, props) => {
-  const queryFromRoute = parseQuery<OcpQuery>(location.search);
-  const query = queryFromRoute;
+  const query = parseQuery<OcpQuery>(location.search);
   const groupBy = getGroupById(query);
   const groupByValue = getGroupByValue(query);
 
@@ -63,7 +62,7 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
       ...(groupBy && { [groupBy]: groupByValue }),
     },
   };
-  const queryString = getLogicalOrQuery(newQuery);
+  const queryString = getQuery(newQuery);
 
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);

--- a/src/pages/views/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/views/details/ocpDetails/detailsTable.tsx
@@ -4,13 +4,14 @@ import { Bullseye, EmptyState, EmptyStateBody, EmptyStateIcon, Spinner } from '@
 import { CalculatorIcon } from '@patternfly/react-icons/dist/js/icons/calculator-icon';
 import { sortable, SortByDirection, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { ProviderType } from 'api/providers';
-import { getQuery, getQueryRoute, OcpQuery } from 'api/queries/ocpQuery';
-import { breakdownDescKey, tagPrefix } from 'api/queries/query';
+import { getQuery, OcpQuery } from 'api/queries/ocpQuery';
+import { tagPrefix } from 'api/queries/query';
 import { OcpReport } from 'api/reports/ocpReports';
 import { ReportPathsType } from 'api/reports/report';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import { EmptyValueState } from 'components/state/emptyValueState/emptyValueState';
 import { Actions } from 'pages/views/details/components/actions/actions';
+import { getBreakdownPath } from 'pages/views/utils/paths';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { Link } from 'react-router-dom';
@@ -72,19 +73,6 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       this.initDatum();
     }
   }
-
-  private buildCostLink = (label: string, description: string) => {
-    const { groupBy, query } = this.props;
-
-    const newQuery = {
-      ...query,
-      ...(description && description !== label && { [breakdownDescKey]: description }),
-      group_by: {
-        [groupBy]: label,
-      },
-    };
-    return `${paths.ocpDetailsBreakdown}?${getQueryRoute(newQuery)}`;
-  };
 
   private initDatum = () => {
     const { isAllSelected, query, report, selectedItems, t } = this.props;
@@ -172,7 +160,19 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       const cost = this.getTotalCost(item, index);
       const actions = this.getActions(item);
 
-      let name = <Link to={this.buildCostLink(label.toString(), item.id)}>{label}</Link>;
+      let name = (
+        <Link
+          to={getBreakdownPath({
+            basePath: paths.ocpDetailsBreakdown,
+            label: label.toString(),
+            description: item.id,
+            groupBy: groupById,
+            query,
+          })}
+        >
+          {label}
+        </Link>
+      );
       if (label === `no-${groupById}` || label === `no-${groupByTagKey}`) {
         name = label as any;
       }

--- a/src/pages/views/utils/paths.ts
+++ b/src/pages/views/utils/paths.ts
@@ -1,0 +1,78 @@
+import { getQueryRoute, Query } from 'api/queries/query';
+import { breakdownDescKey, breakdownTitleKey, orgUnitIdKey } from 'api/queries/query';
+
+export const getBreakdownPath = ({
+  basePath,
+  label,
+  description,
+  groupBy,
+  query,
+}: {
+  basePath: string;
+  label: string;
+  description: string;
+  groupBy: string | number;
+  query: Query;
+}) => {
+  const newQuery = {
+    ...query,
+    ...(description && description !== label && { [breakdownDescKey]: description }),
+    group_by: {
+      [groupBy]: label,
+    },
+  };
+
+  // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
+  newQuery.filter[groupBy] = undefined;
+
+  return `${basePath}?${getQueryRoute(newQuery)}`;
+};
+
+export const getOrgBreakdownPath = ({
+                                      basePath,
+                                      description,
+                                      groupBy,
+                                      groupByOrg,
+                                      id,
+                                      orgUnitId,
+                                      query,
+                                      title,
+                                      type,
+                                    }: {
+  basePath: string;
+  description: string | number; // Used to display a description in the breakdown header
+  groupBy: string | number;
+  groupByOrg: string | number; // Used for group_by[org_unit_id]=<groupByOrg> param in the breakdown page
+  id: string | number; // group_by[account]=<id> param in the breakdown page
+  orgUnitId: string | number; // Used to navigate back to details page
+  query: Query;
+  title: string | number; // Used to display a title in the breakdown header
+  type: string; // account or organizational_unit
+}) => {
+  const newQuery = {
+    ...JSON.parse(JSON.stringify(query)),
+    ...(description && description !== title && { [breakdownDescKey]: description }),
+    ...(title && { [breakdownTitleKey]: title }),
+    ...(groupByOrg && orgUnitId && { [orgUnitIdKey]: orgUnitId }),
+    group_by: {
+      [groupBy]: id, // This may be overridden below
+    },
+  };
+  if (!newQuery.filter) {
+    newQuery.filter = {};
+  }
+  if (type === 'account') {
+    newQuery.filter.account = id;
+    newQuery.group_by = {
+      [orgUnitIdKey]: groupByOrg,
+    };
+  } else if (type === 'organizational_unit') {
+    newQuery.group_by = {
+      [orgUnitIdKey]: id,
+    };
+  }
+  // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
+  newQuery.filter[groupBy] = undefined;
+
+  return `${basePath}?${getQueryRoute(newQuery)}`;
+};

--- a/src/pages/views/utils/paths.ts
+++ b/src/pages/views/utils/paths.ts
@@ -21,24 +21,20 @@ export const getBreakdownPath = ({
       [groupBy]: label,
     },
   };
-
-  // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
-  newQuery.filter[groupBy] = undefined;
-
   return `${basePath}?${getQueryRoute(newQuery)}`;
 };
 
 export const getOrgBreakdownPath = ({
-                                      basePath,
-                                      description,
-                                      groupBy,
-                                      groupByOrg,
-                                      id,
-                                      orgUnitId,
-                                      query,
-                                      title,
-                                      type,
-                                    }: {
+  basePath,
+  description,
+  groupBy,
+  groupByOrg,
+  id,
+  orgUnitId,
+  query,
+  title,
+  type,
+}: {
   basePath: string;
   description: string | number; // Used to display a description in the breakdown header
   groupBy: string | number;
@@ -71,8 +67,5 @@ export const getOrgBreakdownPath = ({
       [orgUnitIdKey]: id,
     };
   }
-  // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
-  newQuery.filter[groupBy] = undefined;
-
   return `${basePath}?${getQueryRoute(newQuery)}`;
 };

--- a/src/store/providers/providersCommon.ts
+++ b/src/store/providers/providersCommon.ts
@@ -12,16 +12,16 @@ export const azureProvidersQuery: ProvidersQuery = {
   type: 'AZURE',
 };
 
-export const ocpProvidersQuery: ProvidersQuery = {
-  type: 'OCP',
-};
-
 export const gcpProvidersQuery: ProvidersQuery = {
   type: 'GCP',
 };
 
 export const ibmProvidersQuery: ProvidersQuery = {
   type: 'GCP',
+};
+
+export const ocpProvidersQuery: ProvidersQuery = {
+  type: 'OCP',
 };
 
 export function getReportId(type: ProviderType, query: string) {


### PR DESCRIPTION
This change to the breakdown page shall omit filters associated with the current group_by in the details page.

- Drop filers associated with the current group_by for API requests in the breakdown page
- Renamed getLogicalOrQuery and getLogicalAndQuery functions as getQuery
- Moved getBreakdownLink function to utils

https://issues.redhat.com/browse/COST-1131