### PR TITLE
OpenShift Infrastructure chart

### DIFF
--- a/src/components/charts/dailyTrendChart/dailyTrendChart.tsx
+++ b/src/components/charts/dailyTrendChart/dailyTrendChart.tsx
@@ -47,6 +47,7 @@ interface DailyTrendChartProps {
   formatDatumOptions?: FormatOptions;
   padding?: any;
   showForecast?: boolean; // Show forecast legend regardless if data is available
+  showInfrastructureLabel?: boolean; // Show supplementary cost labels
   showSupplementaryLabel?: boolean; // Show supplementary cost labels
   showUsageLegendLabel?: boolean; // The cost legend label is shown by default
   title?: string;
@@ -98,6 +99,7 @@ class DailyTrendChart extends React.Component<DailyTrendChartProps, State> {
       forecastConeData,
       previousData,
       showForecast,
+      showInfrastructureLabel = false,
       showSupplementaryLabel = false,
       showUsageLegendLabel = false,
     } = this.props;
@@ -106,12 +108,16 @@ class DailyTrendChart extends React.Component<DailyTrendChartProps, State> {
       ? 'chart.usage_legend_label'
       : showSupplementaryLabel
       ? 'chart.cost_supplementary_legend_label'
+      : showInfrastructureLabel
+      ? 'chart.cost_infrastructure_legend_label'
       : 'chart.cost_legend_label';
 
     const tooltipKey = showUsageLegendLabel
       ? 'chart.usage_legend_tooltip'
       : showSupplementaryLabel
       ? 'chart.cost_supplementary_legend_tooltip'
+      : showInfrastructureLabel
+      ? 'chart.cost_infrastructure_legend_tooltip'
       : 'chart.cost_legend_tooltip';
 
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -44,6 +44,7 @@ interface TrendChartProps {
   formatDatumOptions?: FormatOptions;
   padding?: any;
   showForecast?: boolean; // Show forecast legend regardless if data is available
+  showInfrastructureLabel?: boolean; // Show supplementary cost labels
   showSupplementaryLabel?: boolean; // Show supplementary cost labels
   showUsageLegendLabel?: boolean; // The cost legend label is shown by default
   title?: string;
@@ -95,6 +96,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
       forecastConeData,
       previousData,
       showForecast,
+      showInfrastructureLabel = false,
       showSupplementaryLabel = false,
       showUsageLegendLabel = false,
     } = this.props;
@@ -103,12 +105,16 @@ class TrendChart extends React.Component<TrendChartProps, State> {
       ? 'chart.usage_legend_label'
       : showSupplementaryLabel
       ? 'chart.cost_supplementary_legend_label'
+      : showInfrastructureLabel
+      ? 'chart.cost_infrastructure_legend_label'
       : 'chart.cost_legend_label';
 
     const tooltipKey = showUsageLegendLabel
       ? 'chart.usage_legend_tooltip'
       : showSupplementaryLabel
       ? 'chart.cost_supplementary_legend_tooltip'
+      : showInfrastructureLabel
+      ? 'chart.cost_infrastructure_legend_tooltip'
       : 'chart.cost_legend_tooltip';
 
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -781,6 +781,11 @@
     "supplementary_cost_desc": "All costs not directly attributed to the infrastructure. These costs are determined by applying a price list within a cost model to OpenShift cluster metrics.",
     "title": "OpenShift details"
   },
+  "ocp_infrastructure_dashboard": {
+    "cost_title": "OpenShift infrastructure cost",
+    "cost_trend_title": "OpenShift cumulative infrastructure cost comparison ({{units}})",
+    "daily_cost_trend_title": "OpenShift daily infrastructure cost comparison ({{units}})"
+  },
   "ocp_supplementary_dashboard": {
     "cost_title": "OpenShift supplementary cost",
     "cost_trend_title": "OpenShift cumulative supplementary cost comparison ({{units}})",
@@ -816,7 +821,6 @@
     "ocp_cloud_desc": "Infrastructure cost attributed to OpenShift Container Platform, based on a subset of cloud cost data.",
     "ocp_desc": "Total cost for OpenShift Container Platform, comprising the infrastructure cost and cost calculated from metrics.",
     "perspective": {
-      "all": "All",
       "aws": "Amazon Web Services",
       "aws_cloud": "Amazon Web Services filtered by OpenShift",
       "azure": "Microsoft Azure",
@@ -824,9 +828,11 @@
       "gcp": "Google Cloud Platform",
       "ibm": "IBM Cloud",
       "label": "Perspective",
+      "ocp_all": "All OpenShift",
       "ocp_cloud": "All cloud filtered by OpenShift",
       "ocp_usage": "OpenShift usage",
-      "supplementary": "Supplementary"
+      "ocp_infrastructure": "OpenShift infrastructure",
+      "ocp_supplementary": "OpenShift supplementary"
     }
   },
   "page_cost_models": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -830,9 +830,9 @@
       "label": "Perspective",
       "ocp_all": "All OpenShift",
       "ocp_cloud": "All cloud filtered by OpenShift",
-      "ocp_usage": "OpenShift usage",
       "ocp_infrastructure": "OpenShift infrastructure",
-      "ocp_supplementary": "OpenShift supplementary"
+      "ocp_supplementary": "OpenShift supplementary",
+      "ocp_usage": "OpenShift usage"
     }
   },
   "page_cost_models": {

--- a/src/pages/views/overview/components/dashboardWidgetBase.tsx
+++ b/src/pages/views/overview/components/dashboardWidgetBase.tsx
@@ -102,11 +102,23 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   private getChart = (containerHeight: number, height: number, adjustContainerHeight: boolean = false) => {
     const { chartType, trend } = this.props;
     if (chartType === DashboardChartType.dailyTrend) {
-      return this.getDailyTrendChart(containerHeight, height, adjustContainerHeight, trend.showSupplementaryLabel);
+      return this.getDailyTrendChart(
+        containerHeight,
+        height,
+        adjustContainerHeight,
+        trend.showInfrastructureLabel,
+        trend.showSupplementaryLabel
+      );
     } else if (chartType === DashboardChartType.dailyCost) {
       return this.getDailyCostChart(containerHeight, height, adjustContainerHeight);
     } else if (chartType === DashboardChartType.trend) {
-      return this.getTrendChart(containerHeight, height, adjustContainerHeight, trend.showSupplementaryLabel);
+      return this.getTrendChart(
+        containerHeight,
+        height,
+        adjustContainerHeight,
+        trend.showInfrastructureLabel,
+        trend.showSupplementaryLabel
+      );
     } else if (chartType === DashboardChartType.usage) {
       return this.getUsageChart(height, adjustContainerHeight);
     } else {
@@ -200,6 +212,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     containerHeight: number,
     height: number,
     adjustContainerHeight: boolean = false,
+    showInfrastructureLabel: boolean = false,
     showSupplementaryLabel: boolean = false
   ) => {
     const { currentReport, details, previousReport, trend } = this.props;
@@ -234,6 +247,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
           height={height}
           previousData={previousData}
           showForecast={trend.computedForecastItem !== undefined}
+          showInfrastructureLabel={showInfrastructureLabel}
           showSupplementaryLabel={showSupplementaryLabel}
           showUsageLegendLabel={details.showUsageLegendLabel}
           units={units}
@@ -344,6 +358,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     containerHeight: number,
     height: number,
     adjustContainerHeight: boolean = false,
+    showInfrastructureLabel: boolean = false,
     showSupplementaryLabel: boolean = false
   ) => {
     const { currentReport, details, previousReport, t, trend } = this.props;
@@ -378,6 +393,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         height={height}
         previousData={previousData}
         showForecast={trend.computedForecastItem !== undefined}
+        showInfrastructureLabel={showInfrastructureLabel}
         showSupplementaryLabel={showSupplementaryLabel}
         showUsageLegendLabel={details.showUsageLegendLabel}
         title={title}

--- a/src/pages/views/overview/ocpInfrastructureDashboard/index.ts
+++ b/src/pages/views/overview/ocpInfrastructureDashboard/index.ts
@@ -1,0 +1,3 @@
+import OcpInfrastructureDashboard from './ocpInfrastructureDashboard';
+
+export default OcpInfrastructureDashboard;

--- a/src/pages/views/overview/ocpInfrastructureDashboard/ocpInfrastructureDashboard.tsx
+++ b/src/pages/views/overview/ocpInfrastructureDashboard/ocpInfrastructureDashboard.tsx
@@ -1,0 +1,29 @@
+import { DashboardBase } from 'pages/views/overview/components/dashboardBase';
+import { WithTranslation, withTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps } from 'store/common';
+import { ocpSupplementaryDashboardSelectors } from 'store/dashboard/ocpSupplementaryDashboard';
+
+import { OcpInfrastructureDashboardWidget } from './ocpInfrastructureDashboardWidget';
+
+type OcpSupplementaryDashboardOwnProps = WithTranslation;
+
+interface OcpSupplementaryDashboardStateProps {
+  DashboardWidget: typeof OcpInfrastructureDashboardWidget;
+  widgets: number[];
+}
+
+const mapStateToProps = createMapStateToProps<OcpSupplementaryDashboardOwnProps, OcpSupplementaryDashboardStateProps>(
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  (state, props) => {
+    return {
+      DashboardWidget: OcpInfrastructureDashboardWidget,
+      selectWidgets: ocpSupplementaryDashboardSelectors.selectWidgets(state),
+      widgets: ocpSupplementaryDashboardSelectors.selectCurrentWidgets(state),
+    };
+  }
+);
+
+const OcpInfrastructureDashboard = withTranslation()(connect(mapStateToProps, {})(DashboardBase));
+
+export default OcpInfrastructureDashboard;

--- a/src/pages/views/overview/ocpInfrastructureDashboard/ocpInfrastructureDashboardWidget.tsx
+++ b/src/pages/views/overview/ocpInfrastructureDashboard/ocpInfrastructureDashboardWidget.tsx
@@ -1,0 +1,81 @@
+import {
+  DashboardWidgetBase,
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps,
+} from 'pages/views/overview/components/dashboardWidgetBase';
+import { withTranslation } from 'react-i18next';
+import { connect } from 'react-redux';
+import { createMapStateToProps } from 'store/common';
+import {
+  ocpInfrastructureDashboardActions,
+  ocpInfrastructureDashboardSelectors,
+  OcpInfrastructureDashboardTab,
+} from 'store/dashboard/ocpInfrastructureDashboard';
+import { forecastSelectors } from 'store/forecasts';
+import { reportSelectors } from 'store/reports';
+import { ComputedOcpReportItemsParams } from 'utils/computedReport/getComputedOcpReportItems';
+
+interface OcpInfrastructureDashboardWidgetDispatchProps {
+  fetchForecasts: typeof ocpInfrastructureDashboardActions.fetchWidgetForecasts;
+  fetchReports: typeof ocpInfrastructureDashboardActions.fetchWidgetReports;
+  updateTab: typeof ocpInfrastructureDashboardActions.changeWidgetTab;
+}
+
+export const getIdKeyForTab = (tab: OcpInfrastructureDashboardTab): ComputedOcpReportItemsParams['idKey'] => {
+  switch (tab) {
+    case OcpInfrastructureDashboardTab.clusters:
+      return 'cluster';
+    case OcpInfrastructureDashboardTab.nodes:
+      return 'node';
+    case OcpInfrastructureDashboardTab.projects:
+      return 'project';
+  }
+};
+
+const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, DashboardWidgetStateProps>(
+  (state, { widgetId }) => {
+    const widget = ocpInfrastructureDashboardSelectors.selectWidget(state, widgetId);
+    const queries = ocpInfrastructureDashboardSelectors.selectWidgetQueries(state, widgetId);
+    return {
+      ...widget,
+      getIdKeyForTab,
+      currentQuery: queries.current,
+      forecastQuery: queries.forecast,
+      previousQuery: queries.previous,
+      tabsQuery: queries.tabs,
+      currentReport: reportSelectors.selectReport(state, widget.reportPathsType, widget.reportType, queries.current),
+      currentReportFetchStatus: reportSelectors.selectReportFetchStatus(
+        state,
+        widget.reportPathsType,
+        widget.reportType,
+        queries.current
+      ),
+      forecast: forecastSelectors.selectForecast(
+        state,
+        widget.forecastPathsType,
+        widget.forecastType,
+        queries.forecast
+      ),
+      previousReport: reportSelectors.selectReport(state, widget.reportPathsType, widget.reportType, queries.previous),
+      tabsReport: reportSelectors.selectReport(state, widget.reportPathsType, widget.reportType, queries.tabs),
+      tabsReportFetchStatus: reportSelectors.selectReportFetchStatus(
+        state,
+        widget.reportPathsType,
+        widget.reportType,
+        queries.tabs
+      ),
+    };
+  }
+);
+
+const mapDispatchToProps: OcpInfrastructureDashboardWidgetDispatchProps = {
+  fetchForecasts: ocpInfrastructureDashboardActions.fetchWidgetForecasts,
+  fetchReports: ocpInfrastructureDashboardActions.fetchWidgetReports,
+  updateTab: ocpInfrastructureDashboardActions.changeWidgetTab,
+};
+
+const OcpInfrastructureDashboardWidget = withTranslation()(
+  connect(mapStateToProps, mapDispatchToProps)(DashboardWidgetBase)
+);
+
+export { OcpInfrastructureDashboardWidget };

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -19,6 +19,7 @@ import GcpDashboard from 'pages/views/overview/gcpDashboard';
 import IbmDashboard from 'pages/views/overview/ibmDashboard';
 import OcpCloudDashboard from 'pages/views/overview/ocpCloudDashboard';
 import OcpDashboard from 'pages/views/overview/ocpDashboard';
+import OcpInfrastructureDashboard from 'pages/views/overview/ocpInfrastructureDashboard';
 import OcpSupplementaryDashboard from 'pages/views/overview/ocpSupplementaryDashboard';
 import OcpUsageDashboard from 'pages/views/overview/ocpUsageDashboard';
 import { hasCurrentMonthData, hasPreviousMonthData } from 'pages/views/utils/providers';
@@ -55,6 +56,7 @@ const enum InfrastructurePerspective {
 // eslint-disable-next-line no-shadow
 const enum OcpPerspective {
   all = 'all',
+  infrastructure = 'infrastructure',
   supplementary = 'supplementary',
 }
 
@@ -116,8 +118,9 @@ type OverviewProps = OverviewOwnProps & OverviewStateProps;
 
 // Ocp options
 const ocpOptions = [
-  { label: 'overview.perspective.all', value: 'all' },
-  { label: 'overview.perspective.supplementary', value: 'supplementary' },
+  { label: 'overview.perspective.ocp_all', value: 'all' },
+  { label: 'overview.perspective.ocp_infrastructure', value: 'infrastructure' },
+  { label: 'overview.perspective.ocp_supplementary', value: 'supplementary' },
 ];
 
 // Infrastructure AWS options
@@ -383,6 +386,8 @@ class OverviewBase extends React.Component<OverviewProps> {
       const hasData = hasCurrentMonthData(ocpProviders) || hasPreviousMonthData(ocpProviders);
       if (currentOcpPerspective === OcpPerspective.all) {
         return hasData ? <OcpDashboard /> : noData;
+      } else if (currentOcpPerspective === OcpPerspective.infrastructure) {
+        return hasData ? <OcpInfrastructureDashboard /> : noData;
       } else if (currentOcpPerspective === OcpPerspective.supplementary) {
         return hasData ? <OcpSupplementaryDashboard /> : noData;
       } else {

--- a/src/store/dashboard/common/dashboardCommon.ts
+++ b/src/store/dashboard/common/dashboardCommon.ts
@@ -60,6 +60,7 @@ export interface DashboardWidget<T> {
     computedReportItem: string; // The computed report item to use in charts, summary, etc.
     computedReportItemValue: string; // The computed report value (e.g., raw, markup, total, or usage)
     dailyTitleKey?: string;
+    showInfrastructureLabel?: boolean; // Trend chart legend items show "Infrastructure cost" instead of "cost"
     showSupplementaryLabel?: boolean; // Trend chart legend items show "Supplementary cost" instead of "cost"
     titleKey: string;
     type: number;

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -49,7 +49,7 @@ export const costSummaryWidget: OcpDashboardWidget = {
     formatOptions: {},
   },
   availableTabs: [OcpDashboardTab.projects, OcpDashboardTab.clusters],
-  chartType: DashboardChartType.dailyTrend, // No longer showing infrastructure for DashboardChartType.dailyCost
+  chartType: DashboardChartType.dailyTrend, // No longer showing infrastructure via DashboardChartType.dailyCost
   currentTab: OcpDashboardTab.projects,
 };
 

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -22,7 +22,7 @@ export const costSummaryWidget: OcpDashboardWidget = {
   reportPathsType: ReportPathsType.ocp,
   reportType: ReportType.cost,
   details: {
-    adjustContainerHeight: true,
+    // adjustContainerHeight: true,
     appNavId: 'ocp',
     costKey: 'cost',
     formatOptions: {
@@ -49,7 +49,7 @@ export const costSummaryWidget: OcpDashboardWidget = {
     formatOptions: {},
   },
   availableTabs: [OcpDashboardTab.projects, OcpDashboardTab.clusters],
-  chartType: DashboardChartType.dailyCost,
+  chartType: DashboardChartType.dailyTrend, // No longer showing infrastructure for DashboardChartType.dailyCost
   currentTab: OcpDashboardTab.projects,
 };
 

--- a/src/store/dashboard/ocpInfrastructureDashboard/index.ts
+++ b/src/store/dashboard/ocpInfrastructureDashboard/index.ts
@@ -1,0 +1,17 @@
+import * as ocpInfrastructureDashboardActions from './ocpInfrastructureDashboardActions';
+import {
+  ocpInfrastructureDashboardStateKey,
+  OcpInfrastructureDashboardTab,
+  OcpInfrastructureDashboardWidget,
+} from './ocpInfrastructureDashboardCommon';
+import { ocpInfrastructureDashboardReducer } from './ocpInfrastructureDashboardReducer';
+import * as ocpInfrastructureDashboardSelectors from './ocpInfrastructureDashboardSelectors';
+
+export {
+  ocpInfrastructureDashboardStateKey,
+  ocpInfrastructureDashboardReducer,
+  ocpInfrastructureDashboardActions,
+  ocpInfrastructureDashboardSelectors,
+  OcpInfrastructureDashboardTab,
+  OcpInfrastructureDashboardWidget,
+};

--- a/src/store/dashboard/ocpInfrastructureDashboard/ocpInfrastructureDashboardActions.ts
+++ b/src/store/dashboard/ocpInfrastructureDashboard/ocpInfrastructureDashboardActions.ts
@@ -1,0 +1,44 @@
+import { ThunkAction } from 'store/common';
+import { forecastActions } from 'store/forecasts';
+import { reportActions } from 'store/reports';
+import { createAction } from 'typesafe-actions';
+
+import { OcpInfrastructureDashboardTab } from './ocpInfrastructureDashboardCommon';
+import { selectWidget, selectWidgetQueries } from './ocpInfrastructureDashboardSelectors';
+
+export const fetchWidgetForecasts = (id: number): ThunkAction => {
+  return (dispatch, getState) => {
+    const state = getState();
+    const widget = selectWidget(state, id);
+
+    if (widget.forecastPathsType && widget.forecastType) {
+      const { forecast } = selectWidgetQueries(state, id);
+      dispatch(forecastActions.fetchForecast(widget.forecastPathsType, widget.forecastType, forecast));
+    }
+  };
+};
+
+export const fetchWidgetReports = (id: number): ThunkAction => {
+  return (dispatch, getState) => {
+    const state = getState();
+    const widget = selectWidget(state, id);
+    const { previous, current, tabs } = selectWidgetQueries(state, id);
+    dispatch(reportActions.fetchReport(widget.reportPathsType, widget.reportType, current));
+    dispatch(reportActions.fetchReport(widget.reportPathsType, widget.reportType, previous));
+    if (widget.availableTabs) {
+      dispatch(reportActions.fetchReport(widget.reportPathsType, widget.reportType, tabs));
+    }
+  };
+};
+
+export const setWidgetTab = createAction('ocpInfrastructureDashboard/widget/tab')<{
+  id: number;
+  tab: OcpInfrastructureDashboardTab;
+}>();
+
+export const changeWidgetTab = (id: number, tab: OcpInfrastructureDashboardTab): ThunkAction => {
+  return dispatch => {
+    dispatch(setWidgetTab({ id, tab }));
+    dispatch(fetchWidgetReports(id));
+  };
+};

--- a/src/store/dashboard/ocpInfrastructureDashboard/ocpInfrastructureDashboardCommon.ts
+++ b/src/store/dashboard/ocpInfrastructureDashboard/ocpInfrastructureDashboardCommon.ts
@@ -1,0 +1,55 @@
+import { getQuery, OcpFilters, OcpQuery } from 'api/queries/ocpQuery';
+import { DashboardWidget } from 'store/dashboard/common/dashboardCommon';
+
+export const ocpInfrastructureDashboardStateKey = 'ocpInfrastructureDashboard';
+export const ocpInfrastructureDashboardDefaultFilters: OcpFilters = {
+  time_scope_units: 'month',
+  time_scope_value: -1,
+  resolution: 'daily',
+};
+export const ocpInfrastructureDashboardTabFilters: OcpFilters = {
+  ...ocpInfrastructureDashboardDefaultFilters,
+  limit: 3,
+};
+
+// eslint-disable-next-line no-shadow
+export const enum OcpInfrastructureDashboardTab {
+  nodes = 'nodes',
+  clusters = 'clusters',
+  projects = 'projects',
+}
+
+export interface OcpInfrastructureDashboardWidget extends DashboardWidget<OcpInfrastructureDashboardTab> {}
+
+// Todo: cluster, project, node
+export function getGroupByForTab(tab: OcpInfrastructureDashboardTab): OcpQuery['group_by'] {
+  switch (tab) {
+    case OcpInfrastructureDashboardTab.projects:
+      return { project: '*' };
+    case OcpInfrastructureDashboardTab.clusters:
+      return { cluster: '*' };
+    case OcpInfrastructureDashboardTab.nodes:
+      return { node: '*' };
+    default:
+      return {};
+  }
+}
+
+export function getQueryForWidget(filter: OcpFilters = ocpInfrastructureDashboardDefaultFilters, props?) {
+  const query: OcpQuery = {
+    filter,
+    ...(props ? props : {}),
+  };
+  return getQuery(query);
+}
+
+export function getQueryForWidgetTabs(
+  widget: OcpInfrastructureDashboardWidget,
+  filter: OcpFilters = ocpInfrastructureDashboardDefaultFilters
+) {
+  const query: OcpQuery = {
+    filter,
+    group_by: getGroupByForTab(widget.currentTab),
+  };
+  return getQuery(query);
+}

--- a/src/store/dashboard/ocpInfrastructureDashboard/ocpInfrastructureDashboardReducer.ts
+++ b/src/store/dashboard/ocpInfrastructureDashboard/ocpInfrastructureDashboardReducer.ts
@@ -1,0 +1,43 @@
+import { ActionType, getType } from 'typesafe-actions';
+
+import { setWidgetTab } from './ocpInfrastructureDashboardActions';
+import { OcpInfrastructureDashboardWidget } from './ocpInfrastructureDashboardCommon';
+import { costSummaryWidget, cpuWidget, memoryWidget, volumeWidget } from './ocpInfrastructureDashboardWidgets';
+
+export type OcpInfrastructureDashboardAction = ActionType<typeof setWidgetTab>;
+
+export type OcpInfrastructureDashboardState = Readonly<{
+  widgets: Record<number, OcpInfrastructureDashboardWidget>;
+  currentWidgets: number[];
+}>;
+
+export const defaultState: OcpInfrastructureDashboardState = {
+  currentWidgets: [costSummaryWidget.id, cpuWidget.id, memoryWidget.id, volumeWidget.id],
+  widgets: {
+    [costSummaryWidget.id]: costSummaryWidget,
+    [cpuWidget.id]: cpuWidget,
+    [memoryWidget.id]: memoryWidget,
+    [volumeWidget.id]: volumeWidget,
+  },
+};
+
+export function ocpInfrastructureDashboardReducer(
+  state = defaultState,
+  action: OcpInfrastructureDashboardAction
+): OcpInfrastructureDashboardState {
+  switch (action.type) {
+    case getType(setWidgetTab):
+      return {
+        ...state,
+        widgets: {
+          ...state.widgets,
+          [action.payload.id]: {
+            ...state.widgets[action.payload.id],
+            currentTab: action.payload.tab,
+          },
+        },
+      };
+    default:
+      return state;
+  }
+}

--- a/src/store/dashboard/ocpInfrastructureDashboard/ocpInfrastructureDashboardSelectors.ts
+++ b/src/store/dashboard/ocpInfrastructureDashboard/ocpInfrastructureDashboardSelectors.ts
@@ -1,0 +1,43 @@
+import { RootState } from 'store/rootReducer';
+
+import {
+  getQueryForWidget,
+  getQueryForWidgetTabs,
+  ocpInfrastructureDashboardDefaultFilters,
+  ocpInfrastructureDashboardStateKey,
+  ocpInfrastructureDashboardTabFilters,
+} from './ocpInfrastructureDashboardCommon';
+
+export const selectOcpInfrastructureDashboardState = (state: RootState) => state[ocpInfrastructureDashboardStateKey];
+
+export const selectWidgets = (state: RootState) => selectOcpInfrastructureDashboardState(state).widgets;
+
+export const selectWidget = (state: RootState, id: number) => selectWidgets(state)[id];
+
+export const selectCurrentWidgets = (state: RootState) => selectOcpInfrastructureDashboardState(state).currentWidgets;
+
+export const selectWidgetQueries = (state: RootState, id: number) => {
+  const widget = selectWidget(state, id);
+
+  const defaultFilter = {
+    ...ocpInfrastructureDashboardDefaultFilters,
+    ...(widget.filter ? widget.filter : {}),
+  };
+  const tabsFilter = {
+    ...ocpInfrastructureDashboardTabFilters,
+    ...(widget.tabsFilter ? widget.tabsFilter : {}),
+  };
+
+  return {
+    previous: getQueryForWidget({
+      ...defaultFilter,
+      time_scope_value: -2,
+    }),
+    current: getQueryForWidget(defaultFilter),
+    forecast: getQueryForWidget({}, { limit: 31 }),
+    tabs: getQueryForWidgetTabs(widget, {
+      ...tabsFilter,
+      resolution: 'monthly',
+    }),
+  };
+};

--- a/src/store/dashboard/ocpInfrastructureDashboard/ocpInfrastructureDashboardWidgets.ts
+++ b/src/store/dashboard/ocpInfrastructureDashboard/ocpInfrastructureDashboardWidgets.ts
@@ -8,16 +8,16 @@ import {
 } from 'components/charts/common/chartDatumUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 
-import { OcpSupplementaryDashboardTab, OcpSupplementaryDashboardWidget } from './ocpSupplementaryDashboardCommon';
+import { OcpInfrastructureDashboardTab, OcpInfrastructureDashboardWidget } from './ocpInfrastructureDashboardCommon';
 
 let currrentId = 0;
 const getId = () => currrentId++;
 
-export const costSummaryWidget: OcpSupplementaryDashboardWidget = {
+export const costSummaryWidget: OcpInfrastructureDashboardWidget = {
   id: getId(),
-  titleKey: 'ocp_supplementary_dashboard.cost_title',
+  titleKey: 'ocp_infrastructure_dashboard.cost_title',
   forecastPathsType: ForecastPathsType.ocp,
-  forecastType: ForecastType.supplementary,
+  forecastType: ForecastType.infrastructure,
   reportPathsType: ReportPathsType.ocp,
   reportType: ReportType.cost,
   details: {
@@ -29,13 +29,13 @@ export const costSummaryWidget: OcpSupplementaryDashboardWidget = {
     showHorizontal: true,
   },
   trend: {
-    computedForecastItem: ComputedForecastItemType.supplementary,
-    computedReportItem: ComputedReportItemType.supplementary,
+    computedForecastItem: ComputedForecastItemType.infrastructure,
+    computedReportItem: ComputedReportItemType.infrastructure,
     computedReportItemValue: ComputedReportItemValueType.total,
     formatOptions: {},
-    dailyTitleKey: 'ocp_supplementary_dashboard.daily_cost_trend_title',
-    showSupplementaryLabel: true,
-    titleKey: 'ocp_supplementary_dashboard.cost_trend_title',
+    dailyTitleKey: 'ocp_infrastructure_dashboard.daily_cost_trend_title',
+    showInfrastructureLabel: true,
+    titleKey: 'ocp_infrastructure_dashboard.cost_trend_title',
     type: ChartType.rolling,
   },
   tabsFilter: {
@@ -44,12 +44,12 @@ export const costSummaryWidget: OcpSupplementaryDashboardWidget = {
   topItems: {
     formatOptions: {},
   },
-  availableTabs: [OcpSupplementaryDashboardTab.projects, OcpSupplementaryDashboardTab.clusters],
+  availableTabs: [OcpInfrastructureDashboardTab.projects, OcpInfrastructureDashboardTab.clusters],
   chartType: DashboardChartType.dailyTrend,
-  currentTab: OcpSupplementaryDashboardTab.projects,
+  currentTab: OcpInfrastructureDashboardTab.projects,
 };
 
-export const cpuWidget: OcpSupplementaryDashboardWidget = {
+export const cpuWidget: OcpInfrastructureDashboardWidget = {
   id: getId(),
   titleKey: 'ocp.cpu_usage_and_requests',
   reportPathsType: ReportPathsType.ocp,
@@ -82,14 +82,14 @@ export const cpuWidget: OcpSupplementaryDashboardWidget = {
     formatOptions: {},
   },
   // availableTabs: [
-  //   OcpSupplementaryDashboardTab.projects,
-  //   OcpSupplementaryDashboardTab.clusters,
+  //   OcpInfrastructureDashboardTab.projects,
+  //   OcpInfrastructureDashboardTab.clusters,
   // ],
   chartType: DashboardChartType.usage,
-  currentTab: OcpSupplementaryDashboardTab.projects,
+  currentTab: OcpInfrastructureDashboardTab.projects,
 };
 
-export const memoryWidget: OcpSupplementaryDashboardWidget = {
+export const memoryWidget: OcpInfrastructureDashboardWidget = {
   id: getId(),
   titleKey: 'ocp.memory_usage_and_requests',
   reportPathsType: ReportPathsType.ocp,
@@ -122,14 +122,14 @@ export const memoryWidget: OcpSupplementaryDashboardWidget = {
     formatOptions: {},
   },
   // availableTabs: [
-  //   OcpSupplementaryDashboardTab.projects,
-  //   OcpSupplementaryDashboardTab.clusters,
+  //   OcpInfrastructureDashboardTab.projects,
+  //   OcpInfrastructureDashboardTab.clusters,
   // ],
   chartType: DashboardChartType.usage,
-  currentTab: OcpSupplementaryDashboardTab.projects,
+  currentTab: OcpInfrastructureDashboardTab.projects,
 };
 
-export const volumeWidget: OcpSupplementaryDashboardWidget = {
+export const volumeWidget: OcpInfrastructureDashboardWidget = {
   id: getId(),
   titleKey: 'ocp.volume_usage_and_requests',
   reportPathsType: ReportPathsType.ocp,
@@ -162,9 +162,9 @@ export const volumeWidget: OcpSupplementaryDashboardWidget = {
     formatOptions: {},
   },
   // availableTabs: [
-  //   OcpSupplementaryDashboardTab.projects,
-  //   OcpSupplementaryDashboardTab.clusters,
+  //   OcpInfrastructureDashboardTab.projects,
+  //   OcpInfrastructureDashboardTab.clusters,
   // ],
   chartType: DashboardChartType.usage,
-  currentTab: OcpSupplementaryDashboardTab.projects,
+  currentTab: OcpInfrastructureDashboardTab.projects,
 };

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -23,6 +23,10 @@ import { ibmDashboardReducer, ibmDashboardStateKey } from 'store/dashboard/ibmDa
 import { ocpCloudDashboardReducer, ocpCloudDashboardStateKey } from 'store/dashboard/ocpCloudDashboard';
 import { ocpDashboardReducer, ocpDashboardStateKey } from 'store/dashboard/ocpDashboard';
 import {
+  ocpInfrastructureDashboardReducer,
+  ocpInfrastructureDashboardStateKey,
+} from 'store/dashboard/ocpInfrastructureDashboard';
+import {
   ocpSupplementaryDashboardReducer,
   ocpSupplementaryDashboardStateKey,
 } from 'store/dashboard/ocpSupplementaryDashboard';
@@ -67,6 +71,7 @@ export const rootReducer = combineReducers({
   [ocpCloudDashboardStateKey]: ocpCloudDashboardReducer,
   [ocpCloudDashboardStateKey]: ocpCloudDashboardReducer,
   [ocpHistoricalDataStateKey]: ocpHistoricalDataReducer,
+  [ocpInfrastructureDashboardStateKey]: ocpInfrastructureDashboardReducer,
   [ocpSupplementaryDashboardStateKey]: ocpSupplementaryDashboardReducer,
   [ocpUsageDashboardStateKey]: ocpUsageDashboardReducer,
   [orgStateKey]: orgReducer,


### PR DESCRIPTION
Added OpenShift Infrastructure perspective to overview. This moves the infrastructure data, from the "All" perspective, to its own chart. This new perspective mimics the supplementary view.

https://issues.redhat.com/browse/COST-1491

**New "OpenShift infrastructure" perspective**

<img width="1281" alt="Screen Shot 2021-06-09 at 10 30 07 AM" src="https://user-images.githubusercontent.com/17481322/121375011-62d84d80-c90e-11eb-926e-27be1d98f048.png">

**New "All OpenShift" perspective**

<img width="1282" alt="Screen Shot 2021-06-09 at 10 30 29 AM" src="https://user-images.githubusercontent.com/17481322/121375040-68ce2e80-c90e-11eb-878b-1007c3b654c1.png">

**Old "All" perspective**

<img width="1478" alt="Screen Shot 2021-06-09 at 10 50 58 AM" src="https://user-images.githubusercontent.com/17481322/121378270-0c204300-c911-11eb-9a6f-8329f2c47114.png">

