### PR TITLE
"Microsoft Azure filtered by OpenShift" type-ahead support

### DIFF
--- a/src/api/resources/azureCloudResource.ts
+++ b/src/api/resources/azureCloudResource.ts
@@ -1,0 +1,21 @@
+import axios from 'axios';
+
+import { Resource, ResourceType } from './resource';
+
+export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
+  [ResourceType.resourceLocation]: 'resource-types/azure-regions/',
+  [ResourceType.subscriptionGuid]: 'resource-types/azure-subscription-guids/',
+  [ResourceType.serviceName]: 'resource-types/azure-services/',
+};
+
+export function runResource(resourceType: ResourceType, query: string) {
+  const insights = (window as any).insights;
+  const path = ResourceTypePaths[resourceType];
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => {
+      return axios.get<Resource>(`${path}?openshift=true&${query}`);
+    });
+  } else {
+    return axios.get<Resource>(`${path}?openshift=true&${query}`);
+  }
+}

--- a/src/api/resources/resource.ts
+++ b/src/api/resources/resource.ts
@@ -39,6 +39,7 @@ export const enum ResourcePathsType {
   aws = 'aws',
   awsCloud = 'aws_cloud',
   azure = 'azure',
+  azureCloud = 'azure_cloud',
   gcp = 'gcp',
   ibm = 'ibm',
   ocp = 'ocp',

--- a/src/api/resources/resourceUtils.ts
+++ b/src/api/resources/resourceUtils.ts
@@ -1,5 +1,6 @@
 import { runResource as runAwsCloudResource } from './awsCloudResource';
 import { runResource as runAwsResource } from './awsResource';
+import { runResource as runAzureCloudResource } from './azureCloudResource';
 import { runResource as runAzureResource } from './azureResource';
 import { runResource as runGcpResource } from './gcpResource';
 import { runResource as runIbmResource } from './ibmResource';
@@ -14,6 +15,7 @@ export function isResourceTypeValid(resourcePathsType: ResourcePathsType, resour
     resourcePathsType === ResourcePathsType.aws ||
     resourcePathsType === ResourcePathsType.awsCloud ||
     resourcePathsType === ResourcePathsType.azure ||
+    resourcePathsType === ResourcePathsType.azureCloud ||
     resourcePathsType === ResourcePathsType.gcp ||
     resourcePathsType === ResourcePathsType.ibm ||
     resourcePathsType === ResourcePathsType.ocp
@@ -46,6 +48,9 @@ export function runResource(resourcePathsType: ResourcePathsType, resourceType: 
       break;
     case ResourcePathsType.azure:
       forecast = runAzureResource(resourceType, query);
+      break;
+    case ResourcePathsType.azureCloud:
+      forecast = runAzureCloudResource(resourceType, query);
       break;
     case ResourcePathsType.gcp:
       forecast = runGcpResource(resourceType, query);

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -394,6 +394,9 @@ export const getResourcePathsType = (perspective: string) => {
     case PerspectiveType.azure:
       return ResourcePathsType.azure;
       break;
+    case PerspectiveType.azureCloud:
+      return ResourcePathsType.azureCloud;
+      break;
     case PerspectiveType.gcp:
       return ResourcePathsType.gcp;
     case PerspectiveType.ibm:


### PR DESCRIPTION
Updated Cost Explorer's "Microsoft Azure filtered by OpenShift" perspective to use new type-ahead features (i.e., account, region, services, & project) introduced via the `resource-types` API.

https://issues.redhat.com/browse/COST-1676
