### PR TITLE
Reset ModalSubmit state upon close

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -484,7 +484,7 @@
     "file": {
       "daily": "daily",
       "monthly": "monthly",
-      "name": "cost-management-{{provider}}-$t(group_by.top_values.{{groupBy}})--$t(export.file.{{resolution}})-{{date}}"
+      "name": "{{provider}}-$t(group_by.top_values.{{groupBy}})-$t(export.file.{{resolution}})-{{date}}"
     },
     "heading": "Aggregates of the following {{groupBy}}s will be exported to a .csv file.",
     "monthly": "Monthly",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -481,7 +481,11 @@
     "cancel": "Cancel",
     "confirm": "Generate and download",
     "daily": "Daily",
-    "file_name": "cost-management-{{provider}}-$t(group_by.top_values.{{groupBy}})-{{date}}",
+    "file": {
+      "daily": "daily",
+      "monthly": "monthly",
+      "name": "cost-management-{{provider}}-$t(group_by.top_values.{{groupBy}})--$t(export.file.{{resolution}})-{{date}}"
+    },
     "heading": "Aggregates of the following {{groupBy}}s will be exported to a .csv file.",
     "monthly": "Monthly",
     "resolution_daily": "Daily",

--- a/src/pages/views/components/export/exportSubmit.tsx
+++ b/src/pages/views/components/export/exportSubmit.tsx
@@ -76,11 +76,12 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
   };
 
   private getFileName = () => {
-    const { groupBy, reportPathsType, t } = this.props;
+    const { groupBy, reportPathsType, resolution, t } = this.props;
 
-    const fileName = t('export.file_name', {
+    const fileName = t('export.file.name', {
       provider: reportPathsType,
       groupBy,
+      resolution,
       date: format(new Date(), 'yyyy-MM-dd'),
     });
 
@@ -88,7 +89,9 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
   };
 
   private handleClose = () => {
-    this.props.onClose(false);
+    this.setState({ ...this.defaultState }, () => {
+      this.props.onClose(false);
+    });
   };
 
   private handleFetchReport = () => {

--- a/src/pages/views/components/export/exportSubmit.tsx
+++ b/src/pages/views/components/export/exportSubmit.tsx
@@ -76,13 +76,18 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
   };
 
   private getFileName = () => {
-    const { groupBy, reportPathsType, resolution, t } = this.props;
+    const { groupBy, reportPathsType, resolution, t, timeScope } = this.props;
+
+    const thisMonth = new Date();
+    const lastMonth = new Date().setMonth(thisMonth.getMonth() - 1);
+    const currentMonth = format(thisMonth, 'MMMM_yyyy');
+    const previousMonth = format(lastMonth - 1, 'MMMM_yyyy');
 
     const fileName = t('export.file.name', {
       provider: reportPathsType,
       groupBy,
       resolution,
-      date: format(new Date(), 'yyyy-MM-dd'),
+      date: timeScope && timeScope === -2 ? previousMonth : currentMonth,
     });
 
     return `${fileName}.csv`;


### PR DESCRIPTION
This change resets state for `ModalSubmit` upon close. Also added the current resolution, along with the current and previous months, to the filename.

<img width="315" alt="Screen Shot 2021-03-12 at 12 07 33 AM" src="https://user-images.githubusercontent.com/17481322/110895051-03df4a00-82c7-11eb-9cc7-d4b02dfdbad3.png">

https://issues.redhat.com/browse/COST-1134