### PR TITLE
webpack config should use useCloud=false

### DIFF
--- a/scripts/start-dev-server.js
+++ b/scripts/start-dev-server.js
@@ -6,13 +6,13 @@ const { spawn } = require('child_process');
 async function setEnv() {
   return inquirer
     .prompt([
-      { type: 'list', name: 'uiEnv', message: 'Which UI environment you want to use?', choices: ['beta', 'stable'] },
       {
         type: 'list',
         name: 'clouddotEnv',
         message: 'Which platform environment you want to use',
-        choices: ['ci', 'qa', 'stage', 'prod'],
+        choices: ['stage', 'prod', 'ci'],
       },
+      { type: 'list', name: 'uiEnv', message: 'Which UI environment you want to use?', choices: ['beta', 'stable'] },
       {
         name: 'insightsProxy',
         message: 'Do you want to use the Insights proxy?',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -242,7 +242,7 @@ module.exports = (_env, argv) => {
         appUrl: [`/${isBeta ? 'beta/' : ''}openshift/cost-management`],
         proxyVerbose: true,
         publicPath,
-        useCloud: true,
+        useCloud: false,
       }),
       // Props for webpack-dev-server v4.0.0-beta.2
       //


### PR DESCRIPTION
We want to change webpackk.config.js to `useCloud: false`, since `cloud.stage.readhat.com` is going away.

Also changed the startup script to default to using the `stage` env.

https://issues.redhat.com/browse/COST-1726