### PR TITLE
Hide "GCP filtered by OpenShift" perspective

### DIFF
--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -39,7 +39,7 @@ import {
   infrastructureAwsOptions,
   infrastructureAzureOcpOptions,
   infrastructureAzureOptions,
-  infrastructureGcpOcpOptions,
+  // infrastructureGcpOcpOptions, // Todo: Temp disabled -- see https://issues.redhat.com/browse/COST-1705
   infrastructureGcpOptions,
   infrastructureIbmOptions,
   // infrastructureOcpCloudOptions, // Todo: Temp disabled -- see https://issues.redhat.com/browse/COST-1483
@@ -146,9 +146,11 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
     if (gcp) {
       options.push(...infrastructureGcpOptions);
     }
-    if (gcp && ocp) {
-      options.push(...infrastructureGcpOcpOptions);
-    }
+    // Todo: Temp disabled -- see https://issues.redhat.com/browse/COST-1705
+    //
+    // if (gcp && ocp) {
+    //   options.push(...infrastructureGcpOcpOptions);
+    // }
     if (ibm) {
       options.push(...infrastructureIbmOptions);
     }

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -141,7 +141,10 @@ const infrastructureAzureOcpOptions = [{ label: 'overview.perspective.azure_ocp'
 const infrastructureGcpOptions = [{ label: 'overview.perspective.gcp', value: 'gcp' }];
 
 // Infrastructure GCP filtered by OCP options
-const infrastructureGcpOcpOptions = [{ label: 'overview.perspective.gcp_ocp', value: 'gcp_ocp' }];
+//
+// Todo: Temp disabled -- see https://issues.redhat.com/browse/COST-1705
+//
+// const infrastructureGcpOcpOptions = [{ label: 'overview.perspective.gcp_ocp', value: 'gcp_ocp' }];
 
 // Infrastructure IBM options
 const infrastructureIbmOptions = [{ label: 'overview.perspective.ibm', value: 'ibm' }];
@@ -293,9 +296,11 @@ class OverviewBase extends React.Component<OverviewProps> {
       if (gcp) {
         options.push(...infrastructureGcpOptions);
       }
-      if (gcp && ocp) {
-        options.push(...infrastructureGcpOcpOptions);
-      }
+      // Todo: Temp disabled -- see https://issues.redhat.com/browse/COST-1705
+      //
+      // if (gcp && ocp) {
+      //   options.push(...infrastructureGcpOcpOptions);
+      // }
       if (ibm) {
         options.push(...infrastructureIbmOptions);
       }


### PR DESCRIPTION
Temporarily hide the "GCP filtered by OpenShift" perspective from the overview and Cost Explorer, until new APIs are ready. This will ensure the new feature is not accidentally pushed to production.

https://issues.redhat.com/browse/COST-1705