### PR TITLE
"AWS filtered by OpenShift" type-ahead support

### DIFF
--- a/src/api/resources/awsCloudResource.ts
+++ b/src/api/resources/awsCloudResource.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+
+import { Resource, ResourceType } from './resource';
+
+export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
+  [ResourceType.account]: 'resource-types/aws-accounts/',
+  [ResourceType.region]: 'resource-types/aws-regions/',
+  [ResourceType.service]: 'resource-types/aws-services/',
+};
+
+export function runResource(resourceType: ResourceType, query: string) {
+  const insights = (window as any).insights;
+  const path = ResourceTypePaths[resourceType];
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => {
+      return axios.get<Resource>(`${path}?openshift=true&${query}`);
+    });
+  } else {
+    return axios.get<Resource>(`${path}?openshift=true&${query}`);
+  }
+}

--- a/src/api/resources/resource.ts
+++ b/src/api/resources/resource.ts
@@ -37,6 +37,7 @@ export const enum ResourceType {
 // eslint-disable-next-line no-shadow
 export const enum ResourcePathsType {
   aws = 'aws',
+  awsCloud = 'aws_cloud',
   azure = 'azure',
   gcp = 'gcp',
   ibm = 'ibm',

--- a/src/api/resources/resourceUtils.ts
+++ b/src/api/resources/resourceUtils.ts
@@ -1,3 +1,4 @@
+import { runResource as runAwsCloudResource } from './awsCloudResource';
 import { runResource as runAwsResource } from './awsResource';
 import { runResource as runAzureResource } from './azureResource';
 import { runResource as runGcpResource } from './gcpResource';
@@ -11,6 +12,7 @@ export function isResourceTypeValid(resourcePathsType: ResourcePathsType, resour
 
   if (
     resourcePathsType === ResourcePathsType.aws ||
+    resourcePathsType === ResourcePathsType.awsCloud ||
     resourcePathsType === ResourcePathsType.azure ||
     resourcePathsType === ResourcePathsType.gcp ||
     resourcePathsType === ResourcePathsType.ibm ||
@@ -38,6 +40,9 @@ export function runResource(resourcePathsType: ResourcePathsType, resourceType: 
   switch (resourcePathsType) {
     case ResourcePathsType.aws:
       forecast = runAwsResource(resourceType, query);
+      break;
+    case ResourcePathsType.awsCloud:
+      forecast = runAwsCloudResource(resourceType, query);
       break;
     case ResourcePathsType.azure:
       forecast = runAzureResource(resourceType, query);

--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -105,7 +105,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
     });
   }
 
-  public componentDidUpdate(prevProps: ExplorerHeaderProps, prevState: ExplorerHeaderState) {
+  public componentDidUpdate(prevProps: ExplorerHeaderProps) {
     const { perspective } = this.props;
 
     if (prevProps.perspective !== perspective) {

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -388,6 +388,9 @@ export const getResourcePathsType = (perspective: string) => {
     case PerspectiveType.aws:
       return ResourcePathsType.aws;
       break;
+    case PerspectiveType.awsCloud:
+      return ResourcePathsType.awsCloud;
+      break;
     case PerspectiveType.azure:
       return ResourcePathsType.azure;
       break;


### PR DESCRIPTION
Updated Cost Explorer's "AWS filtered by OpenShift" perspective to use new type-ahead features (i.e., account, region, services, & project) introduced via the `resource-types` API.

https://issues.redhat.com/browse/COST-1675

![chrome-capture](https://user-images.githubusercontent.com/17481322/125995054-bf20a277-c21a-4a40-ad04-ad2b60d9b2fb.gif)
