### PR TITLE
Update webpack to include CLOUDOT_ENV

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -187,7 +187,7 @@ module.exports = (_env, argv) => {
           './RootApp': path.resolve(__dirname, './src/federatedEntry.tsx'),
           // Shared component module path. Must include default export!
           // './OcpOverviewWidget': path.resolve(__dirname, './src/modules/ocpOverviewWidget'),
-        }
+        },
       }),
       new ChunkMapperPlugin({
         modules: [moduleName],
@@ -237,13 +237,13 @@ module.exports = (_env, argv) => {
       https: useProxy,
       ...proxy({
         port,
-        env: `ci-${isBeta ? 'beta' : 'stable'}`,
+        env: `${process.env.CLOUDOT_ENV}-${isBeta ? 'beta' : 'stable'}`,
         useProxy,
         appUrl: [`/${isBeta ? 'beta/' : ''}openshift/cost-management`],
         proxyVerbose: true,
         publicPath,
-        useCloud: true
-      })
+        useCloud: true,
+      }),
       // Props for webpack-dev-server v4.0.0-beta.2
       //
       // host: 'localhost',


### PR DESCRIPTION
Update webpack to include `CLOUDOT_ENV` for the proxy's `env` prop. This will ensure we can run against prod-beta, prod-stable, etc. and not just CI environments.

Follow up to https://github.com/project-koku/koku-ui/pull/2005.