### PR TITLE
Update Travis to push to stage-beta only

### DIFF
--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -4,14 +4,10 @@ set -x
 
 # If current dev branch is master, push to build repo stage-beta
 if [[ "${TRAVIS_BRANCH}" = "master" || "${TRAVIS_BRANCH}" = "main" ]]; then
-  .travis/release.sh "ci-beta"
-
-  # Release stage
-  rm -rf $APP_BUILD_DIR/.git
   .travis/release.sh "stage-beta"
 fi
 
 # If current dev branch is deployment branch, push to build repo
-if [[ "${TRAVIS_BRANCH}" = "ci-stable" || "${TRAVIS_BRANCH}" = "stage-stable" || "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
+if [[ "${TRAVIS_BRANCH}" = "stage-stable" || "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
   .travis/release.sh "${TRAVIS_BRANCH}"
 fi


### PR DESCRIPTION
Now that stage-beta is being promoted as expected, we no longer need to push to ci-beta.

https://issues.redhat.com/browse/COST-1759