### PR TITLE
remove hard coded unit in azure's storage widget

### DIFF
--- a/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
+++ b/src/store/dashboard/azureCloudDashboard/azureCloudDashboardWidgets.ts
@@ -138,7 +138,6 @@ export const storageWidget: AzureCloudDashboardWidget = {
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
-    units: 'gb-mo',
     usageFormatOptions: {
       fractionDigits: 0,
     },

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -142,7 +142,6 @@ export const storageWidget: AzureDashboardWidget = {
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
-    units: 'gb-mo',
     usageFormatOptions: {
       fractionDigits: 0,
     },


### PR DESCRIPTION
The API endpoint for azure storage is now providing units.

![Screen Shot 2021-07-10 at 8 00 28 AM](https://user-images.githubusercontent.com/57504257/125162733-78cc6e80-e157-11eb-94f8-8cc4a3518cce.png)

![Screen Shot 2021-07-10 at 8 20 12 AM](https://user-images.githubusercontent.com/57504257/125162773-b3cea200-e157-11eb-80a6-1b78137fe2a9.png)

