### PR TITLE
Cost Explorer empty state

### DIFF
--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -435,10 +435,10 @@ class Explorer extends React.Component<ExplorerProps> {
 
     // Test for no providers
     const noProviders = !(
-      isAwsAvailable(userAccess, awsProviders, awsProvidersFetchStatus) &&
-      isAzureAvailable(userAccess, azureProviders, azureProvidersFetchStatus) &&
-      isGcpAvailable(gcpUserAccess, gcpProviders, gcpProvidersFetchStatus) &&
-      isIbmAvailable(ibmUserAccess, ibmProviders, ibmProvidersFetchStatus) &&
+      isAwsAvailable(userAccess, awsProviders, awsProvidersFetchStatus) ||
+      isAzureAvailable(userAccess, azureProviders, azureProvidersFetchStatus) ||
+      isGcpAvailable(gcpUserAccess, gcpProviders, gcpProvidersFetchStatus) ||
+      isIbmAvailable(ibmUserAccess, ibmProviders, ibmProvidersFetchStatus) ||
       isOcpAvailable(userAccess, ocpProviders, ocpProvidersFetchStatus)
     );
 


### PR DESCRIPTION
The Cost Explorer page is showing the "no providers" empty state incorrectly. For example, if we don't have a provider for GCP or IBM. It should only show that state if there are absolutely no providers available.

https://issues.redhat.com/browse/COST-1195