### PR TITLE
Replaced chart legend triangleUp symbols with triangleLeft

### DIFF
--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -242,7 +242,7 @@ class CostChart extends React.Component<CostChartProps, State> {
           name: getCostRangeString(forecastConeData, 'chart.cost_forecast_cone_legend_label', false, false),
           symbol: {
             fill: chartStyles.forecastConeDataColorScale[0],
-            type: 'triangleUp',
+            type: 'triangleLeft',
           },
           tooltip: getCostRangeString(forecastConeData, 'chart.cost_forecast_cone_legend_tooltip', false, false),
         },
@@ -265,7 +265,7 @@ class CostChart extends React.Component<CostChartProps, State> {
           ),
           symbol: {
             fill: chartStyles.forecastInfrastructureConeDataColorScale[0],
-            type: 'triangleUp',
+            type: 'triangleLeft',
           },
           tooltip: getCostRangeString(
             forecastInfrastructureConeData,

--- a/src/components/charts/dailyCostChart/dailyCostChart.tsx
+++ b/src/components/charts/dailyCostChart/dailyCostChart.tsx
@@ -247,7 +247,7 @@ class DailyCostChart extends React.Component<DailyCostChartProps, State> {
           name: getCostRangeString(forecastConeData, 'chart.cost_forecast_cone_legend_label', false, false),
           symbol: {
             fill: chartStyles.forecastConeDataColorScale[0],
-            type: 'triangleUp',
+            type: 'triangleLeft',
           },
           tooltip: getCostRangeString(forecastConeData, 'chart.cost_forecast_cone_legend_tooltip', false, false),
         },
@@ -271,7 +271,7 @@ class DailyCostChart extends React.Component<DailyCostChartProps, State> {
           ),
           symbol: {
             fill: chartStyles.forecastInfrastructureConeDataColorScale[0],
-            type: 'triangleUp',
+            type: 'triangleLeft',
           },
           tooltip: getCostRangeString(
             forecastInfrastructureConeData,

--- a/src/components/charts/dailyTrendChart/dailyTrendChart.tsx
+++ b/src/components/charts/dailyTrendChart/dailyTrendChart.tsx
@@ -182,7 +182,7 @@ class DailyTrendChart extends React.Component<DailyTrendChartProps, State> {
           name: getCostRangeString(forecastConeData, 'chart.cost_forecast_cone_legend_label', false, false),
           symbol: {
             fill: chartStyles.forecastConeDataColorScale[0],
-            type: 'triangleUp',
+            type: 'triangleLeft',
           },
           tooltip: getCostRangeString(forecastConeData, 'chart.cost_forecast_cone_legend_tooltip', false, false),
         },

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -178,7 +178,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
           name: getCostRangeString(forecastConeData, 'chart.cost_forecast_cone_legend_label', false, false),
           symbol: {
             fill: chartStyles.forecastConeDataColorScale[0],
-            type: 'triangleUp',
+            type: 'triangleLeft',
           },
           tooltip: getCostRangeString(forecastConeData, 'chart.cost_forecast_cone_legend_tooltip', false, false),
         },


### PR DESCRIPTION
We want to use left pointing triangles as chart legend symbols. Until now, PatternFly / Victory only supported up and down pointing triangles, not left and right. A left pointing triangle would better represent a forecast's "cone of confidence" in our tooltips.

https://issues.redhat.com/browse/COST-1484

<img width="1063" alt="triangle" src="https://user-images.githubusercontent.com/17481322/120544723-bc46f680-c3bb-11eb-9b37-bdced523a9d0.png">
