### PR TITLE
Cost Explorer bar width

### DIFF
--- a/src/components/charts/costExplorerChart/costExplorerChart.tsx
+++ b/src/components/charts/costExplorerChart/costExplorerChart.tsx
@@ -251,7 +251,7 @@ class CostExplorerChart extends React.Component<CostExplorerChartProps, State> {
     // Divide available width into equal sections
     const sections = maxValue * 2 + 1;
 
-    return maxValue > 0 ? width / sections : 0;
+    return maxValue > 0 ? width / sections : undefined;
   };
 
   private getChart = (series: ChartSeries, index: number, barWidth: number) => {
@@ -453,7 +453,7 @@ class CostExplorerChart extends React.Component<CostExplorerChartProps, State> {
             {series && series.length > 0 && (
               <ChartStack>{series.map((s, index) => this.getChart(s, index, barWidth))}</ChartStack>
             )}
-            <ChartAxis style={chartStyles.xAxis} tickValues={this.getTickValues()} />
+            <ChartAxis style={chartStyles.xAxis} tickValues={this.getTickValues()} fixLabelOverlap />
             <ChartAxis dependentAxis style={chartStyles.yAxis} tickFormat={this.getTickValue} />
           </Chart>
         </div>

--- a/src/components/charts/costExplorerChart/costExplorerChart.tsx
+++ b/src/components/charts/costExplorerChart/costExplorerChart.tsx
@@ -356,8 +356,11 @@ class CostExplorerChart extends React.Component<CostExplorerChartProps, State> {
 
     // Prune tick values
     const tickValues = [];
+    const modVal = values.length < 6 ? 2 : 3;
     for (let i = 0; i < values.length; i++) {
-      if (i % 3 === 0 && i + 2 < values.length) {
+      if (i % modVal === 0 && i + 2 < values.length) {
+        tickValues.push(values[i]);
+      } else if (values.length < 3 && i + 1 < values.length) {
         tickValues.push(values[i]);
       }
     }

--- a/src/components/charts/costExplorerChart/costExplorerChart.tsx
+++ b/src/components/charts/costExplorerChart/costExplorerChart.tsx
@@ -234,8 +234,10 @@ class CostExplorerChart extends React.Component<CostExplorerChartProps, State> {
     return adjustedContainerHeight;
   };
 
-  private getBarWidth = () => {
+  // If bar width exceeds max and domainPadding is true, extra width is returned to help center bars horizontally
+  private getBarWidth = (domainPadding: boolean = false) => {
     const { hiddenSeries, series, width } = this.state;
+    const maxWidth = 200;
     let maxValue = -1;
 
     if (series) {
@@ -250,8 +252,14 @@ class CostExplorerChart extends React.Component<CostExplorerChartProps, State> {
 
     // Divide available width into equal sections
     const sections = maxValue * 2 + 1;
+    const sectionWidth = maxValue > 0 ? width / sections : 0;
 
-    return maxValue > 0 ? width / sections : undefined;
+    if (domainPadding) {
+      // Add any extra bar width for domain padding
+      const extraWidth = sectionWidth > maxWidth ? (sectionWidth - maxWidth) * maxValue : 0;
+      return (sectionWidth + extraWidth / 2) * 2;
+    }
+    return sectionWidth > maxWidth ? maxWidth : sectionWidth;
   };
 
   private getChart = (series: ChartSeries, index: number, barWidth: number) => {
@@ -441,7 +449,7 @@ class CostExplorerChart extends React.Component<CostExplorerChartProps, State> {
           <Chart
             containerComponent={container}
             domain={this.getDomain(series, hiddenSeries)}
-            domainPadding={{ x: barWidth * 2 }}
+            domainPadding={{ x: this.getBarWidth(true) }}
             events={this.getEvents()}
             height={height}
             legendAllowWrap


### PR DESCRIPTION
This modifies the Cost Explorer to dynamically adjust bar widths based on the screen size. Spacing is divided equally so bars fill up the available space in the chart.

https://issues.redhat.com/browse/COST-1383

![chrome-capture](https://user-images.githubusercontent.com/17481322/118068840-0e729a00-b371-11eb-9195-cb448d6505e1.gif)
