### PR TITLE
Restore count to "Others" label

### DIFF
--- a/src/api/reports/report.ts
+++ b/src/api/reports/report.ts
@@ -74,15 +74,16 @@ export interface ReportMeta {
     percent: number;
     value: number;
   };
+  filter?: {
+    [filter: string]: any;
+  };
   group_by?: {
     [group: string]: string[];
   };
   order_by?: {
     [order: string]: string;
   };
-  filter?: {
-    [filter: string]: any;
-  };
+  others?: number;
   total?: {
     capacity?: ReportValue;
     cost?: ReportItemValue;

--- a/src/components/reports/reportSummary/reportSummaryItems.tsx
+++ b/src/components/reports/reportSummary/reportSummaryItems.tsx
@@ -39,7 +39,7 @@ class ReportSummaryItemsBase extends React.Component<ReportSummaryItemsProps> {
     const otherIndex = computedItems.findIndex(i => {
       const id = i.id;
       if (id && id !== null) {
-        return id.toString().includes('Other');
+        return id === 'Other' || id === 'Others';
       }
     });
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -116,6 +116,8 @@
     "limit_legend_tooltip": "Limit ($t(months_abbr.{{month}}))",
     "month_legend_label": "$t(months_abbr.{{month}})",
     "no_data": "no data",
+    "others": "{{count}} Other",
+    "others_plural": "{{count}} Others",
     "requests_legend_label": "Requests ({{startDate}} $t(months_abbr.{{month}}))",
     "requests_legend_label_no_data": "Requests (no data)",
     "requests_legend_label_plural": "Requests ({{startDate}}-{{endDate}} $t(months_abbr.{{month}}))",

--- a/src/pages/views/details/components/summary/summaryCard.tsx
+++ b/src/pages/views/details/components/summary/summaryCard.tsx
@@ -108,7 +108,7 @@ class SummaryBase extends React.Component<SummaryProps> {
     const otherIndex = computedItems.findIndex(i => {
       const id = i.id;
       if (id && id !== null) {
-        return id.toString().includes('Other');
+        return id === 'Other' || id === 'Others';
       }
     });
 

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -158,7 +158,7 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
         const source_uuid = val.source_uuid ? val.source_uuid : [];
 
         let label;
-        if (report.meta.others && (id === 'Other' || id === 'Others')) {
+        if (report.meta && report.meta.others && (id === 'Other' || id === 'Others')) {
           // Add count to "Others" label
           label = i18next.t('chart.others', { count: report.meta.others });
         } else {

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -1,6 +1,6 @@
 import { Report, ReportData, ReportItem, ReportItemValue, ReportValue } from 'api/reports/report';
-import { sort, SortDirection } from 'utils/sort';
 import i18next from 'i18next';
+import { sort, SortDirection } from 'utils/sort';
 
 import { getItemLabel } from './getItemLabel';
 

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -1,5 +1,6 @@
 import { Report, ReportData, ReportItem, ReportItemValue, ReportValue } from 'api/reports/report';
 import { sort, SortDirection } from 'utils/sort';
+import i18next from 'i18next';
 
 import { getItemLabel } from './getItemLabel';
 
@@ -157,20 +158,25 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
         const source_uuid = val.source_uuid ? val.source_uuid : [];
 
         let label;
-        const itemLabelKey = getItemLabel({ report, idKey, value: val });
-        if (itemLabelKey === 'org_entities' && val.alias) {
-          label = val.alias;
-        } else if (itemLabelKey === 'account' && val.account_alias) {
-          label = val.account_alias;
-        } else if (itemLabelKey === 'cluster' && cluster_alias) {
-          label = cluster_alias;
-        } else if (val[itemLabelKey] instanceof Object) {
-          label = val[itemLabelKey].value;
+        if (report.meta.others && (id === 'Other' || id === 'Others')) {
+          // Add count to "Others" label
+          label = i18next.t('chart.others', { count: report.meta.others });
         } else {
-          label = val[itemLabelKey];
-        }
-        if (label === undefined) {
-          label = val.alias ? val.alias : val[idKey];
+          const itemLabelKey = getItemLabel({ report, idKey, value: val });
+          if (itemLabelKey === 'org_entities' && val.alias) {
+            label = val.alias;
+          } else if (itemLabelKey === 'account' && val.account_alias) {
+            label = val.account_alias;
+          } else if (itemLabelKey === 'cluster' && cluster_alias) {
+            label = cluster_alias;
+          } else if (val[itemLabelKey] instanceof Object) {
+            label = val[itemLabelKey].value;
+          } else {
+            label = val[itemLabelKey];
+          }
+          if (label === undefined) {
+            label = val.alias ? val.alias : val[idKey];
+          }
         }
 
         if (daily) {


### PR DESCRIPTION
This restores the count to "Other/Others" labels, shown via the top costliest projects in the Overview and Cost Explorer pages.

The costs API removed the "others" count from each project ID (e.g., "1 Other", "6 Others", etc.). There is now a single project, named "Others" and the count is provided via meta data.

https://issues.redhat.com/browse/COST-1328

Cost Explorer
<img width="661" alt="Screen Shot 2021-04-22 at 11 38 19 PM" src="https://user-images.githubusercontent.com/17481322/115814938-0653ba00-a3c4-11eb-8df8-7b8ab612162a.png">

Cost by projects
<img width="856" alt="Screen Shot 2021-04-22 at 6 56 25 PM" src="https://user-images.githubusercontent.com/17481322/115814997-297e6980-a3c4-11eb-9872-e674263525d1.png">

Top regions
<img width="559" alt="Screen Shot 2021-04-22 at 6 55 53 PM" src="https://user-images.githubusercontent.com/17481322/115814977-1c617a80-a3c4-11eb-89c9-d423887f1d1f.png">