### PR TITLE
IBM type-ahead support

### DIFF
--- a/src/api/resources/ibmResource.ts
+++ b/src/api/resources/ibmResource.ts
@@ -1,0 +1,22 @@
+import axios from 'axios';
+
+import { Resource, ResourceType } from './resource';
+
+export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
+  [ResourceType.account]: 'resource-types/gcp-accounts/',
+  [ResourceType.project]: 'resource-types/gcp-projects/',
+  [ResourceType.region]: 'resource-types/gcp-regions/',
+  [ResourceType.service]: 'resource-types/gcp-services/',
+};
+
+export function runResource(resourceType: ResourceType, query: string) {
+  const insights = (window as any).insights;
+  const path = ResourceTypePaths[resourceType];
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => {
+      return axios.get<Resource>(`${path}?${query}`);
+    });
+  } else {
+    return axios.get<Resource>(`${path}?${query}`);
+  }
+}

--- a/src/api/resources/resource.ts
+++ b/src/api/resources/resource.ts
@@ -38,5 +38,6 @@ export const enum ResourcePathsType {
   aws = 'aws',
   azure = 'azure',
   gcp = 'gcp',
+  ibm = 'ibm',
   ocp = 'ocp',
 }

--- a/src/api/resources/resourceUtils.ts
+++ b/src/api/resources/resourceUtils.ts
@@ -44,6 +44,7 @@ export function runResource(resourcePathsType: ResourcePathsType, resourceType: 
       break;
     case ResourcePathsType.gcp:
       forecast = runGcpResource(resourceType, query);
+      break;
     case ResourcePathsType.ibm:
       forecast = runIbmResource(resourceType, query);
       break;

--- a/src/api/resources/resourceUtils.ts
+++ b/src/api/resources/resourceUtils.ts
@@ -1,6 +1,7 @@
 import { runResource as runAwsResource } from './awsResource';
 import { runResource as runAzureResource } from './azureResource';
 import { runResource as runGcpResource } from './gcpResource';
+import { runResource as runIbmResource } from './ibmResource';
 import { runResource as runOcpResource } from './ocpResource';
 import { ResourcePathsType, ResourceType } from './resource';
 
@@ -12,6 +13,7 @@ export function isResourceTypeValid(resourcePathsType: ResourcePathsType, resour
     resourcePathsType === ResourcePathsType.aws ||
     resourcePathsType === ResourcePathsType.azure ||
     resourcePathsType === ResourcePathsType.gcp ||
+    resourcePathsType === ResourcePathsType.ibm ||
     resourcePathsType === ResourcePathsType.ocp
   ) {
     switch (resourceType) {
@@ -42,6 +44,8 @@ export function runResource(resourcePathsType: ResourcePathsType, resourceType: 
       break;
     case ResourcePathsType.gcp:
       forecast = runGcpResource(resourceType, query);
+    case ResourcePathsType.ibm:
+      forecast = runIbmResource(resourceType, query);
       break;
     case ResourcePathsType.ocp:
       forecast = runOcpResource(resourceType, query);

--- a/src/pages/views/details/ibmDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ibmDetails/detailsToolbar.tsx
@@ -1,6 +1,7 @@
 import { ToolbarChipGroup } from '@patternfly/react-core';
 import { getQuery, IbmQuery } from 'api/queries/ibmQuery';
 import { tagKey } from 'api/queries/query';
+import { ResourcePathsType } from 'api/resources/resource';
 import { Tag, TagPathsType, TagType } from 'api/tags/tag';
 import { DataToolbar } from 'pages/views/components/dataToolbar/dataToolbar';
 import React from 'react';
@@ -10,7 +11,6 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { isEqual } from 'utils/equal';
-import { ResourcePathsType } from 'api/resources/resource';
 
 interface DetailsToolbarOwnProps {
   isAllSelected?: boolean;

--- a/src/pages/views/details/ibmDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ibmDetails/detailsToolbar.tsx
@@ -10,6 +10,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { isEqual } from 'utils/equal';
+import { ResourcePathsType } from 'api/resources/resource';
 
 interface DetailsToolbarOwnProps {
   isAllSelected?: boolean;
@@ -124,6 +125,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         onFilterRemoved={onFilterRemoved}
         pagination={pagination}
         query={query}
+        resourcePathsType={ResourcePathsType.ibm}
         selectedItems={selectedItems}
         showBulkSelect
         showExport

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -391,6 +391,8 @@ export const getResourcePathsType = (perspective: string) => {
       break;
     case PerspectiveType.gcp:
       return ResourcePathsType.gcp;
+    case PerspectiveType.ibm:
+      return ResourcePathsType.ibm;
       break;
     case PerspectiveType.ocp:
     case PerspectiveType.ocpSupplementary:


### PR DESCRIPTION
Update the IBM details page and Cost Explorer to use new type-ahead features (i.e., account, region, services, & project) introduced via the `resource-types` API.

Implemented functionality using GCP APIs, for now.

![chrome-capture](https://user-images.githubusercontent.com/17481322/125345732-e67ac500-e326-11eb-87e8-75e9437ac9c8.gif)

