### PR TITLE
Clear sort when group_by is updated

### DIFF
--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -308,7 +308,7 @@ class Explorer extends React.Component<ExplorerProps> {
       group_by: {
         [groupByKey]: value,
       },
-      // order_by: { cost: 'desc' }, // // Todo: omit default sort
+      order_by: undefined, // Clear sort
     };
     history.replace(getRouteForQuery(history, newQuery, true));
     this.setState({ isAllSelected: false, selectedItems: [] });
@@ -379,7 +379,7 @@ class Explorer extends React.Component<ExplorerProps> {
         getRouteForQuery(history, {
           filter_by: query ? query.filter_by : undefined,
           group_by: query ? query.group_by : undefined,
-          // order_by: { cost: 'desc' }, // Todo: omit default sort
+          order_by: query ? query.order_by : undefined,
           dateRange, // Preserve date range
         })
       );
@@ -585,7 +585,6 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
     },
     filter_by: queryFromRoute.filter_by || baseQuery.filter_by,
     group_by: queryFromRoute.group_by || { [getGroupByDefault(perspective)]: '*' } || baseQuery.group_by,
-    // order_by: queryFromRoute.order_by || baseQuery.order_by, // Todo: omit default sort
     order_by: queryFromRoute.order_by,
     perspective,
     dateRange,

--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -162,8 +162,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
       ...JSON.parse(JSON.stringify(query)),
       filter_by: undefined,
       group_by: { [getGroupByDefault(value)]: '*' },
-      // order_by: { cost: 'desc' }, // Todo: omit default sort
-      order_by: undefined, // Clear sort because table columns are not a match
+      order_by: undefined, // Clear sort
       perspective: value,
     };
     history.replace(getRouteForQuery(history, newQuery, true));
@@ -298,7 +297,6 @@ const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHe
       },
       filter_by: queryFromRoute.filter_by || baseQuery.filter_by,
       group_by: queryFromRoute.group_by || { [getGroupByDefault(perspective)]: '*' } || baseQuery.group_by,
-      // order_by: queryFromRoute.order_by || baseQuery.order_by, // Todo: omit default sort
       order_by: queryFromRoute.order_by,
       perspective,
     };


### PR DESCRIPTION
Since each perspective (i.e., OCP, AWS, etc.) has unique order_by values (i.e., account Vs account_alias, etc.), we need to clear the Cost Explorer sort whenever a new perspective or group_by is selected. Otherwise, the order_by value may not be valid for new API requests.

https://issues.redhat.com/browse/COST-1411