### PR TITLE
OCP type-ahead support

### DIFF
--- a/src/api/resources/ocpResource.ts
+++ b/src/api/resources/ocpResource.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+
+import { Resource, ResourceType } from './resource';
+
+export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
+  [ResourceType.cluster]: 'resource-types/openshift-clusters/',
+  [ResourceType.node]: 'resource-types/openshift-nodes/',
+  [ResourceType.project]: 'resource-types/openshift-projects/',
+};
+
+export function runResource(resourceType: ResourceType, query: string) {
+  const insights = (window as any).insights;
+  const path = ResourceTypePaths[resourceType];
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => {
+      return axios.get<Resource>(`${path}?${query}`);
+    });
+  } else {
+    return axios.get<Resource>(`${path}?${query}`);
+  }
+}

--- a/src/api/resources/resource.ts
+++ b/src/api/resources/resource.ts
@@ -23,6 +23,9 @@ export interface Resource {
 // eslint-disable-next-line no-shadow
 export const enum ResourceType {
   account = 'account',
+  cluster = 'cluster',
+  node = 'node',
+  project = 'project',
   region = 'region',
   resourceLocation = 'resource_location',
   service = 'service',
@@ -34,4 +37,5 @@ export const enum ResourceType {
 export const enum ResourcePathsType {
   aws = 'aws',
   azure = 'azure',
+  ocp = 'ocp',
 }

--- a/src/api/resources/resourceUtils.ts
+++ b/src/api/resources/resourceUtils.ts
@@ -1,19 +1,27 @@
 import { runResource as runAwsResource } from './awsResource';
 import { runResource as runAzureResource } from './azureResource';
+import { runResource as runOcpResource } from './ocpResource';
 import { ResourcePathsType, ResourceType } from './resource';
 
 // Temporary check until typeahead is implemented for all filters
 export function isResourceTypeValid(resourcePathsType: ResourcePathsType, resourceType: ResourceType) {
   let result = false;
 
-  if (resourcePathsType === ResourcePathsType.aws || resourcePathsType === ResourcePathsType.azure) {
+  if (
+    resourcePathsType === ResourcePathsType.aws ||
+    resourcePathsType === ResourcePathsType.azure ||
+    resourcePathsType === ResourcePathsType.ocp
+  ) {
     switch (resourceType) {
       case ResourceType.account:
+      case ResourceType.cluster:
+      case ResourceType.node:
+      case ResourceType.project:
       case ResourceType.region:
-      case ResourceType.resourceLocation: // Azure
+      case ResourceType.resourceLocation:
       case ResourceType.service:
-      case ResourceType.serviceName: // Azure
-      case ResourceType.subscriptionGuid: // Azure
+      case ResourceType.serviceName:
+      case ResourceType.subscriptionGuid:
         result = true;
         break;
     }
@@ -29,6 +37,9 @@ export function runResource(resourcePathsType: ResourcePathsType, resourceType: 
       break;
     case ResourcePathsType.azure:
       forecast = runAzureResource(resourceType, query);
+      break;
+    case ResourcePathsType.ocp:
+      forecast = runOcpResource(resourceType, query);
       break;
   }
   return forecast;

--- a/src/pages/views/components/resourceTypeahead/resourceSelect.tsx
+++ b/src/pages/views/components/resourceTypeahead/resourceSelect.tsx
@@ -124,7 +124,7 @@ class ResourceSelectBase extends React.Component<ResourceSelectProps> {
     });
   };
 
-  private handleOnFilter = (event, value) => {
+  private handleOnFilter = event => {
     if (event === null) {
       return null;
     }

--- a/src/pages/views/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ocpDetails/detailsToolbar.tsx
@@ -1,6 +1,7 @@
 import { ToolbarChipGroup } from '@patternfly/react-core';
 import { getQuery, OcpQuery } from 'api/queries/ocpQuery';
 import { tagKey } from 'api/queries/query';
+import { ResourcePathsType } from 'api/resources/resource';
 import { OcpTag } from 'api/tags/ocpTags';
 import { TagPathsType, TagType } from 'api/tags/tag';
 import { DataToolbar } from 'pages/views/components/dataToolbar/dataToolbar';
@@ -123,6 +124,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         onFilterRemoved={onFilterRemoved}
         pagination={pagination}
         query={query}
+        resourcePathsType={ResourcePathsType.ocp}
         selectedItems={selectedItems}
         showBulkSelect
         showColumnManagement

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -389,6 +389,9 @@ export const getResourcePathsType = (perspective: string) => {
     case PerspectiveType.azure:
       return ResourcePathsType.azure;
       break;
+    case PerspectiveType.ocp:
+      return ResourcePathsType.ocp;
+      break;
     default:
       result = undefined;
       break;


### PR DESCRIPTION
Update the OCP details page and Cost Explorer to use new typeahead features (i.e., clusters, projects, & nodes) introduced via the `resource-types` API.

![chrome-capture](https://user-images.githubusercontent.com/17481322/125331420-f807a100-e315-11eb-87af-cf2bb785d89f.gif)
