### PR TITLE
Move date in details page heading to its own line

### DIFF
--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -907,8 +907,8 @@
   "rate": "Rate",
   "save": "Save",
   "settings": "Settings",
-  "since_date": "{{startDate}} $t(months.{{month}})",
-  "since_date_plural": "{{startDate}}-{{endDate}} $t(months.{{month}})",
+  "since_date": "$t(months.{{month}}) {{startDate}}",
+  "since_date_plural": "$t(months.{{month}}) {{startDate}}-{{endDate}}",
   "sources": "Sources",
   "source_details": {
     "filter": {

--- a/src/pages/views/details/awsDetails/detailsHeader.styles.ts
+++ b/src/pages/views/details/awsDetails/detailsHeader.styles.ts
@@ -1,30 +1,21 @@
 import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
 import global_Color_100 from '@patternfly/react-tokens/dist/js/global_Color_100';
-import global_Color_200 from '@patternfly/react-tokens/dist/js/global_Color_200';
 import global_FontSize_sm from '@patternfly/react-tokens/dist/js/global_FontSize_sm';
 import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
-import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
 import global_spacer_sm from '@patternfly/react-tokens/dist/js/global_spacer_sm';
 import React from 'react';
 
 export const styles = {
-  cost: {
-    display: 'flex',
-    alignItems: 'center',
-  },
-  costLabel: {},
   costValue: {
     marginTop: 0,
     marginBottom: 0,
-    marginRight: global_spacer_md.var,
   },
   costLabelUnit: {
     fontSize: global_FontSize_sm.value,
     color: global_Color_100.var,
   },
-  costLabelDate: {
-    fontSize: global_FontSize_sm.value,
-    color: global_Color_200.var,
+  dateTitle: {
+    textAlign: 'end',
   },
   header: {
     display: 'flex',

--- a/src/pages/views/details/awsDetails/detailsHeader.tsx
+++ b/src/pages/views/details/awsDetails/detailsHeader.tsx
@@ -81,14 +81,11 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           />
         </div>
         {Boolean(showContent) && (
-          <div style={styles.cost}>
+          <div>
             <Title headingLevel="h2" style={styles.costValue} size="4xl">
               {formatCurrency(hasCost ? report.meta.total.cost.total.value : 0)}
             </Title>
-            <div style={styles.costLabel}>
-              <div style={styles.costLabelUnit}>{t('details.total_cost')}</div>
-              <div style={styles.costLabelDate}>{getSinceDateRangeString()}</div>
-            </div>
+            <div style={styles.dateTitle}>{getSinceDateRangeString()}</div>
           </div>
         )}
       </header>

--- a/src/pages/views/details/azureDetails/detailsHeader.styles.ts
+++ b/src/pages/views/details/azureDetails/detailsHeader.styles.ts
@@ -1,30 +1,21 @@
 import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
 import global_Color_100 from '@patternfly/react-tokens/dist/js/global_Color_100';
-import global_Color_200 from '@patternfly/react-tokens/dist/js/global_Color_200';
 import global_FontSize_sm from '@patternfly/react-tokens/dist/js/global_FontSize_sm';
 import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
-import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
 import global_spacer_sm from '@patternfly/react-tokens/dist/js/global_spacer_sm';
 import React from 'react';
 
 export const styles = {
-  cost: {
-    display: 'flex',
-    alignItems: 'center',
-  },
-  costLabel: {},
   costValue: {
     marginTop: 0,
     marginBottom: 0,
-    marginRight: global_spacer_md.var,
   },
   costLabelUnit: {
     fontSize: global_FontSize_sm.value,
     color: global_Color_100.var,
   },
-  costLabelDate: {
-    fontSize: global_FontSize_sm.value,
-    color: global_Color_200.var,
+  dateTitle: {
+    textAlign: 'end',
   },
   header: {
     display: 'flex',

--- a/src/pages/views/details/azureDetails/detailsHeader.tsx
+++ b/src/pages/views/details/azureDetails/detailsHeader.tsx
@@ -77,14 +77,11 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           />
         </div>
         {Boolean(showContent) && (
-          <div style={styles.cost}>
+          <div>
             <Title headingLevel="h2" style={styles.costValue} size="4xl">
               {formatCurrency(hasCost ? report.meta.total.cost.total.value : 0)}
             </Title>
-            <div style={styles.costLabel}>
-              <div style={styles.costLabelUnit}>{t('details.total_cost')}</div>
-              <div style={styles.costLabelDate}>{getSinceDateRangeString()}</div>
-            </div>
+            <div style={styles.dateTitle}>{getSinceDateRangeString()}</div>
           </div>
         )}
       </header>

--- a/src/pages/views/details/components/breakdown/breakdownHeader.styles.ts
+++ b/src/pages/views/details/components/breakdown/breakdownHeader.styles.ts
@@ -1,7 +1,5 @@
 import global_BackgroundColor_100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_100';
-import global_Color_200 from '@patternfly/react-tokens/dist/js/global_Color_200';
 import global_disabled_color_100 from '@patternfly/react-tokens/dist/js/global_disabled_color_100';
-import global_FontSize_sm from '@patternfly/react-tokens/dist/js/global_FontSize_sm';
 import global_FontSize_xs from '@patternfly/react-tokens/dist/js/global_FontSize_xs';
 import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
 import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
@@ -22,8 +20,6 @@ export const styles = {
     textAlign: 'right',
   },
   costLabelDate: {
-    fontSize: global_FontSize_sm.value,
-    color: global_Color_200.var,
     textAlign: 'right',
   },
   header: {

--- a/src/pages/views/details/components/columnManagement/columnManagementModal.tsx
+++ b/src/pages/views/details/components/columnManagement/columnManagementModal.tsx
@@ -8,6 +8,7 @@ import {
   DataListItemCells,
   DataListItemRow,
   Modal,
+  ModalVariant,
   Text,
   TextContent,
   TextVariants,
@@ -18,6 +19,7 @@ import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 
 export interface ColumnManagementModalOption {
+  description?: string;
   hidden?: boolean;
   label: string;
   value: string;
@@ -133,7 +135,7 @@ export class ColumnManagementModalBase extends React.Component<ColumnManagementM
         isOpen={this.props.isOpen}
         onClose={this.handleClose}
         title={t('details.column_management.title')}
-        variant="small"
+        variant={ModalVariant.medium}
         actions={[
           <Button key="save" onClick={this.handleSave} variant={ButtonVariant.link}>
             {t('details.column_management.save')}
@@ -158,6 +160,9 @@ export class ColumnManagementModalBase extends React.Component<ColumnManagementM
                   dataListCells={[
                     <DataListCell id="table-column-management-item1" key="table-column-management-item1">
                       <label htmlFor="check1">{t(option.label)}</label>
+                    </DataListCell>,
+                    <DataListCell id="table-column-management-item2" key="table-column-management-item2">
+                      {option.description && <span>{t(option.description)}</span>}
                     </DataListCell>,
                   ]}
                 />

--- a/src/pages/views/details/gcpDetails/detailsHeader.styles.ts
+++ b/src/pages/views/details/gcpDetails/detailsHeader.styles.ts
@@ -1,30 +1,21 @@
 import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
 import global_Color_100 from '@patternfly/react-tokens/dist/js/global_Color_100';
-import global_Color_200 from '@patternfly/react-tokens/dist/js/global_Color_200';
 import global_FontSize_sm from '@patternfly/react-tokens/dist/js/global_FontSize_sm';
 import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
-import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
 import global_spacer_sm from '@patternfly/react-tokens/dist/js/global_spacer_sm';
 import React from 'react';
 
 export const styles = {
-  cost: {
-    display: 'flex',
-    alignItems: 'center',
-  },
-  costLabel: {},
   costValue: {
     marginTop: 0,
     marginBottom: 0,
-    marginRight: global_spacer_md.var,
   },
   costLabelUnit: {
     fontSize: global_FontSize_sm.value,
     color: global_Color_100.var,
   },
-  costLabelDate: {
-    fontSize: global_FontSize_sm.value,
-    color: global_Color_200.var,
+  dateTitle: {
+    textAlign: 'end',
   },
   header: {
     display: 'flex',

--- a/src/pages/views/details/gcpDetails/detailsHeader.tsx
+++ b/src/pages/views/details/gcpDetails/detailsHeader.tsx
@@ -78,14 +78,11 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           />
         </div>
         {Boolean(showContent) && (
-          <div style={styles.cost}>
+          <div>
             <Title headingLevel="h2" style={styles.costValue} size="4xl">
               {formatCurrency(hasCost ? report.meta.total.cost.total.value : 0)}
             </Title>
-            <div style={styles.costLabel}>
-              <div style={styles.costLabelUnit}>{t('details.total_cost')}</div>
-              <div style={styles.costLabelDate}>{getSinceDateRangeString()}</div>
-            </div>
+            <div style={styles.dateTitle}>{getSinceDateRangeString()}</div>
           </div>
         )}
       </header>

--- a/src/pages/views/details/ibmDetails/detailsHeader.styles.ts
+++ b/src/pages/views/details/ibmDetails/detailsHeader.styles.ts
@@ -1,30 +1,21 @@
 import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
 import global_Color_100 from '@patternfly/react-tokens/dist/js/global_Color_100';
-import global_Color_200 from '@patternfly/react-tokens/dist/js/global_Color_200';
 import global_FontSize_sm from '@patternfly/react-tokens/dist/js/global_FontSize_sm';
 import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
-import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
 import global_spacer_sm from '@patternfly/react-tokens/dist/js/global_spacer_sm';
 import React from 'react';
 
 export const styles = {
-  cost: {
-    display: 'flex',
-    alignItems: 'center',
-  },
-  costLabel: {},
   costValue: {
     marginTop: 0,
     marginBottom: 0,
-    marginRight: global_spacer_md.var,
   },
   costLabelUnit: {
     fontSize: global_FontSize_sm.value,
     color: global_Color_100.var,
   },
-  costLabelDate: {
-    fontSize: global_FontSize_sm.value,
-    color: global_Color_200.var,
+  dateTitle: {
+    textAlign: 'end',
   },
   header: {
     display: 'flex',

--- a/src/pages/views/details/ibmDetails/detailsHeader.tsx
+++ b/src/pages/views/details/ibmDetails/detailsHeader.tsx
@@ -78,14 +78,11 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           />
         </div>
         {Boolean(showContent) && (
-          <div style={styles.cost}>
+          <div>
             <Title headingLevel="h2" style={styles.costValue} size="4xl">
               {formatCurrency(hasCost ? report.meta.total.cost.total.value : 0)}
             </Title>
-            <div style={styles.costLabel}>
-              <div style={styles.costLabelUnit}>{t('details.total_cost')}</div>
-              <div style={styles.costLabelDate}>{getSinceDateRangeString()}</div>
-            </div>
+            <div style={styles.dateTitle}>{getSinceDateRangeString()}</div>
           </div>
         )}
       </header>

--- a/src/pages/views/details/ocpDetails/detailsHeader.styles.ts
+++ b/src/pages/views/details/ocpDetails/detailsHeader.styles.ts
@@ -1,31 +1,22 @@
 import global_BackgroundColor_light_100 from '@patternfly/react-tokens/dist/js/global_BackgroundColor_light_100';
 import global_Color_100 from '@patternfly/react-tokens/dist/js/global_Color_100';
-import global_Color_200 from '@patternfly/react-tokens/dist/js/global_Color_200';
 import global_FontSize_md from '@patternfly/react-tokens/dist/js/global_FontSize_md';
 import global_FontSize_sm from '@patternfly/react-tokens/dist/js/global_FontSize_sm';
 import global_spacer_lg from '@patternfly/react-tokens/dist/js/global_spacer_lg';
-import global_spacer_md from '@patternfly/react-tokens/dist/js/global_spacer_md';
 import global_spacer_sm from '@patternfly/react-tokens/dist/js/global_spacer_sm';
 import React from 'react';
 
 export const styles = {
-  cost: {
-    display: 'flex',
-    alignItems: 'center',
-  },
-  costLabel: {},
   costValue: {
     marginTop: 0,
     marginBottom: 0,
-    marginRight: global_spacer_md.var,
   },
   costLabelUnit: {
     fontSize: global_FontSize_sm.value,
     color: global_Color_100.var,
   },
-  costLabelDate: {
-    fontSize: global_FontSize_sm.value,
-    color: global_Color_200.var,
+  dateTitle: {
+    textAlign: 'end',
   },
   header: {
     display: 'flex',

--- a/src/pages/views/details/ocpDetails/detailsHeader.tsx
+++ b/src/pages/views/details/ocpDetails/detailsHeader.tsx
@@ -1,5 +1,4 @@
-import { Button, ButtonVariant, Popover, Title, Tooltip } from '@patternfly/react-core';
-import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
+import { Title, Tooltip } from '@patternfly/react-core';
 import { Providers, ProviderType } from 'api/providers';
 import { getQuery, OcpQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
@@ -103,7 +102,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           />
         </div>
         {Boolean(showContent) && (
-          <div style={styles.cost}>
+          <div>
             <Title headingLevel="h2" style={styles.costValue} size="4xl">
               <Tooltip
                 content={t('dashboard.total_cost_tooltip', {
@@ -115,31 +114,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
                 <span>{cost}</span>
               </Tooltip>
             </Title>
-            <div style={styles.costLabel}>
-              <div style={styles.costLabelUnit}>
-                {t('cost')}
-                <span style={styles.infoIcon}>
-                  <Popover
-                    aria-label={t('ocp_details.supplementary_aria_label')}
-                    enableFlip
-                    bodyContent={
-                      <>
-                        <p style={styles.infoTitle}>{t('ocp_details.supplementary_cost')}</p>
-                        <p>{t('ocp_details.supplementary_cost_desc')}</p>
-                        <br />
-                        <p style={styles.infoTitle}>{t('ocp_details.infrastructure_cost')}</p>
-                        <p>{t('ocp_details.infrastructure_cost_desc')}</p>
-                      </>
-                    }
-                  >
-                    <Button variant={ButtonVariant.plain}>
-                      <OutlinedQuestionCircleIcon style={styles.info} />
-                    </Button>
-                  </Popover>
-                </span>
-              </div>
-              <div style={styles.costLabelDate}>{getSinceDateRangeString()}</div>
-            </div>
+            <div style={styles.dateTitle}>{getSinceDateRangeString()}</div>
           </div>
         )}
       </header>

--- a/src/pages/views/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/views/details/ocpDetails/ocpDetails.tsx
@@ -83,8 +83,18 @@ const baseQuery: OcpQuery = {
 
 const defaultColumnOptions: ColumnManagementModalOption[] = [
   { label: 'details.month_over_month_change', value: DetailsTableColumnIds.monthOverMonth },
-  { label: 'ocp_details.infrastructure_cost', value: DetailsTableColumnIds.infrastructure, hidden: true },
-  { label: 'ocp_details.supplementary_cost', value: DetailsTableColumnIds.supplementary, hidden: true },
+  {
+    description: 'ocp_details.infrastructure_cost_desc',
+    label: 'ocp_details.infrastructure_cost',
+    value: DetailsTableColumnIds.infrastructure,
+    hidden: true,
+  },
+  {
+    description: 'ocp_details.supplementary_cost_desc',
+    label: 'ocp_details.supplementary_cost',
+    value: DetailsTableColumnIds.supplementary,
+    hidden: true,
+  },
 ];
 
 const reportType = ReportType.cost;


### PR DESCRIPTION
Move date in details page heading to its own line and increase font size to 16px.
Add infrastructure and supplementary descriptions to column management dialog.

**Ocp details:**

<img width="1367" alt="Screen Shot 2021-07-27 at 6 32 24 PM" src="https://user-images.githubusercontent.com/17481322/127236497-212fd4ad-ac55-4d54-a33f-6727aa37af5d.png">


**Column management:**

<img width="886" alt="Screen Shot 2021-07-27 at 6 32 33 PM" src="https://user-images.githubusercontent.com/17481322/127236516-d16ba335-79ff-482f-bbf8-276edfb02666.png">
