### PR TITLE
Forecast should include gap in the data

### DIFF
--- a/src/pages/views/overview/components/dashboardWidgetBase.tsx
+++ b/src/pages/views/overview/components/dashboardWidgetBase.tsx
@@ -297,55 +297,55 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
               newForecast.data.push(item);
             }
           }
-        }
 
-        // For cumulative data, forecast values should begin at last reported total with zero confidence values
-        if (type === ChartType.rolling) {
-          const date = newForecast.data[0].values[0].date;
-          newForecast.data.unshift({
-            date,
-            values: [
-              {
-                date,
-                cost: {
-                  confidence_max: {
-                    value: 0,
+          // For cumulative data, forecast values should begin at last reported total with zero confidence values
+          if (type === ChartType.rolling) {
+            const date = forecast.data[0].values[0].date;
+            newForecast.data.unshift({
+              date,
+              values: [
+                {
+                  date,
+                  cost: {
+                    confidence_max: {
+                      value: 0,
+                    },
+                    confidence_min: {
+                      value: 0,
+                    },
+                    total: {
+                      value: total,
+                      units: 'USD',
+                    },
                   },
-                  confidence_min: {
-                    value: 0,
+                  infrastructure: {
+                    confidence_max: {
+                      value: 0,
+                    },
+                    confidence_min: {
+                      value: 0,
+                    },
+                    total: {
+                      value: total,
+                      units: 'USD',
+                    },
                   },
-                  total: {
-                    value: total,
-                    units: 'USD',
+                  supplementary: {
+                    confidence_max: {
+                      value: 0,
+                    },
+                    confidence_min: {
+                      value: 0,
+                    },
+                    total: {
+                      value: total,
+                      units: 'USD',
+                    },
                   },
                 },
-                infrastructure: {
-                  confidence_max: {
-                    value: 0,
-                  },
-                  confidence_min: {
-                    value: 0,
-                  },
-                  total: {
-                    value: total,
-                    units: 'USD',
-                  },
-                },
-                supplementary: {
-                  confidence_max: {
-                    value: 0,
-                  },
-                  confidence_min: {
-                    value: 0,
-                  },
-                  total: {
-                    value: total,
-                    units: 'USD',
-                  },
-                },
-              },
-            ],
-          });
+              ],
+            });
+          }
         }
       }
       forecastData = transformForecast(newForecast, type, computedForecastItem);

--- a/src/pages/views/overview/components/dashboardWidgetBase.tsx
+++ b/src/pages/views/overview/components/dashboardWidgetBase.tsx
@@ -299,13 +299,14 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
           }
         }
 
-        // For cumulative data, show continuous line from current report to forecast
+        // For cumulative data, forecast values should begin at last reported total with zero confidence values
         if (type === ChartType.rolling) {
+          const date = newForecast.data[0].values[0].date;
           newForecast.data.unshift({
-            date: lastReported,
+            date,
             values: [
               {
-                date: lastReported,
+                date,
                 cost: {
                   confidence_max: {
                     value: 0,


### PR DESCRIPTION
Currently, we connect the cone of confidence with the last day of the current month. However, it's preferred to show the gap when data is missing.

https://issues.redhat.com/browse/COST-1468

<img width="1015" alt="poc" src="https://user-images.githubusercontent.com/17481322/125662355-eea01a57-5766-427f-8d02-1f9f08994954.png">
