### PR TITLE
Breakdown chart should use ResizeObserver

### DIFF
--- a/src/pages/views/details/components/costChart/costChart.styles.ts
+++ b/src/pages/views/details/components/costChart/costChart.styles.ts
@@ -5,6 +5,7 @@ import React from 'react';
 
 export const chartStyles = {
   chartHeight: 150,
+  chartWidth: 350,
   subTitle: {
     fontWeight: global_FontWeight_bold.value as any,
   },

--- a/src/pages/views/details/components/costChart/costChart.tsx
+++ b/src/pages/views/details/components/costChart/costChart.tsx
@@ -1,11 +1,13 @@
 import { ChartLabel, ChartLegend, ChartPie, ChartThemeColor } from '@patternfly/react-charts';
 import { Skeleton } from '@patternfly/react-core';
 import { Report } from 'api/reports/report';
+import { getResizeObserver } from 'components/charts/common/chartUtils';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { FetchStatus } from 'store/common';
 import { reportActions } from 'store/reports';
 import { formatValue } from 'utils/formatValue';
+import { noop } from 'utils/noop';
 import { skeletonWidth } from 'utils/skeleton';
 
 import { chartStyles, styles } from './costChart.styles';
@@ -31,21 +33,19 @@ type CostChartProps = CostChartOwnProps & CostChartStateProps & CostChartDispatc
 
 class CostChartBase extends React.Component<CostChartProps> {
   private containerRef = React.createRef<HTMLDivElement>();
+  private observer: any = noop;
   public state: CostChartState = {
     width: 0,
   };
 
   public componentDidMount() {
-    setTimeout(() => {
-      if (this.containerRef.current) {
-        this.setState({ width: this.containerRef.current.clientWidth });
-      }
-      window.addEventListener('resize', this.handleResize);
-    });
+    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
   }
 
   public componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    if (this.observer) {
+      this.observer();
+    }
   }
 
   // Override legend layout
@@ -68,8 +68,11 @@ class CostChartBase extends React.Component<CostChartProps> {
   };
 
   private handleResize = () => {
-    if (this.containerRef.current) {
-      this.setState({ width: this.containerRef.current.clientWidth });
+    const { width } = this.state;
+    const { clientWidth = 0 } = this.containerRef.current || {};
+
+    if (clientWidth !== width) {
+      this.setState({ width: clientWidth });
     }
   };
 

--- a/src/pages/views/details/components/costChart/costChart.tsx
+++ b/src/pages/views/details/components/costChart/costChart.tsx
@@ -1,13 +1,11 @@
 import { ChartLabel, ChartLegend, ChartPie, ChartThemeColor } from '@patternfly/react-charts';
 import { Skeleton } from '@patternfly/react-core';
 import { Report } from 'api/reports/report';
-import { getResizeObserver } from 'components/charts/common/chartUtils';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { FetchStatus } from 'store/common';
 import { reportActions } from 'store/reports';
 import { formatValue } from 'utils/formatValue';
-import { noop } from 'utils/noop';
 import { skeletonWidth } from 'utils/skeleton';
 
 import { chartStyles, styles } from './costChart.styles';
@@ -25,29 +23,9 @@ interface CostChartDispatchProps {
   fetchReport?: typeof reportActions.fetchReport;
 }
 
-interface CostChartState {
-  width: number;
-}
-
 type CostChartProps = CostChartOwnProps & CostChartStateProps & CostChartDispatchProps & WithTranslation;
 
 class CostChartBase extends React.Component<CostChartProps> {
-  private containerRef = React.createRef<HTMLDivElement>();
-  private observer: any = noop;
-  public state: CostChartState = {
-    width: 0,
-  };
-
-  public componentDidMount() {
-    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
-  }
-
-  public componentWillUnmount() {
-    if (this.observer) {
-      this.observer();
-    }
-  }
-
   // Override legend layout
   private getLegendLabel = () => {
     return ({ values, ...props }) => (
@@ -67,18 +45,8 @@ class CostChartBase extends React.Component<CostChartProps> {
     );
   };
 
-  private handleResize = () => {
-    const { width } = this.state;
-    const { clientWidth = 0 } = this.containerRef.current || {};
-
-    if (clientWidth !== width) {
-      this.setState({ width: clientWidth });
-    }
-  };
-
   public render() {
     const { report, reportFetchStatus, t } = this.props;
-    const { width } = this.state;
 
     const hasCost = report && report.meta && report.meta.total && report.meta.total.cost;
     const hasMarkup = hasCost && report.meta.total.cost.markup;
@@ -113,7 +81,7 @@ class CostChartBase extends React.Component<CostChartProps> {
     );
 
     return (
-      <div ref={this.containerRef} style={{ height: chartStyles.chartHeight }}>
+      <div style={{ height: chartStyles.chartHeight, width: chartStyles.chartWidth }}>
         {reportFetchStatus === FetchStatus.inProgress ? (
           this.getSkeleton()
         ) : (
@@ -150,11 +118,11 @@ class CostChartBase extends React.Component<CostChartProps> {
             padding={{
               bottom: 20,
               left: 0,
-              right: width - chartStyles.chartHeight, // Adjusted to accommodate legend
+              right: 225, // Adjusted to accommodate legend
               top: 20,
             }}
             themeColor={ChartThemeColor.green}
-            width={width}
+            width={chartStyles.chartWidth}
           />
         )}
       </div>

--- a/src/pages/views/details/components/usageChart/usageChart.tsx
+++ b/src/pages/views/details/components/usageChart/usageChart.tsx
@@ -6,6 +6,7 @@ import { OcpQuery, parseQuery } from 'api/queries/ocpQuery';
 import { getQuery, Query } from 'api/queries/query';
 import { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
+import { getResizeObserver } from 'components/charts/common/chartUtils';
 import { getGroupById, getGroupByValue } from 'pages/views/utils/groupBy';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
@@ -13,6 +14,7 @@ import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
 import { formatValue, unitLookupKey } from 'utils/formatValue';
+import { noop } from 'utils/noop';
 import { skeletonWidth } from 'utils/skeleton';
 
 import { styles } from './usageChart.styles';
@@ -47,6 +49,7 @@ type UsageChartProps = UsageChartOwnProps & UsageChartStateProps & UsageChartDis
 
 class UsageChartBase extends React.Component<UsageChartProps> {
   private containerRef = React.createRef<HTMLDivElement>();
+  private observer: any = noop;
   public state: State = {
     width: 0,
   };
@@ -55,8 +58,7 @@ class UsageChartBase extends React.Component<UsageChartProps> {
     const { fetchReport, queryString, reportPathsType, reportType } = this.props;
     fetchReport(reportPathsType, reportType, queryString);
 
-    window.addEventListener('resize', this.handleResize);
-    this.handleResize();
+    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
   }
 
   public componentDidUpdate(prevProps: UsageChartProps) {
@@ -67,12 +69,17 @@ class UsageChartBase extends React.Component<UsageChartProps> {
   }
 
   public componentWillUnmount() {
-    window.removeEventListener('resize', this.handleResize);
+    if (this.observer) {
+      this.observer();
+    }
   }
 
   private handleResize = () => {
-    if (this.containerRef.current && this.containerRef.current.clientWidth) {
-      this.setState({ width: this.containerRef.current.clientWidth });
+    const { width } = this.state;
+    const { clientWidth = 0 } = this.containerRef.current || {};
+
+    if (clientWidth !== width) {
+      this.setState({ width: clientWidth });
     }
   };
 


### PR DESCRIPTION
Updated the usage chart, shown in the breakdown page, to use the our `ResizeObserver` util. 

I also removed the resize listener from the cost chart, shown in the same breakdown page. It isn't necessary to resize a pie chart, since it does not span the entire width of the card. 