### PR TITLE
Ensure charts save project alias

### DIFF
--- a/src/components/charts/common/chartDatumUtils.ts
+++ b/src/components/charts/common/chartDatumUtils.ts
@@ -205,6 +205,7 @@ export function createReportDatum<T extends ComputedReportItem>(
     x: xVal,
     y: value === null ? null : yVal, // For displaying "no data" labels in chart tooltips
     key: computedItem.id,
+    name: computedItem.label ? computedItem.label : computedItem.id, // legend item label
     units: computedItem[reportItem]
       ? computedItem[reportItem][reportItemValue]
         ? computedItem[reportItem][reportItemValue].units // cost, infrastructure, supplementary

--- a/src/pages/views/explorer/explorerChart.tsx
+++ b/src/pages/views/explorer/explorerChart.tsx
@@ -96,7 +96,7 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
       y: value === null ? null : yVal, // For displaying "no data" labels in chart tooltips
       date: computedItem.date,
       key: computedItem.id,
-      name: computedItem.label ? computedItem.label : computedItem.id,
+      name: computedItem.label ? computedItem.label : computedItem.id, // legend item label
       units: computedItem[reportItem]
         ? computedItem[reportItem][reportItemValue]
           ? computedItem[reportItem][reportItemValue].units // cost, infrastructure, supplementary


### PR DESCRIPTION
This is a follow up to https://github.com/project-koku/koku-ui/pull/1949. Want to ensure charts save the project alias, similar to the Cost Explorer chart. 

https://issues.redhat.com/browse/COST-1316