### PR TITLE
Cone of confidence legend item

### DIFF
--- a/src/components/charts/common/chartUtils.ts
+++ b/src/components/charts/common/chartUtils.ts
@@ -84,7 +84,7 @@ export const getLegendData = (series: ChartSeries[], hiddenSeries: Set<number>, 
     };
     return data;
   });
-  return tooltip ? result : result.filter(d => d.childName.indexOf('Cone') === -1);
+  return result;
 };
 
 // Note: Forecast is expected to use both datum.y and datum.y0
@@ -140,21 +140,6 @@ export const initHiddenSeries = (series: ChartSeries[], hiddenSeries: Set<number
   const result = new Set(hiddenSeries);
   if (!result.delete(index)) {
     result.add(index);
-  }
-
-  // Toggle forecast confidence
-  const childName = series[index].childName;
-  if (childName.indexOf('forecast') !== -1) {
-    let _index;
-    for (let i = 0; i < series.length; i++) {
-      if (series[i].childName === `${childName}Cone`) {
-        _index = i;
-        break;
-      }
-    }
-    if (index !== undefined && !result.delete(_index)) {
-      result.add(_index);
-    }
   }
   return result;
 };

--- a/src/components/charts/dailyTrendChart/dailyTrendChart.tsx
+++ b/src/components/charts/dailyTrendChart/dailyTrendChart.tsx
@@ -188,7 +188,7 @@ class DailyTrendChart extends React.Component<DailyTrendChartProps, State> {
           name: getCostRangeString(forecastConeData, 'chart.cost_forecast_cone_legend_label', false, false),
           symbol: {
             fill: chartStyles.forecastConeDataColorScale[0],
-            type: 'triangleLeft',
+            type: 'minus',
           },
           tooltip: getCostRangeString(forecastConeData, 'chart.cost_forecast_cone_legend_tooltip', false, false),
         },

--- a/src/components/charts/dailyTrendChart/dailyTrendChart.tsx
+++ b/src/components/charts/dailyTrendChart/dailyTrendChart.tsx
@@ -212,13 +212,21 @@ class DailyTrendChart extends React.Component<DailyTrendChartProps, State> {
   };
 
   private getAdjustedContainerHeight = () => {
-    const { adjustContainerHeight, height, containerHeight = height, showForecast } = this.props;
+    const {
+      adjustContainerHeight,
+      height,
+      containerHeight = height,
+      showForecast,
+      showInfrastructureLabel,
+      showSupplementaryLabel,
+    } = this.props;
     const { width } = this.state;
 
     let adjustedContainerHeight = containerHeight;
     if (adjustContainerHeight) {
       if (showForecast) {
-        if (width < 700) {
+        const maxWidth = showSupplementaryLabel || showInfrastructureLabel ? 850 : 700;
+        if (width < maxWidth) {
           adjustedContainerHeight += 25;
         }
       }

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -201,13 +201,21 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   };
 
   private getAdjustedContainerHeight = () => {
-    const { adjustContainerHeight, height, containerHeight = height, showForecast } = this.props;
+    const {
+      adjustContainerHeight,
+      height,
+      containerHeight = height,
+      showForecast,
+      showInfrastructureLabel,
+      showSupplementaryLabel,
+    } = this.props;
     const { width } = this.state;
 
     let adjustedContainerHeight = containerHeight;
     if (adjustContainerHeight) {
       if (showForecast) {
-        if (width < 700) {
+        const maxWidth = showSupplementaryLabel || showInfrastructureLabel ? 850 : 700;
+        if (width < maxWidth) {
           adjustedContainerHeight += 25;
         }
       }
@@ -253,12 +261,15 @@ class TrendChart extends React.Component<TrendChartProps, State> {
   };
 
   private getEndDate() {
-    const { currentData, forecastData, previousData } = this.props;
+    const { currentData, forecastData, forecastConeData, previousData } = this.props;
     const previousDate = previousData ? getDate(getDateRange(previousData, true, true)[1]) : 0;
     const currentDate = currentData ? getDate(getDateRange(currentData, true, true)[1]) : 0;
     const forecastDate = forecastData ? getDate(getDateRange(forecastData, true, true)[1]) : 0;
+    const forecastConeDate = forecastConeData ? getDate(getDateRange(forecastConeData, true, true)[1]) : 0;
 
-    return currentDate > 0 || previousDate > 0 ? Math.max(currentDate, forecastDate, previousDate) : 31;
+    return currentDate > 0 || previousDate > 0
+      ? Math.max(currentDate, forecastDate, forecastConeDate, previousDate)
+      : 31;
   }
 
   // Returns onMouseOver, onMouseOut, and onClick events for the interactive legend

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -22,7 +22,7 @@ export const costSummaryWidget: OcpDashboardWidget = {
   reportPathsType: ReportPathsType.ocp,
   reportType: ReportType.cost,
   details: {
-    // adjustContainerHeight: true,
+    adjustContainerHeight: true,
     appNavId: 'ocp',
     costKey: 'cost',
     formatOptions: {


### PR DESCRIPTION
Updated the charts to show the forecast cone of confidence as its own legend item. I also used that new left-pointed triangle I created for PatternFly charts

https://issues.redhat.com/browse/COST-1492

**Cumulative view**
<img width="881" alt="Screen Shot 2021-06-09 at 1 37 00 PM" src="https://user-images.githubusercontent.com/17481322/121402720-3c271080-c928-11eb-8147-d9cf0e622a30.png">

**Daily view**
<img width="838" alt="Screen Shot 2021-06-09 at 1 47 33 PM" src="https://user-images.githubusercontent.com/17481322/121404048-907ec000-c929-11eb-9540-f2245049b01f.png">

