### PR TITLE
GCP and IBM should use beta flag

### DIFF
--- a/src/api/queries/userAccessQuery.ts
+++ b/src/api/queries/userAccessQuery.ts
@@ -3,6 +3,7 @@ import { parse, stringify } from 'qs';
 export interface UserAccessQuery {
   page_size?: number;
   type?: '' | 'AWS' | 'AZURE' | 'cost_model' | 'GCP' | 'IBM' | 'OCP';
+  beta?: true;
 }
 
 export function getUserAccessQuery(query: UserAccessQuery) {

--- a/src/api/userAccess.ts
+++ b/src/api/userAccess.ts
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 import { PagedLinks, PagedMetaData } from './api';
 
-export interface UserAcces {
+export interface UserAccessData {
   access?: boolean;
   type?: UserAccessType;
 }
@@ -10,7 +10,7 @@ export interface UserAcces {
 export interface UserAccess {
   meta: PagedMetaData;
   links?: PagedLinks;
-  data: UserAcces[] | boolean;
+  data: UserAccessData[] | boolean;
 }
 
 // eslint-disable-next-line no-shadow

--- a/src/components/async/permissionsComponent/permissions.tsx
+++ b/src/components/async/permissionsComponent/permissions.tsx
@@ -9,13 +9,27 @@ import { connect } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { paths, routes } from 'routes';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { allUserAccessQuery, userAccessActions, userAccessSelectors } from 'store/userAccess';
+import {
+  allUserAccessQuery,
+  gcpUserAccessQuery,
+  ibmUserAccessQuery,
+  userAccessActions,
+  userAccessSelectors,
+} from 'store/userAccess';
 
 interface PermissionsOwnProps extends RouteComponentProps<void> {
   children?: React.ReactNode;
 }
 
 interface PermissionsStateProps {
+  gcpUserAccess: UserAccess;
+  gcpUserAccessError: AxiosError;
+  gcpUserAccessFetchStatus: FetchStatus;
+  gcpUserAccessQueryString: string;
+  ibmUserAccess: UserAccess;
+  ibmUserAccessError: AxiosError;
+  ibmUserAccessFetchStatus: FetchStatus;
+  ibmUserAccessQueryString: string;
   userAccess: UserAccess;
   userAccessError: AxiosError;
   userAccessFetchStatus: FetchStatus;
@@ -39,46 +53,40 @@ class PermissionsBase extends React.Component<PermissionsProps> {
   public state: PermissionsState = { ...this.defaultState };
 
   public componentDidMount() {
-    const { userAccessQueryString, fetchUserAccess } = this.props;
+    const { gcpUserAccessQueryString, ibmUserAccessQueryString, userAccessQueryString, fetchUserAccess } = this.props;
 
     fetchUserAccess(UserAccessType.all, userAccessQueryString);
+    fetchUserAccess(UserAccessType.gcp, gcpUserAccessQueryString);
+    fetchUserAccess(UserAccessType.ibm, ibmUserAccessQueryString);
   }
 
   private hasPermissions() {
-    const { location, userAccess }: any = this.props;
+    const { location, gcpUserAccess, ibmUserAccess, userAccess }: any = this.props;
 
     if (!userAccess) {
       return false;
     }
 
-    // Todo: Remove override when API is available
-    if (userAccess && userAccess.data) {
-      userAccess.data.push({
-        type: 'explorer',
-        access: true,
-      });
-    }
-
-    const aws = userAccess.data.find(d => d.type === UserAccessType.aws);
-    const azure = userAccess.data.find(d => d.type === UserAccessType.azure);
-    const costModel = userAccess.data.find(d => d.type === UserAccessType.cost_model);
-    const explorer = userAccess.data.find(d => d.type === UserAccessType.explorer);
-    const gcp = userAccess.data.find(d => d.type === UserAccessType.gcp);
-    const ibm = userAccess.data.find(d => d.type === UserAccessType.ibm);
-    const ocp = userAccess.data.find(d => d.type === UserAccessType.ocp);
+    const aws = userAccess && userAccess.data.find(d => d.type === UserAccessType.aws);
+    const azure = userAccess && userAccess.data.find(d => d.type === UserAccessType.azure);
+    const costModel = userAccess && userAccess.data.find(d => d.type === UserAccessType.cost_model);
+    const gcp = gcpUserAccess && gcpUserAccess.data === true;
+    const ibm = ibmUserAccess && ibmUserAccess.data === true;
+    const ocp = userAccess && userAccess.data.find(d => d.type === UserAccessType.ocp);
 
     // cost models may include :uuid
     const _pathname = location.pathname.includes(paths.costModels) ? paths.costModels : location.pathname;
     const currRoute = routes.find(({ path }) => path.includes(_pathname));
 
     switch (currRoute.path) {
+      case paths.explorer:
       case paths.overview:
         return (
           (aws && aws.access) ||
           (azure && azure.access) ||
           (costModel && costModel.access) ||
-          (gcp && gcp.access) ||
-          (ibm && ibm.access) ||
+          gcp ||
+          ibm ||
           (ocp && ocp.access)
         );
       case paths.awsDetails:
@@ -89,14 +97,12 @@ class PermissionsBase extends React.Component<PermissionsProps> {
         return azure && azure.access;
       case paths.costModels:
         return costModel && costModel.access;
-      case paths.explorer:
-        return explorer && explorer.access;
       case paths.gcpDetails:
       case paths.gcpDetailsBreakdown:
-        return gcp && gcp.access;
+        return gcp;
       case paths.ibmDetails:
       case paths.ibmDetailsBreakdown:
-        return ibm && ibm.access;
+        return ibm;
       case paths.ocpDetails:
       case paths.ocpDetailsBreakdown:
         return ocp && ocp.access;
@@ -132,7 +138,43 @@ const mapStateToProps = createMapStateToProps<PermissionsOwnProps, PermissionsSt
     userAccessQueryString
   );
 
+  // Todo: temporarily request GCP separately with beta flag.
+  const gcpUserAccessQueryString = getUserAccessQuery(gcpUserAccessQuery);
+  const gcpUserAccess = userAccessSelectors.selectUserAccess(state, UserAccessType.gcp, gcpUserAccessQueryString);
+  const gcpUserAccessError = userAccessSelectors.selectUserAccessError(
+    state,
+    UserAccessType.gcp,
+    gcpUserAccessQueryString
+  );
+  const gcpUserAccessFetchStatus = userAccessSelectors.selectUserAccessFetchStatus(
+    state,
+    UserAccessType.gcp,
+    gcpUserAccessQueryString
+  );
+
+  // Todo: temporarily request IBM separately with beta flag.
+  const ibmUserAccessQueryString = getUserAccessQuery(ibmUserAccessQuery);
+  const ibmUserAccess = userAccessSelectors.selectUserAccess(state, UserAccessType.ibm, ibmUserAccessQueryString);
+  const ibmUserAccessError = userAccessSelectors.selectUserAccessError(
+    state,
+    UserAccessType.ibm,
+    ibmUserAccessQueryString
+  );
+  const ibmUserAccessFetchStatus = userAccessSelectors.selectUserAccessFetchStatus(
+    state,
+    UserAccessType.ibm,
+    ibmUserAccessQueryString
+  );
+
   return {
+    gcpUserAccess,
+    gcpUserAccessError,
+    gcpUserAccessFetchStatus,
+    gcpUserAccessQueryString,
+    ibmUserAccess,
+    ibmUserAccessError,
+    ibmUserAccessFetchStatus,
+    ibmUserAccessQueryString,
     userAccess,
     userAccessError,
     userAccessFetchStatus,

--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -29,7 +29,7 @@ import {
   providersSelectors,
 } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
-import { allUserAccessQuery, userAccessSelectors } from 'store/userAccess';
+import { allUserAccessQuery, gcpUserAccessQuery, ibmUserAccessQuery, userAccessSelectors } from 'store/userAccess';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 
@@ -68,9 +68,17 @@ interface ExplorerStateProps {
   gcpProviders: Providers;
   gcpProvidersFetchStatus: FetchStatus;
   gcpProvidersQueryString: string;
+  gcpUserAccess: UserAccess;
+  gcpUserAccessError: AxiosError;
+  gcpUserAccessFetchStatus: FetchStatus;
+  gcpUserAccessQueryString: string;
   ibmProviders: Providers;
   ibmProvidersFetchStatus: FetchStatus;
   ibmProvidersQueryString: string;
+  ibmUserAccess: UserAccess;
+  ibmUserAccessError: AxiosError;
+  ibmUserAccessFetchStatus: FetchStatus;
+  ibmUserAccessQueryString: string;
   ocpProviders: Providers;
   ocpProvidersFetchStatus: FetchStatus;
   ocpProvidersQueryString: string;
@@ -397,7 +405,11 @@ class Explorer extends React.Component<ExplorerProps> {
       awsProvidersFetchStatus,
       azureProvidersFetchStatus,
       gcpProvidersFetchStatus,
+      gcpUserAccess,
+      gcpUserAccessFetchStatus,
       ibmProvidersFetchStatus,
+      ibmUserAccess,
+      ibmUserAccessFetchStatus,
       ocpProvidersFetchStatus,
       perspective,
       userAccessFetchStatus,
@@ -415,7 +427,9 @@ class Explorer extends React.Component<ExplorerProps> {
       gcpProvidersFetchStatus === FetchStatus.inProgress ||
       ibmProvidersFetchStatus === FetchStatus.inProgress ||
       ocpProvidersFetchStatus === FetchStatus.inProgress ||
-      userAccessFetchStatus === FetchStatus.inProgress;
+      userAccessFetchStatus === FetchStatus.inProgress ||
+      gcpUserAccessFetchStatus === FetchStatus.inProgress ||
+      ibmUserAccessFetchStatus === FetchStatus.inProgress;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByTagKey = getGroupByTagKey(query);
@@ -427,8 +441,8 @@ class Explorer extends React.Component<ExplorerProps> {
     const noProviders = !(
       isAwsAvailable(awsProviders, awsProvidersFetchStatus, userAccess) &&
       isAzureAvailable(azureProviders, azureProvidersFetchStatus, userAccess) &&
-      isGcpAvailable(gcpProviders, gcpProvidersFetchStatus, userAccess) &&
-      isIbmAvailable(ibmProviders, ibmProvidersFetchStatus, userAccess) &&
+      isGcpAvailable(gcpProviders, gcpProvidersFetchStatus, gcpUserAccess) &&
+      isIbmAvailable(ibmProviders, ibmProvidersFetchStatus, ibmUserAccess) &&
       isOcpAvailable(ocpProviders, ocpProvidersFetchStatus, userAccess)
     );
 
@@ -569,6 +583,34 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
     userAccessQueryString
   );
 
+  // Todo: temporarily request GCP separately with beta flag.
+  const gcpUserAccessQueryString = getUserAccessQuery(gcpUserAccessQuery);
+  const gcpUserAccess = userAccessSelectors.selectUserAccess(state, UserAccessType.gcp, gcpUserAccessQueryString);
+  const gcpUserAccessError = userAccessSelectors.selectUserAccessError(
+    state,
+    UserAccessType.gcp,
+    gcpUserAccessQueryString
+  );
+  const gcpUserAccessFetchStatus = userAccessSelectors.selectUserAccessFetchStatus(
+    state,
+    UserAccessType.gcp,
+    gcpUserAccessQueryString
+  );
+
+  // Todo: temporarily request IBM separately with beta flag.
+  const ibmUserAccessQueryString = getUserAccessQuery(ibmUserAccessQuery);
+  const ibmUserAccess = userAccessSelectors.selectUserAccess(state, UserAccessType.ibm, ibmUserAccessQueryString);
+  const ibmUserAccessError = userAccessSelectors.selectUserAccessError(
+    state,
+    UserAccessType.ibm,
+    ibmUserAccessQueryString
+  );
+  const ibmUserAccessFetchStatus = userAccessSelectors.selectUserAccessFetchStatus(
+    state,
+    UserAccessType.ibm,
+    ibmUserAccessQueryString
+  );
+
   return {
     awsProviders,
     awsProvidersFetchStatus,
@@ -580,9 +622,17 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
     gcpProviders,
     gcpProvidersFetchStatus,
     gcpProvidersQueryString,
+    gcpUserAccess,
+    gcpUserAccessError,
+    gcpUserAccessFetchStatus,
+    gcpUserAccessQueryString,
     ibmProviders,
     ibmProvidersFetchStatus,
     ibmProvidersQueryString,
+    ibmUserAccess,
+    ibmUserAccessError,
+    ibmUserAccessFetchStatus,
+    ibmUserAccessQueryString,
     ocpProviders,
     ocpProvidersFetchStatus,
     ocpProvidersQueryString,

--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -20,7 +20,7 @@ import {
   ocpProvidersQuery,
   providersSelectors,
 } from 'store/providers';
-import { allUserAccessQuery, userAccessSelectors } from 'store/userAccess';
+import { allUserAccessQuery, gcpUserAccessQuery, ibmUserAccessQuery, userAccessSelectors } from 'store/userAccess';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
 
 import { ExplorerFilter } from './explorerFilter';
@@ -68,9 +68,17 @@ interface ExplorerHeaderStateProps {
   gcpProviders: Providers;
   gcpProvidersFetchStatus: FetchStatus;
   gcpProvidersQueryString: string;
+  gcpUserAccess: UserAccess;
+  gcpUserAccessError: AxiosError;
+  gcpUserAccessFetchStatus: FetchStatus;
+  gcpUserAccessQueryString: string;
   ibmProviders: Providers;
   ibmProvidersFetchStatus: FetchStatus;
   ibmProvidersQueryString: string;
+  ibmUserAccess: UserAccess;
+  ibmUserAccessError: AxiosError;
+  ibmUserAccessFetchStatus: FetchStatus;
+  ibmUserAccessQueryString: string;
   ocpProviders: Providers;
   ocpProvidersFetchStatus: FetchStatus;
   ocpProvidersQueryString: string;
@@ -112,8 +120,10 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
       azureProvidersFetchStatus,
       gcpProviders,
       gcpProvidersFetchStatus,
+      gcpUserAccess,
       ibmProviders,
       ibmProvidersFetchStatus,
+      ibmUserAccess,
       ocpProviders,
       ocpProvidersFetchStatus,
       perspective,
@@ -132,10 +142,10 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
     if (isAzureAvailable(azureProviders, azureProvidersFetchStatus, userAccess)) {
       return PerspectiveType.azure;
     }
-    if (isGcpAvailable(gcpProviders, gcpProvidersFetchStatus, userAccess)) {
+    if (isGcpAvailable(gcpProviders, gcpProvidersFetchStatus, gcpUserAccess)) {
       return PerspectiveType.gcp;
     }
-    if (isIbmAvailable(ibmProviders, ibmProvidersFetchStatus, userAccess)) {
+    if (isIbmAvailable(ibmProviders, ibmProvidersFetchStatus, ibmUserAccess)) {
       return PerspectiveType.ibm;
     }
     return undefined;
@@ -149,8 +159,10 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
       azureProvidersFetchStatus,
       gcpProviders,
       gcpProvidersFetchStatus,
+      gcpUserAccess,
       ibmProviders,
       ibmProvidersFetchStatus,
+      ibmUserAccess,
       ocpProviders,
       ocpProvidersFetchStatus,
       userAccess,
@@ -159,8 +171,8 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
 
     const _isAwsAvailable = isAwsAvailable(awsProviders, awsProvidersFetchStatus, userAccess);
     const _isAzureAvailable = isAzureAvailable(azureProviders, azureProvidersFetchStatus, userAccess);
-    const _isGcpAvailable = isGcpAvailable(gcpProviders, gcpProvidersFetchStatus, userAccess);
-    const _isIbmAvailable = isIbmAvailable(ibmProviders, ibmProvidersFetchStatus, userAccess);
+    const _isGcpAvailable = isGcpAvailable(gcpProviders, gcpProvidersFetchStatus, gcpUserAccess);
+    const _isIbmAvailable = isIbmAvailable(ibmProviders, ibmProvidersFetchStatus, ibmUserAccess);
     const _isOcpAvailable = isOcpAvailable(ocpProviders, ocpProvidersFetchStatus, userAccess);
 
     if (!(_isAwsAvailable || _isAzureAvailable || _isGcpAvailable || _isIbmAvailable || _isOcpAvailable)) {
@@ -234,7 +246,9 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
       awsProvidersFetchStatus,
       azureProvidersFetchStatus,
       gcpProvidersFetchStatus,
+      gcpUserAccess,
       ibmProvidersFetchStatus,
+      ibmUserAccess,
       groupBy,
       ocpProvidersFetchStatus,
       onFilterAdded,
@@ -250,8 +264,8 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
     const noProviders = !(
       isAwsAvailable(awsProviders, awsProvidersFetchStatus, userAccess) &&
       isAzureAvailable(azureProviders, azureProvidersFetchStatus, userAccess) &&
-      isGcpAvailable(gcpProviders, gcpProvidersFetchStatus, userAccess) &&
-      isIbmAvailable(ibmProviders, ibmProvidersFetchStatus, userAccess) &&
+      isGcpAvailable(gcpProviders, gcpProvidersFetchStatus, gcpUserAccess) &&
+      isIbmAvailable(ibmProviders, ibmProvidersFetchStatus, ibmUserAccess) &&
       isOcpAvailable(ocpProviders, ocpProvidersFetchStatus, userAccess)
     );
 
@@ -365,6 +379,34 @@ const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHe
     userAccessQueryString
   );
 
+  // Todo: temporarily request GCP separately with beta flag.
+  const gcpUserAccessQueryString = getUserAccessQuery(gcpUserAccessQuery);
+  const gcpUserAccess = userAccessSelectors.selectUserAccess(state, UserAccessType.gcp, gcpUserAccessQueryString);
+  const gcpUserAccessError = userAccessSelectors.selectUserAccessError(
+    state,
+    UserAccessType.gcp,
+    gcpUserAccessQueryString
+  );
+  const gcpUserAccessFetchStatus = userAccessSelectors.selectUserAccessFetchStatus(
+    state,
+    UserAccessType.gcp,
+    gcpUserAccessQueryString
+  );
+
+  // Todo: temporarily request IBM separately with beta flag.
+  const ibmUserAccessQueryString = getUserAccessQuery(ibmUserAccessQuery);
+  const ibmUserAccess = userAccessSelectors.selectUserAccess(state, UserAccessType.ibm, ibmUserAccessQueryString);
+  const ibmUserAccessError = userAccessSelectors.selectUserAccessError(
+    state,
+    UserAccessType.ibm,
+    ibmUserAccessQueryString
+  );
+  const ibmUserAccessFetchStatus = userAccessSelectors.selectUserAccessFetchStatus(
+    state,
+    UserAccessType.ibm,
+    ibmUserAccessQueryString
+  );
+
   return {
     awsProviders,
     awsProvidersFetchStatus,
@@ -375,9 +417,17 @@ const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHe
     gcpProviders,
     gcpProvidersFetchStatus,
     gcpProvidersQueryString,
+    gcpUserAccess,
+    gcpUserAccessError,
+    gcpUserAccessFetchStatus,
+    gcpUserAccessQueryString,
     ibmProviders,
     ibmProvidersFetchStatus,
     ibmProvidersQueryString,
+    ibmUserAccess,
+    ibmUserAccessError,
+    ibmUserAccessFetchStatus,
+    ibmUserAccessQueryString,
     ocpProviders,
     ocpProvidersFetchStatus,
     ocpProvidersQueryString,

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -426,8 +426,9 @@ export const isGcpAvailable = (
 ) => {
   let result = false;
   if (gcpsProvidersFetchStatus === FetchStatus.complete) {
-    const data = (userAccess.data as any).find(d => d.type === UserAccessType.gcp);
-    const isUserAccessAllowed = data && data.access;
+    // const data = (userAccess.data as any).find(d => d.type === UserAccessType.gcp);
+    // const isUserAccessAllowed = data && data.access;
+    const isUserAccessAllowed = userAccess && userAccess.data === true;
 
     // providers API returns empty data array for no sources
     result =
@@ -446,8 +447,9 @@ export const isIbmAvailable = (
 ) => {
   let result = false;
   if (ibmProvidersFetchStatus === FetchStatus.complete) {
-    const data = (userAccess.data as any).find(d => d.type === UserAccessType.ibm);
-    const isUserAccessAllowed = data && data.access;
+    // const data = (userAccess.data as any).find(d => d.type === UserAccessType.ibm);
+    // const isUserAccessAllowed = data && data.access;
+    const isUserAccessAllowed = userAccess && userAccess.data === true;
 
     // providers API returns empty data array for no sources
     result =

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -35,7 +35,7 @@ import {
   ocpProvidersQuery,
   providersSelectors,
 } from 'store/providers';
-import { allUserAccessQuery, userAccessSelectors } from 'store/userAccess';
+import { allUserAccessQuery, gcpUserAccessQuery, ibmUserAccessQuery, userAccessSelectors } from 'store/userAccess';
 
 import { styles } from './overview.styles';
 
@@ -84,9 +84,17 @@ interface OverviewStateProps {
   gcpProviders: Providers;
   gcpProvidersFetchStatus: FetchStatus;
   gcpProvidersQueryString: string;
+  gcpUserAccess: UserAccess;
+  gcpUserAccessError: AxiosError;
+  gcpUserAccessFetchStatus: FetchStatus;
+  gcpUserAccessQueryString: string;
   ibmProviders: Providers;
   ibmProvidersFetchStatus: FetchStatus;
   ibmProvidersQueryString: string;
+  ibmUserAccess: UserAccess;
+  ibmUserAccessError: AxiosError;
+  ibmUserAccessFetchStatus: FetchStatus;
+  ibmUserAccessQueryString: string;
   ocpProviders: Providers;
   ocpProvidersFetchStatus: FetchStatus;
   ocpProvidersQueryString: string;
@@ -433,7 +441,7 @@ class OverviewBase extends React.Component<OverviewProps> {
   private isAwsAvailable = () => {
     const { awsProviders, userAccess } = this.props;
 
-    const data = (userAccess.data as any).find(d => d.type === UserAccessType.aws);
+    const data = userAccess && (userAccess.data as any).find(d => d.type === UserAccessType.aws);
     const isUserAccessAllowed = data && data.access;
 
     // providers API returns empty data array for no sources
@@ -448,7 +456,7 @@ class OverviewBase extends React.Component<OverviewProps> {
   private isAzureAvailable = () => {
     const { azureProviders, userAccess } = this.props;
 
-    const data = (userAccess.data as any).find(d => d.type === UserAccessType.azure);
+    const data = userAccess && (userAccess.data as any).find(d => d.type === UserAccessType.azure);
     const isUserAccessAllowed = data && data.access;
 
     // providers API returns empty data array for no sources
@@ -461,10 +469,11 @@ class OverviewBase extends React.Component<OverviewProps> {
   };
 
   private isGcpAvailable = () => {
-    const { gcpProviders, userAccess } = this.props;
+    const { gcpProviders, gcpUserAccess } = this.props;
 
-    const data = (userAccess.data as any).find(d => d.type === UserAccessType.gcp);
-    const isUserAccessAllowed = data && data.access;
+    // const data = (userAccess.data as any).find(d => d.type === UserAccessType.gcp);
+    // const isUserAccessAllowed = data && data.access;
+    const isUserAccessAllowed = gcpUserAccess && gcpUserAccess.data === true;
 
     // providers API returns empty data array for no sources
     return (
@@ -476,10 +485,11 @@ class OverviewBase extends React.Component<OverviewProps> {
   };
 
   private isIbmAvailable = () => {
-    const { ibmProviders, userAccess } = this.props;
+    const { ibmProviders, ibmUserAccess } = this.props;
 
-    const data = (userAccess.data as any).find(d => d.type === UserAccessType.ibm);
-    const isUserAccessAllowed = data && data.access;
+    // const data = (userAccess.data as any).find(d => d.type === UserAccessType.ibm);
+    // const isUserAccessAllowed = data && data.access;
+    const isUserAccessAllowed = ibmUserAccess && ibmUserAccess.data === true;
 
     // providers API returns empty data array for no sources
     return (
@@ -493,7 +503,7 @@ class OverviewBase extends React.Component<OverviewProps> {
   private isOcpAvailable = () => {
     const { ocpProviders, userAccess } = this.props;
 
-    const data = (userAccess.data as any).find(d => d.type === UserAccessType.ocp);
+    const data = userAccess && (userAccess.data as any).find(d => d.type === UserAccessType.ocp);
     const isUserAccessAllowed = data && data.access;
 
     // providers API returns empty data array for no sources
@@ -646,6 +656,34 @@ const mapStateToProps = createMapStateToProps<OverviewOwnProps, OverviewStatePro
     userAccessQueryString
   );
 
+  // Todo: temporarily request GCP separately with beta flag.
+  const gcpUserAccessQueryString = getUserAccessQuery(gcpUserAccessQuery);
+  const gcpUserAccess = userAccessSelectors.selectUserAccess(state, UserAccessType.gcp, gcpUserAccessQueryString);
+  const gcpUserAccessError = userAccessSelectors.selectUserAccessError(
+    state,
+    UserAccessType.gcp,
+    gcpUserAccessQueryString
+  );
+  const gcpUserAccessFetchStatus = userAccessSelectors.selectUserAccessFetchStatus(
+    state,
+    UserAccessType.gcp,
+    gcpUserAccessQueryString
+  );
+
+  // Todo: temporarily request IBM separately with beta flag.
+  const ibmUserAccessQueryString = getUserAccessQuery(ibmUserAccessQuery);
+  const ibmUserAccess = userAccessSelectors.selectUserAccess(state, UserAccessType.ibm, ibmUserAccessQueryString);
+  const ibmUserAccessError = userAccessSelectors.selectUserAccessError(
+    state,
+    UserAccessType.ibm,
+    ibmUserAccessQueryString
+  );
+  const ibmUserAccessFetchStatus = userAccessSelectors.selectUserAccessFetchStatus(
+    state,
+    UserAccessType.ibm,
+    ibmUserAccessQueryString
+  );
+
   return {
     awsProviders,
     awsProvidersFetchStatus,
@@ -656,9 +694,17 @@ const mapStateToProps = createMapStateToProps<OverviewOwnProps, OverviewStatePro
     gcpProviders,
     gcpProvidersFetchStatus,
     gcpProvidersQueryString,
+    gcpUserAccess,
+    gcpUserAccessError,
+    gcpUserAccessFetchStatus,
+    gcpUserAccessQueryString,
     ibmProviders,
     ibmProvidersFetchStatus,
     ibmProvidersQueryString,
+    ibmUserAccess,
+    ibmUserAccessError,
+    ibmUserAccessFetchStatus,
+    ibmUserAccessQueryString,
     ocpProviders,
     ocpProvidersFetchStatus,
     ocpProvidersQueryString,

--- a/src/store/userAccess/userAccessCommon.ts
+++ b/src/store/userAccess/userAccessCommon.ts
@@ -26,10 +26,12 @@ export const ocpUserAccessQuery: UserAccessQuery = {
 
 export const gcpUserAccessQuery: UserAccessQuery = {
   type: 'GCP',
+  beta: true,
 };
 
 export const ibmUserAccessQuery: UserAccessQuery = {
   type: 'GCP',
+  beta: true,
 };
 
 export function getReportId(type: UserAccessType, query: string) {


### PR DESCRIPTION
GCP and IBM currently appear in the overview perspective menu for the stage environment.

For the Insights nav, we use type=beta with the user-access API to restrict access to the CI and QA environments. However, we're not currently using the param in the overview page itself.

https://issues.redhat.com/browse/COST-1172