### PR TITLE
fix for assign source button

### DIFF
--- a/src/pages/costModels/costModel/addSourceStep.tsx
+++ b/src/pages/costModels/costModel/addSourceStep.tsx
@@ -48,7 +48,7 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
           const disabled = cur.cost_models.length > 0;
           return {
             ...acc,
-            [cur.uuid]: { selected: disabled ? selected : isSelected, meta: cur },
+            [cur.uuid]: { selected: disabled ? selected : isSelected, meta: cur, disabled },
           };
         }, {});
         this.props.setState(

--- a/src/pages/costModels/costModel/addSourceWizard.tsx
+++ b/src/pages/costModels/costModel/addSourceWizard.tsx
@@ -25,6 +25,7 @@ import AddSourceStep from './addSourceStep';
 
 interface AddSourcesStepState {
   checked: { [uuid: string]: { selected: boolean; meta: Provider } };
+  initialChecked: { [uuid: string]: { selected: boolean; meta: Provider } };
 }
 
 interface Props extends WithTranslation {
@@ -49,7 +50,7 @@ const sourceTypeMap = {
 };
 
 class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
-  public state = { checked: {} };
+  public state = { checked: {}, initialChecked: {}, initialCheckCalled: false };
   public componentDidMount() {
     const {
       costModel: { source_type },
@@ -70,6 +71,7 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
         };
       }, {}) as { [uuid: string]: { selected: boolean; meta: Provider } };
       this.setState({ checked: initChecked });
+      this.setState({ initialChecked: initChecked });
     }
   }
   public render() {
@@ -83,7 +85,12 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
         actions={[
           <Button
             key="save"
-            isDisabled={isUpdateInProgress || this.props.isLoadingSources || this.props.fetchingSourcesError !== null}
+            isDisabled={
+              this.state.checked === this.state.initialChecked ||
+              isUpdateInProgress ||
+              this.props.isLoadingSources ||
+              this.props.fetchingSourcesError !== null
+            }
             onClick={() => {
               onSave(Object.keys(this.state.checked).filter(uuid => this.state.checked[uuid].selected));
             }}

--- a/src/pages/costModels/costModel/addSourceWizard.tsx
+++ b/src/pages/costModels/costModel/addSourceWizard.tsx
@@ -50,7 +50,8 @@ const sourceTypeMap = {
 };
 
 class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
-  public state = { checked: {}, initialChecked: {}, initialCheckCalled: false };
+  private checkChecked = (a, b) => Object.keys(a).every(key => b[key] && a[key].selected === b[key].selected);
+  public state = { checked: {}, initialChecked: {} };
   public componentDidMount() {
     const {
       costModel: { source_type },
@@ -86,7 +87,7 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
           <Button
             key="save"
             isDisabled={
-              this.state.checked === this.state.initialChecked ||
+              this.checkChecked(this.state.checked, this.state.initialChecked) ||
               isUpdateInProgress ||
               this.props.isLoadingSources ||
               this.props.fetchingSourcesError !== null

--- a/src/pages/costModels/costModel/addSourceWizard.tsx
+++ b/src/pages/costModels/costModel/addSourceWizard.tsx
@@ -50,8 +50,8 @@ const sourceTypeMap = {
 };
 
 class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
-  private checkChecked = (a, b) => Object.keys(a).every(key => b[key] && a[key].selected === b[key].selected);
   public state = { checked: {}, initialChecked: {} };
+  private compareSelected = (a, b) => Object.keys(a).every(key => b[key] && a[key].selected === b[key].selected);
   public componentDidMount() {
     const {
       costModel: { source_type },
@@ -87,7 +87,7 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
           <Button
             key="save"
             isDisabled={
-              this.checkChecked(this.state.checked, this.state.initialChecked) ||
+              this.compareSelected(this.state.checked, this.state.initialChecked) ||
               isUpdateInProgress ||
               this.props.isLoadingSources ||
               this.props.fetchingSourcesError !== null

--- a/src/pages/costModels/costModel/addSourceWizard.tsx
+++ b/src/pages/costModels/costModel/addSourceWizard.tsx
@@ -25,7 +25,7 @@ import AddSourceStep from './addSourceStep';
 
 interface AddSourcesStepState {
   checked: { [uuid: string]: { selected: boolean; meta: Provider } };
-  initialChecked: { [uuid: string]: { selected: boolean; meta: Provider } };
+  initialSelectedCount: number;
 }
 
 interface Props extends WithTranslation {
@@ -50,8 +50,18 @@ const sourceTypeMap = {
 };
 
 class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
-  public state = { checked: {}, initialChecked: {} };
-  private compareSelected = (a, b) => Object.keys(a).every(key => b[key] && a[key].selected === b[key].selected);
+  public state = { checked: {}, initialSelectedCount: 0 };
+
+  private getSelectedCount = a => {
+    let cnt = 0;
+    for (const key in a) {
+      if (a[key].selected && a[key].selected === true) {
+        ++cnt;
+      }
+    }
+    return cnt;
+  };
+
   public componentDidMount() {
     const {
       costModel: { source_type },
@@ -72,7 +82,7 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
         };
       }, {}) as { [uuid: string]: { selected: boolean; meta: Provider } };
       this.setState({ checked: initChecked });
-      this.setState({ initialChecked: initChecked });
+      this.setState({ initialSelectedCount: this.getSelectedCount(initChecked) });
     }
   }
   public render() {
@@ -87,7 +97,7 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
           <Button
             key="save"
             isDisabled={
-              this.compareSelected(this.state.checked, this.state.initialChecked) ||
+              this.state.initialSelectedCount === this.getSelectedCount(this.state.checked) ||
               isUpdateInProgress ||
               this.props.isLoadingSources ||
               this.props.fetchingSourcesError !== null


### PR DESCRIPTION
closed: https://issues.redhat.com/browse/COST-1758

The assign sources button should be disabled until there is a change from the current config.

![Screen Shot 2021-08-06 at 11 11 45 AM](https://user-images.githubusercontent.com/57504257/128541996-9a5b9be1-05c6-41f8-bb80-c10c3db47614.png)


With the fix we can see the button is disabled util there is change from current state/config

![Screen Shot 2021-08-06 at 12 12 07 PM](https://user-images.githubusercontent.com/57504257/128542067-833a47dc-96a0-40a1-97aa-90b8adb4ed2c.png)

![Screen Shot 2021-08-06 at 12 22 49 PM](https://user-images.githubusercontent.com/57504257/128542089-bf584d19-8c27-4de3-97e6-7c23dbf9c762.png)

With a source previously assigned
![Screen Shot 2021-08-06 at 12 25 34 PM](https://user-images.githubusercontent.com/57504257/128542198-bdd0aeb8-100f-459e-93d9-092d0eec5afb.png)

![Screen Shot 2021-08-06 at 12 27 12 PM](https://user-images.githubusercontent.com/57504257/128542205-c1b35ddc-a49a-4a9e-8d20-786dc61fce98.png)

