### PR TITLE
Added new URLs to spandx

### DIFF
--- a/config/spandx.config.js
+++ b/config/spandx.config.js
@@ -16,6 +16,13 @@ module.exports = {
     '/beta/cost-management': {
       host: `http://${localhost}:8002`,
     },
+    // New URLs
+    '/openshift/cost-management': {
+      host: `http://${localhost}:8002`,
+    },
+    '/beta/openshift/cost-management': {
+      host: `http://${localhost}:8002`,
+    },
     // For testing cloud-services-config https://github.com/RedHatInsights/cloud-services-config#testing-your-changes-locally
     // '/beta/config': {
     //   host: `http://${localhost}:8889`,


### PR DESCRIPTION
Insights moved Cost Management under OpenShift, so the spandx needs to be updated. Note that the old URLs still work for certain CI environments.