### PR TITLE
Add stage as an option for start script

### DIFF
--- a/scripts/start-dev-server.js
+++ b/scripts/start-dev-server.js
@@ -11,7 +11,7 @@ async function setEnv() {
         type: 'list',
         name: 'clouddotEnv',
         message: 'Which platform environment you want to use',
-        choices: ['ci', 'qa', 'prod'],
+        choices: ['ci', 'qa', 'stage', 'prod'],
       },
       {
         name: 'insightsProxy',


### PR DESCRIPTION
Although `stage.foo.redhat.com` isn't working at the moment, this makes it possible to test the environment. That is, along with the package update in https://github.com/project-koku/koku-ui/pull/2001.