### PR TITLE
Fix base name for new /beta/openshift/cost-management path

### DIFF
--- a/src/utils/getBaseName.ts
+++ b/src/utils/getBaseName.ts
@@ -9,6 +9,8 @@ export const getBaseName = pathname => {
     release = `/beta/`;
   }
 
-  // return `${release}${pathName[0]}/${pathName[1] || ''}`;
+  if (pathName[1]) {
+    return `${release}${pathName[0]}/${pathName[1]}`;
+  }
   return `${release}${pathName[0]}`;
 };


### PR DESCRIPTION
Cost Management has been moved under OpenShift. However, the Insights nav does not work as expected (e.g., with /beta/openshift/cost-management as the URL).

When we provide the router with a base name, we're not accounting for the new "openshift" path.

https://issues.redhat.com/browse/COST-1221