### PR TITLE
Adjust chart legend responsiveness

### DIFF
--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -214,7 +214,7 @@ class TrendChart extends React.Component<TrendChartProps, State> {
     let adjustedContainerHeight = containerHeight;
     if (adjustContainerHeight) {
       if (showForecast) {
-        const maxWidth = showSupplementaryLabel || showInfrastructureLabel ? 850 : 700;
+        const maxWidth = showSupplementaryLabel || showInfrastructureLabel ? 900 : 700;
         if (width < maxWidth) {
           adjustedContainerHeight += 25;
         }


### PR DESCRIPTION
Small tweak to adjust chart legend responsiveness for OCP supplementary view.

![chrome-capture](https://user-images.githubusercontent.com/17481322/122226349-e56b8a80-ce83-11eb-86f0-e004710b978b.gif)
