### PR TITLE
no-project items shouldn't be exportable

### DIFF
--- a/src/pages/views/details/awsDetails/awsDetails.tsx
+++ b/src/pages/views/details/awsDetails/awsDetails.tsx
@@ -139,12 +139,19 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     const groupByTagKey = getGroupByTagKey(query);
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
+    // Omit items labeled 'no-project'
+    const items = [];
+    selectedItems.map(item => {
+      if (!(item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`)) {
+        items.push(item);
+      }
+    });
     return (
       <ExportModal
         isAllItems={(isAllSelected || selectedItems.length === itemsTotal) && computedItems.length > 0}
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isOpen={isExportModalOpen}
-        items={selectedItems}
+        items={items}
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={reportPathsType}

--- a/src/pages/views/details/awsDetails/detailsTable.tsx
+++ b/src/pages/views/details/awsDetails/detailsTable.tsx
@@ -156,7 +156,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           {label}
         </Link>
       );
-      if (label === `no-${groupById}` || label === `no-${groupByTagKey}`) {
+
+      const selectable = !(label === `no-${groupById}` || label === `no-${groupByTagKey}`);
+      if (!selectable) {
         name = label as any;
       }
 
@@ -176,7 +178,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           { title: <div>{cost}</div> },
           { title: <div>{actions}</div> },
         ],
-        disableSelection: item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`,
+        disableSelection: !selectable,
         item,
         selected: isAllSelected || (selectedItems && selectedItems.find(val => val.id === item.id) !== undefined),
       });

--- a/src/pages/views/details/azureDetails/azureDetails.tsx
+++ b/src/pages/views/details/azureDetails/azureDetails.tsx
@@ -137,12 +137,19 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     const groupByTagKey = getGroupByTagKey(query);
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
+    // Omit items labeled 'no-project'
+    const items = [];
+    selectedItems.map(item => {
+      if (!(item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`)) {
+        items.push(item);
+      }
+    });
     return (
       <ExportModal
         isAllItems={(isAllSelected || selectedItems.length === itemsTotal) && computedItems.length > 0}
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isOpen={isExportModalOpen}
-        items={selectedItems}
+        items={items}
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={reportPathsType}

--- a/src/pages/views/details/azureDetails/detailsTable.tsx
+++ b/src/pages/views/details/azureDetails/detailsTable.tsx
@@ -149,7 +149,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           {label}
         </Link>
       );
-      if (label === `no-${groupById}` || label === `no-${groupByTagKey}`) {
+
+      const selectable = !(label === `no-${groupById}` || label === `no-${groupByTagKey}`);
+      if (!selectable) {
         name = label as any;
       }
 
@@ -169,7 +171,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           { title: <div>{cost}</div> },
           { title: <div>{actions}</div> },
         ],
-        disableSelection: item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`,
+        disableSelection: !selectable,
         isOpen: false,
         item,
         selected: isAllSelected || (selectedItems && selectedItems.find(val => val.id === item.id) !== undefined),

--- a/src/pages/views/details/gcpDetails/detailsTable.tsx
+++ b/src/pages/views/details/gcpDetails/detailsTable.tsx
@@ -149,7 +149,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           {label}
         </Link>
       );
-      if (label === `no-${groupById}` || label === `no-${groupByTagKey}`) {
+
+      const selectable = !(label === `no-${groupById}` || label === `no-${groupByTagKey}`);
+      if (!selectable) {
         name = label as any;
       }
 
@@ -169,7 +171,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           { title: <div>{cost}</div> },
           { title: <div>{actions}</div> },
         ],
-        disableSelection: item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`,
+        disableSelection: !selectable,
         isOpen: false,
         item,
         selected: isAllSelected || (selectedItems && selectedItems.find(val => val.id === item.id) !== undefined),

--- a/src/pages/views/details/gcpDetails/gcpDetails.tsx
+++ b/src/pages/views/details/gcpDetails/gcpDetails.tsx
@@ -137,12 +137,19 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
     const groupByTagKey = getGroupByTagKey(query);
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
+    // Omit items labeled 'no-project'
+    const items = [];
+    selectedItems.map(item => {
+      if (!(item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`)) {
+        items.push(item);
+      }
+    });
     return (
       <ExportModal
         isAllItems={(isAllSelected || selectedItems.length === itemsTotal) && computedItems.length > 0}
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isOpen={isExportModalOpen}
-        items={selectedItems}
+        items={items}
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={reportPathsType}

--- a/src/pages/views/details/ibmDetails/detailsTable.tsx
+++ b/src/pages/views/details/ibmDetails/detailsTable.tsx
@@ -149,7 +149,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           {label}
         </Link>
       );
-      if (label === `no-${groupById}` || label === `no-${groupByTagKey}`) {
+
+      const selectable = !(label === `no-${groupById}` || label === `no-${groupByTagKey}`);
+      if (!selectable) {
         name = label as any;
       }
 
@@ -169,7 +171,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           { title: <div>{cost}</div> },
           { title: <div>{actions}</div> },
         ],
-        disableSelection: item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`,
+        disableSelection: !selectable,
         isOpen: false,
         item,
         selected: isAllSelected || (selectedItems && selectedItems.find(val => val.id === item.id) !== undefined),

--- a/src/pages/views/details/ibmDetails/ibmDetails.tsx
+++ b/src/pages/views/details/ibmDetails/ibmDetails.tsx
@@ -137,12 +137,19 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
     const groupByTagKey = getGroupByTagKey(query);
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
+    // Omit items labeled 'no-project'
+    const items = [];
+    selectedItems.map(item => {
+      if (!(item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`)) {
+        items.push(item);
+      }
+    });
     return (
       <ExportModal
         isAllItems={(isAllSelected || selectedItems.length === itemsTotal) && computedItems.length > 0}
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isOpen={isExportModalOpen}
-        items={selectedItems}
+        items={items}
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={reportPathsType}

--- a/src/pages/views/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/views/details/ocpDetails/detailsTable.tsx
@@ -187,7 +187,9 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           {label}
         </Link>
       );
-      if (label === `no-${groupById}` || label === `no-${groupByTagKey}`) {
+
+      const selectable = !(label === `no-${groupById}` || label === `no-${groupByTagKey}`);
+      if (!selectable) {
         name = label as any;
       }
 
@@ -209,7 +211,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           { title: <div>{cost}</div> },
           { title: <div>{actions}</div> },
         ],
-        disableSelection: item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`,
+        disableSelection: !selectable,
         isOpen: false,
         item,
         selected: isAllSelected || (selectedItems && selectedItems.find(val => val.id === item.id) !== undefined),

--- a/src/pages/views/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/views/details/ocpDetails/ocpDetails.tsx
@@ -174,12 +174,19 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     const groupByTagKey = getGroupByTagKey(query);
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
+    // Omit items labeled 'no-project'
+    const items = [];
+    selectedItems.map(item => {
+      if (!(item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`)) {
+        items.push(item);
+      }
+    });
     return (
       <ExportModal
         isAllItems={(isAllSelected || selectedItems.length === itemsTotal) && computedItems.length > 0}
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isOpen={isExportModalOpen}
-        items={selectedItems}
+        items={items}
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={reportPathsType}

--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -167,12 +167,19 @@ class Explorer extends React.Component<ExplorerProps> {
     const groupByTagKey = getGroupByTagKey(query);
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
+    // Omit items labeled 'no-project'
+    const items = [];
+    selectedItems.map(item => {
+      if (!(item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`)) {
+        items.push(item);
+      }
+    });
     return (
       <ExportModal
         isAllItems={(isAllSelected || selectedItems.length === itemsTotal) && computedItems.length > 0}
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isOpen={isExportModalOpen}
-        items={selectedItems}
+        items={items}
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={getReportPathsType(perspective)}


### PR DESCRIPTION
For OCP details, the "no-project" checkbox is disabled. However, the user may choose to "select-all items" or "select all items in the page" via the bulk selector.

This change omits "no-project" from the export modal.

https://issues.redhat.com/browse/COST-1580

<img width="916" alt="Screen Shot 2021-06-22 at 10 15 55 AM" src="https://user-images.githubusercontent.com/17481322/122944075-84d9c300-d345-11eb-8ad2-9f8056cf9982.png">
