### PR TITLE
Move overview card title dates

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -349,8 +349,6 @@
   },
   "dashboard": {
     "cumulative_cost_comparison": "Cumulative cost comparison ({{units}})",
-    "date_title": "$t(months.{{month}}) {{startDate}}",
-    "date_title_plural": "$t(months.{{month}}) {{startDate}}-{{endDate}}",
     "daily_usage_comparison": "Daily usage comparison ({{units}})",
     "database_title": "Database services cost",
     "network_title": "Network services cost",
@@ -907,8 +905,8 @@
   "rate": "Rate",
   "save": "Save",
   "settings": "Settings",
-  "since_date": "{{startDate}} $t(months.{{month}})",
-  "since_date_plural": "{{startDate}}-{{endDate}} $t(months.{{month}})",
+  "since_date": "$t(months.{{month}}) {{startDate}}",
+  "since_date_plural": "$t(months.{{month}}) {{startDate}}-{{endDate}}",
   "sources": "Sources",
   "source_details": {
     "filter": {

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -349,14 +349,14 @@
   },
   "dashboard": {
     "cumulative_cost_comparison": "Cumulative cost comparison ({{units}})",
+    "date_title": "$t(months.{{month}}) {{startDate}}",
+    "date_title_plural": "$t(months.{{month}}) {{startDate}}-{{endDate}}",
     "daily_usage_comparison": "Daily usage comparison ({{units}})",
     "database_title": "Database services cost",
     "network_title": "Network services cost",
     "storage_title": "Storage services usage",
     "total_cost_tooltip": "This total cost is the sum of the infrastructure cost {{infrastructureCost}} and supplementary cost {{supplementaryCost}}",
-    "usage": "Usage",
-    "widget_subtitle": "{{startDate}} $t(months.{{month}})",
-    "widget_subtitle_plural": "{{startDate}}-{{endDate}} $t(months.{{month}})"
+    "usage": "Usage"
   },
   "description": "Description",
   "details": {

--- a/src/pages/views/overview/components/__snapshots__/dashboardWidget.test.tsx.snap
+++ b/src/pages/views/overview/components/__snapshots__/dashboardWidget.test.tsx.snap
@@ -1,28 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`subtitle is translated with date range 1`] = `
-Array [
-  "dashboard.widget_subtitle",
-  Object {
-    "count": 2,
-    "endDate": "formated date",
-    "month": 1,
-    "startDate": "formated date",
-  },
-]
-`;
+exports[`subtitle is translated with date range 1`] = `undefined`;
 
-exports[`subtitle is translated with single date 1`] = `
-Array [
-  "dashboard.widget_subtitle",
-  Object {
-    "count": 1,
-    "endDate": "formated date",
-    "month": 1,
-    "startDate": "formated date",
-  },
-]
-`;
+exports[`subtitle is translated with single date 1`] = `undefined`;
 
 exports[`title is translated 1`] = `
 Array [

--- a/src/pages/views/overview/components/dashboardWidgetBase.tsx
+++ b/src/pages/views/overview/components/dashboardWidgetBase.tsx
@@ -21,7 +21,7 @@ import {
   ReportSummaryTrend,
   ReportSummaryUsage,
 } from 'components/reports/reportSummary';
-import { format, getDate, getMonth, startOfMonth } from 'date-fns';
+import { format, getMonth, startOfMonth } from 'date-fns';
 import { cloneDeep } from 'lodash';
 import React from 'react';
 import { WithTranslation } from 'react-i18next';
@@ -516,7 +516,6 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
       <ReportSummaryAlt
         detailsLink={this.getDetailsLink()}
         status={currentReportFetchStatus}
-        subTitle={this.getSubTitle()}
         tabs={this.getTabs()}
         title={this.getTitle()}
       >
@@ -524,22 +523,6 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         {this.getChart(containerAltHeight, chartAltHeight, details.adjustContainerHeight)}
       </ReportSummaryAlt>
     );
-  };
-
-  private getSubTitle = () => {
-    const { t } = this.props;
-
-    const today = new Date();
-    const month = getMonth(today);
-    const endDate = format(today, 'd');
-    const startDate = format(startOfMonth(today), 'd');
-
-    return t('dashboard.widget_subtitle', {
-      count: getDate(today),
-      endDate,
-      month,
-      startDate,
-    });
   };
 
   private getTab = <T extends DashboardWidget<any>>(tab: T, index: number) => {
@@ -663,12 +646,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     const { availableTabs, currentReportFetchStatus, details } = this.props;
 
     return (
-      <ReportSummary
-        detailsLink={this.getDetailsLink()}
-        status={currentReportFetchStatus}
-        subTitle={this.getSubTitle()}
-        title={this.getTitle()}
-      >
+      <ReportSummary detailsLink={this.getDetailsLink()} status={currentReportFetchStatus} title={this.getTitle()}>
         {this.getDetails()}
         {this.getChart(chartStyles.containerTrendHeight, chartStyles.chartHeight, details.adjustContainerHeight)}
         {Boolean(availableTabs) && <div style={styles.tabs}>{this.getTabs()}</div>}

--- a/src/pages/views/overview/overview.styles.ts
+++ b/src/pages/views/overview/overview.styles.ts
@@ -3,6 +3,11 @@ import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg'
 import React from 'react';
 
 export const styles = {
+  date: {
+    alignSelf: 'center',
+    flexGrow: 1,
+    textAlign: 'end',
+  },
   infoIcon: {
     fontSize: global_FontSize_md.value,
   },
@@ -10,6 +15,7 @@ export const styles = {
     fontWeight: 'bold',
   },
   perspective: {
+    display: 'flex',
     marginTop: global_spacer_lg.value,
   },
   tabs: {

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -7,7 +7,6 @@ import { getProvidersQuery } from 'api/queries/providersQuery';
 import { getUserAccessQuery } from 'api/queries/userAccessQuery';
 import { UserAccess, UserAccessType } from 'api/userAccess';
 import { AxiosError } from 'axios';
-import { format, getDate, getMonth, startOfMonth } from 'date-fns';
 import Loading from 'pages/state/loading';
 import NoData from 'pages/state/noData/noData';
 import NoProviders from 'pages/state/noProviders';
@@ -39,6 +38,7 @@ import {
   providersSelectors,
 } from 'store/providers';
 import { allUserAccessQuery, ibmUserAccessQuery, userAccessSelectors } from 'store/userAccess';
+import { getSinceDateRangeString } from 'utils/dateRange';
 import { isAwsAvailable, isAzureAvailable, isGcpAvailable, isIbmAvailable, isOcpAvailable } from 'utils/userAccess';
 
 import { styles } from './overview.styles';
@@ -235,22 +235,6 @@ class OverviewBase extends React.Component<OverviewProps> {
     } else {
       return activeTabKey === 0 ? OverviewTab.ocp : OverviewTab.infrastructure;
     }
-  };
-
-  private getDateTitle = () => {
-    const { t } = this.props;
-
-    const today = new Date();
-    const month = getMonth(today);
-    const endDate = format(today, 'd');
-    const startDate = format(startOfMonth(today), 'd');
-
-    return t('dashboard.date_title', {
-      count: getDate(today),
-      endDate,
-      month,
-      startDate,
-    });
   };
 
   private getDefaultInfrastructurePerspective = () => {
@@ -577,7 +561,7 @@ class OverviewBase extends React.Component<OverviewProps> {
           <div style={styles.tabs}>{this.getTabs(availableTabs)}</div>
           <div style={styles.perspective}>
             {this.getPerspective()}
-            <div style={styles.date}>{this.getDateTitle()}</div>
+            <div style={styles.date}>{getSinceDateRangeString()}</div>
           </div>
         </section>
         <section className="pf-l-page__main-section pf-c-page__main-section" page-type="cost-management-overview">

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -7,6 +7,7 @@ import { getProvidersQuery } from 'api/queries/providersQuery';
 import { getUserAccessQuery } from 'api/queries/userAccessQuery';
 import { UserAccess, UserAccessType } from 'api/userAccess';
 import { AxiosError } from 'axios';
+import { format, getDate, getMonth, startOfMonth } from 'date-fns';
 import Loading from 'pages/state/loading';
 import NoData from 'pages/state/noData/noData';
 import NoProviders from 'pages/state/noProviders';
@@ -234,6 +235,22 @@ class OverviewBase extends React.Component<OverviewProps> {
     } else {
       return activeTabKey === 0 ? OverviewTab.ocp : OverviewTab.infrastructure;
     }
+  };
+
+  private getDateTitle = () => {
+    const { t } = this.props;
+
+    const today = new Date();
+    const month = getMonth(today);
+    const endDate = format(today, 'd');
+    const startDate = format(startOfMonth(today), 'd');
+
+    return t('dashboard.date_title', {
+      count: getDate(today),
+      endDate,
+      month,
+      startDate,
+    });
   };
 
   private getDefaultInfrastructurePerspective = () => {
@@ -558,7 +575,10 @@ class OverviewBase extends React.Component<OverviewProps> {
             </Title>
           </header>
           <div style={styles.tabs}>{this.getTabs(availableTabs)}</div>
-          <div style={styles.perspective}>{this.getPerspective()}</div>
+          <div style={styles.perspective}>
+            {this.getPerspective()}
+            <div style={styles.date}>{this.getDateTitle()}</div>
+          </div>
         </section>
         <section className="pf-l-page__main-section pf-c-page__main-section" page-type="cost-management-overview">
           {this.getTabContent(availableTabs)}


### PR DESCRIPTION
Move dates from card subtitles to overview page heading.

https://issues.redhat.com/browse/COST-1721

**After:**

<img width="1366" alt="Screen Shot 2021-07-27 at 5 40 39 PM" src="https://user-images.githubusercontent.com/17481322/127231247-8e902f44-c777-439d-a263-c8885e15c768.png">


**Before:**

<img width="1366" alt="old" src="https://user-images.githubusercontent.com/17481322/127231039-8eaa2ca7-3a4a-4e24-9637-dabdd5798cd3.png">
