### PR TITLE
change name from search input to filter input

### DIFF
--- a/src/pages/costModels/costModel/addSourceStep.tsx
+++ b/src/pages/costModels/costModel/addSourceStep.tsx
@@ -117,7 +117,7 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
               name: this.props.query.name ? this.props.query.name.split(',') : [],
             },
           }}
-          searchInputProps={{
+          filterInputProps={{
             id: 'assign-sources-modal-toolbar',
             onChange: value =>
               this.props.updateFilter({

--- a/src/pages/costModels/costModel/assignSourcesModalToolbar.tsx
+++ b/src/pages/costModels/costModel/assignSourcesModalToolbar.tsx
@@ -14,7 +14,7 @@ import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { Omit } from 'react-redux';
 
-interface SearchInputProps {
+interface FilterInputProps {
   id: string;
   value: string;
   onChange: (value: string, event: React.FormEvent<HTMLInputElement>) => void;
@@ -22,7 +22,7 @@ interface SearchInputProps {
   placeholder?: string;
 }
 
-const SearchInput: React.SFC<SearchInputProps> = ({ id, placeholder = '', value, onChange, onSearch }) => {
+const FilterInput: React.SFC<FilterInputProps> = ({ id, placeholder = '', value, onChange, onSearch }) => {
   return (
     <InputGroup>
       <TextInput
@@ -46,7 +46,7 @@ const SearchInput: React.SFC<SearchInputProps> = ({ id, placeholder = '', value,
 
 interface AssignSourcesToolbarBaseProps extends WithTranslation {
   paginationProps: PaginationProps;
-  searchInputProps: Omit<SearchInputProps, 'placeholder'>;
+  filterInputProps: Omit<FilterInputProps, 'placeholder'>;
   filter: {
     onRemove: (category: string, chip: string) => void;
     onClearAll: () => void;
@@ -56,7 +56,7 @@ interface AssignSourcesToolbarBaseProps extends WithTranslation {
 
 export const AssignSourcesToolbarBase: React.SFC<AssignSourcesToolbarBaseProps> = ({
   t,
-  searchInputProps,
+  filterInputProps,
   paginationProps,
   filter,
 }) => {
@@ -65,7 +65,7 @@ export const AssignSourcesToolbarBase: React.SFC<AssignSourcesToolbarBaseProps> 
       <ToolbarContent>
         <ToolbarItem variant="search-filter">
           <ToolbarFilter deleteChip={filter.onRemove} chips={filter.query.name} categoryName="name">
-            <SearchInput placeholder={t('cost_models_wizard.source_table.filter_placeholder')} {...searchInputProps} />
+            <FilterInput placeholder={t('cost_models_wizard.source_table.filter_placeholder')} {...filterInputProps} />
           </ToolbarFilter>
         </ToolbarItem>
         <ToolbarItem variant="pagination">

--- a/src/pages/costModels/costModel/sourcesToolbar.tsx
+++ b/src/pages/costModels/costModel/sourcesToolbar.tsx
@@ -15,7 +15,7 @@ import { SearchIcon } from '@patternfly/react-icons/dist/js/icons/search-icon';
 import { ReadOnlyTooltip } from 'pages/costModels/components/readOnlyTooltip';
 import React from 'react';
 
-interface SearchInputProps {
+interface FilterInputProps {
   id: string;
   value: string;
   onChange: (value: string, event: React.FormEvent<HTMLInputElement>) => void;
@@ -23,7 +23,7 @@ interface SearchInputProps {
   placeholder?: string;
 }
 
-const SearchInput: React.SFC<SearchInputProps> = ({ id, placeholder = '', value, onChange, onSearch }) => {
+const FilterInput: React.SFC<FilterInputProps> = ({ id, placeholder = '', value, onChange, onSearch }) => {
   return (
     <InputGroup>
       <TextInput
@@ -48,7 +48,7 @@ const SearchInput: React.SFC<SearchInputProps> = ({ id, placeholder = '', value,
 interface SourcesToolbarProps {
   actionButtonProps: ButtonProps;
   paginationProps: PaginationProps;
-  searchInputProps: SearchInputProps;
+  filterInputProps: FilterInputProps;
   filter: {
     onRemove: (category: string, chip: string) => void;
     onClearAll: () => void;
@@ -58,7 +58,7 @@ interface SourcesToolbarProps {
 }
 
 export const SourcesToolbar: React.SFC<SourcesToolbarProps> = ({
-  searchInputProps,
+  filterInputProps,
   paginationProps,
   filter,
   actionButtonProps,
@@ -72,7 +72,7 @@ export const SourcesToolbar: React.SFC<SourcesToolbarProps> = ({
             chips={filter.query.name}
             categoryName={filter.categoryNames.name}
           >
-            <SearchInput {...searchInputProps} />
+            <FilterInput {...filterInputProps} />
           </ToolbarFilter>
         </ToolbarItem>
         <ToolbarItem>

--- a/src/pages/costModels/costModel/table.tsx
+++ b/src/pages/costModels/costModel/table.tsx
@@ -92,7 +92,7 @@ class TableBase extends React.Component<Props, State> {
                 pagination: { page: 1, perPage: newPerPage },
               }),
           }}
-          searchInputProps={{
+          filterInputProps={{
             id: 'sources-tab-toolbar',
             onChange: (value: string) =>
               this.setState({

--- a/src/pages/costModels/costModelsDetails/utils/filters.tsx
+++ b/src/pages/costModels/costModelsDetails/utils/filters.tsx
@@ -22,14 +22,14 @@ import { costModelsSelectors } from 'store/costModels';
 import { CostModelsQuery, initialCostModelsQuery, stringifySearch } from './query';
 import { HistoryPush, Inputer, Opener } from './types';
 
-interface SearchInputProps {
+interface FilterInputProps {
   value: string;
   onChange: (value: string, event: React.FormEvent<HTMLInputElement>) => void;
   onKeyPress: (evt: React.KeyboardEvent<HTMLInputElement>) => void;
   placeholder?: string;
 }
 
-const SearchInput: React.SFC<SearchInputProps> = ({ placeholder = '', value, onChange, onKeyPress }) => {
+const FilterInput: React.SFC<FilterInputProps> = ({ placeholder = '', value, onChange, onKeyPress }) => {
   return (
     <InputGroup>
       <TextInput
@@ -103,7 +103,7 @@ const descriptionMergeProps = (
   const { filterType, query } = stateProps;
   const children =
     filterType === 'description' ? (
-      <SearchInput
+      <FilterInput
         placeholder={t('page_cost_models.filter_by_description')}
         value={value}
         onChange={(text: string) => setValue(text)}
@@ -146,7 +146,7 @@ const nameFilterMergeProps = (
   const { filterType, query } = stateProps;
   const children =
     filterType === 'name' ? (
-      <SearchInput
+      <FilterInput
         placeholder={t('page_cost_models.filter_by_name')}
         value={value}
         onChange={(text: string) => setValue(text)}

--- a/src/pages/costModels/createCostModelWizard/assignSourcesToolbar.tsx
+++ b/src/pages/costModels/createCostModelWizard/assignSourcesToolbar.tsx
@@ -14,7 +14,7 @@ import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { Omit } from 'react-redux';
 
-interface SearchInputProps {
+interface FilterInputProps {
   id: string;
   value: string;
   onChange: (value: string, event: React.FormEvent<HTMLInputElement>) => void;
@@ -22,7 +22,7 @@ interface SearchInputProps {
   placeholder?: string;
 }
 
-const SearchInput: React.SFC<SearchInputProps> = ({ id, placeholder = '', value, onChange, onSearch }) => {
+const FilterInput: React.SFC<FilterInputProps> = ({ id, placeholder = '', value, onChange, onSearch }) => {
   return (
     <InputGroup>
       <TextInput
@@ -46,7 +46,7 @@ const SearchInput: React.SFC<SearchInputProps> = ({ id, placeholder = '', value,
 
 interface AssignSourcesToolbarBaseProps extends WithTranslation {
   paginationProps: PaginationProps;
-  searchInputProps: Omit<SearchInputProps, 'placeholder'>;
+  filterInputProps: Omit<FilterInputProps, 'placeholder'>;
   filter: {
     onRemove: (category: string, chip: string) => void;
     onClearAll: () => void;
@@ -56,7 +56,7 @@ interface AssignSourcesToolbarBaseProps extends WithTranslation {
 
 export const AssignSourcesToolbarBase: React.SFC<AssignSourcesToolbarBaseProps> = ({
   t,
-  searchInputProps,
+  filterInputProps,
   paginationProps,
   filter,
 }) => {
@@ -65,7 +65,7 @@ export const AssignSourcesToolbarBase: React.SFC<AssignSourcesToolbarBaseProps> 
       <ToolbarContent>
         <ToolbarItem variant="search-filter">
           <ToolbarFilter deleteChip={filter.onRemove} chips={filter.query.name} categoryName="name">
-            <SearchInput placeholder={t('cost_models_wizard.source_table.filter_placeholder')} {...searchInputProps} />
+            <FilterInput placeholder={t('cost_models_wizard.source_table.filter_placeholder')} {...filterInputProps} />
           </ToolbarFilter>
         </ToolbarItem>
         <ToolbarItem variant="pagination">

--- a/src/pages/costModels/createCostModelWizard/table.tsx
+++ b/src/pages/costModels/createCostModelWizard/table.tsx
@@ -44,7 +44,7 @@ const SourcesTable: React.SFC<WithTranslation> = ({ t }) => {
                   onClearAll: () => fetchSources(sourceType, {}, 1, perPage),
                   query,
                 }}
-                searchInputProps={{
+                filterInputProps={{
                   id: 'assign-source-search-input',
                   value: filterName,
                   onChange: onFilterChange,


### PR DESCRIPTION
Closes: https://issues.redhat.com/browse/COST-1291

change search Input naming to filter input, this removes any confusion on if we are using the patternfly "SearchInput" or not.

filtering example:

https://user-images.githubusercontent.com/57504257/114737863-6cca3f80-9d15-11eb-8cc1-ba2fc94cc384.mov


