### PR TITLE
Items in the "Add source" dialog should remain disabled

### DIFF
--- a/src/pages/costModels/costModel/addSourceStep.tsx
+++ b/src/pages/costModels/costModel/addSourceStep.tsx
@@ -44,9 +44,11 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
     const onSelect = (_evt, isSelected, rowId) => {
       if (rowId === -1) {
         const newState = this.props.providers.reduce((acc, cur) => {
+          const selected = this.props.checked[cur.uuid] ? this.props.checked[cur.uuid].selected : false;
+          const disabled = cur.cost_models.length > 0;
           return {
             ...acc,
-            [cur.uuid]: { selected: isSelected, meta: cur },
+            [cur.uuid]: { selected: disabled ? selected : isSelected, meta: cur },
           };
         }, {});
         this.props.setState(
@@ -88,7 +90,7 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
       return {
         cells: [cellName, provCostModels || ''],
         selected: isSelected,
-        disableCheckbox: providerData.cost_models.length > 0,
+        disableSelection: providerData.cost_models.length > 0,
       };
     });
     const sourceTypeMap = {


### PR DESCRIPTION
If a source is disabled, the "Add source" dialog's "select-all" checkbox should not be able to toggle that selection. Otherwise, users encounter an error when a source has already been assigned to a different cost model.

https://issues.redhat.com/browse/COST-1290

Source assigned to same cost model
![cost-model1](https://user-images.githubusercontent.com/17481322/114880684-461d0f00-9dd0-11eb-9aad-b650a8475653.gif)

Source assigned to a different cost model
![cost-model2](https://user-images.githubusercontent.com/17481322/114880701-4917ff80-9dd0-11eb-862e-3c2bea3b6bd0.gif)
