### PR TITLE
Page titles should use h1 tags

### DIFF
--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -9,7 +9,7 @@ import {
   createContainer,
   getInteractiveLegendEvents,
 } from '@patternfly/react-charts';
-import { Title } from '@patternfly/react-core';
+import { Title, TitleSizes } from '@patternfly/react-core';
 import { default as ChartTheme } from 'components/charts/chartTheme';
 import { getCostRangeString } from 'components/charts/common/chartDatumUtils';
 import { getDateRange } from 'components/charts/common/chartDatumUtils';
@@ -311,7 +311,7 @@ class HistoricalCostChart extends React.Component<HistoricalCostChartProps, Stat
 
     return (
       <div className="chartOverride" ref={this.containerRef}>
-        <Title headingLevel="h2" style={styles.title} size="xl">
+        <Title headingLevel="h2" style={styles.title} size={TitleSizes.xl}>
           {title}
         </Title>
         <div style={{ ...styles.chart, height: adjustedContainerHeight }}>

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -9,7 +9,7 @@ import {
   createContainer,
   getInteractiveLegendEvents,
 } from '@patternfly/react-charts';
-import { Title } from '@patternfly/react-core';
+import { Title, TitleSizes } from '@patternfly/react-core';
 import { default as ChartTheme } from 'components/charts/chartTheme';
 import { getCostRangeString, getDateRange } from 'components/charts/common/chartDatumUtils';
 import {
@@ -252,7 +252,7 @@ class HistoricalTrendChart extends React.Component<HistoricalTrendChartProps, St
 
     return (
       <div className="chartOverride" ref={this.containerRef}>
-        <Title headingLevel="h2" style={styles.title} size="xl">
+        <Title headingLevel="h2" style={styles.title} size={TitleSizes.xl}>
           {title}
         </Title>
         <div style={{ ...styles.chart, height: containerHeight }}>

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -9,7 +9,7 @@ import {
   createContainer,
   getInteractiveLegendEvents,
 } from '@patternfly/react-charts';
-import { Title } from '@patternfly/react-core';
+import { Title, TitleSizes } from '@patternfly/react-core';
 import { default as ChartTheme } from 'components/charts/chartTheme';
 import { getDateRange } from 'components/charts/common/chartDatumUtils';
 import { getUsageRangeString } from 'components/charts/common/chartDatumUtils';
@@ -358,7 +358,7 @@ class HistoricalUsageChart extends React.Component<HistoricalUsageChartProps, St
 
     return (
       <div className="chartOverride" ref={this.containerRef}>
-        <Title headingLevel="h2" style={styles.title} size="xl">
+        <Title headingLevel="h2" style={styles.title} size={TitleSizes.xl}>
           {title}
         </Title>
         <div style={{ ...styles.chart, height: adjustedContainerHeight }}>

--- a/src/components/reports/reportSummary/reportSummary.tsx
+++ b/src/components/reports/reportSummary/reportSummary.tsx
@@ -1,6 +1,6 @@
 import './reportSummary.scss';
 
-import { Card, CardBody, CardFooter, CardTitle, Skeleton, Title } from '@patternfly/react-core';
+import { Card, CardBody, CardFooter, CardTitle, Skeleton, Title, TitleSizes } from '@patternfly/react-core';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { FetchStatus } from 'store/common';
@@ -17,7 +17,7 @@ interface ReportSummaryProps extends WithTranslation {
 const ReportSummaryBase: React.SFC<ReportSummaryProps> = ({ children, detailsLink, title, subTitle, status }) => (
   <Card className="reportSummary">
     <CardTitle>
-      <Title headingLevel="h2" size="lg">
+      <Title headingLevel="h2" size={TitleSizes.lg}>
         {title}
       </Title>
       {Boolean(subTitle) && <p className="subtitle">{subTitle}</p>}

--- a/src/components/reports/reportSummary/reportSummaryAlt.tsx
+++ b/src/components/reports/reportSummary/reportSummaryAlt.tsx
@@ -1,6 +1,16 @@
 import './reportSummaryAlt.scss';
 
-import { Card, CardBody, CardFooter, CardTitle, Grid, GridItem, Skeleton, Title, TitleSizes } from '@patternfly/react-core';
+import {
+  Card,
+  CardBody,
+  CardFooter,
+  CardTitle,
+  Grid,
+  GridItem,
+  Skeleton,
+  Title,
+  TitleSizes,
+} from '@patternfly/react-core';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { FetchStatus } from 'store/common';

--- a/src/components/reports/reportSummary/reportSummaryAlt.tsx
+++ b/src/components/reports/reportSummary/reportSummaryAlt.tsx
@@ -1,6 +1,6 @@
 import './reportSummaryAlt.scss';
 
-import { Card, CardBody, CardFooter, CardTitle, Grid, GridItem, Skeleton, Title } from '@patternfly/react-core';
+import { Card, CardBody, CardFooter, CardTitle, Grid, GridItem, Skeleton, Title, TitleSizes } from '@patternfly/react-core';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { FetchStatus } from 'store/common';
@@ -28,7 +28,7 @@ const OcpCloudReportSummaryAltBase: React.SFC<OcpCloudReportSummaryAltProps> = (
       <GridItem xl={8}>
         <div className="cost">
           <CardTitle>
-            <Title headingLevel="h2" size="lg">
+            <Title headingLevel="h2" size={TitleSizes.lg}>
               {title}
             </Title>
             {Boolean(subTitle) && <p className="subtitle">{subTitle}</p>}

--- a/src/components/state/emptyFilterState/emptyFilterState.tsx
+++ b/src/components/state/emptyFilterState/emptyFilterState.tsx
@@ -1,4 +1,4 @@
-import { EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
+import { EmptyState, EmptyStateBody, EmptyStateIcon, Title, TitleSizes } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons/dist/js/icons/search-icon';
 import { OcpCloudQuery, parseQuery } from 'api/queries/ocpCloudQuery';
 import React from 'react';
@@ -86,7 +86,7 @@ const EmptyFilterStateBase: React.SFC<EmptyFilterStateProps> = ({
     >
       <EmptyState>
         {getIcon()}
-        <Title headingLevel="h2" size="lg">
+        <Title headingLevel="h2" size={TitleSizes.lg}>
           {title}
         </Title>
         <EmptyStateBody>{subTitle}</EmptyStateBody>

--- a/src/pages/costModels/components/addPriceList.tsx
+++ b/src/pages/costModels/components/addPriceList.tsx
@@ -9,6 +9,7 @@ import {
   TextContent,
   TextVariants,
   Title,
+  TitleSizes,
 } from '@patternfly/react-core';
 import { MetricHash } from 'api/metrics';
 import {
@@ -35,7 +36,7 @@ const AddPriceList: React.FunctionComponent<AddPriceListProps> = ({ submitRate, 
   return (
     <Stack hasGutter>
       <StackItem>
-        <Title headingLevel="h2" size="xl">
+        <Title headingLevel="h2" size={TitleSizes.xl}>
           {t('cost_models_wizard.price_list.title')}
         </Title>
       </StackItem>

--- a/src/pages/costModels/components/errorState.tsx
+++ b/src/pages/costModels/components/errorState.tsx
@@ -8,6 +8,7 @@ import {
   Stack,
   StackItem,
   Title,
+  TitleSizes,
 } from '@patternfly/react-core';
 import { ExclamationCircleIcon } from '@patternfly/react-icons/dist/js/icons/exclamation-circle-icon';
 import global_DangerColor_100 from '@patternfly/react-tokens/dist/js/global_danger_color_100';
@@ -60,7 +61,7 @@ export const SourceStepErrorState: React.FunctionComponent<SourcesErrorStateProp
   return (
     <Stack hasGutter>
       <StackItem>
-        <Title headingLevel="h2" size="xl">
+        <Title headingLevel="h2" size={TitleSizes.xl}>
           {t('cost_models_wizard.source.title')}
         </Title>
       </StackItem>

--- a/src/pages/costModels/costModel/distribution.tsx
+++ b/src/pages/costModels/costModel/distribution.tsx
@@ -9,6 +9,7 @@ import {
   DropdownPosition,
   KebabToggle,
   Title,
+  TitleSizes,
 } from '@patternfly/react-core';
 import { CostModel } from 'api/costModels';
 import { ReadOnlyTooltip } from 'pages/costModels/components/readOnlyTooltip';
@@ -45,7 +46,7 @@ const DistributionCardBase: React.FunctionComponent<Props> = ({
       <Card style={styles.card}>
         <CardHeader>
           <CardHeaderMain>
-            <Title headingLevel="h2" size="md">
+            <Title headingLevel="h2" size={TitleSizes.md}>
               {t('cost_models_details.distribution_type')}
             </Title>
           </CardHeaderMain>

--- a/src/pages/costModels/costModel/header.tsx
+++ b/src/pages/costModels/costModel/header.tsx
@@ -12,6 +12,7 @@ import {
   Tabs,
   TabTitleText,
   Title,
+  TitleSizes,
 } from '@patternfly/react-core';
 import { CostModel } from 'api/costModels';
 import * as H from 'history';
@@ -107,15 +108,15 @@ const Header: React.FunctionComponent<Props> = ({
         </Breadcrumb>
         <Split>
           <SplitItem style={styles.headerDescription}>
-            <Title headingLevel="h2" style={styles.title} size="2xl">
+            <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
               {current.name}
             </Title>
             {current.description && (
-              <Title headingLevel="h2" style={styles.title} size="md">
+              <Title headingLevel="h2" style={styles.title} size={TitleSizes.md}>
                 {current.description}
               </Title>
             )}
-            <Title headingLevel="h2" style={styles.sourceTypeTitle} size="md">
+            <Title headingLevel="h2" style={styles.sourceTypeTitle} size={TitleSizes.md}>
               {t('cost_models_details.cost_model.source_type')}: {current.source_type}
             </Title>
           </SplitItem>

--- a/src/pages/costModels/costModel/index.tsx
+++ b/src/pages/costModels/costModel/index.tsx
@@ -1,4 +1,13 @@
-import { EmptyState, EmptyStateBody, EmptyStateIcon, Grid, GridItem, TabContent, Title } from '@patternfly/react-core';
+import {
+  EmptyState,
+  EmptyStateBody,
+  EmptyStateIcon,
+  Grid,
+  GridItem,
+  TabContent,
+  Title,
+  TitleSizes,
+} from '@patternfly/react-core';
 import { ErrorCircleOIcon } from '@patternfly/react-icons/dist/js/icons/error-circle-o-icon';
 import Main from '@redhat-cloud-services/frontend-components/Main';
 import PageHeader, { PageHeaderTitle } from '@redhat-cloud-services/frontend-components/PageHeader';
@@ -83,7 +92,7 @@ class CostModelInformation extends React.Component<Props, State> {
                     <Main>
                       <EmptyState>
                         <EmptyStateIcon icon={ErrorCircleOIcon} />
-                        <Title headingLevel="h2" size="lg">
+                        <Title headingLevel="h2" size={TitleSizes.lg}>
                           {t('cost_models_details.empty_state_bad_uuid.title')}
                         </Title>
                         <EmptyStateBody>

--- a/src/pages/costModels/costModel/markup.tsx
+++ b/src/pages/costModels/costModel/markup.tsx
@@ -9,6 +9,7 @@ import {
   DropdownPosition,
   KebabToggle,
   Title,
+  TitleSizes,
 } from '@patternfly/react-core';
 import { CostModel } from 'api/costModels';
 import { ReadOnlyTooltip } from 'pages/costModels/components/readOnlyTooltip';
@@ -51,7 +52,7 @@ const MarkupCardBase: React.FunctionComponent<Props> = ({
       <Card style={styles.card}>
         <CardHeader>
           <CardHeaderMain>
-            <Title headingLevel="h2" size="md">
+            <Title headingLevel="h2" size={TitleSizes.md}>
               {t('cost_models_details.markup_or_discount')}
             </Title>
           </CardHeaderMain>

--- a/src/pages/costModels/costModel/priceListTable.tsx
+++ b/src/pages/costModels/costModel/priceListTable.tsx
@@ -8,6 +8,7 @@ import {
   ListItem,
   Pagination,
   Title,
+  TitleSizes,
   Toolbar,
   ToolbarContent,
   ToolbarItem,
@@ -237,7 +238,7 @@ class PriceListTable extends React.Component<Props, State> {
                     <Bullseye>
                       <EmptyState>
                         <EmptyStateIcon icon={FileInvoiceDollarIcon} />
-                        <Title headingLevel="h2" size="lg">
+                        <Title headingLevel="h2" size={TitleSizes.lg}>
                           {t('cost_models_details.empty_state_rate.title')}
                         </Title>
                         <EmptyStateBody>{t('cost_models_details.empty_state_rate.description')}</EmptyStateBody>

--- a/src/pages/costModels/costModel/table.tsx
+++ b/src/pages/costModels/costModel/table.tsx
@@ -1,4 +1,4 @@
-import { EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
+import { EmptyState, EmptyStateBody, EmptyStateIcon, Title, TitleSizes } from '@patternfly/react-core';
 import { DollarSignIcon } from '@patternfly/react-icons/dist/js/icons/dollar-sign-icon';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import { addMultiValueQuery, removeMultiValueQuery } from 'pages/costModels/components/filterLogic';
@@ -120,7 +120,7 @@ class TableBase extends React.Component<Props, State> {
           <div style={styles.emptyState}>
             <EmptyState>
               <EmptyStateIcon icon={DollarSignIcon} />
-              <Title headingLevel="h2" size="lg">
+              <Title headingLevel="h2" size={TitleSizes.lg}>
                 {t('cost_models_details.empty_state_source.title')}
               </Title>
               <EmptyStateBody>{t('cost_models_details.empty_state_source.description')}</EmptyStateBody>

--- a/src/pages/costModels/costModel/updateMarkupDialog.tsx
+++ b/src/pages/costModels/costModel/updateMarkupDialog.tsx
@@ -138,7 +138,7 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
           </StackItem>
           <StackItem>
             <TextContent>
-              <Title headingLevel="h6" size="md">
+              <Title headingLevel="h2" size="md">
                 {t('cost_models_details.markup_or_discount')}
               </Title>
             </TextContent>
@@ -189,7 +189,7 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
           <StackItem />
           <StackItem>
             <TextContent>
-              <Title headingLevel="h6" size="md">
+              <Title headingLevel="h3" size="md">
                 {t('cost_models_details.examples.title')}
               </Title>
             </TextContent>

--- a/src/pages/costModels/costModelsDetails/emptyStateBase.tsx
+++ b/src/pages/costModels/costModelsDetails/emptyStateBase.tsx
@@ -1,4 +1,4 @@
-import { EmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
+import { EmptyState, EmptyStateBody, EmptyStateIcon, Title, TitleSizes } from '@patternfly/react-core';
 import React from 'react';
 
 interface EmptyStateBaseProps {
@@ -12,7 +12,7 @@ function EmptyStateBase(props: EmptyStateBaseProps): JSX.Element {
   return (
     <EmptyState className="pf-m-redhat-font">
       <EmptyStateIcon icon={props.icon} />
-      <Title headingLevel="h2" size="lg">
+      <Title headingLevel="h2" size={TitleSizes.lg}>
         {props.title}
       </Title>
       <EmptyStateBody>{props.description}</EmptyStateBody>

--- a/src/pages/costModels/costModelsDetails/header.tsx
+++ b/src/pages/costModels/costModelsDetails/header.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonVariant, Popover, TextContent, Title } from '@patternfly/react-core';
+import { Button, ButtonVariant, Popover, TextContent, Title, TitleSizes } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
 import React from 'react';
 import { Trans, WithTranslation, withTranslation } from 'react-i18next';
@@ -12,7 +12,7 @@ interface HeaderProps {
 function HeaderBase({ children }: HeaderProps): JSX.Element {
   return (
     <TextContent>
-      <Title headingLevel="h1" size="2xl">
+      <Title headingLevel="h1" size={TitleSizes['2xl']}>
         {children}
       </Title>
     </TextContent>

--- a/src/pages/costModels/createCostModelWizard/generalInformation.tsx
+++ b/src/pages/costModels/createCostModelWizard/generalInformation.tsx
@@ -7,6 +7,7 @@ import {
   TextArea,
   TextInput,
   Title,
+  TitleSizes,
 } from '@patternfly/react-core';
 import { Form } from 'components/forms/form';
 import React from 'react';
@@ -22,7 +23,7 @@ const GeneralInformation: React.SFC<WithTranslation> = ({ t }) => {
       {({ name, dirtyName, description, type, onNameChange, onDescChange, onTypeChange }) => (
         <Stack hasGutter>
           <StackItem>
-            <Title headingLevel="h2" size="xl">
+            <Title headingLevel="h2" size={TitleSizes.xl}>
               {t('cost_models_wizard.general_info.title')}
             </Title>
           </StackItem>

--- a/src/pages/costModels/createCostModelWizard/markup.tsx
+++ b/src/pages/costModels/createCostModelWizard/markup.tsx
@@ -14,6 +14,7 @@ import {
   TextInput,
   TextVariants,
   Title,
+  TitleSizes,
 } from '@patternfly/react-core';
 import { Form } from 'components/forms/form';
 import React from 'react';
@@ -42,7 +43,7 @@ class MarkupWithDistribution extends React.Component<WithTranslation> {
           return (
             <Stack hasGutter>
               <StackItem>
-                <Title headingLevel="h2" size="xl">
+                <Title headingLevel="h2" size={TitleSizes.xl}>
                   {t('cost_calculations')}
                 </Title>
               </StackItem>

--- a/src/pages/costModels/createCostModelWizard/priceListTable.tsx
+++ b/src/pages/costModels/createCostModelWizard/priceListTable.tsx
@@ -11,6 +11,7 @@ import {
   TextContent,
   TextVariants,
   Title,
+  TitleSizes,
 } from '@patternfly/react-core';
 import { PlusCircleIcon } from '@patternfly/react-icons/dist/js/icons/plus-circle-icon';
 import { MetricHash } from 'api/metrics';
@@ -40,7 +41,7 @@ const NoTiersEmptyState = ({ t }) => (
   <Bullseye>
     <EmptyState>
       <EmptyStateIcon icon={PlusCircleIcon} />
-      <Title headingLevel="h2" size="lg">
+      <Title headingLevel="h2" size={TitleSizes.lg}>
         {t('cost_models_wizard.empty_state.title')}
       </Title>
       <EmptyStateBody>
@@ -83,7 +84,7 @@ class PriceListTable extends React.Component<Props, State> {
           return (
             <Stack hasGutter>
               <StackItem>
-                <Title headingLevel="h2" size="xl">
+                <Title headingLevel="h2" size={TitleSizes.xl}>
                   {t('cost_models_wizard.price_list.title')}
                 </Title>
               </StackItem>

--- a/src/pages/costModels/createCostModelWizard/review.tsx
+++ b/src/pages/costModels/createCostModelWizard/review.tsx
@@ -15,6 +15,7 @@ import {
   TextListVariants,
   TextVariants,
   Title,
+  TitleSizes,
 } from '@patternfly/react-core';
 import { OkIcon } from '@patternfly/react-icons/dist/js/icons/ok-icon';
 import { RateTable } from 'pages/costModels/components/rateTable';
@@ -29,7 +30,7 @@ const ReviewSuccessBase: React.SFC<WithTranslation> = ({ t }) => (
     {({ onClose, name }) => (
       <EmptyState>
         <EmptyStateIcon icon={OkIcon} color="green" />
-        <Title headingLevel="h2" size="lg">
+        <Title headingLevel="h2" size={TitleSizes.lg}>
           {t('cost_models_wizard.review.title_success')}
         </Title>
         <EmptyStateBody>
@@ -57,7 +58,7 @@ const ReviewDetailsBase: React.SFC<WithTranslation> = ({ t }) => (
           {createError && <Alert variant="danger" title={`${createError}`} />}
           <Stack hasGutter>
             <StackItem>
-              <Title headingLevel="h2" size="xl">
+              <Title headingLevel="h2" size={TitleSizes.xl}>
                 {t('cost_models_wizard.review.title_details')}
               </Title>
             </StackItem>

--- a/src/pages/costModels/createCostModelWizard/table.tsx
+++ b/src/pages/costModels/createCostModelWizard/table.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Stack, StackItem, Text, TextContent, TextVariants, Title } from '@patternfly/react-core';
+import { Checkbox, Stack, StackItem, Text, TextContent, TextVariants, Title, TitleSizes } from '@patternfly/react-core';
 import { Table, TableBody, TableHeader } from '@patternfly/react-table';
 import { LoadingState } from 'components/state/loadingState/loadingState';
 import { addMultiValueQuery, removeMultiValueQuery } from 'pages/costModels/components/filterLogic';
@@ -18,7 +18,7 @@ const SourcesTable: React.SFC<WithTranslation> = ({ t }) => {
         return (
           <Stack hasGutter>
             <StackItem>
-              <Title headingLevel="h2" size="xl">
+              <Title headingLevel="h2" size={TitleSizes.xl}>
                 {t(`cost_models_wizard.source.title`)}
               </Title>
             </StackItem>

--- a/src/pages/views/details/awsDetails/detailsHeader.tsx
+++ b/src/pages/views/details/awsDetails/detailsHeader.tsx
@@ -1,4 +1,4 @@
-import { Title } from '@patternfly/react-core';
+import { Title, TitleSizes } from '@patternfly/react-core';
 import { OrgPathsType } from 'api/orgs/org';
 import { Providers, ProviderType } from 'api/providers';
 import { AwsQuery, getQuery } from 'api/queries/awsQuery';
@@ -65,7 +65,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     return (
       <header style={styles.header}>
         <div>
-          <Title headingLevel="h2" style={styles.title} size="2xl">
+          <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
             {t('navigation.aws_details')}
           </Title>
           <GroupBy
@@ -82,7 +82,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
         </div>
         {Boolean(showContent) && (
           <div>
-            <Title headingLevel="h2" style={styles.costValue} size="4xl">
+            <Title headingLevel="h2" style={styles.costValue} size={TitleSizes['4xl']}>
               {formatCurrency(hasCost ? report.meta.total.cost.total.value : 0)}
             </Title>
             <div style={styles.dateTitle}>{getSinceDateRangeString()}</div>

--- a/src/pages/views/details/azureDetails/detailsHeader.tsx
+++ b/src/pages/views/details/azureDetails/detailsHeader.tsx
@@ -1,4 +1,4 @@
-import { Title } from '@patternfly/react-core';
+import { Title, TitleSizes } from '@patternfly/react-core';
 import { Providers, ProviderType } from 'api/providers';
 import { AzureQuery, getQuery } from 'api/queries/azureQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
@@ -63,7 +63,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     return (
       <header style={styles.header}>
         <div>
-          <Title headingLevel="h2" style={styles.title} size="2xl">
+          <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
             {t('navigation.azure_details')}
           </Title>
           <GroupBy
@@ -78,7 +78,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
         </div>
         {Boolean(showContent) && (
           <div>
-            <Title headingLevel="h2" style={styles.costValue} size="4xl">
+            <Title headingLevel="h2" style={styles.costValue} size={TitleSizes['4xl']}>
               {formatCurrency(hasCost ? report.meta.total.cost.total.value : 0)}
             </Title>
             <div style={styles.dateTitle}>{getSinceDateRangeString()}</div>

--- a/src/pages/views/details/components/breakdown/breakdownHeader.tsx
+++ b/src/pages/views/details/components/breakdown/breakdownHeader.tsx
@@ -1,6 +1,6 @@
 import './breakdownHeader.scss';
 
-import { Title } from '@patternfly/react-core';
+import { Title, TitleSizes } from '@patternfly/react-core';
 import { AngleLeftIcon } from '@patternfly/react-icons/dist/js/icons/angle-left-icon';
 import { breakdownDescKey, breakdownTitleKey, getQueryRoute, orgUnitIdKey, Query } from 'api/queries/query';
 import { Report } from 'api/reports/report';
@@ -99,7 +99,7 @@ class BreakdownHeaderBase extends React.Component<BreakdownHeaderProps> {
               </li>
             </ol>
           </nav>
-          <Title headingLevel="h2" style={styles.title} size="2xl">
+          <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
             {t('breakdown.title', { value: title })}
             {description && <div style={styles.infoDescription}>{description}</div>}
           </Title>
@@ -112,7 +112,7 @@ class BreakdownHeaderBase extends React.Component<BreakdownHeaderProps> {
         </div>
         <div style={styles.cost}>
           <div style={styles.costLabel}>
-            <Title headingLevel="h2" style={styles.costValue} size="4xl">
+            <Title headingLevel="h2" style={styles.costValue} size={TitleSizes['4xl']}>
               <span>{this.getTotalCost()}</span>
             </Title>
           </div>

--- a/src/pages/views/details/components/costOverview/costOverviewBase.tsx
+++ b/src/pages/views/details/components/costOverview/costOverviewBase.tsx
@@ -8,6 +8,7 @@ import {
   GridItem,
   Popover,
   Title,
+  TitleSizes,
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons';
 import { orgUnitIdKey, Query, tagPrefix } from 'api/queries/query';
@@ -52,7 +53,7 @@ class CostOverviewBase extends React.Component<CostOverviewProps> {
       return (
         <Card>
           <CardTitle>
-            <Title headingLevel="h2" size="lg">
+            <Title headingLevel="h2" size={TitleSizes.lg}>
               {t('breakdown.cluster_title')}
             </Title>
           </CardTitle>
@@ -72,7 +73,7 @@ class CostOverviewBase extends React.Component<CostOverviewProps> {
     return (
       <Card>
         <CardTitle>
-          <Title headingLevel="h2" size="lg">
+          <Title headingLevel="h2" size={TitleSizes.lg}>
             {t('breakdown.cost_breakdown_title')}
             <Popover
               aria-label={t('breakdown.cost_breakdown_aria_label')}
@@ -114,7 +115,7 @@ class CostOverviewBase extends React.Component<CostOverviewProps> {
     return (
       <Card>
         <CardTitle>
-          <Title headingLevel="h2" size="lg">
+          <Title headingLevel="h2" size={TitleSizes.lg}>
             {t(`breakdown.cpu_title`)}
           </Title>
         </CardTitle>
@@ -132,7 +133,7 @@ class CostOverviewBase extends React.Component<CostOverviewProps> {
     return (
       <Card>
         <CardTitle>
-          <Title headingLevel="h2" size="lg">
+          <Title headingLevel="h2" size={TitleSizes.lg}>
             {t(`breakdown.memory_title`)}
           </Title>
         </CardTitle>

--- a/src/pages/views/details/components/historicalData/historicalDataBase.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataBase.tsx
@@ -1,4 +1,4 @@
-import { Card, CardBody, CardTitle, Grid, GridItem, Title } from '@patternfly/react-core';
+import { Card, CardBody, CardTitle, Grid, GridItem, Title, TitleSizes } from '@patternfly/react-core';
 import React from 'react';
 import { WithTranslation } from 'react-i18next';
 import {
@@ -29,7 +29,7 @@ class HistoricalDataBase extends React.Component<HistoricalDataProps> {
     return (
       <Card>
         <CardTitle>
-          <Title headingLevel="h2" size="lg">
+          <Title headingLevel="h2" size={TitleSizes.lg}>
             {t(`breakdown.historical_chart.${widget.reportType}_title`)}
           </Title>
         </CardTitle>
@@ -47,7 +47,7 @@ class HistoricalDataBase extends React.Component<HistoricalDataProps> {
     return (
       <Card>
         <CardTitle>
-          <Title headingLevel="h2" size="lg">
+          <Title headingLevel="h2" size={TitleSizes.lg}>
             {t(`breakdown.historical_chart.${widget.reportType}_title`)}
           </Title>
         </CardTitle>
@@ -65,7 +65,7 @@ class HistoricalDataBase extends React.Component<HistoricalDataProps> {
     return (
       <Card>
         <CardTitle>
-          <Title headingLevel="h2" size="lg">
+          <Title headingLevel="h2" size={TitleSizes.lg}>
             {t(`breakdown.historical_chart.${widget.reportType}_title`)}
           </Title>
         </CardTitle>

--- a/src/pages/views/details/components/priceList/noRatesState.tsx
+++ b/src/pages/views/details/components/priceList/noRatesState.tsx
@@ -1,4 +1,4 @@
-import { EmptyState as PfEmptyState, EmptyStateBody, EmptyStateIcon, Title } from '@patternfly/react-core';
+import { EmptyState as PfEmptyState, EmptyStateBody, EmptyStateIcon, Title, TitleSizes } from '@patternfly/react-core';
 import { MoneyCheckAltIcon } from '@patternfly/react-icons/dist/js/icons/money-check-alt-icon';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
@@ -14,7 +14,7 @@ const NoRatesStateBase: React.SFC<Props> = ({ t, cluster }) => {
     <div style={styles.container}>
       <PfEmptyState>
         <EmptyStateIcon icon={MoneyCheckAltIcon} />
-        <Title headingLevel="h2" size="xl">
+        <Title headingLevel="h2" size={TitleSizes.xl}>
           {t('no_rates_state.title')}
         </Title>
         <EmptyStateBody>{t('no_rates_state.desc', { cluster })}</EmptyStateBody>

--- a/src/pages/views/details/components/summary/summaryCard.tsx
+++ b/src/pages/views/details/components/summary/summaryCard.tsx
@@ -8,6 +8,7 @@ import {
   CardTitle,
   Skeleton,
   Title,
+  TitleSizes,
 } from '@patternfly/react-core';
 import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
 import { OcpReport } from 'api/reports/ocpReports';
@@ -157,7 +158,7 @@ class SummaryBase extends React.Component<SummaryProps> {
     return (
       <Card style={styles.card}>
         <CardTitle>
-          <Title headingLevel="h2" size="lg">
+          <Title headingLevel="h2" size={TitleSizes.lg}>
             {t('breakdown.summary_title', { groupBy: reportGroupBy })}
           </Title>
         </CardTitle>

--- a/src/pages/views/details/components/summary/summaryModalView.tsx
+++ b/src/pages/views/details/components/summary/summaryModalView.tsx
@@ -1,4 +1,4 @@
-import { Title } from '@patternfly/react-core';
+import { Title, TitleSizes } from '@patternfly/react-core';
 import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
 import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import { ReportSummaryItem, ReportSummaryItems } from 'components/reports/reportSummary';
@@ -60,7 +60,7 @@ class SummaryModalViewBase extends React.Component<SummaryModalViewProps> {
     return (
       <>
         <div style={styles.subTitle}>
-          <Title headingLevel="h2" size="xl">
+          <Title headingLevel="h2" size={TitleSizes.xl}>
             {t('details.cost_value', { value: cost })}
           </Title>
         </div>

--- a/src/pages/views/details/gcpDetails/detailsHeader.tsx
+++ b/src/pages/views/details/gcpDetails/detailsHeader.tsx
@@ -1,4 +1,4 @@
-import { Title } from '@patternfly/react-core';
+import { Title, TitleSizes } from '@patternfly/react-core';
 import { Providers, ProviderType } from 'api/providers';
 import { GcpQuery, getQuery } from 'api/queries/gcpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
@@ -64,7 +64,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     return (
       <header style={styles.header}>
         <div>
-          <Title headingLevel="h2" style={styles.title} size="2xl">
+          <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
             {t('navigation.gcp_details')}
           </Title>
           <GroupBy
@@ -79,7 +79,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
         </div>
         {Boolean(showContent) && (
           <div>
-            <Title headingLevel="h2" style={styles.costValue} size="4xl">
+            <Title headingLevel="h2" style={styles.costValue} size={TitleSizes['4xl']}>
               {formatCurrency(hasCost ? report.meta.total.cost.total.value : 0)}
             </Title>
             <div style={styles.dateTitle}>{getSinceDateRangeString()}</div>

--- a/src/pages/views/details/ibmDetails/detailsHeader.tsx
+++ b/src/pages/views/details/ibmDetails/detailsHeader.tsx
@@ -1,4 +1,4 @@
-import { Title } from '@patternfly/react-core';
+import { Title, TitleSizes } from '@patternfly/react-core';
 import { Providers, ProviderType } from 'api/providers';
 import { getQuery, IbmQuery } from 'api/queries/ibmQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
@@ -64,7 +64,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     return (
       <header style={styles.header}>
         <div>
-          <Title headingLevel="h2" style={styles.title} size="2xl">
+          <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
             {t('navigation.ibm_details')}
           </Title>
           <GroupBy
@@ -79,7 +79,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
         </div>
         {Boolean(showContent) && (
           <div>
-            <Title headingLevel="h2" style={styles.costValue} size="4xl">
+            <Title headingLevel="h2" style={styles.costValue} size={TitleSizes['4xl']}>
               {formatCurrency(hasCost ? report.meta.total.cost.total.value : 0)}
             </Title>
             <div style={styles.dateTitle}>{getSinceDateRangeString()}</div>

--- a/src/pages/views/details/ocpDetails/detailsHeader.tsx
+++ b/src/pages/views/details/ocpDetails/detailsHeader.tsx
@@ -1,4 +1,4 @@
-import { Title, Tooltip } from '@patternfly/react-core';
+import { Title, TitleSizes, Tooltip } from '@patternfly/react-core';
 import { Providers, ProviderType } from 'api/providers';
 import { getQuery, OcpQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
@@ -88,7 +88,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     return (
       <header style={styles.header}>
         <div>
-          <Title headingLevel="h2" style={styles.title} size="2xl">
+          <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
             {t('ocp_details.title')}
           </Title>
           <GroupBy
@@ -103,7 +103,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
         </div>
         {Boolean(showContent) && (
           <div>
-            <Title headingLevel="h2" style={styles.costValue} size="4xl">
+            <Title headingLevel="h2" style={styles.costValue} size={TitleSizes['4xl']}>
               <Tooltip
                 content={t('dashboard.total_cost_tooltip', {
                   supplementaryCost,

--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -1,4 +1,4 @@
-import { Title } from '@patternfly/react-core';
+import { Title, TitleSizes } from '@patternfly/react-core';
 import { Providers, ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import { getQuery, parseQuery, Query } from 'api/queries/query';
@@ -256,7 +256,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
     return (
       <header style={styles.header}>
         <div>
-          <Title headingLevel="h2" style={styles.title} size="2xl">
+          <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
             {t('navigation.explorer')}
           </Title>
           <div style={styles.perspectiveContainer}>

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -1,6 +1,6 @@
 import './overview.scss';
 
-import { Button, ButtonVariant, Popover, Tab, TabContent, Tabs, TabTitleText, Title } from '@patternfly/react-core';
+import { Button, ButtonVariant, Popover, Tab, TabContent, Tabs, TabTitleText, Title, TitleSizes } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
 import { Providers, ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/queries/providersQuery';
@@ -502,7 +502,7 @@ class OverviewBase extends React.Component<OverviewProps> {
           className={`pf-l-page-header pf-c-page-header pf-l-page__main-section pf-c-page__main-section pf-m-light headerOverride}`}
         >
           <header className="pf-u-display-flex pf-u-justify-content-space-between pf-u-align-items-center">
-            <Title headingLevel="h2" size="2xl">
+            <Title headingLevel="h1" size={TitleSizes['2xl']}>
               {t('cost_management_overview')}
               <span style={styles.infoIcon}>
                 <Popover

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -1,6 +1,16 @@
 import './overview.scss';
 
-import { Button, ButtonVariant, Popover, Tab, TabContent, Tabs, TabTitleText, Title, TitleSizes } from '@patternfly/react-core';
+import {
+  Button,
+  ButtonVariant,
+  Popover,
+  Tab,
+  TabContent,
+  Tabs,
+  TabTitleText,
+  Title,
+  TitleSizes,
+} from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons/dist/js/icons/outlined-question-circle-icon';
 import { Providers, ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/queries/providersQuery';


### PR DESCRIPTION
Ensures all page titles use h1 heading level. Also replaces strings with `TitleSizes` variants.

https://issues.redhat.com/browse/COST-1741