### PR TITLE
API interfaces should extend PagedResponse

### DIFF
--- a/src/api/api.ts
+++ b/src/api/api.ts
@@ -12,8 +12,8 @@ export interface PagedLinks {
   last: string;
 }
 
-export interface PagedResponse<D = any> {
-  meta: PagedMetaData;
+export interface PagedResponse<D = any, M = any> {
+  meta: M;
   links: PagedLinks;
   data: D[];
 }

--- a/src/api/forecasts/forecast.ts
+++ b/src/api/forecasts/forecast.ts
@@ -1,3 +1,5 @@
+import { PagedMetaData, PagedResponse } from 'api/api';
+
 export interface ForecastValue {
   units?: string;
   value?: number | string;
@@ -23,22 +25,7 @@ export interface ForecastData {
   values?: ForecastItem[];
 }
 
-export interface ForecastMeta {
-  count: number;
-}
-
-export interface ForecastLinks {
-  first: string;
-  previous?: string;
-  next?: string;
-  last: string;
-}
-
-export interface Forecast {
-  meta: ForecastMeta;
-  links: ForecastLinks;
-  data: ForecastData[];
-}
+export interface Forecast extends PagedResponse<ForecastData, PagedMetaData> {}
 
 // eslint-disable-next-line no-shadow
 export const enum ForecastType {

--- a/src/api/orgs/org.ts
+++ b/src/api/orgs/org.ts
@@ -1,3 +1,5 @@
+import { PagedMetaData, PagedResponse } from 'api/api';
+
 export interface OrgData {
   accounts: string[];
   level?: number;
@@ -7,8 +9,7 @@ export interface OrgData {
   sub_orgs: string[];
 }
 
-export interface OrgMeta {
-  count: number;
+export interface OrgMeta extends PagedMetaData {
   key_only: boolean;
   group_by?: {
     [group: string]: string[];
@@ -21,18 +22,7 @@ export interface OrgMeta {
   };
 }
 
-export interface OrgLinks {
-  first: string;
-  previous?: string;
-  next?: string;
-  last: string;
-}
-
-export interface Org {
-  data: OrgData[];
-  links?: OrgLinks;
-  meta: OrgMeta;
-}
+export interface Org extends PagedResponse<OrgData, OrgMeta> {}
 
 // eslint-disable-next-line no-shadow
 export const enum OrgType {

--- a/src/api/providers.ts
+++ b/src/api/providers.ts
@@ -1,6 +1,6 @@
 import axios from 'axios';
 
-import { PagedLinks, PagedMetaData } from './api';
+import { PagedMetaData, PagedResponse } from './api';
 
 export interface ProviderAuthentication {
   uuid?: string;
@@ -46,11 +46,7 @@ export interface Provider {
   uuid?: string;
 }
 
-export interface Providers {
-  meta: PagedMetaData;
-  links?: PagedLinks;
-  data: Provider[];
-}
+export interface Providers extends PagedResponse<Provider, PagedMetaData> {}
 
 // eslint-disable-next-line no-shadow
 export const enum ProviderType {

--- a/src/api/reports/report.ts
+++ b/src/api/reports/report.ts
@@ -1,3 +1,5 @@
+import { PagedMetaData, PagedResponse } from 'api/api';
+
 export interface ReportValue {
   units?: string;
   value?: number;
@@ -68,7 +70,7 @@ export interface ReportData extends ReportOrgData {
   values?: ReportAwsItem[] | ReportAzureItem[] | ReportGcpItem[] | ReportOcpItem[] | ReportOrgItem[];
 }
 
-export interface ReportMeta {
+export interface ReportMeta extends PagedMetaData {
   count: number;
   delta?: {
     percent: number;
@@ -96,18 +98,7 @@ export interface ReportMeta {
   };
 }
 
-export interface ReportLinks {
-  first: string;
-  previous?: string;
-  next?: string;
-  last: string;
-}
-
-export interface Report {
-  data: ReportData[];
-  links?: ReportLinks;
-  meta: ReportMeta;
-}
+export interface Report extends PagedResponse<ReportData, ReportMeta> {}
 
 // eslint-disable-next-line no-shadow
 export const enum ReportType {

--- a/src/api/resources/resource.ts
+++ b/src/api/resources/resource.ts
@@ -1,25 +1,12 @@
+import { PagedMetaData, PagedResponse } from 'api/api';
+
 export interface ResourceData {
   account_alias: string;
   cluster_alias: string;
   value?: string;
 }
 
-export interface ResourceMeta {
-  count: number;
-}
-
-export interface ResourceLinks {
-  first: string;
-  previous?: string;
-  next?: string;
-  last: string;
-}
-
-export interface Resource {
-  meta: ResourceMeta;
-  links: ResourceLinks;
-  data: ResourceData[];
-}
+export interface Resource extends PagedResponse<ResourceData, PagedMetaData> {}
 
 // eslint-disable-next-line no-shadow
 export const enum ResourceType {

--- a/src/api/tags/tag.ts
+++ b/src/api/tags/tag.ts
@@ -1,11 +1,12 @@
+import { PagedMetaData, PagedResponse } from 'api/api';
+
 export interface TagData {
   enabled?: boolean;
   key?: string;
   values?: string[];
 }
 
-export interface TagMeta {
-  count: number;
+export interface TagMeta extends PagedMetaData {
   group_by?: {
     [group: string]: string[];
   };
@@ -17,18 +18,7 @@ export interface TagMeta {
   };
 }
 
-export interface TagLinks {
-  first: string;
-  previous?: string;
-  next?: string;
-  last: string;
-}
-
-export interface Tag {
-  data: TagData[];
-  links?: TagLinks;
-  meta: TagMeta;
-}
+export interface Tag extends PagedResponse<TagData, TagMeta> {}
 
 // eslint-disable-next-line no-shadow
 export const enum TagType {


### PR DESCRIPTION
The `Report` interface currently defines its own types for `ReportData`, `ReportLinks`, and `ReportMeta`. However, `api.ts` also defines similar interfaces for `PagedLinks`, `PagedMetaData`, and `PagedResponse`.

With a slight modification, the `Report` interface could extend `PagedResponse`. Thus, eliminating the need for the `ReportLinks` interface.

There are similar interfaces for tags, resources, forecasts, etc.

https://issues.redhat.com/browse/COST-1708