### PR TITLE
OCP filtered by OpenShift - Cost Explorer

### DIFF
--- a/src/api/tags/gcpOcpTags.test.ts
+++ b/src/api/tags/gcpOcpTags.test.ts
@@ -1,0 +1,12 @@
+jest.mock('axios');
+
+import axios from 'axios';
+
+import { runTag } from './gcpOcpTags';
+import { TagType } from './tag';
+
+test('api run reports calls axios get', () => {
+  const query = 'filter[resolution]=daily';
+  runTag(TagType.tag, query);
+  expect(axios.get).toBeCalledWith(`tags/gcp/?${query}`);
+});

--- a/src/api/tags/gcpOcpTags.ts
+++ b/src/api/tags/gcpOcpTags.ts
@@ -1,0 +1,14 @@
+import axios from 'axios';
+
+import { Tag, TagType } from './tag';
+
+export interface GcpOcpTag extends Tag {}
+
+export const TagTypePaths: Partial<Record<TagType, string>> = {
+  [TagType.tag]: 'tags/gcp/',
+};
+
+export function runTag(tagType: TagType, query: string) {
+  const path = TagTypePaths[tagType];
+  return axios.get<GcpOcpTag>(`${path}?${query}`);
+}

--- a/src/api/tags/tag.ts
+++ b/src/api/tags/tag.ts
@@ -42,6 +42,7 @@ export const enum TagPathsType {
   azure = 'azure',
   azureCloud = 'azure_cloud',
   gcp = 'gcp',
+  gcpOcp = 'gcp_ocp',
   ibm = 'gcp', // Todo: update to use ibm backend apis when they become available
   ocp = 'ocp',
   ocpCloud = 'ocp_cloud',

--- a/src/api/tags/tagUtils.ts
+++ b/src/api/tags/tagUtils.ts
@@ -2,6 +2,7 @@ import { runTag as runAwsCloudTag } from './awsCloudTags';
 import { runTag as runAwsTag } from './awsTags';
 import { runTag as runAzureCloudTag } from './azureCloudTags';
 import { runTag as runAzureTag } from './azureTags';
+import { runTag as runGcpOcpTag } from './gcpOcpTags';
 import { runTag as runGcpTag } from './gcpTags';
 import { runTag as runIbmTag } from './ibmTags';
 import { runTag as runOcpCloudTag } from './ocpCloudTags';
@@ -25,6 +26,9 @@ export function runTag(tagPathsType: TagPathsType, tagType: TagType, query: stri
       break;
     case TagPathsType.gcp:
       tagReport = runGcpTag(tagType, query);
+      break;
+    case TagPathsType.gcpOcp:
+      tagReport = runGcpOcpTag(tagType, query);
       break;
     case TagPathsType.ibm:
       tagReport = runIbmTag(tagType, query);

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -475,6 +475,7 @@
       "azure": "Microsoft Azure",
       "azure_cloud": "Microsoft Azure filtered by OpenShift",
       "gcp": "Google Cloud Platform",
+      "gcp_ocp": "Google Cloud Platform filtered by OpenShift",
       "ibm": "IBM Cloud",
       "ocp": "All OpenShift cost",
       "ocp_cloud": "All cloud filtered by OpenShift",

--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -39,6 +39,7 @@ import {
   infrastructureAwsOptions,
   infrastructureAzureCloudOptions,
   infrastructureAzureOptions,
+  infrastructureGcpOcpOptions,
   infrastructureGcpOptions,
   infrastructureIbmOptions,
   // infrastructureOcpCloudOptions, // Todo: Temp disabled -- see https://issues.redhat.com/browse/COST-1483
@@ -139,11 +140,14 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
     if (aws) {
       options.push(...infrastructureAwsOptions);
     }
-    if (ocp && aws) {
+    if (aws && ocp) {
       options.push(...infrastructureAwsCloudOptions);
     }
     if (gcp) {
       options.push(...infrastructureGcpOptions);
+    }
+    if (gcp && ocp) {
+      options.push(...infrastructureGcpOcpOptions);
     }
     if (ibm) {
       options.push(...infrastructureIbmOptions);
@@ -151,7 +155,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
     if (azure) {
       options.push(...infrastructureAzureOptions);
     }
-    if (ocp && azure) {
+    if (azure && ocp) {
       options.push(...infrastructureAzureCloudOptions);
     }
     if (ocp) {

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -32,6 +32,7 @@ export const enum PerspectiveType {
   azure = 'azure',
   azureCloud = 'azure_cloud', // Azure filtered by Ocp
   gcp = 'gcp',
+  gcpOcp = 'gcp_ocp', // Gcp filtered by Ocp
   ocp = 'ocp',
   ibm = 'ibm',
   ocpCloud = 'ocp_cloud', // All filtered by Ocp
@@ -110,17 +111,20 @@ export const groupByOcpOptions: {
 // Infrastructure AWS options
 export const infrastructureAwsOptions = [{ label: 'explorer.perspective.aws', value: 'aws' }];
 
-// Infrastructure AWS cloud options
+// Infrastructure AWS filtered by OpenShift options
 export const infrastructureAwsCloudOptions = [{ label: 'explorer.perspective.aws_cloud', value: 'aws_cloud' }];
 
 // Infrastructure Azure options
 export const infrastructureAzureOptions = [{ label: 'explorer.perspective.azure', value: 'azure' }];
 
-// Infrastructure Azure cloud options
+// Infrastructure Azure filtered by OpenShift options
 export const infrastructureAzureCloudOptions = [{ label: 'explorer.perspective.azure_cloud', value: 'azure_cloud' }];
 
 // Infrastructure GCP options
 export const infrastructureGcpOptions = [{ label: 'explorer.perspective.gcp', value: 'gcp' }];
+
+// Infrastructure GCP filtered by OpenShift options
+export const infrastructureGcpOcpOptions = [{ label: 'explorer.perspective.gcp_ocp', value: 'gcp_ocp' }];
 
 // Infrastructure IBM options
 export const infrastructureIbmOptions = [{ label: 'explorer.perspective.ibm', value: 'ibm' }];
@@ -250,6 +254,7 @@ export const getGroupByDefault = (perspective: string) => {
     case PerspectiveType.aws:
     case PerspectiveType.awsCloud:
     case PerspectiveType.gcp:
+    case PerspectiveType.gcpOcp:
     case PerspectiveType.ibm:
       result = 'account';
       break;
@@ -282,6 +287,7 @@ export const getGroupByOptions = (perspective: string) => {
       result = groupByAzureOptions;
       break;
     case PerspectiveType.gcp:
+    case PerspectiveType.gcpOcp:
       result = groupByGcpOptions;
       break;
     case PerspectiveType.ibm:
@@ -306,15 +312,6 @@ export const getOrgReportPathsType = (perspective: string) => {
     case PerspectiveType.aws:
       result = OrgPathsType.aws;
       break;
-    case PerspectiveType.awsCloud:
-    case PerspectiveType.azure:
-    case PerspectiveType.azureCloud:
-    case PerspectiveType.gcp:
-    case PerspectiveType.ibm:
-    case PerspectiveType.ocp:
-    case PerspectiveType.ocpCloud:
-    case PerspectiveType.ocpSupplementary:
-    case PerspectiveType.ocpUsage:
     default:
       result = undefined;
       break;
@@ -325,16 +322,6 @@ export const getOrgReportPathsType = (perspective: string) => {
 export const getReportType = (perspective: string) => {
   let result;
   switch (perspective) {
-    case PerspectiveType.aws:
-    case PerspectiveType.awsCloud:
-    case PerspectiveType.azure:
-    case PerspectiveType.azureCloud:
-    case PerspectiveType.gcp:
-    case PerspectiveType.ibm:
-    case PerspectiveType.ocp:
-    case PerspectiveType.ocpCloud:
-    case PerspectiveType.ocpSupplementary:
-    case PerspectiveType.ocpUsage:
     default:
       result = ReportType.cost;
       break;
@@ -359,6 +346,9 @@ export const getReportPathsType = (perspective: string) => {
       break;
     case PerspectiveType.gcp:
       result = ReportPathsType.gcp;
+      break;
+    case PerspectiveType.gcpOcp:
+      result = ReportPathsType.gcpOcp;
       break;
     case PerspectiveType.ibm:
       result = ReportPathsType.ibm;
@@ -399,6 +389,8 @@ export const getResourcePathsType = (perspective: string) => {
       break;
     case PerspectiveType.gcp:
       return ResourcePathsType.gcp;
+    case PerspectiveType.gcpOcp:
+      return ResourcePathsType.gcpOcp;
     case PerspectiveType.ibm:
       return ResourcePathsType.ibm;
       break;
@@ -431,6 +423,9 @@ export const getTagReportPathsType = (perspective: string) => {
       break;
     case PerspectiveType.gcp:
       return TagPathsType.gcp;
+      break;
+    case PerspectiveType.gcpOcp:
+      return TagPathsType.gcpOcp;
       break;
     case PerspectiveType.ibm:
       return TagPathsType.ibm;


### PR DESCRIPTION
This stubs-out the "GCP filtered by OpenShift" perspective for the Cost Explorer. Until new APIs are ready, we will use the existing GCP APIs.

https://issues.redhat.com/browse/COST-1703

<img width="1796" alt="Screen Shot 2021-07-21 at 4 27 08 PM" src="https://user-images.githubusercontent.com/17481322/126555924-05a4d944-29af-44b1-996f-a3f9fa7d38f4.png">
