### PR TITLE
Replace Azure's VM-hours with hours

### DIFF
--- a/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
+++ b/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
@@ -187,7 +187,6 @@ export const virtualMachineWidget: AzureCloudDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    units: 'vm-hours',
     usageKey: 'dashboard.usage',
   },
   filter: {

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -191,7 +191,6 @@ export const virtualMachineWidget: AzureDashboardWidget = {
     usageFormatOptions: {
       fractionDigits: 0,
     },
-    units: 'vm-hours',
     usageKey: 'dashboard.usage',
   },
   filter: {


### PR DESCRIPTION
At one time, the Azure cost report did not provide units for the Overview's "Virtual machines usage" card. The API returned undefined as the value, so the UI hard-coded "VM-hours".

https://issues.redhat.com/browse/COST-1644

<img width="499" alt="Screen Shot 2021-07-09 at 11 52 46 PM" src="https://user-images.githubusercontent.com/17481322/125150875-0638a000-e111-11eb-8d4d-228affab7195.png">
