### PR TITLE
Omit empty strings returned by APIs

### DIFF
--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -174,8 +174,8 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
           } else {
             label = val[itemLabelKey];
           }
-          if (label === undefined) {
-            label = val.alias ? val.alias : val[idKey];
+          if (label === undefined || label.trim().length === 0) {
+            label = val.alias && val.alias.trim().length > 0 ? val.alias : val[idKey];
           }
         }
 


### PR DESCRIPTION
As a workaround, I've updated the UI to ignore empty account_alias strings. However, it would be ideal if the API did not return empty strings.

https://issues.redhat.com/browse/COST-1326