### PR TITLE
Breakdown link's group_by param is missing tag key

### DIFF
--- a/src/pages/views/details/awsDetails/detailsTable.tsx
+++ b/src/pages/views/details/awsDetails/detailsTable.tsx
@@ -20,6 +20,7 @@ import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/comput
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dateRange';
 import { formatCurrency } from 'utils/formatValue';
 
+import { tagPrefix } from '../../../../api/queries/query';
 import { styles } from './detailsTable.styles';
 
 interface DetailsTableOwnProps {
@@ -143,7 +144,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           to={getOrgBreakdownPath({
             basePath: paths.awsDetailsBreakdown,
             description: item.id,
-            groupBy: groupById,
+            groupBy: groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById,
             groupByOrg,
             id: item.id,
             orgUnitId: getGroupByOrgValue(query),

--- a/src/pages/views/details/awsDetails/detailsTable.tsx
+++ b/src/pages/views/details/awsDetails/detailsTable.tsx
@@ -4,6 +4,7 @@ import { Bullseye, EmptyState, EmptyStateBody, EmptyStateIcon, Spinner } from '@
 import { CalculatorIcon } from '@patternfly/react-icons/dist/js/icons/calculator-icon';
 import { sortable, SortByDirection, Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { AwsQuery, getQuery } from 'api/queries/awsQuery';
+import { tagPrefix } from 'api/queries/query';
 import { AwsReport } from 'api/reports/awsReports';
 import { ReportPathsType } from 'api/reports/report';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
@@ -20,7 +21,6 @@ import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/comput
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dateRange';
 import { formatCurrency } from 'utils/formatValue';
 
-import { tagPrefix } from '../../../../api/queries/query';
 import { styles } from './detailsTable.styles';
 
 interface DetailsTableOwnProps {

--- a/src/pages/views/details/azureDetails/detailsTable.tsx
+++ b/src/pages/views/details/azureDetails/detailsTable.tsx
@@ -142,7 +142,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             basePath: paths.azureDetailsBreakdown,
             label: label.toString(),
             description: item.id,
-            groupBy: groupById,
+            groupBy: groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById,
             query,
           })}
         >

--- a/src/pages/views/details/gcpDetails/detailsTable.tsx
+++ b/src/pages/views/details/gcpDetails/detailsTable.tsx
@@ -142,7 +142,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             basePath: paths.gcpDetailsBreakdown,
             label: label.toString(),
             description: item.id,
-            groupBy: groupById,
+            groupBy: groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById,
             query,
           })}
         >

--- a/src/pages/views/details/ibmDetails/detailsTable.tsx
+++ b/src/pages/views/details/ibmDetails/detailsTable.tsx
@@ -142,7 +142,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             basePath: paths.ibmDetailsBreakdown,
             label: label.toString(),
             description: item.id,
-            groupBy: groupById,
+            groupBy: groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById,
             query,
           })}
         >

--- a/src/pages/views/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/views/details/ocpDetails/detailsTable.tsx
@@ -180,7 +180,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             basePath: paths.ocpDetailsBreakdown,
             label: label.toString(),
             description: item.id,
-            groupBy: groupById,
+            groupBy: groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById,
             query,
           })}
         >


### PR DESCRIPTION
The details pages generate links with `group_by[date]` instead of `group_by[tag:tag_key]`

https://issues.redhat.com/browse/COST-1510