### PR TITLE
Added choice to startup script for using shared PatternFly modules

### DIFF
--- a/scripts/start-dev-server.js
+++ b/scripts/start-dev-server.js
@@ -19,6 +19,11 @@ async function setEnv() {
         type: 'confirm',
         default: false,
       },
+      {
+        name: 'sharedDependencies',
+        message: 'Use shared PatternFly dependencies?',
+        type: 'confirm',
+      },
       // {
       //   name: 'localApi',
       //   message: 'Do you want to use local api?',
@@ -27,11 +32,12 @@ async function setEnv() {
       // },
     ])
     .then(answers => {
-      const { uiEnv, clouddotEnv, insightsProxy, localApi } = answers;
+      const { uiEnv, clouddotEnv, insightsProxy, localApi, sharedDependencies } = answers;
 
       process.env.BETA_ENV = uiEnv === 'beta' ? 'true' : 'false';
       process.env.CLOUDOT_ENV = clouddotEnv;
       process.env.USE_PROXY = (!insightsProxy).toString(); // Set 'true' for webpack proxy
+      process.env.USE_SHARED_DEPS = sharedDependencies.toString(); // Set 'true' for shared dependencies
       // process.env.USE_LOCAL_ROUTES = localApi.toString();
     });
 }

--- a/src/federatedEntry.tsx
+++ b/src/federatedEntry.tsx
@@ -8,7 +8,8 @@ import { getBaseName } from 'utils/getBaseName';
 import App from './app';
 import { configureStore } from './store';
 
-require.resolve('@patternfly/patternfly/patternfly.css');
+// Todo: uncomment for testing PatternFly pre-release packages
+// require.resolve('@patternfly/patternfly/patternfly.css');
 require.resolve('@patternfly/patternfly/patternfly-addons.css');
 
 import './styles/global.css';

--- a/src/federatedEntry.tsx
+++ b/src/federatedEntry.tsx
@@ -8,7 +8,7 @@ import { getBaseName } from 'utils/getBaseName';
 import App from './app';
 import { configureStore } from './store';
 
-// Todo: uncomment for testing PatternFly pre-release packages
+// Todo: Uncomment for use with non-shared PatternFly packages
 // require.resolve('@patternfly/patternfly/patternfly.css');
 require.resolve('@patternfly/patternfly/patternfly-addons.css');
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,20 +23,17 @@ const singletonDeps = [
   'react-router-dom',
   'react-redux',
   'react-promise-middleware',
-  // '@patternfly/react-core',
-  // '@patternfly/react-charts',
-  // '@patternfly/react-table',
-  // '@patternfly/react-icons',
-  // '@patternfly/react-tokens',
   '@redhat-cloud-services/frontend-components',
   '@redhat-cloud-services/frontend-components-utilities',
   '@redhat-cloud-services/frontend-components-notifications',
 ];
 const patternFlyDeps = [
+  '@patternfly/patternfly',
   '@patternfly/react-core',
   '@patternfly/react-charts',
   '@patternfly/react-table',
   '@patternfly/react-icons',
+  '@patternfly/react-styles',
   '@patternfly/react-tokens',
 ];
 const fileRegEx = /\.(png|woff|woff2|eot|ttf|svg|gif|jpe?g|png)(\?[a-z0-9=.]+)?$/;
@@ -74,6 +71,7 @@ module.exports = (_env, argv) => {
   const isProduction = nodeEnv === 'production' || argv.mode === 'production';
   const isBeta = betaEnv === 'true';
   const useLocalRoutes = process.env.USE_LOCAL_ROUTES === 'true';
+  const useSharedDeps = process.env.USE_SHARED_DEPS === 'true';
   const appDeployment = (isProduction && betaBranches.includes(gitBranch)) || isBeta ? 'beta/apps' : 'apps';
   const publicPath = `/${appDeployment}/${insights.appname}/`;
   // Moved multiple entries to index.tsx in order to help speed up webpack
@@ -87,7 +85,18 @@ module.exports = (_env, argv) => {
   log.info(`Using deployments: ${appDeployment}`);
   log.info(`Public path: ${publicPath}`);
   log.info(`Using Insights proxy: ${!useProxy}`);
+  log.info(`Using shared PatternFly dependencies: ${useSharedDeps}`);
   log.info('~~~~~~~~~~~~~~~~~~~~~');
+
+  let sharedDependencies = dependencies;
+  if (useSharedDeps) {
+    sharedDependencies = Object.keys(dependencies)
+      .filter(key => !patternFlyDeps.includes(key))
+      .reduce((obj, key) => {
+        obj[key] = dependencies[key];
+        return obj;
+      }, {});
+  }
 
   const stats = {
     excludeAssets: fileRegEx,
@@ -212,13 +221,9 @@ module.exports = (_env, argv) => {
           // './OcpOverviewWidget': path.resolve(__dirname, './src/modules/ocpOverviewWidget'),
         },
         shared: {
-          ...dependencies,
+          ...sharedDependencies,
           ...singletonDeps.reduce((acc, dep) => {
             acc[dep] = { singleton: true, requiredVersion: dependencies[dep] };
-            return acc;
-          }, {}),
-          ...patternFlyDeps.reduce((acc, dep) => {
-            acc[dep] = { singleton: false, requiredVersion: dependencies[dep] };
             return acc;
           }, {}),
         },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -88,8 +88,9 @@ module.exports = (_env, argv) => {
   log.info(`Using shared PatternFly dependencies: ${useSharedDeps}`);
   log.info('~~~~~~~~~~~~~~~~~~~~~');
 
+  // Cannot share dependencies with local repo paths
   let sharedDependencies = dependencies;
-  if (useSharedDeps) {
+  if (!useSharedDeps) {
     sharedDependencies = Object.keys(dependencies)
       .filter(key => !patternFlyDeps.includes(key))
       .reduce((obj, key) => {


### PR DESCRIPTION
For testing PatternFly pre-release packages, we cannot use shared PatternFly dependencies. We also cannot use paths to local repos as a package dependency.

This update simply adds a choice to the start up script to share (default) PatternFly dependencies or not. If true, we prune PatternFly from the package dependencies shared with Insights.