### PR TITLE
Rename Cost Explorer's "OpenShift usage" perspective label

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -460,7 +460,7 @@
       "ocp": "All OpenShift cost",
       "ocp_cloud": "All cloud filtered by OpenShift",
       "ocp_supplementary": "OpenShift supplementary cost",
-      "ocp_usage": "OpenShift usage"
+      "ocp_usage": "OpenShift infrastructure usage cost"
     },
     "title": {
       "aws": "Amazon Web Services - Top 5 Costliest",
@@ -472,7 +472,7 @@
       "ocp": "All OpenShift cost - Top 5 Costliest",
       "ocp_cloud": "All cloud filtered by OpenShift - Top 5 Costliest",
       "ocp_supplementary": "OpenShift supplementary cost - Top 5 Costliest",
-      "ocp_usage": "OpenShift usage - Top 5 Costliest"
+      "ocp_usage": "OpenShift infrastructure usage cost - Top 5 Costliest"
     }
   },
   "export": {


### PR DESCRIPTION
The Cost Explorer perspective option should be renamed as "OpenShift infrastructure usage cost".

Currently, the Cost Explorer shows "OpenShift usage" as a perspective option; however, this view is shown under the "Infrastructure" tab of the overview page.

https://issues.redhat.com/browse/COST-1660