### PR TITLE
Additional tag requests for Cost Explorer

### DIFF
--- a/src/api/tags/awsCloudTags.ts
+++ b/src/api/tags/awsCloudTags.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+import { Tag, TagType } from './tag';
+
+export interface AwsCloudTag extends Tag {}
+
+export const TagTypePaths: Partial<Record<TagType, string>> = {
+  [TagType.tag]: 'tags/openshift/infrastructures/aws/',
+};
+
+export function runTag(tagType: TagType, query: string) {
+  const path = TagTypePaths[tagType];
+  return axios.get<AwsCloudTag>(`${path}?${query}`);
+}

--- a/src/api/tags/azureCloudTags.ts
+++ b/src/api/tags/azureCloudTags.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+import { Tag, TagType } from './tag';
+
+export interface AzureCloudTag extends Tag {}
+
+export const TagTypePaths: Partial<Record<TagType, string>> = {
+  [TagType.tag]: 'tags/openshift/infrastructures/azure/',
+};
+
+export function runTag(tagType: TagType, query: string) {
+  const path = TagTypePaths[tagType];
+  return axios.get<AzureCloudTag>(`${path}?${query}`);
+}

--- a/src/api/tags/ocpCloudTags.ts
+++ b/src/api/tags/ocpCloudTags.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+import { Tag, TagType } from './tag';
+
+export interface OcpCloudTag extends Tag {}
+
+export const TagTypePaths: Partial<Record<TagType, string>> = {
+  [TagType.tag]: 'tags/openshift/infrastructures/all/',
+};
+
+export function runTag(tagType: TagType, query: string) {
+  const path = TagTypePaths[tagType];
+  return axios.get<OcpCloudTag>(`${path}?${query}`);
+}

--- a/src/api/tags/tag.ts
+++ b/src/api/tags/tag.ts
@@ -38,8 +38,11 @@ export const enum TagType {
 // eslint-disable-next-line no-shadow
 export const enum TagPathsType {
   aws = 'aws',
+  awsCloud = 'aws_cloud',
   azure = 'azure',
+  azureCloud = 'azure_cloud',
   gcp = 'gcp',
   ibm = 'gcp', // Todo: update to use ibm backend apis when they become available
   ocp = 'ocp',
+  ocpCloud = 'ocp_cloud',
 }

--- a/src/api/tags/tagUtils.ts
+++ b/src/api/tags/tagUtils.ts
@@ -1,7 +1,10 @@
+import { runTag as runAwsCloudTag } from './awsCloudTags';
 import { runTag as runAwsTag } from './awsTags';
+import { runTag as runAzureCloudTag } from './azureCloudTags';
 import { runTag as runAzureTag } from './azureTags';
 import { runTag as runGcpTag } from './gcpTags';
 import { runTag as runIbmTag } from './ibmTags';
+import { runTag as runOcpCloudTag } from './ocpCloudTags';
 import { runTag as runOcpTag } from './ocpTags';
 import { TagPathsType, TagType } from './tag';
 
@@ -11,8 +14,14 @@ export function runTag(tagPathsType: TagPathsType, tagType: TagType, query: stri
     case TagPathsType.aws:
       tagReport = runAwsTag(tagType, query);
       break;
+    case TagPathsType.awsCloud:
+      tagReport = runAwsCloudTag(tagType, query);
+      break;
     case TagPathsType.azure:
       tagReport = runAzureTag(tagType, query);
+      break;
+    case TagPathsType.azureCloud:
+      tagReport = runAzureCloudTag(tagType, query);
       break;
     case TagPathsType.gcp:
       tagReport = runGcpTag(tagType, query);
@@ -22,6 +31,9 @@ export function runTag(tagPathsType: TagPathsType, tagType: TagType, query: stri
       break;
     case TagPathsType.ocp:
       tagReport = runOcpTag(tagType, query);
+      break;
+    case TagPathsType.ocpCloud:
+      tagReport = runOcpCloudTag(tagType, query);
       break;
   }
   return tagReport;

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -443,7 +443,6 @@
     "no_data": "no data",
     "org_unit_column_title": "Names",
     "perspective": {
-      "all_cloud": "All cloud filtered by OpenShift",
       "aws": "Amazon Web Services",
       "aws_cloud": "Amazon Web Services filtered by OpenShift",
       "azure": "Microsoft Azure",
@@ -451,11 +450,11 @@
       "gcp": "Google Cloud Platform",
       "ibm": "IBM Cloud",
       "ocp": "All OpenShift cost",
+      "ocp_cloud": "All cloud filtered by OpenShift",
       "ocp_supplementary": "OpenShift supplementary cost",
       "ocp_usage": "OpenShift usage"
     },
     "title": {
-      "all_cloud": "All cloud filtered by OpenShift - Top 5 Costliest",
       "aws": "Amazon Web Services - Top 5 Costliest",
       "aws_cloud": "Amazon Web Services filtered by OpenShift - Top 5 Costliest",
       "azure": "Microsoft Azure - Top 5 Costliest",
@@ -463,6 +462,7 @@
       "gcp": "Google Cloud Platform - Top 5 Costliest",
       "ibm": "IBM Cloud - Top 5 Costliest",
       "ocp": "All OpenShift cost - Top 5 Costliest",
+      "ocp_cloud": "All cloud filtered by OpenShift - Top 5 Costliest",
       "ocp_supplementary": "OpenShift supplementary cost - Top 5 Costliest",
       "ocp_usage": "OpenShift usage - Top 5 Costliest"
     }
@@ -816,7 +816,6 @@
     "ocp_desc": "Total cost for OpenShift Container Platform, comprising the infrastructure cost and cost calculated from metrics.",
     "perspective": {
       "all": "All",
-      "all_cloud": "All cloud filtered by OpenShift",
       "aws": "Amazon Web Services",
       "aws_cloud": "Amazon Web Services filtered by OpenShift",
       "azure": "Microsoft Azure",
@@ -824,6 +823,7 @@
       "gcp": "Google Cloud Platform",
       "ibm": "IBM Cloud",
       "label": "Perspective",
+      "ocp_cloud": "All cloud filtered by OpenShift",
       "ocp_usage": "OpenShift usage",
       "supplementary": "Supplementary"
     }

--- a/src/pages/views/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/awsDetails/detailsToolbar.tsx
@@ -11,7 +11,6 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { orgActions, orgSelectors } from 'store/orgs';
 import { tagActions, tagSelectors } from 'store/tags';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
-import { getLast60DaysDate } from 'utils/dateRange';
 import { isEqual } from 'utils/equal';
 
 interface DetailsToolbarOwnProps {
@@ -152,12 +151,13 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
-  const { start_date, end_date } = getLast60DaysDate();
-
   // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
   const queryString = getQuery({
-    start_date,
-    end_date,
+    filter: {
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
+    },
     // key_only: true
   });
   const orgReport = orgSelectors.selectOrg(state, orgReportPathsType, orgReportType, queryString);

--- a/src/pages/views/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/awsDetails/detailsToolbar.tsx
@@ -11,6 +11,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { orgActions, orgSelectors } from 'store/orgs';
 import { tagActions, tagSelectors } from 'store/tags';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
+import { getLast60DaysDate } from 'utils/dateRange';
 import { isEqual } from 'utils/equal';
 
 interface DetailsToolbarOwnProps {
@@ -151,8 +152,12 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
-  // Omitting key_only to share a single request -- the toolbar needs key values
+  const { start_date, end_date } = getLast60DaysDate();
+
+  // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
   const queryString = getQuery({
+    start_date,
+    end_date,
     // key_only: true
   });
   const orgReport = orgSelectors.selectOrg(state, orgReportPathsType, orgReportType, queryString);

--- a/src/pages/views/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/azureDetails/detailsToolbar.tsx
@@ -10,7 +10,6 @@ import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
-import { getLast60DaysDate } from 'utils/dateRange';
 import { isEqual } from 'utils/equal';
 
 interface DetailsToolbarOwnProps {
@@ -140,12 +139,13 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
-  const { start_date, end_date } = getLast60DaysDate();
-
   // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
   const queryString = getQuery({
-    start_date,
-    end_date,
+    filter: {
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
+    },
     // key_only: true
   });
   const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);

--- a/src/pages/views/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/azureDetails/detailsToolbar.tsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
+import { getLast60DaysDate } from 'utils/dateRange';
 import { isEqual } from 'utils/equal';
 
 interface DetailsToolbarOwnProps {
@@ -139,13 +140,12 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
-  // Omitting key_only to share a single request -- the toolbar needs key values
+  const { start_date, end_date } = getLast60DaysDate();
+
+  // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
   const queryString = getQuery({
-    filter: {
-      resolution: 'monthly',
-      time_scope_units: 'month',
-      time_scope_value: -1,
-    },
+    start_date,
+    end_date,
     // key_only: true
   });
   const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);

--- a/src/pages/views/details/components/tag/tagLink.tsx
+++ b/src/pages/views/details/components/tag/tagLink.tsx
@@ -8,7 +8,6 @@ import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 import { getTestProps, testIds } from 'testIds';
-import { getLast60DaysDate } from 'utils/dateRange';
 
 import { styles } from './tag.styles';
 import { TagModal } from './tagModal';
@@ -108,17 +107,19 @@ const mapStateToProps = createMapStateToProps<TagLinkOwnProps, TagLinkStateProps
   const groupByOrgValue = getGroupByOrgValue(query);
   const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
   const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
-  const { start_date, end_date } = getLast60DaysDate();
 
   const newQuery: Query = {
+    filter: {
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
+    },
     filter_by: {
       // Add filters here to apply logical OR/AND
       ...(query && query.filter_by && query.filter_by),
       ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
       ...(groupBy && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
     },
-    start_date,
-    end_date,
     // key_only: true
   };
   const queryString = getQuery(newQuery);

--- a/src/pages/views/details/components/tag/tagLink.tsx
+++ b/src/pages/views/details/components/tag/tagLink.tsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 import { getTestProps, testIds } from 'testIds';
+import { getLast60DaysDate } from 'utils/dateRange';
 
 import { styles } from './tag.styles';
 import { TagModal } from './tagModal';
@@ -107,19 +108,18 @@ const mapStateToProps = createMapStateToProps<TagLinkOwnProps, TagLinkStateProps
   const groupByOrgValue = getGroupByOrgValue(query);
   const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
   const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
+  const { start_date, end_date } = getLast60DaysDate();
 
   const newQuery: Query = {
-    filter: {
-      resolution: 'monthly',
-      time_scope_units: 'month',
-      time_scope_value: -1,
-    },
     filter_by: {
       // Add filters here to apply logical OR/AND
       ...(query && query.filter_by && query.filter_by),
       ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
       ...(groupBy && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
     },
+    start_date,
+    end_date,
+    // key_only: true
   };
   const queryString = getQuery(newQuery);
 

--- a/src/pages/views/details/components/tag/tagModal.tsx
+++ b/src/pages/views/details/components/tag/tagModal.tsx
@@ -9,7 +9,6 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 
 import { TagView } from './tagView';
-import { getLast60DaysDate } from 'utils/dateRange';
 
 interface TagModalOwnProps {
   isOpen: boolean;
@@ -101,17 +100,19 @@ const mapStateToProps = createMapStateToProps<TagModalOwnProps, TagModalStatePro
   const groupByOrgValue = getGroupByOrgValue(query);
   const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
   const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
-  const { start_date, end_date } = getLast60DaysDate();
 
   const newQuery: Query = {
+    filter: {
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
+    },
     filter_by: {
       // Add filters here to apply logical OR/AND
       ...(query && query.filter_by && query.filter_by),
       ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
       ...(groupBy && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
     },
-    start_date,
-    end_date,
     // key_only: true
   };
   const queryString = getQuery(newQuery);

--- a/src/pages/views/details/components/tag/tagModal.tsx
+++ b/src/pages/views/details/components/tag/tagModal.tsx
@@ -9,6 +9,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 
 import { TagView } from './tagView';
+import { getLast60DaysDate } from 'utils/dateRange';
 
 interface TagModalOwnProps {
   isOpen: boolean;
@@ -100,19 +101,18 @@ const mapStateToProps = createMapStateToProps<TagModalOwnProps, TagModalStatePro
   const groupByOrgValue = getGroupByOrgValue(query);
   const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
   const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
+  const { start_date, end_date } = getLast60DaysDate();
 
   const newQuery: Query = {
-    filter: {
-      resolution: 'monthly',
-      time_scope_units: 'month',
-      time_scope_value: -1,
-    },
     filter_by: {
       // Add filters here to apply logical OR/AND
       ...(query && query.filter_by && query.filter_by),
       ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
       ...(groupBy && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
     },
+    start_date,
+    end_date,
+    // key_only: true
   };
   const queryString = getQuery(newQuery);
 

--- a/src/pages/views/details/gcpDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/gcpDetails/detailsToolbar.tsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
+import { getLast60DaysDate } from 'utils/dateRange';
 import { isEqual } from 'utils/equal';
 
 interface DetailsToolbarOwnProps {
@@ -136,8 +137,12 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
-  // Omitting key_only to share a single request -- the toolbar needs key values
+  const { start_date, end_date } = getLast60DaysDate();
+
+  // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
   const queryString = getQuery({
+    start_date,
+    end_date,
     // key_only: true
   });
 

--- a/src/pages/views/details/gcpDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/gcpDetails/detailsToolbar.tsx
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
-import { getLast60DaysDate } from 'utils/dateRange';
 import { isEqual } from 'utils/equal';
 
 interface DetailsToolbarOwnProps {
@@ -137,12 +136,13 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
-  const { start_date, end_date } = getLast60DaysDate();
-
   // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
   const queryString = getQuery({
-    start_date,
-    end_date,
+    filter: {
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
+    },
     // key_only: true
   });
 

--- a/src/pages/views/details/ibmDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ibmDetails/detailsToolbar.tsx
@@ -9,6 +9,7 @@ import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
+import { getLast60DaysDate } from 'utils/dateRange';
 import { isEqual } from 'utils/equal';
 
 interface DetailsToolbarOwnProps {
@@ -136,8 +137,12 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
-  // Omitting key_only to share a single request -- the toolbar needs key values
+  const { start_date, end_date } = getLast60DaysDate();
+
+  // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
   const queryString = getQuery({
+    start_date,
+    end_date,
     // key_only: true
   });
 

--- a/src/pages/views/details/ibmDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ibmDetails/detailsToolbar.tsx
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
-import { getLast60DaysDate } from 'utils/dateRange';
 import { isEqual } from 'utils/equal';
 
 interface DetailsToolbarOwnProps {
@@ -137,12 +136,13 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
-  const { start_date, end_date } = getLast60DaysDate();
-
   // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
   const queryString = getQuery({
-    start_date,
-    end_date,
+    filter: {
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
+    },
     // key_only: true
   });
 

--- a/src/pages/views/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ocpDetails/detailsToolbar.tsx
@@ -10,6 +10,7 @@ import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
+import { getLast60DaysDate } from 'utils/dateRange';
 import { isEqual } from 'utils/equal';
 
 interface DetailsToolbarOwnProps {
@@ -132,13 +133,12 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
-  // Omitting key_only to share a single request -- the toolbar needs key values
+  const { start_date, end_date } = getLast60DaysDate();
+
+  // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
   const queryString = getQuery({
-    filter: {
-      resolution: 'monthly',
-      time_scope_units: 'month',
-      time_scope_value: -1,
-    },
+    start_date,
+    end_date,
     // key_only: true
   });
   const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);

--- a/src/pages/views/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ocpDetails/detailsToolbar.tsx
@@ -10,7 +10,6 @@ import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
-import { getLast60DaysDate } from 'utils/dateRange';
 import { isEqual } from 'utils/equal';
 
 interface DetailsToolbarOwnProps {
@@ -133,12 +132,13 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
-  const { start_date, end_date } = getLast60DaysDate();
-
   // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
   const queryString = getQuery({
-    start_date,
-    end_date,
+    filter: {
+      resolution: 'monthly',
+      time_scope_units: 'month',
+      time_scope_value: -1,
+    },
     // key_only: true
   });
   const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);

--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -503,7 +503,7 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
   const queryFromRoute = parseQuery<Query>(location.search);
   const perspective = getPerspectiveDefault(queryFromRoute, userAccess);
   const dateRange = getDateRangeDefault(queryFromRoute);
-  const { end_date, start_date } = getDateRange(queryFromRoute);
+  const { end_date, start_date } = getDateRange(getDateRangeDefault(queryFromRoute));
 
   const query = {
     filter: {

--- a/src/pages/views/explorer/explorerChart.tsx
+++ b/src/pages/views/explorer/explorerChart.tsx
@@ -283,7 +283,7 @@ const mapStateToProps = createMapStateToProps<ExplorerChartOwnProps, ExplorerCha
   const queryFromRoute = parseQuery<Query>(location.search);
   const perspective = getPerspectiveDefault(queryFromRoute, userAccess);
   const dateRange = getDateRangeDefault(queryFromRoute);
-  const { end_date, start_date } = getDateRange(queryFromRoute);
+  const { end_date, start_date } = getDateRange(getDateRangeDefault(queryFromRoute));
 
   const query = {
     filter: {

--- a/src/pages/views/explorer/explorerChart.tsx
+++ b/src/pages/views/explorer/explorerChart.tsx
@@ -139,9 +139,6 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
   private getChartTitle = (perspective: string) => {
     let result;
     switch (perspective) {
-      case PerspectiveType.allCloud:
-        result = 'explorer.title.all_cloud';
-        break;
       case PerspectiveType.aws:
         result = 'explorer.title.aws';
         break;
@@ -162,6 +159,9 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
         break;
       case PerspectiveType.ocp:
         result = 'explorer.title.ocp';
+        break;
+      case PerspectiveType.ocpCloud:
+        result = 'explorer.title.ocp_cloud';
         break;
       case PerspectiveType.ocpSupplementary:
         result = 'explorer.title.ocp_supplementary';

--- a/src/pages/views/explorer/explorerFilter.tsx
+++ b/src/pages/views/explorer/explorerFilter.tsx
@@ -221,6 +221,7 @@ const mapStateToProps = createMapStateToProps<ExplorerFilterOwnProps, ExplorerFi
     orgReportFetchStatus = orgSelectors.selectOrgFetchStatus(state, orgReportPathsType, orgReportType, orgQueryString);
   }
 
+  // Fetch tags with largest date range available
   const { start_date, end_date } = getLast60DaysDate();
 
   // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does

--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -35,13 +35,13 @@ import {
   getPerspectiveDefault,
   getRouteForQuery,
   getTagReportPathsType,
-  infrastructureAllCloudOptions,
   infrastructureAwsCloudOptions,
   infrastructureAwsOptions,
   infrastructureAzureCloudOptions,
   infrastructureAzureOptions,
   infrastructureGcpOptions,
   infrastructureIbmOptions,
+  infrastructureOcpCloudOptions,
   infrastructureOcpOptions,
   ocpOptions,
   PerspectiveType,
@@ -146,7 +146,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
     const options = [];
     if (ocp) {
       options.push(...ocpOptions);
-      options.push(...infrastructureAllCloudOptions);
+      options.push(...infrastructureOcpCloudOptions);
     }
     if (aws) {
       options.push(...infrastructureAwsOptions);

--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -22,6 +22,7 @@ import {
 } from 'store/providers';
 import { allUserAccessQuery, ibmUserAccessQuery, userAccessSelectors } from 'store/userAccess';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
+import { getLast60DaysDate } from 'utils/dateRange';
 import { isAwsAvailable, isAzureAvailable, isGcpAvailable, isIbmAvailable, isOcpAvailable } from 'utils/userAccess';
 
 import { ExplorerFilter } from './explorerFilter';
@@ -259,6 +260,9 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
     const orgReportPathsType = getOrgReportPathsType(perspective);
     const tagReportPathsType = getTagReportPathsType(perspective);
 
+    // Fetch tags with largest date range available
+    const { start_date, end_date } = getLast60DaysDate();
+
     return (
       <header style={styles.header}>
         <div>
@@ -269,6 +273,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
             {this.getPerspective(noProviders)}
             <div style={styles.groupBy}>
               <GroupBy
+                endDate={end_date}
                 getIdKeyForGroupBy={getIdKeyForGroupBy}
                 groupBy={groupBy}
                 isDisabled={noProviders}
@@ -278,6 +283,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
                 perspective={perspective}
                 showOrgs={orgReportPathsType}
                 showTags={tagReportPathsType}
+                startDate={start_date}
                 tagReportPathsType={tagReportPathsType}
               />
             </div>

--- a/src/pages/views/explorer/explorerTable.tsx
+++ b/src/pages/views/explorer/explorerTable.tsx
@@ -351,7 +351,7 @@ const mapStateToProps = createMapStateToProps<ExplorerTableOwnProps, ExplorerTab
   const queryFromRoute = parseQuery<Query>(location.search);
   const perspective = getPerspectiveDefault(queryFromRoute, userAccess);
   const dateRange = getDateRangeDefault(queryFromRoute);
-  const { end_date, start_date } = getDateRange(queryFromRoute);
+  const { end_date, start_date } = getDateRange(getDateRangeDefault(queryFromRoute));
 
   return {
     dateRange,

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -353,12 +353,16 @@ export const getTagReportPathsType = (perspective: string) => {
   let result;
   switch (perspective) {
     case PerspectiveType.aws:
-    case PerspectiveType.awsCloud:
       return TagPathsType.aws;
       break;
+    case PerspectiveType.awsCloud:
+      return TagPathsType.awsCloud;
+      break;
     case PerspectiveType.azure:
-    case PerspectiveType.azureCloud:
       return TagPathsType.azure;
+      break;
+    case PerspectiveType.azureCloud:
+      return TagPathsType.azureCloud;
       break;
     case PerspectiveType.gcp:
       return TagPathsType.gcp;
@@ -367,10 +371,12 @@ export const getTagReportPathsType = (perspective: string) => {
       return TagPathsType.ibm;
       break;
     case PerspectiveType.ocp:
-    case PerspectiveType.ocpCloud:
     case PerspectiveType.ocpSupplementary:
     case PerspectiveType.ocpUsage:
       return TagPathsType.ocp;
+      break;
+    case PerspectiveType.ocpCloud:
+      return TagPathsType.ocpCloud;
       break;
     default:
       result = undefined;

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -159,12 +159,12 @@ export const getComputedReportItemType = (perspective: string) => {
   return result;
 };
 
-export const getDateRange = queryFromRoute => {
+export const getDateRange = (dateRangeType: DateRangeType) => {
   const endDate = new Date();
   const startDate = new Date();
   let dateRange;
 
-  switch (getDateRangeDefault(queryFromRoute)) {
+  switch (dateRangeType) {
     case DateRangeType.previousMonthToDate:
       startDate.setDate(1); // Required to obtain correct month
       startDate.setMonth(startDate.getMonth() - 1); // Note: Must include previous and current month

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -4,12 +4,13 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import { TagPathsType } from 'api/tags/tag';
 import { UserAccess } from 'api/userAccess';
 import { ComputedReportItemType } from 'components/charts/common/chartDatumUtils';
+import { format } from 'date-fns';
 import { ComputedAwsReportItemsParams } from 'utils/computedReport/getComputedAwsReportItems';
 import { ComputedAzureReportItemsParams } from 'utils/computedReport/getComputedAzureReportItems';
 import { ComputedGcpReportItemsParams } from 'utils/computedReport/getComputedGcpReportItems';
 import { ComputedIbmReportItemsParams } from 'utils/computedReport/getComputedIbmReportItems';
 import { ComputedOcpReportItemsParams } from 'utils/computedReport/getComputedOcpReportItems';
-import { getCurrentMonthDate, getLast30DaysDate, getLast60DaysDate, getPreviousMonthDate } from 'utils/dateRange';
+import { getCurrentMonthDate, getLast30DaysDate, getLast60DaysDate } from 'utils/dateRange';
 import { hasAwsAccess, hasAzureAccess, hasGcpAccess, hasIbmAccess, hasOcpAccess } from 'utils/userAccess';
 
 // The date range drop down has the options below (if today is Jan 18th…)
@@ -159,11 +160,19 @@ export const getComputedReportItemType = (perspective: string) => {
 };
 
 export const getDateRange = queryFromRoute => {
+  const endDate = new Date();
+  const startDate = new Date();
   let dateRange;
 
   switch (getDateRangeDefault(queryFromRoute)) {
     case DateRangeType.previousMonthToDate:
-      dateRange = getPreviousMonthDate();
+      startDate.setDate(1); // Required to obtain correct month
+      startDate.setMonth(startDate.getMonth() - 1); // Note: Must include previous and current month
+
+      dateRange = {
+        end_date: format(endDate, 'yyyy-MM-dd'),
+        start_date: format(startDate, 'yyyy-MM-dd'),
+      };
       break;
     case DateRangeType.lastSixtyDays:
       dateRange = getLast60DaysDate();

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -4,13 +4,12 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import { TagPathsType } from 'api/tags/tag';
 import { UserAccess } from 'api/userAccess';
 import { ComputedReportItemType } from 'components/charts/common/chartDatumUtils';
-import { format } from 'date-fns';
 import { ComputedAwsReportItemsParams } from 'utils/computedReport/getComputedAwsReportItems';
 import { ComputedAzureReportItemsParams } from 'utils/computedReport/getComputedAzureReportItems';
 import { ComputedGcpReportItemsParams } from 'utils/computedReport/getComputedGcpReportItems';
 import { ComputedIbmReportItemsParams } from 'utils/computedReport/getComputedIbmReportItems';
 import { ComputedOcpReportItemsParams } from 'utils/computedReport/getComputedOcpReportItems';
-import { getCurrentMonthDate } from 'utils/dateRange';
+import { getCurrentMonthDate, getLast30DaysDate, getLast60DaysDate, getPreviousMonthDate } from 'utils/dateRange';
 import { hasAwsAccess, hasAzureAccess, hasGcpAccess, hasIbmAccess, hasOcpAccess } from 'utils/userAccess';
 
 // The date range drop down has the options below (if today is Jan 18th…)
@@ -160,37 +159,17 @@ export const getComputedReportItemType = (perspective: string) => {
 };
 
 export const getDateRange = queryFromRoute => {
-  const endDate = new Date();
-  const startDate = new Date();
   let dateRange;
 
   switch (getDateRangeDefault(queryFromRoute)) {
     case DateRangeType.previousMonthToDate:
-      startDate.setDate(1); // Required to obtain correct month
-      startDate.setMonth(startDate.getMonth() - 1);
-
-      dateRange = {
-        end_date: format(endDate, 'yyyy-MM-dd'),
-        start_date: format(startDate, 'yyyy-MM-dd'),
-      };
+      dateRange = getPreviousMonthDate();
       break;
     case DateRangeType.lastSixtyDays:
-      // 61 days, including today's date. See https://issues.redhat.com/browse/COST-1117
-      startDate.setDate(startDate.getDate() - 60);
-
-      dateRange = {
-        end_date: format(endDate, 'yyyy-MM-dd'),
-        start_date: format(startDate, 'yyyy-MM-dd'),
-      };
+      dateRange = getLast60DaysDate();
       break;
     case DateRangeType.lastThirtyDays:
-      // 31 days, including today's date. See https://issues.redhat.com/browse/COST-1117
-      startDate.setDate(startDate.getDate() - 30);
-
-      dateRange = {
-        end_date: format(endDate, 'yyyy-MM-dd'),
-        start_date: format(startDate, 'yyyy-MM-dd'),
-      };
+      dateRange = getLast30DaysDate();
       break;
     case DateRangeType.currentMonthToDate:
     default:

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -24,7 +24,6 @@ export const enum DateRangeType {
 
 // eslint-disable-next-line no-shadow
 export const enum PerspectiveType {
-  allCloud = 'all_cloud', // All filtered by Ocp
   aws = 'aws',
   awsCloud = 'aws_cloud', // Aws filtered by Ocp
   azure = 'azure',
@@ -32,6 +31,7 @@ export const enum PerspectiveType {
   gcp = 'gcp',
   ocp = 'ocp',
   ibm = 'ibm',
+  ocpCloud = 'ocp_cloud', // All filtered by Ocp
   ocpSupplementary = 'ocp_supplementary',
   ocpUsage = 'ocp_usage',
 }
@@ -107,9 +107,6 @@ export const groupByOcpOptions: {
   { label: 'project', value: 'project' },
 ];
 
-// Infrastructure all cloud options
-export const infrastructureAllCloudOptions = [{ label: 'explorer.perspective.all_cloud', value: 'all_cloud' }];
-
 // Infrastructure AWS options
 export const infrastructureAwsOptions = [{ label: 'explorer.perspective.aws', value: 'aws' }];
 
@@ -131,6 +128,9 @@ export const infrastructureIbmOptions = [{ label: 'explorer.perspective.ibm', va
 // Infrastructure Ocp options
 export const infrastructureOcpOptions = [{ label: 'explorer.perspective.ocp_usage', value: 'ocp_usage' }];
 
+// Infrastructure Ocp cloud options
+export const infrastructureOcpCloudOptions = [{ label: 'explorer.perspective.ocp_cloud', value: 'ocp_cloud' }];
+
 // Ocp options
 export const ocpOptions = [
   { label: 'explorer.perspective.ocp', value: 'ocp' },
@@ -144,13 +144,13 @@ export const getComputedReportItemType = (perspective: string) => {
       result = ComputedReportItemType.supplementary;
       break;
     case PerspectiveType.aws:
-    case PerspectiveType.allCloud:
     case PerspectiveType.awsCloud:
     case PerspectiveType.azure:
     case PerspectiveType.azureCloud:
     case PerspectiveType.gcp:
     case PerspectiveType.ibm:
     case PerspectiveType.ocp:
+    case PerspectiveType.ocpCloud:
     case PerspectiveType.ocpUsage:
     default:
       result = ComputedReportItemType.cost;
@@ -224,8 +224,8 @@ export const getGroupByDefault = (perspective: string) => {
     case PerspectiveType.azureCloud:
       result = 'subscription_guid';
       break;
-    case PerspectiveType.allCloud:
     case PerspectiveType.ocp:
+    case PerspectiveType.ocpCloud:
     case PerspectiveType.ocpSupplementary:
     case PerspectiveType.ocpUsage:
       result = 'project';
@@ -254,8 +254,8 @@ export const getGroupByOptions = (perspective: string) => {
     case PerspectiveType.ibm:
       result = groupByIbmOptions;
       break;
-    case PerspectiveType.allCloud:
     case PerspectiveType.ocp:
+    case PerspectiveType.ocpCloud:
     case PerspectiveType.ocpSupplementary:
     case PerspectiveType.ocpUsage:
       result = groupByOcpOptions;
@@ -273,13 +273,13 @@ export const getOrgReportPathsType = (perspective: string) => {
     case PerspectiveType.aws:
       result = OrgPathsType.aws;
       break;
-    case PerspectiveType.allCloud:
     case PerspectiveType.awsCloud:
     case PerspectiveType.azure:
     case PerspectiveType.azureCloud:
     case PerspectiveType.gcp:
     case PerspectiveType.ibm:
     case PerspectiveType.ocp:
+    case PerspectiveType.ocpCloud:
     case PerspectiveType.ocpSupplementary:
     case PerspectiveType.ocpUsage:
     default:
@@ -292,7 +292,6 @@ export const getOrgReportPathsType = (perspective: string) => {
 export const getReportType = (perspective: string) => {
   let result;
   switch (perspective) {
-    case PerspectiveType.allCloud:
     case PerspectiveType.aws:
     case PerspectiveType.awsCloud:
     case PerspectiveType.azure:
@@ -300,6 +299,7 @@ export const getReportType = (perspective: string) => {
     case PerspectiveType.gcp:
     case PerspectiveType.ibm:
     case PerspectiveType.ocp:
+    case PerspectiveType.ocpCloud:
     case PerspectiveType.ocpSupplementary:
     case PerspectiveType.ocpUsage:
     default:
@@ -312,9 +312,6 @@ export const getReportType = (perspective: string) => {
 export const getReportPathsType = (perspective: string) => {
   let result;
   switch (perspective) {
-    case PerspectiveType.allCloud:
-      result = ReportPathsType.ocpCloud;
-      break;
     case PerspectiveType.aws:
       result = ReportPathsType.aws;
       break;
@@ -335,6 +332,9 @@ export const getReportPathsType = (perspective: string) => {
       break;
     case PerspectiveType.ocp:
       result = ReportPathsType.ocp;
+      break;
+    case PerspectiveType.ocpCloud:
+      result = ReportPathsType.ocpCloud;
       break;
     case PerspectiveType.ocpSupplementary:
       result = ReportPathsType.ocp;
@@ -366,8 +366,8 @@ export const getTagReportPathsType = (perspective: string) => {
     case PerspectiveType.ibm:
       return TagPathsType.ibm;
       break;
-    case PerspectiveType.allCloud:
     case PerspectiveType.ocp:
+    case PerspectiveType.ocpCloud:
     case PerspectiveType.ocpSupplementary:
     case PerspectiveType.ocpUsage:
       return TagPathsType.ocp;

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -42,13 +42,13 @@ import { styles } from './overview.styles';
 
 // eslint-disable-next-line no-shadow
 const enum InfrastructurePerspective {
-  allCloud = 'all_cloud', // All filtered by Ocp
   aws = 'aws',
   awsCloud = 'aws_cloud', // Aws filtered by Ocp
   azure = 'azure',
   azureCloud = 'azure_cloud', // Azure filtered by Ocp
   gcp = 'gcp',
   ibm = 'ibm',
+  ocpCloud = 'ocp_cloud', // All filtered by Ocp
   ocpUsage = 'ocp_usage',
 }
 
@@ -120,9 +120,6 @@ const ocpOptions = [
   { label: 'overview.perspective.supplementary', value: 'supplementary' },
 ];
 
-// Infrastructure all cloud options
-const infrastructureAllCloudOptions = [{ label: 'overview.perspective.all_cloud', value: 'all_cloud' }];
-
 // Infrastructure AWS options
 const infrastructureAwsOptions = [{ label: 'overview.perspective.aws', value: 'aws' }];
 
@@ -143,6 +140,9 @@ const infrastructureIbmOptions = [{ label: 'overview.perspective.ibm', value: 'i
 
 // Infrastructure Ocp options
 const infrastructureOcpOptions = [{ label: 'overview.perspective.ocp_usage', value: 'ocp_usage' }];
+
+// Infrastructure Ocp cloud options
+const infrastructureOcpCloudOptions = [{ label: 'overview.perspective.ocp_cloud', value: 'ocp_cloud' }];
 
 class OverviewBase extends React.Component<OverviewProps> {
   protected defaultState: OverviewState = {
@@ -224,7 +224,7 @@ class OverviewBase extends React.Component<OverviewProps> {
 
   private getDefaultInfrastructurePerspective = () => {
     if (this.isOcpAvailable()) {
-      return InfrastructurePerspective.allCloud;
+      return InfrastructurePerspective.ocpCloud;
     }
     if (this.isAwsAvailable()) {
       return InfrastructurePerspective.aws;
@@ -267,7 +267,7 @@ class OverviewBase extends React.Component<OverviewProps> {
     const options = [];
     if (this.getCurrentTab() === OverviewTab.infrastructure) {
       if (ocp) {
-        options.push(...infrastructureAllCloudOptions);
+        options.push(...infrastructureOcpCloudOptions);
       }
       if (aws) {
         options.push(...infrastructureAwsOptions);
@@ -344,7 +344,7 @@ class OverviewBase extends React.Component<OverviewProps> {
     }
     const currentTab = getIdKeyForTab(tab);
     if (currentTab === OverviewTab.infrastructure) {
-      if (currentInfrastructurePerspective === InfrastructurePerspective.allCloud) {
+      if (currentInfrastructurePerspective === InfrastructurePerspective.ocpCloud) {
         const hasData = hasCurrentMonthData(ocpProviders) || hasPreviousMonthData(ocpProviders);
         return hasData ? <OcpCloudDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.aws) {

--- a/src/utils/dateRange.ts
+++ b/src/utils/dateRange.ts
@@ -87,3 +87,26 @@ export function getCurrentMonthDate() {
 export function getPreviousMonthDate() {
   return getMonthDate(1);
 }
+
+// Returns offset + 1 days, including today's date. See https://issues.redhat.com/browse/COST-1117
+export function getLastDaysDate(offset: number) {
+  const endDate = new Date();
+  const startDate = new Date();
+
+  startDate.setDate(startDate.getDate() - offset);
+
+  return {
+    end_date: format(endDate, 'yyyy-MM-dd'),
+    start_date: format(startDate, 'yyyy-MM-dd'),
+  };
+}
+
+// Returns 31 days, including today's date
+export function getLast30DaysDate() {
+  return getLastDaysDate(30);
+}
+
+// Returns 61 days, including today's date
+export function getLast60DaysDate() {
+  return getLastDaysDate(60);
+}


### PR DESCRIPTION
Added unique API requests for OCP on cloud, OCP on AWS, and OCP on Azure. When the Cost Explorer's "Perspective" menu changes, these additional requests are mad for tags.

<img width="631" alt="Screen Shot 2021-04-27 at 4 31 00 PM" src="https://user-images.githubusercontent.com/17481322/116308822-fcd8a200-a775-11eb-8c43-2934415de7fa.png">

https://issues.redhat.com/browse/COST-1338

