### PR TITLE
Cost models filter outputs a11y error message

### DIFF
--- a/src/pages/costModels/costModelsDetails/utils/filters.tsx
+++ b/src/pages/costModels/costModelsDetails/utils/filters.tsx
@@ -33,6 +33,7 @@ const FilterInput: React.SFC<FilterInputProps> = ({ placeholder = '', value, onC
   return (
     <InputGroup>
       <TextInput
+        aria-label={placeholder}
         value={value}
         placeholder={placeholder}
         onChange={onChange}


### PR DESCRIPTION
The PatternFly TextInput requires either an ID or aria-label to be specified.

https://issues.redhat.com/browse/COST-1585

