### PR TITLE
Add cluster_alias to OCP type-ahead

### DIFF
--- a/src/api/resources/resource.ts
+++ b/src/api/resources/resource.ts
@@ -1,5 +1,6 @@
 export interface ResourceData {
   account_alias: string;
+  cluster_alias: string;
   value?: string;
 }
 

--- a/src/pages/views/components/resourceTypeahead/resourceSelect.tsx
+++ b/src/pages/views/components/resourceTypeahead/resourceSelect.tsx
@@ -72,7 +72,7 @@ class ResourceSelectBase extends React.Component<ResourceSelectProps> {
     let options = [];
     if (resource && resource.data && resource.data.length > 0 && resourceFetchStatus !== FetchStatus.inProgress) {
       options = resource.data.map(item => {
-        const value = item.account_alias || item.value;
+        const value = item.account_alias || item.cluster_alias || item.value;
         return {
           key: value,
           name: value,


### PR DESCRIPTION
The `cluster_alias` property was recently added to the resources-types/openshift-clusters API. This allows users to search by cluster name Vs ID only.

https://issues.redhat.com/browse/COST-1655

![chrome-capture](https://user-images.githubusercontent.com/17481322/125352703-994f2100-e32f-11eb-8afa-a04aa0cb612d.gif)
