### PR TITLE
1649 type-ahead azure

### DIFF
--- a/src/api/resources/azureResource.ts
+++ b/src/api/resources/azureResource.ts
@@ -3,9 +3,9 @@ import axios from 'axios';
 import { Resource, ResourceType } from './resource';
 
 export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
-  [ResourceType.account]: 'resource-types/aws-accounts/',
-  [ResourceType.region]: 'resource-types/aws-regions/',
-  [ResourceType.service]: 'resource-types/aws-services/',
+  [ResourceType.resourceLocation]: 'resource-types/azure-regions/',
+  [ResourceType.subscriptionGuid]: 'resource-types/azure-subscription-guids/',
+  [ResourceType.serviceName]: 'resource-types/azure-services/',
 };
 
 export function runResource(resourceType: ResourceType, query: string) {

--- a/src/api/resources/resource.ts
+++ b/src/api/resources/resource.ts
@@ -24,10 +24,14 @@ export interface Resource {
 export const enum ResourceType {
   account = 'account',
   region = 'region',
+  resourceLocation = 'resource_location',
   service = 'service',
+  serviceName = 'service_name',
+  subscriptionGuid = 'subscription_guid',
 }
 
 // eslint-disable-next-line no-shadow
 export const enum ResourcePathsType {
   aws = 'aws',
+  azure = 'azure',
 }

--- a/src/api/resources/resourceUtils.ts
+++ b/src/api/resources/resourceUtils.ts
@@ -1,14 +1,19 @@
 import { runResource as runAwsResource } from './awsResource';
+import { runResource as runAzureResource } from './azureResource';
 import { ResourcePathsType, ResourceType } from './resource';
 
+// Temporary check until typeahead is implemented for all filters
 export function isResourceTypeValid(resourcePathsType: ResourcePathsType, resourceType: ResourceType) {
   let result = false;
 
-  if (resourcePathsType === ResourcePathsType.aws) {
+  if (resourcePathsType === ResourcePathsType.aws || resourcePathsType === ResourcePathsType.azure) {
     switch (resourceType) {
       case ResourceType.account:
       case ResourceType.region:
+      case ResourceType.resourceLocation: // Azure
       case ResourceType.service:
+      case ResourceType.serviceName: // Azure
+      case ResourceType.subscriptionGuid: // Azure
         result = true;
         break;
     }
@@ -21,6 +26,9 @@ export function runResource(resourcePathsType: ResourcePathsType, resourceType: 
   switch (resourcePathsType) {
     case ResourcePathsType.aws:
       forecast = runAwsResource(resourceType, query);
+      break;
+    case ResourcePathsType.azure:
+      forecast = runAzureResource(resourceType, query);
       break;
   }
   return forecast;

--- a/src/pages/views/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/awsDetails/detailsToolbar.tsx
@@ -140,11 +140,11 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         orgReport={orgReport}
         pagination={pagination}
         query={query}
+        resourcePathsType={ResourcePathsType.aws}
         selectedItems={selectedItems}
         showBulkSelect
         showExport
         showFilter
-        resourcePathsType={ResourcePathsType.aws}
         tagReport={tagReport}
       />
     );

--- a/src/pages/views/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/azureDetails/detailsToolbar.tsx
@@ -1,6 +1,7 @@
 import { ToolbarChipGroup } from '@patternfly/react-core';
 import { AzureQuery, getQuery } from 'api/queries/azureQuery';
 import { tagKey } from 'api/queries/query';
+import { ResourcePathsType } from 'api/resources/resource';
 import { AzureTag } from 'api/tags/azureTags';
 import { TagPathsType, TagType } from 'api/tags/tag';
 import { DataToolbar } from 'pages/views/components/dataToolbar/dataToolbar';
@@ -127,6 +128,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         onFilterRemoved={onFilterRemoved}
         pagination={pagination}
         query={query}
+        resourcePathsType={ResourcePathsType.azure}
         selectedItems={selectedItems}
         showBulkSelect
         showExport

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -386,6 +386,9 @@ export const getResourcePathsType = (perspective: string) => {
     case PerspectiveType.aws:
       return ResourcePathsType.aws;
       break;
+    case PerspectiveType.azure:
+      return ResourcePathsType.azure;
+      break;
     default:
       result = undefined;
       break;


### PR DESCRIPTION
Update the Azure details page and Cost Explorer to use new type-ahead features (i.e., account, region, & services) introduced via the `resource-types` API.

![chrome-capture](https://user-images.githubusercontent.com/17481322/125327184-d821ae80-e310-11eb-8169-355c799f98b9.gif)
