### PR TITLE
Omit "All cloud filtered by OpenShift" option

### DIFF
--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -40,7 +40,7 @@ import {
   infrastructureAzureOptions,
   infrastructureGcpOptions,
   infrastructureIbmOptions,
-  infrastructureOcpCloudOptions,
+  // infrastructureOcpCloudOptions, // Todo: Temp disabled -- see https://issues.redhat.com/browse/COST-1483
   infrastructureOcpOptions,
   ocpOptions,
   PerspectiveType,
@@ -121,7 +121,9 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
     const options = [];
     if (ocp) {
       options.push(...ocpOptions);
-      options.push(...infrastructureOcpCloudOptions);
+      // Todo: Temp disabled -- see https://issues.redhat.com/browse/COST-1483
+      //
+      // options.push(...infrastructureOcpCloudOptions);
     }
     if (aws) {
       options.push(...infrastructureAwsOptions);

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -142,7 +142,10 @@ const infrastructureIbmOptions = [{ label: 'overview.perspective.ibm', value: 'i
 const infrastructureOcpOptions = [{ label: 'overview.perspective.ocp_usage', value: 'ocp_usage' }];
 
 // Infrastructure Ocp cloud options
-const infrastructureOcpCloudOptions = [{ label: 'overview.perspective.ocp_cloud', value: 'ocp_cloud' }];
+//
+// Todo: Temp disabled -- see https://issues.redhat.com/browse/COST-1483
+//
+// const infrastructureOcpCloudOptions = [{ label: 'overview.perspective.ocp_cloud', value: 'ocp_cloud' }];
 
 class OverviewBase extends React.Component<OverviewProps> {
   protected defaultState: OverviewState = {
@@ -223,9 +226,11 @@ class OverviewBase extends React.Component<OverviewProps> {
   };
 
   private getDefaultInfrastructurePerspective = () => {
-    if (this.isOcpAvailable()) {
-      return InfrastructurePerspective.ocpCloud;
-    }
+    // Todo: Temp disabled -- see https://issues.redhat.com/browse/COST-1483
+    //
+    // if (this.isOcpAvailable()) {
+    //   return InfrastructurePerspective.ocpCloud;
+    // }
     if (this.isAwsAvailable()) {
       return InfrastructurePerspective.aws;
     }
@@ -266,9 +271,11 @@ class OverviewBase extends React.Component<OverviewProps> {
     // Dynamically show options if providers are available
     const options = [];
     if (this.getCurrentTab() === OverviewTab.infrastructure) {
-      if (ocp) {
-        options.push(...infrastructureOcpCloudOptions);
-      }
+      // Todo: Temp disabled -- see https://issues.redhat.com/browse/COST-1483
+      //
+      // if (ocp) {
+      //   options.push(...infrastructureOcpCloudOptions);
+      // }
       if (aws) {
         options.push(...infrastructureAwsOptions);
       }


### PR DESCRIPTION
The team requested that we temporary omit "All cloud filtered by OpenShift" option from the overview and cost explorer pages.

https://issues.redhat.com/browse/COST-1483