### PR TITLE
Interactive chart legend remains disabled

### DIFF
--- a/src/components/charts/costExplorerChart/costExplorerChart.tsx
+++ b/src/components/charts/costExplorerChart/costExplorerChart.tsx
@@ -236,19 +236,11 @@ class CostExplorerChart extends React.Component<CostExplorerChartProps, State> {
 
   private getChart = (series: ChartSeries, index: number) => {
     const { hiddenSeries } = this.state;
+    const data = !hiddenSeries.has(index) ? series.data : [{ y: null }];
 
-    if (!hiddenSeries.has(index)) {
-      return (
-        <ChartBar
-          alignment="start"
-          data={series.data}
-          key={series.childName}
-          name={series.childName}
-          style={series.style}
-        />
-      );
-    }
-    return null;
+    return (
+      <ChartBar alignment="start" data={data} key={series.childName} name={series.childName} style={series.style} />
+    );
   };
 
   // Returns CursorVoronoiContainer component

--- a/src/components/charts/dailyCostChart/dailyCostChart.tsx
+++ b/src/components/charts/dailyCostChart/dailyCostChart.tsx
@@ -327,19 +327,20 @@ class DailyCostChart extends React.Component<DailyCostChartProps, State> {
   private getChart = (series: ChartSeries, index: number) => {
     const { hiddenSeries } = this.state;
 
-    if (!hiddenSeries.has(index) && !series.isForecast) {
+    if (!series.isForecast) {
+      const data = !hiddenSeries.has(index) ? series.data : [{ y: null }];
       if (series.isBar) {
         return (
           <ChartBar
             alignment="middle"
-            data={series.data}
+            data={data}
             key={series.childName}
             name={series.childName}
             style={series.style}
           />
         );
       } else if (series.isLine) {
-        return <ChartLine data={series.data} key={series.childName} name={series.childName} style={series.style} />;
+        return <ChartLine data={data} key={series.childName} name={series.childName} style={series.style} />;
       }
     }
     return null;
@@ -348,15 +349,10 @@ class DailyCostChart extends React.Component<DailyCostChartProps, State> {
   private getForecastBarChart = (series: ChartSeries, index: number) => {
     const { hiddenSeries } = this.state;
 
-    if (!hiddenSeries.has(index) && series.isForecast && series.isBar) {
+    if (series.isForecast && series.isBar) {
+      const data = !hiddenSeries.has(index) ? series.data : [{ y: null }];
       return (
-        <ChartBar
-          alignment="middle"
-          data={series.data}
-          key={series.childName}
-          name={series.childName}
-          style={series.style}
-        />
+        <ChartBar alignment="middle" data={data} key={series.childName} name={series.childName} style={series.style} />
       );
     }
     return null;
@@ -365,12 +361,13 @@ class DailyCostChart extends React.Component<DailyCostChartProps, State> {
   private getForecastLineChart = (series: ChartSeries, index: number) => {
     const { hiddenSeries } = this.state;
 
-    if (!hiddenSeries.has(index) && series.isForecast && series.isLine) {
+    if (series.isForecast && series.isLine) {
+      const data = !hiddenSeries.has(index) ? series.data : [{ y: null }];
       return (
         <ChartBar
           alignment="middle"
           barWidth={1}
-          data={series.data}
+          data={data}
           key={series.childName}
           name={series.childName}
           style={series.style}


### PR DESCRIPTION
The Explorer chart's interactive legend remains disabled after all items have been hidden. Need to omit the data instead of the entire component.

https://issues.redhat.com/browse/COST-1319

![chrome-capture](https://user-images.githubusercontent.com/17481322/115283241-18f69680-a119-11eb-9aa3-3fa39be55c87.gif)
