### PR TITLE
GCP type-ahead support

### DIFF
--- a/src/api/resources/gcpResource.ts
+++ b/src/api/resources/gcpResource.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+
+import { Resource, ResourceType } from './resource';
+
+export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
+  [ResourceType.account]: 'resource-types/gcp-accounts/',
+  [ResourceType.project]: 'resource-types/gcp-projects/',
+  [ResourceType.region]: 'resource-types/gcp-regions/',
+  [ResourceType.service]: 'resource-types/gcp-services/',
+};
+
+export function runResource(resourceType: ResourceType, query: string) {
+  const insights = (window as any).insights;
+  const path = ResourceTypePaths[resourceType];
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => {
+      return axios.get<Resource>(`${path}?${query}`);
+    });
+  } else {
+    return axios.get<Resource>(`${path}?${query}`);
+  }
+}

--- a/src/api/resources/resource.ts
+++ b/src/api/resources/resource.ts
@@ -37,5 +37,6 @@ export const enum ResourceType {
 export const enum ResourcePathsType {
   aws = 'aws',
   azure = 'azure',
+  gcp = 'gcp',
   ocp = 'ocp',
 }

--- a/src/api/resources/resourceUtils.ts
+++ b/src/api/resources/resourceUtils.ts
@@ -1,5 +1,6 @@
 import { runResource as runAwsResource } from './awsResource';
 import { runResource as runAzureResource } from './azureResource';
+import { runResource as runGcpResource } from './gcpResource';
 import { runResource as runOcpResource } from './ocpResource';
 import { ResourcePathsType, ResourceType } from './resource';
 
@@ -10,6 +11,7 @@ export function isResourceTypeValid(resourcePathsType: ResourcePathsType, resour
   if (
     resourcePathsType === ResourcePathsType.aws ||
     resourcePathsType === ResourcePathsType.azure ||
+    resourcePathsType === ResourcePathsType.gcp ||
     resourcePathsType === ResourcePathsType.ocp
   ) {
     switch (resourceType) {
@@ -37,6 +39,9 @@ export function runResource(resourcePathsType: ResourcePathsType, resourceType: 
       break;
     case ResourcePathsType.azure:
       forecast = runAzureResource(resourceType, query);
+      break;
+    case ResourcePathsType.gcp:
+      forecast = runGcpResource(resourceType, query);
       break;
     case ResourcePathsType.ocp:
       forecast = runOcpResource(resourceType, query);

--- a/src/pages/views/details/gcpDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/gcpDetails/detailsToolbar.tsx
@@ -1,6 +1,7 @@
 import { ToolbarChipGroup } from '@patternfly/react-core';
 import { GcpQuery, getQuery } from 'api/queries/gcpQuery';
 import { tagKey } from 'api/queries/query';
+import { ResourcePathsType } from 'api/resources/resource';
 import { Tag, TagPathsType, TagType } from 'api/tags/tag';
 import { DataToolbar } from 'pages/views/components/dataToolbar/dataToolbar';
 import React from 'react';
@@ -124,6 +125,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         onFilterRemoved={onFilterRemoved}
         pagination={pagination}
         query={query}
+        resourcePathsType={ResourcePathsType.gcp}
         selectedItems={selectedItems}
         showBulkSelect
         showExport

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -389,6 +389,9 @@ export const getResourcePathsType = (perspective: string) => {
     case PerspectiveType.azure:
       return ResourcePathsType.azure;
       break;
+    case PerspectiveType.gcp:
+      return ResourcePathsType.gcp;
+      break;
     case PerspectiveType.ocp:
       return ResourcePathsType.ocp;
       break;


### PR DESCRIPTION
Update the GCP details page and Cost Explorer to use new type-ahead features (i.e., account, region, services, & project) introduced via the `resource-types` API.

![chrome-capture (1)](https://user-images.githubusercontent.com/17481322/125339180-102fee00-e31f-11eb-8117-17549ec3476b.gif)
