### PR TITLE
Cost model empty state not displaying when no models

### DIFF
--- a/src/pages/costModels/costModelsDetails/utils/table.tsx
+++ b/src/pages/costModels/costModelsDetails/utils/table.tsx
@@ -32,7 +32,7 @@ export function getRowsByStateName(stateName: string, data: any) {
         heightAuto: true,
         cells: [
           {
-            props: { colSpan: 8 },
+            props: { colSpan: 5 },
             title: <Bullseye> {component} </Bullseye>,
           },
         ],

--- a/src/store/costModels/selectors.ts
+++ b/src/store/costModels/selectors.ts
@@ -63,12 +63,12 @@ export const stateName = (state: RootState) => {
   }
   const hasNoFilters = Object.keys(costQuery).every(key => {
     switch (key) {
-      case 'limit':
-        return costQuery[key] === '10';
-      case 'offset':
-        return costQuery[key] === '0';
-      default:
+      case 'description':
+      case 'name':
+      case 'source_type':
         return costQuery[key] === null;
+      default:
+        return true;
     }
   });
   if (hasNoFilters) {


### PR DESCRIPTION
Refactored cost models' empty state to test user filters only. 

Instead of looking at query params; `limit` and `offset`, it would be best to test if the `name`, `description`, and `source_type` have been filtered. In addition, there's no need to test `ordering` -- the empty state should be shown, regardless.

https://issues.redhat.com/browse/COST-1518

**Empty state**
<img width="1481" alt="Screen Shot 2021-06-15 at 11 21 11 PM" src="https://user-images.githubusercontent.com/17481322/122153161-67ca5f00-ce30-11eb-8899-70246edca2ee.png">

**No match**
<img width="1486" alt="Screen Shot 2021-06-15 at 11 22 01 PM" src="https://user-images.githubusercontent.com/17481322/122153217-86305a80-ce30-11eb-99f7-f2b1e9778e72.png">

**Loading**
<img width="1487" alt="Screen Shot 2021-06-15 at 11 22 54 PM (2)" src="https://user-images.githubusercontent.com/17481322/122153369-d27b9a80-ce30-11eb-8ef9-cdd7aa3ee1d2.png">
