### PR TITLE
Remove insights.chrome.appNavClick

### DIFF
--- a/src/pages/views/overview/components/dashboardWidgetBase.tsx
+++ b/src/pages/views/overview/components/dashboardWidgetBase.tsx
@@ -493,7 +493,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
 
     if (details.viewAllPath) {
       return (
-        <Link to={this.buildDetailsLink(currentTab)} onClick={this.handleInsightsNavClick}>
+        <Link to={this.buildDetailsLink(currentTab)}>
           {this.getDetailsLinkTitle(currentTab)}
         </Link>
       );
@@ -682,16 +682,6 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
 
   private handleComparisonClick = (value: string) => {
     this.setState({ currentComparison: value });
-  };
-
-  private handleInsightsNavClick = () => {
-    const { details } = this.props;
-    if (details.appNavId) {
-      insights.chrome.appNavClick({
-        id: details.appNavId,
-        secondaryNav: true,
-      });
-    }
   };
 
   private handleTabClick = (event, tabIndex) => {

--- a/src/pages/views/overview/components/dashboardWidgetBase.tsx
+++ b/src/pages/views/overview/components/dashboardWidgetBase.tsx
@@ -492,11 +492,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     const { currentTab, details } = this.props;
 
     if (details.viewAllPath) {
-      return (
-        <Link to={this.buildDetailsLink(currentTab)}>
-          {this.getDetailsLinkTitle(currentTab)}
-        </Link>
-      );
+      return <Link to={this.buildDetailsLink(currentTab)}>{this.getDetailsLinkTitle(currentTab)}</Link>;
     }
     return null;
   };

--- a/src/store/costModels/actions.ts
+++ b/src/store/costModels/actions.ts
@@ -122,7 +122,6 @@ export const redirectToCostModelFromSourceUuid = (source_uuid: string, history: 
     return apiGetCostModels(`source_uuid=${source_uuid}`)
       .then(res => {
         const uuid = res.data.data[0].uuid;
-        insights.chrome.appNavClick({ id: 'cost-models', secondaryNav: null });
         history.push(`/cost-models/${uuid}`);
       })
       .catch(() => {

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -68,7 +68,6 @@ export const costSummaryWidget: AwsDashboardWidget = {
   reportType: ReportType.cost,
   details: {
     adjustContainerHeight: true,
-    appNavId: 'aws',
     costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -23,7 +23,6 @@ export const costSummaryWidget: AzureDashboardWidget = {
   reportType: ReportType.cost,
   details: {
     adjustContainerHeight: true,
-    appNavId: 'azure',
     costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,

--- a/src/store/dashboard/common/dashboardCommon.ts
+++ b/src/store/dashboard/common/dashboardCommon.ts
@@ -20,7 +20,6 @@ export interface DashboardWidget<T> {
   currentTab?: T;
   details: {
     adjustContainerHeight?: boolean; // Adjust chart container height for responsiveness
-    appNavId?: string; // Highlights Insights nav-item when view all link is clicked
     costKey?: string; // i18n key
     formatOptions: ValueFormatOptions;
     requestFormatOptions?: {

--- a/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
@@ -69,7 +69,6 @@ export const costSummaryWidget: GcpDashboardWidget = {
   reportType: ReportType.cost,
   details: {
     adjustContainerHeight: true,
-    appNavId: 'gcp',
     costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,

--- a/src/store/dashboard/ibmDashboard/ibmDashboardWidgets.ts
+++ b/src/store/dashboard/ibmDashboard/ibmDashboardWidgets.ts
@@ -69,7 +69,6 @@ export const costSummaryWidget: IbmDashboardWidget = {
   reportType: ReportType.cost,
   details: {
     adjustContainerHeight: true,
-    appNavId: 'ibm',
     costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -23,7 +23,6 @@ export const costSummaryWidget: OcpDashboardWidget = {
   reportType: ReportType.cost,
   details: {
     adjustContainerHeight: true,
-    appNavId: 'ocp',
     costKey: 'cost',
     formatOptions: {
       fractionDigits: 2,


### PR DESCRIPTION
The Insights team recently changed the Chrome navigation and calling `insights.chrome.appNavClick` is no longer necessary.

https://issues.redhat.com/browse/COST-1640