### PR TITLE
Replaced start:dev target with start:beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "i18n:key:check:notfound": "scripts/utils/i18n_key_tool.py --Xreport-found --json-file src/locales/en.json --search-path src --exclude-file scripts/utils/i18n_excludes",
     "i18n:key:check:duplicates": "scripts/utils/i18n_key_tool.py --find-duplicates --Xreport-found --Xreport-not-found --json-file src/locales/en.json --search-path src --exclude-file scripts/utils/i18n_excludes",
     "start": "NODE_OPTIONS=--max-old-space-size=8192 webpack serve -c ./webpack.config.js",
-    "start:dev": "APP_ENV=proxy yarn start",
+    "start:beta": "BETA_ENV=true yarn start",
     "stats": "yarn build:client --profile --json > stats.json",
     "test": "jest",
     "manifest:update": "node scripts/createManifest",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,7 +33,7 @@ const singletonDeps = [
 const fileRegEx = /\.(png|woff|woff2|eot|ttf|svg|gif|jpe?g|png)(\?[a-z0-9=.]+)?$/;
 const srcDir = path.resolve(__dirname, './src');
 const distDir = path.resolve(__dirname, './public/');
-const appEnv = process.env.APP_ENV;
+const betaEnv = process.env.BETA_ENV;
 const nodeEnv = process.env.NODE_ENV;
 
 // See index.js from @redhat-cloud-services/frontend-components-config
@@ -61,7 +61,7 @@ class WatchRunPlugin {
 module.exports = (_env, argv) => {
   const gitBranch = process.env.TRAVIS_BRANCH || process.env.BRANCH || gitRevisionPlugin.branch();
   const isProduction = nodeEnv === 'production' || argv.mode === 'production';
-  const appDeployment = (isProduction && betaBranches.includes(gitBranch)) || appEnv === 'proxy' ? 'beta/apps' : 'apps';
+  const appDeployment = (isProduction && betaBranches.includes(gitBranch)) || betaEnv === 'true' ? 'beta/apps' : 'apps';
   const publicPath = `/${appDeployment}/${insights.appname}/`;
   // Moved multiple entries to index.tsx in order to help speed up webpack
   const entry = path.join(srcDir, 'index.tsx');


### PR DESCRIPTION
Replaced the `start:dev` target with `start:beta` to make it clear what environment devs are running locally. This mimics the `start:beta` target of the Insights starter app.

When accessing `https://ci.foo.redhat.com:1337/beta/openshift/cost-management/`; for example, we should run the `start:beta` target. However, when accessing `https://ci.foo.redhat.com:1337/openshift/cost-management/`, we must run the `start` target. Otherwise, `fed-mods.json` is not located via webpack's public path.