### PR TITLE
Remove beta flag for GCP

### DIFF
--- a/src/components/async/permissionsComponent/permissions.tsx
+++ b/src/components/async/permissionsComponent/permissions.tsx
@@ -9,13 +9,7 @@ import { connect } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { paths, routes } from 'routes';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import {
-  allUserAccessQuery,
-  gcpUserAccessQuery,
-  ibmUserAccessQuery,
-  userAccessActions,
-  userAccessSelectors,
-} from 'store/userAccess';
+import { allUserAccessQuery, ibmUserAccessQuery, userAccessActions, userAccessSelectors } from 'store/userAccess';
 import {
   hasAwsAccess,
   hasAzureAccess,
@@ -30,10 +24,6 @@ interface PermissionsOwnProps extends RouteComponentProps<void> {
 }
 
 interface PermissionsStateProps {
-  gcpUserAccess: UserAccess;
-  gcpUserAccessError: AxiosError;
-  gcpUserAccessFetchStatus: FetchStatus;
-  gcpUserAccessQueryString: string;
   ibmUserAccess: UserAccess;
   ibmUserAccessError: AxiosError;
   ibmUserAccessFetchStatus: FetchStatus;
@@ -61,15 +51,14 @@ class PermissionsBase extends React.Component<PermissionsProps> {
   public state: PermissionsState = { ...this.defaultState };
 
   public componentDidMount() {
-    const { gcpUserAccessQueryString, ibmUserAccessQueryString, userAccessQueryString, fetchUserAccess } = this.props;
+    const { ibmUserAccessQueryString, userAccessQueryString, fetchUserAccess } = this.props;
 
     fetchUserAccess(UserAccessType.all, userAccessQueryString);
-    fetchUserAccess(UserAccessType.gcp, gcpUserAccessQueryString);
     fetchUserAccess(UserAccessType.ibm, ibmUserAccessQueryString);
   }
 
   private hasPermissions() {
-    const { location, gcpUserAccess, ibmUserAccess, userAccess }: any = this.props;
+    const { location, ibmUserAccess, userAccess }: any = this.props;
 
     if (!userAccess) {
       return false;
@@ -78,7 +67,7 @@ class PermissionsBase extends React.Component<PermissionsProps> {
     const aws = hasAwsAccess(userAccess);
     const azure = hasAzureAccess(userAccess);
     const costModel = hasCostModelAccess(userAccess);
-    const gcp = hasGcpAccess(gcpUserAccess);
+    const gcp = hasGcpAccess(userAccess);
     const ibm = hasIbmAccess(ibmUserAccess);
     const ocp = hasOcpAccess(userAccess);
 
@@ -139,20 +128,6 @@ const mapStateToProps = createMapStateToProps<PermissionsOwnProps, PermissionsSt
     userAccessQueryString
   );
 
-  // Todo: temporarily request GCP separately with beta flag.
-  const gcpUserAccessQueryString = getUserAccessQuery(gcpUserAccessQuery);
-  const gcpUserAccess = userAccessSelectors.selectUserAccess(state, UserAccessType.gcp, gcpUserAccessQueryString);
-  const gcpUserAccessError = userAccessSelectors.selectUserAccessError(
-    state,
-    UserAccessType.gcp,
-    gcpUserAccessQueryString
-  );
-  const gcpUserAccessFetchStatus = userAccessSelectors.selectUserAccessFetchStatus(
-    state,
-    UserAccessType.gcp,
-    gcpUserAccessQueryString
-  );
-
   // Todo: temporarily request IBM separately with beta flag.
   const ibmUserAccessQueryString = getUserAccessQuery(ibmUserAccessQuery);
   const ibmUserAccess = userAccessSelectors.selectUserAccess(state, UserAccessType.ibm, ibmUserAccessQueryString);
@@ -168,10 +143,6 @@ const mapStateToProps = createMapStateToProps<PermissionsOwnProps, PermissionsSt
   );
 
   return {
-    gcpUserAccess,
-    gcpUserAccessError,
-    gcpUserAccessFetchStatus,
-    gcpUserAccessQueryString,
     ibmUserAccess,
     ibmUserAccessError,
     ibmUserAccessFetchStatus,

--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -29,7 +29,7 @@ import {
   providersSelectors,
 } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
-import { allUserAccessQuery, gcpUserAccessQuery, ibmUserAccessQuery, userAccessSelectors } from 'store/userAccess';
+import { allUserAccessQuery, ibmUserAccessQuery, userAccessSelectors } from 'store/userAccess';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { isAwsAvailable, isAzureAvailable, isGcpAvailable, isIbmAvailable, isOcpAvailable } from 'utils/userAccess';
@@ -64,10 +64,6 @@ interface ExplorerStateProps {
   gcpProviders: Providers;
   gcpProvidersFetchStatus: FetchStatus;
   gcpProvidersQueryString: string;
-  gcpUserAccess: UserAccess;
-  gcpUserAccessError: AxiosError;
-  gcpUserAccessFetchStatus: FetchStatus;
-  gcpUserAccessQueryString: string;
   ibmProviders: Providers;
   ibmProvidersFetchStatus: FetchStatus;
   ibmProvidersQueryString: string;
@@ -399,8 +395,6 @@ class Explorer extends React.Component<ExplorerProps> {
       azureProvidersFetchStatus,
       gcpProviders,
       gcpProvidersFetchStatus,
-      gcpUserAccess,
-      gcpUserAccessFetchStatus,
       ibmProviders,
       ibmProvidersFetchStatus,
       ibmUserAccess,
@@ -424,7 +418,6 @@ class Explorer extends React.Component<ExplorerProps> {
       ibmProvidersFetchStatus === FetchStatus.inProgress ||
       ocpProvidersFetchStatus === FetchStatus.inProgress ||
       userAccessFetchStatus === FetchStatus.inProgress ||
-      gcpUserAccessFetchStatus === FetchStatus.inProgress ||
       ibmUserAccessFetchStatus === FetchStatus.inProgress;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
@@ -437,7 +430,7 @@ class Explorer extends React.Component<ExplorerProps> {
     const noProviders = !(
       isAwsAvailable(userAccess, awsProviders, awsProvidersFetchStatus) ||
       isAzureAvailable(userAccess, azureProviders, azureProvidersFetchStatus) ||
-      isGcpAvailable(gcpUserAccess, gcpProviders, gcpProvidersFetchStatus) ||
+      isGcpAvailable(userAccess, gcpProviders, gcpProvidersFetchStatus) ||
       isIbmAvailable(ibmUserAccess, ibmProviders, ibmProvidersFetchStatus) ||
       isOcpAvailable(userAccess, ocpProviders, ocpProvidersFetchStatus)
     );
@@ -579,20 +572,6 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
     ocpProvidersQueryString
   );
 
-  // Todo: temporarily request GCP separately with beta flag.
-  const gcpUserAccessQueryString = getUserAccessQuery(gcpUserAccessQuery);
-  const gcpUserAccess = userAccessSelectors.selectUserAccess(state, UserAccessType.gcp, gcpUserAccessQueryString);
-  const gcpUserAccessError = userAccessSelectors.selectUserAccessError(
-    state,
-    UserAccessType.gcp,
-    gcpUserAccessQueryString
-  );
-  const gcpUserAccessFetchStatus = userAccessSelectors.selectUserAccessFetchStatus(
-    state,
-    UserAccessType.gcp,
-    gcpUserAccessQueryString
-  );
-
   // Todo: temporarily request IBM separately with beta flag.
   const ibmUserAccessQueryString = getUserAccessQuery(ibmUserAccessQuery);
   const ibmUserAccess = userAccessSelectors.selectUserAccess(state, UserAccessType.ibm, ibmUserAccessQueryString);
@@ -618,10 +597,6 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
     gcpProviders,
     gcpProvidersFetchStatus,
     gcpProvidersQueryString,
-    gcpUserAccess,
-    gcpUserAccessError,
-    gcpUserAccessFetchStatus,
-    gcpUserAccessQueryString,
     ibmProviders,
     ibmProvidersFetchStatus,
     ibmProvidersQueryString,

--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -20,7 +20,7 @@ import {
   ocpProvidersQuery,
   providersSelectors,
 } from 'store/providers';
-import { allUserAccessQuery, gcpUserAccessQuery, ibmUserAccessQuery, userAccessSelectors } from 'store/userAccess';
+import { allUserAccessQuery, ibmUserAccessQuery, userAccessSelectors } from 'store/userAccess';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
 import { isAwsAvailable, isAzureAvailable, isGcpAvailable, isIbmAvailable, isOcpAvailable } from 'utils/userAccess';
 
@@ -64,10 +64,6 @@ interface ExplorerHeaderStateProps {
   gcpProviders: Providers;
   gcpProvidersFetchStatus: FetchStatus;
   gcpProvidersQueryString: string;
-  gcpUserAccess: UserAccess;
-  gcpUserAccessError: AxiosError;
-  gcpUserAccessFetchStatus: FetchStatus;
-  gcpUserAccessQueryString: string;
   ibmProviders: Providers;
   ibmProvidersFetchStatus: FetchStatus;
   ibmProvidersQueryString: string;
@@ -213,8 +209,8 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
   };
 
   private isGcpAvailable = () => {
-    const { gcpProviders, gcpProvidersFetchStatus, gcpUserAccess } = this.props;
-    return isGcpAvailable(gcpUserAccess, gcpProviders, gcpProvidersFetchStatus);
+    const { gcpProviders, gcpProvidersFetchStatus, userAccess } = this.props;
+    return isGcpAvailable(userAccess, gcpProviders, gcpProvidersFetchStatus);
   };
 
   private isIbmAvailable = () => {
@@ -236,11 +232,10 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
       ocpProviders,
       awsProvidersFetchStatus,
       azureProvidersFetchStatus,
-      gcpProvidersFetchStatus,
-      gcpUserAccess,
       ibmProvidersFetchStatus,
       ibmUserAccess,
       groupBy,
+      gcpProvidersFetchStatus,
       ocpProvidersFetchStatus,
       onFilterAdded,
       onFilterRemoved,
@@ -255,7 +250,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
     const noProviders = !(
       isAwsAvailable(userAccess, awsProviders, awsProvidersFetchStatus) ||
       isAzureAvailable(userAccess, azureProviders, azureProvidersFetchStatus) ||
-      isGcpAvailable(gcpUserAccess, gcpProviders, gcpProvidersFetchStatus) ||
+      isGcpAvailable(userAccess, gcpProviders, gcpProvidersFetchStatus) ||
       isIbmAvailable(ibmUserAccess, ibmProviders, ibmProvidersFetchStatus) ||
       isOcpAvailable(userAccess, ocpProviders, ocpProvidersFetchStatus)
     );
@@ -370,20 +365,6 @@ const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHe
     ocpProvidersQueryString
   );
 
-  // Todo: temporarily request GCP separately with beta flag.
-  const gcpUserAccessQueryString = getUserAccessQuery(gcpUserAccessQuery);
-  const gcpUserAccess = userAccessSelectors.selectUserAccess(state, UserAccessType.gcp, gcpUserAccessQueryString);
-  const gcpUserAccessError = userAccessSelectors.selectUserAccessError(
-    state,
-    UserAccessType.gcp,
-    gcpUserAccessQueryString
-  );
-  const gcpUserAccessFetchStatus = userAccessSelectors.selectUserAccessFetchStatus(
-    state,
-    UserAccessType.gcp,
-    gcpUserAccessQueryString
-  );
-
   // Todo: temporarily request IBM separately with beta flag.
   const ibmUserAccessQueryString = getUserAccessQuery(ibmUserAccessQuery);
   const ibmUserAccess = userAccessSelectors.selectUserAccess(state, UserAccessType.ibm, ibmUserAccessQueryString);
@@ -408,10 +389,6 @@ const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHe
     gcpProviders,
     gcpProvidersFetchStatus,
     gcpProvidersQueryString,
-    gcpUserAccess,
-    gcpUserAccessError,
-    gcpUserAccessFetchStatus,
-    gcpUserAccessQueryString,
     ibmProviders,
     ibmProvidersFetchStatus,
     ibmProvidersQueryString,

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -35,7 +35,7 @@ import {
   ocpProvidersQuery,
   providersSelectors,
 } from 'store/providers';
-import { allUserAccessQuery, gcpUserAccessQuery, ibmUserAccessQuery, userAccessSelectors } from 'store/userAccess';
+import { allUserAccessQuery, ibmUserAccessQuery, userAccessSelectors } from 'store/userAccess';
 import { isAwsAvailable, isAzureAvailable, isGcpAvailable, isIbmAvailable, isOcpAvailable } from 'utils/userAccess';
 
 import { styles } from './overview.styles';
@@ -85,10 +85,6 @@ interface OverviewStateProps {
   gcpProviders: Providers;
   gcpProvidersFetchStatus: FetchStatus;
   gcpProvidersQueryString: string;
-  gcpUserAccess: UserAccess;
-  gcpUserAccessError: AxiosError;
-  gcpUserAccessFetchStatus: FetchStatus;
-  gcpUserAccessQueryString: string;
   ibmProviders: Providers;
   ibmProvidersFetchStatus: FetchStatus;
   ibmProvidersQueryString: string;
@@ -440,8 +436,8 @@ class OverviewBase extends React.Component<OverviewProps> {
   };
 
   private isGcpAvailable = () => {
-    const { gcpProviders, gcpProvidersFetchStatus, gcpUserAccess } = this.props;
-    return isGcpAvailable(gcpUserAccess, gcpProviders, gcpProvidersFetchStatus);
+    const { gcpProviders, gcpProvidersFetchStatus, userAccess } = this.props;
+    return isGcpAvailable(userAccess, gcpProviders, gcpProvidersFetchStatus);
   };
 
   private isIbmAvailable = () => {
@@ -595,20 +591,6 @@ const mapStateToProps = createMapStateToProps<OverviewOwnProps, OverviewStatePro
     userAccessQueryString
   );
 
-  // Todo: temporarily request GCP separately with beta flag.
-  const gcpUserAccessQueryString = getUserAccessQuery(gcpUserAccessQuery);
-  const gcpUserAccess = userAccessSelectors.selectUserAccess(state, UserAccessType.gcp, gcpUserAccessQueryString);
-  const gcpUserAccessError = userAccessSelectors.selectUserAccessError(
-    state,
-    UserAccessType.gcp,
-    gcpUserAccessQueryString
-  );
-  const gcpUserAccessFetchStatus = userAccessSelectors.selectUserAccessFetchStatus(
-    state,
-    UserAccessType.gcp,
-    gcpUserAccessQueryString
-  );
-
   // Todo: temporarily request IBM separately with beta flag.
   const ibmUserAccessQueryString = getUserAccessQuery(ibmUserAccessQuery);
   const ibmUserAccess = userAccessSelectors.selectUserAccess(state, UserAccessType.ibm, ibmUserAccessQueryString);
@@ -633,10 +615,6 @@ const mapStateToProps = createMapStateToProps<OverviewOwnProps, OverviewStatePro
     gcpProviders,
     gcpProvidersFetchStatus,
     gcpProvidersQueryString,
-    gcpUserAccess,
-    gcpUserAccessError,
-    gcpUserAccessFetchStatus,
-    gcpUserAccessQueryString,
     ibmProviders,
     ibmProvidersFetchStatus,
     ibmProvidersQueryString,

--- a/src/store/userAccess/userAccessCommon.ts
+++ b/src/store/userAccess/userAccessCommon.ts
@@ -26,7 +26,6 @@ export const ocpUserAccessQuery: UserAccessQuery = {
 
 export const gcpUserAccessQuery: UserAccessQuery = {
   type: 'GCP',
-  beta: true,
 };
 
 export const ibmUserAccessQuery: UserAccessQuery = {


### PR DESCRIPTION
This removes special code in the UI that calls the `user-access` API with `type=GCP` and `beta=true`. Since we no longer need the `beta=true` flag, we can call `user-access` with `type=` and get all providers via a single request.

Note that we still need to update the Insights nav in various CI environments.

https://issues.redhat.com/browse/COST-1225