### PR TITLE
Hide aggregate type from Cost Explorer's export dialog

### DIFF
--- a/src/pages/views/components/export/exportModal.tsx
+++ b/src/pages/views/components/export/exportModal.tsx
@@ -27,6 +27,7 @@ export interface ExportModalOwnProps extends WithTranslation {
   queryString?: string;
   reportPathsType: ReportPathsType;
   resolution?: 'daily' | 'monthly'; // Default resolution
+  showAggregateType?: boolean; // monthly resolution filters are not valid with date range
   showTimeScope?: boolean; // timeScope filters are not valid with date range
 }
 
@@ -90,7 +91,16 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
   };
 
   public render() {
-    const { groupBy, isAllItems, items, query, reportPathsType, showTimeScope, t } = this.props;
+    const {
+      groupBy,
+      isAllItems,
+      items,
+      query,
+      reportPathsType,
+      showAggregateType = true,
+      showTimeScope = true,
+      t,
+    } = this.props;
     const { resolution, timeScope } = this.state;
 
     let sortedItems = [...items];
@@ -149,23 +159,25 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
           <span>{t('export.heading', { groupBy })}</span>
         </div>
         <Form style={styles.form}>
-          <FormGroup label={t('export.aggregate_type')} fieldId="aggregate-type">
-            <React.Fragment>
-              {resolutionOptions.map((option, index) => (
-                <Radio
-                  key={index}
-                  id={`resolution-${index}`}
-                  isValid={option.value !== undefined}
-                  label={t(option.label)}
-                  value={option.value}
-                  checked={resolution === option.value}
-                  name="resolution"
-                  onChange={this.handleResolutionChange}
-                  aria-label={t(option.label)}
-                />
-              ))}
-            </React.Fragment>
-          </FormGroup>
+          {showAggregateType && (
+            <FormGroup label={t('export.aggregate_type')} fieldId="aggregate-type">
+              <React.Fragment>
+                {resolutionOptions.map((option, index) => (
+                  <Radio
+                    key={index}
+                    id={`resolution-${index}`}
+                    isValid={option.value !== undefined}
+                    label={t(option.label)}
+                    value={option.value}
+                    checked={resolution === option.value}
+                    name="resolution"
+                    onChange={this.handleResolutionChange}
+                    aria-label={t(option.label)}
+                  />
+                ))}
+              </React.Fragment>
+            </FormGroup>
+          )}
           {showTimeScope && (
             <FormGroup label={t('export.time_scope_title')} fieldId="timeScope">
               <React.Fragment>

--- a/src/pages/views/details/awsDetails/awsDetails.tsx
+++ b/src/pages/views/details/awsDetails/awsDetails.tsx
@@ -148,7 +148,6 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={reportPathsType}
-        showTimeScope
       />
     );
   };

--- a/src/pages/views/details/azureDetails/azureDetails.tsx
+++ b/src/pages/views/details/azureDetails/azureDetails.tsx
@@ -146,7 +146,6 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={reportPathsType}
-        showTimeScope
       />
     );
   };

--- a/src/pages/views/details/components/actions/actions.tsx
+++ b/src/pages/views/details/components/actions/actions.tsx
@@ -64,7 +64,6 @@ class DetailsActionsBase extends React.Component<DetailsActionsProps> {
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={reportPathsType}
-        showTimeScope
       />
     );
   };

--- a/src/pages/views/details/gcpDetails/gcpDetails.tsx
+++ b/src/pages/views/details/gcpDetails/gcpDetails.tsx
@@ -146,7 +146,6 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={reportPathsType}
-        showTimeScope
       />
     );
   };

--- a/src/pages/views/details/ibmDetails/ibmDetails.tsx
+++ b/src/pages/views/details/ibmDetails/ibmDetails.tsx
@@ -146,7 +146,6 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={reportPathsType}
-        showTimeScope
       />
     );
   };

--- a/src/pages/views/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/views/details/ocpDetails/ocpDetails.tsx
@@ -146,7 +146,6 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={reportPathsType}
-        showTimeScope
       />
     );
   };

--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -177,6 +177,8 @@ class Explorer extends React.Component<ExplorerProps> {
         query={query}
         reportPathsType={getReportPathsType(perspective)}
         resolution="daily"
+        showAggregateType={false}
+        showTimeScope={false}
       />
     );
   };


### PR DESCRIPTION
The Cost Explorer work uses the new `start_date` and `end_date` parameters introduced to the cost APIs. However, the monthly resolution was disabled for the API.

Until monthly resolution can be supported, we want to hide the aggregate type selection from the Cost Explorer's export dialog.

https://issues.redhat.com/browse/COST-1453

<img width="1239" alt="Screen Shot 2021-05-24 at 12 04 39 PM" src="https://user-images.githubusercontent.com/17481322/119375145-75a12000-bc88-11eb-8867-dbf72f17818c.png">
