### PR TITLE
Update config utils.

### DIFF
--- a/koku-ui-manifest
+++ b/koku-ui-manifest
@@ -97,7 +97,7 @@ mgmt_services/cost-mgmt:koku-ui/@patternfly/react-styles:4.11.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/@patternfly/react-table:4.29.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/@patternfly/react-tokens:4.12.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/@popperjs/core:2.9.1.yarnlock
-mgmt_services/cost-mgmt:koku-ui/@redhat-cloud-services/frontend-components-config-utilities:1.1.1.yarnlock
+mgmt_services/cost-mgmt:koku-ui/@redhat-cloud-services/frontend-components-config-utilities:1.3.1.yarnlock
 mgmt_services/cost-mgmt:koku-ui/@redhat-cloud-services/frontend-components-notifications:3.2.2.yarnlock
 mgmt_services/cost-mgmt:koku-ui/@redhat-cloud-services/frontend-components-utilities:3.1.1.yarnlock
 mgmt_services/cost-mgmt:koku-ui/@redhat-cloud-services/frontend-components-utilities:3.1.1.yarnlock
@@ -1058,6 +1058,7 @@ mgmt_services/cost-mgmt:koku-ui/node-modules-regexp:1.0.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/node-notifier:8.0.2.yarnlock
 mgmt_services/cost-mgmt:koku-ui/node-releases:1.1.71.yarnlock
 mgmt_services/cost-mgmt:koku-ui/nodesi:1.16.0.yarnlock
+mgmt_services/cost-mgmt:koku-ui/nodesi:1.17.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/normalize-package-data:2.5.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/normalize-package-data:2.5.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/normalize-path:2.1.1.yarnlock

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "xstate": "4.16.2"
   },
   "devDependencies": {
-    "@redhat-cloud-services/frontend-components-config-utilities": "^1.1.1",
+    "@redhat-cloud-services/frontend-components-config-utilities": "^1.3.1",
     "@testing-library/react": "11.2.5",
     "@types/enzyme": "3.10.8",
     "@types/jest": "26.0.20",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -221,6 +221,7 @@ module.exports = (_env, argv) => {
     },
     devServer: useProxy
       ? proxy({
+          useCloud: true,
           betaEnv: process.env.CLOUDOT_ENV,
           rootFolder: path.resolve(__dirname),
           localChrome: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -646,10 +646,12 @@
   resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.9.1.tgz#7f554e7368c9ab679a11f4a042ca17149d70cf12"
   integrity sha512-DvJbbn3dUgMxDnJLH+RZQPnXak1h4ZVYQ7CWiFWjQwBFkVajT4rfw2PdpHLTSTwxrYfnoEXkuBiwkDm6tPMQeA==
 
-"@redhat-cloud-services/frontend-components-config-utilities@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.1.1.tgz#067fed07c260ebd0afc46bab91b2c8cef8216351"
-  integrity sha512-0nRMr5PD20fDMp6tCN2zYKSEkP/W8iPVqjk77F5i5HyyPDHSm+BJitk1+GVoriDAltqN27Dvj8vp4veUj5EISg==
+"@redhat-cloud-services/frontend-components-config-utilities@^1.3.1":
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.3.1.tgz#4fe920e1511b9df0412a2435b3d03d1b7df09e35"
+  integrity sha512-eeIBS6tk1Cjfd3T8evSjZui0EWmqb7hbVOZy940rEvEsKBZ9i1l2gOqUYi75CWCW6ni+SNh93xK/l1PgRghM7Q==
+  dependencies:
+    nodesi "^1.17.0"
 
 "@redhat-cloud-services/frontend-components-notifications@^3.2.2":
   version "3.2.2"
@@ -6403,6 +6405,15 @@ nodesi@^1.16.0:
   version "1.16.0"
   resolved "https://registry.yarnpkg.com/nodesi/-/nodesi-1.16.0.tgz#b7129778c15fa06e1fa928ff85ccd71f59790aef"
   integrity sha512-fmMvsQ9I/rTE62LVw7adLlVq8Of6gbDv3FxkBGTOOZTc5eIz4IMRxZ3ec7mvBLEYNPNO2OW/C3aywStYvDIipA==
+  dependencies:
+    clone "1.0.3"
+    good-guy-http "1.14.0"
+    he "1.2.0"
+
+nodesi@^1.17.0:
+  version "1.17.0"
+  resolved "https://registry.yarnpkg.com/nodesi/-/nodesi-1.17.0.tgz#8d193e588564a72c0569d92aa7268f4f86e54ec8"
+  integrity sha512-xDdTZbmzfiDlizkPWP21hKr22ISyZdD7v+mXWohnacubhGzvyO5WQfuxuO202rIXt+sL4aJccrzQjR6dwLwT4g==
   dependencies:
     clone "1.0.3"
     good-guy-http "1.14.0"


### PR DESCRIPTION
jira: https://issues.redhat.com/browse/RHCLOUD-14981

We also have to add the `useCloud` flag to use the `cloud.redhat.com` instead `console.redhat.com` until the migration happens.

cc @dlabrecq 