### PR TITLE
AWS regions and services typeahead

### DIFF
--- a/src/api/resources/awsResource.ts
+++ b/src/api/resources/awsResource.ts
@@ -4,8 +4,8 @@ import { Resource, ResourceType } from './resource';
 
 export const ForecastTypePaths: Partial<Record<ResourceType, string>> = {
   [ResourceType.account]: 'resource-types/aws-accounts/',
-  [ResourceType.region]: 'resource-types/aws-regions/', // TBD: not available
-  [ResourceType.service]: 'resource-types/aws-services/', // TBD: not available
+  [ResourceType.region]: 'resource-types/aws-regions/',
+  [ResourceType.service]: 'resource-types/aws-services/',
 };
 
 export function runResource(resourceType: ResourceType, query: string) {

--- a/src/api/resources/resourceUtils.ts
+++ b/src/api/resources/resourceUtils.ts
@@ -7,8 +7,8 @@ export function isResourceTypeValid(resourcePathsType: ResourcePathsType, resour
   if (resourcePathsType === ResourcePathsType.aws) {
     switch (resourceType) {
       case ResourceType.account:
-        // case ResourceType.region: // Todo: Not currently supported by the resource-types API
-        // case ResourceType.service:
+      case ResourceType.region:
+      case ResourceType.service:
         result = true;
         break;
     }


### PR DESCRIPTION
Enables the AWS regions and services typeahead feature.

https://issues.redhat.com/browse/COST-1565

**Regions**
![chrome-capture](https://user-images.githubusercontent.com/17481322/122141313-0fd52d80-ce1b-11eb-9792-cfc7d9ed2c99.gif)

**Services**
![chrome-capture (1)](https://user-images.githubusercontent.com/17481322/122141352-1c598600-ce1b-11eb-9ac5-094114f66506.gif)
