### PR TITLE
Explorer chart legend items should use account aliases

### DIFF
--- a/src/pages/views/explorer/explorerChart.tsx
+++ b/src/pages/views/explorer/explorerChart.tsx
@@ -96,7 +96,7 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
       y: value === null ? null : yVal, // For displaying "no data" labels in chart tooltips
       date: computedItem.date,
       key: computedItem.id,
-      name: computedItem.label || computedItem.id,
+      name: computedItem.label ? computedItem.label : computedItem.id,
       units: computedItem[reportItem]
         ? computedItem[reportItem][reportItemValue]
           ? computedItem[reportItem][reportItemValue].units // cost, infrastructure, supplementary
@@ -214,6 +214,7 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
 
     items.map(datums => {
       const key = datums[0].key;
+      const label = datums[0].name;
       const newItems = [];
 
       for (
@@ -227,7 +228,7 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
           newItems.push(chartDatum);
         } else {
           const date = format(padDate, 'yyyy-MM-dd');
-          newItems.push(this.createReportDatum(null, { date, id: key }, 'cost', null));
+          newItems.push(this.createReportDatum(null, { date, id: key, label }, 'cost', null));
         }
       }
       result.push(newItems);


### PR DESCRIPTION
This ensures that the Explorer chart legend displays account aliases.

https://issues.redhat.com/browse/COST-1316

<img width="1416" alt="Screen Shot 2021-04-19 at 11 19 42 AM" src="https://user-images.githubusercontent.com/17481322/115260966-36b80180-a101-11eb-849e-58a29779c53b.png">
