### PR TITLE
Cost 1740

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ public/
 dist/
 .DS_Store
 .idea
+/report.*.json

--- a/src/pages/costModels/costModel/header.tsx
+++ b/src/pages/costModels/costModel/header.tsx
@@ -112,9 +112,6 @@ const Header: React.FunctionComponent<Props> = ({
               {current.name}
             </Title>
             {current.description}
-            <Title headingLevel="h2" style={styles.sourceTypeTitle} size={TitleSizes.md}>
-              {t('cost_models_details.cost_model.source_type')}: {current.source_type}
-            </Title>
           </SplitItem>
           <SplitItem>
             <Dropdown


### PR DESCRIPTION
Closes: COST-1740

It appears that when a merge/revert happened it also reverted the code and put the source type back up at the top level as well as having it under the source tab. 

![Screen Shot 2021-08-04 at 4 36 23 AM](https://user-images.githubusercontent.com/57504257/128354762-244df71c-a931-40b1-8697-537c453e5e50.png)
