### PR TITLE
Cost explorer should show infrastructure.usage values

### DIFF
--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -43,6 +43,7 @@ import {
   baseQuery,
   DateRangeType,
   getComputedReportItemType,
+  getComputedReportItemValueType,
   getDateRange,
   getDateRangeDefault,
   getGroupByDefault,
@@ -228,6 +229,7 @@ class Explorer extends React.Component<ExplorerProps> {
     return (
       <ExplorerTable
         computedReportItemType={getComputedReportItemType(perspective)}
+        computedReportItemValueType={getComputedReportItemValueType(perspective)}
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isAllSelected={isAllSelected}
         isLoading={reportFetchStatus === FetchStatus.inProgress}
@@ -479,6 +481,7 @@ class Explorer extends React.Component<ExplorerProps> {
             <div style={styles.chartContainer}>
               <ExplorerChart
                 computedReportItemType={getComputedReportItemType(perspective)}
+                computedReportItemValueType={getComputedReportItemValueType(perspective)}
                 perspective={perspective}
               />
             </div>

--- a/src/pages/views/explorer/explorerChart.tsx
+++ b/src/pages/views/explorer/explorerChart.tsx
@@ -2,7 +2,13 @@ import { Skeleton, Title } from '@patternfly/react-core';
 import { getQuery, parseQuery, Query } from 'api/queries/query';
 import { Report } from 'api/reports/report';
 import { AxiosError } from 'axios';
-import { ChartDatum, ComputedReportItemType, isFloat, isInt } from 'components/charts/common/chartDatumUtils';
+import {
+  ChartDatum,
+  ComputedReportItemType,
+  ComputedReportItemValueType,
+  isFloat,
+  isInt,
+} from 'components/charts/common/chartDatumUtils';
 import { CostExplorerChart } from 'components/charts/costExplorerChart';
 import { format, getDate, getMonth } from 'date-fns';
 import { getGroupByOrgValue, getGroupByTagKey } from 'pages/views/utils/groupBy';
@@ -30,6 +36,7 @@ import {
 
 interface ExplorerChartOwnProps extends RouteComponentProps<void>, WithTranslation {
   computedReportItemType?: ComputedReportItemType;
+  computedReportItemValueType?: ComputedReportItemValueType;
   perspective: PerspectiveType;
 }
 
@@ -114,10 +121,13 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
   };
 
   private getChartDatums = (computedItems: ComputedReportItem[]) => {
-    const { computedReportItemType = ComputedReportItemType.cost } = this.props;
+    const {
+      computedReportItemType = ComputedReportItemType.cost,
+      computedReportItemValueType = ComputedReportItemValueType.total,
+    } = this.props;
 
     const reportItem = computedReportItemType;
-    const reportItemValue = 'total';
+    const reportItemValue = computedReportItemValueType;
     const chartDatums = [];
 
     computedItems.map(computedItem => {

--- a/src/pages/views/explorer/explorerTable.tsx
+++ b/src/pages/views/explorer/explorerTable.tsx
@@ -6,7 +6,7 @@ import { nowrap, sortable, SortByDirection, Table, TableBody, TableHeader } from
 import { AwsQuery, getQuery } from 'api/queries/awsQuery';
 import { parseQuery, Query } from 'api/queries/query';
 import { AwsReport } from 'api/reports/awsReports';
-import { ComputedReportItemType } from 'components/charts/common/chartDatumUtils';
+import { ComputedReportItemType, ComputedReportItemValueType } from 'components/charts/common/chartDatumUtils';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import { format, getDate, getMonth } from 'date-fns';
 import { getGroupByOrgValue, getGroupByTagKey } from 'pages/views/utils/groupBy';
@@ -23,6 +23,7 @@ import { DateRangeType, getDateRange, getDateRangeDefault, PerspectiveType } fro
 
 interface ExplorerTableOwnProps {
   computedReportItemType?: ComputedReportItemType;
+  computedReportItemValueType?: ComputedReportItemValueType;
   groupBy: string;
   isAllSelected?: boolean;
   isLoading?: boolean;
@@ -85,6 +86,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
   private initDatum = () => {
     const {
       computedReportItemType = ComputedReportItemType.cost,
+      computedReportItemValueType = ComputedReportItemValueType.total,
       end_date,
       isAllSelected,
       perspective,
@@ -156,6 +158,9 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
       });
     }
 
+    const reportItem = computedReportItemType;
+    const reportItemValue = computedReportItemValueType;
+
     // Sort by date and fill in missing cells
     computedItems.map(rowItem => {
       const cells = [];
@@ -187,8 +192,8 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
         // Add row cells
         cells.push({
           title:
-            item[computedReportItemType] && item[computedReportItemType].total
-              ? formatCurrency(item[computedReportItemType].total.value)
+            item[reportItem] && item[reportItem][reportItemValue]
+              ? formatCurrency(item[reportItem][reportItemValue].value)
               : t('explorer.no_data'),
         });
       });

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -149,14 +149,6 @@ export const getComputedReportItemType = (perspective: string) => {
     case PerspectiveType.ocpUsage:
       result = ComputedReportItemType.infrastructure;
       break;
-    case PerspectiveType.aws:
-    case PerspectiveType.awsCloud:
-    case PerspectiveType.azure:
-    case PerspectiveType.azureCloud:
-    case PerspectiveType.gcp:
-    case PerspectiveType.ibm:
-    case PerspectiveType.ocp:
-    case PerspectiveType.ocpCloud:
     default:
       result = ComputedReportItemType.cost;
       break;
@@ -170,15 +162,6 @@ export const getComputedReportItemValueType = (perspective: string) => {
     case PerspectiveType.ocpUsage:
       result = ComputedReportItemValueType.usage;
       break;
-    case PerspectiveType.ocpSupplementary:
-    case PerspectiveType.aws:
-    case PerspectiveType.awsCloud:
-    case PerspectiveType.azure:
-    case PerspectiveType.azureCloud:
-    case PerspectiveType.gcp:
-    case PerspectiveType.ibm:
-    case PerspectiveType.ocp:
-    case PerspectiveType.ocpCloud:
     default:
       result = ComputedReportItemValueType.total;
       break;

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -5,7 +5,7 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import { ResourcePathsType } from 'api/resources/resource';
 import { TagPathsType } from 'api/tags/tag';
 import { UserAccess } from 'api/userAccess';
-import { ComputedReportItemType } from 'components/charts/common/chartDatumUtils';
+import { ComputedReportItemType, ComputedReportItemValueType } from 'components/charts/common/chartDatumUtils';
 import { format } from 'date-fns';
 import { FetchStatus } from 'store/common';
 import { ComputedAwsReportItemsParams } from 'utils/computedReport/getComputedAwsReportItems';
@@ -159,6 +159,28 @@ export const getComputedReportItemType = (perspective: string) => {
     case PerspectiveType.ocpCloud:
     default:
       result = ComputedReportItemType.cost;
+      break;
+  }
+  return result;
+};
+
+export const getComputedReportItemValueType = (perspective: string) => {
+  let result;
+  switch (perspective) {
+    case PerspectiveType.ocpUsage:
+      result = ComputedReportItemValueType.usage;
+      break;
+    case PerspectiveType.ocpSupplementary:
+    case PerspectiveType.aws:
+    case PerspectiveType.awsCloud:
+    case PerspectiveType.azure:
+    case PerspectiveType.azureCloud:
+    case PerspectiveType.gcp:
+    case PerspectiveType.ibm:
+    case PerspectiveType.ocp:
+    case PerspectiveType.ocpCloud:
+    default:
+      result = ComputedReportItemValueType.total;
       break;
   }
   return result;


### PR DESCRIPTION
The Cost Explorer's "OpenShift infrastructure usage cost" perspective option appears to be using `infrastructure.total` instead of `infrastructure.usage`.

<img width="1448" alt="Screen Shot 2021-07-13 at 5 12 49 PM" src="https://user-images.githubusercontent.com/17481322/125526668-172f8f16-6aac-4399-aabe-375e48ccca4a.png">

https://issues.redhat.com/browse/COST-1661