### PR TITLE
Cost Explorer to show infrastructure cost for "OpenShift usage"

### DIFF
--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -145,6 +145,9 @@ export const getComputedReportItemType = (perspective: string) => {
     case PerspectiveType.ocpSupplementary:
       result = ComputedReportItemType.supplementary;
       break;
+    case PerspectiveType.ocpUsage:
+      result = ComputedReportItemType.infrastructure;
+      break;
     case PerspectiveType.aws:
     case PerspectiveType.awsCloud:
     case PerspectiveType.azure:
@@ -153,7 +156,6 @@ export const getComputedReportItemType = (perspective: string) => {
     case PerspectiveType.ibm:
     case PerspectiveType.ocp:
     case PerspectiveType.ocpCloud:
-    case PerspectiveType.ocpUsage:
     default:
       result = ComputedReportItemType.cost;
       break;


### PR DESCRIPTION
The Cost Explorer should show infrastructure cost for the "OpenShift usage" perspective. Currently, we're showing the same cost as "All OpenShift".

https://issues.redhat.com/browse/COST-1371