### PR TITLE
Webpack

### DIFF
--- a/.travis/custom_release.sh
+++ b/.travis/custom_release.sh
@@ -8,6 +8,7 @@ if [[ "${TRAVIS_BRANCH}" = "master" || "${TRAVIS_BRANCH}" = "main" ]]; then
 fi
 
 # If current dev branch is deployment branch, push to build repo
-if [[ "${TRAVIS_BRANCH}" = "stage-stable" || "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ]]; then
+if [[ "${TRAVIS_BRANCH}" = "stage-stable" || "${TRAVIS_BRANCH}" = "prod-beta" || "${TRAVIS_BRANCH}" = "prod-stable" ||
+      "${TRAVIS_BRANCH}" = "ci-beta" || "${TRAVIS_BRANCH}" = "ci-stable" ]]; then
   .travis/release.sh "${TRAVIS_BRANCH}"
 fi

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,8 +62,8 @@ module.exports = (_env, argv) => {
   log.info(`Current branch: ${gitBranch}`);
   log.info(`Beta branches: ${betaBranches}`);
   log.info(`Using deployments: ${appDeployment}`);
-  log.info(`Public path: ${publicPath}`);
   log.info(`Using Insights proxy: ${!useProxy}`);
+  log.info(`Public path: ${publicPath}`);
   log.info('~~~~~~~~~~~~~~~~~~~~~');
 
   const stats = {
@@ -242,7 +242,7 @@ module.exports = (_env, argv) => {
         appUrl: [`/${isBeta ? 'beta/' : ''}openshift/cost-management`],
         proxyVerbose: true,
         publicPath,
-        useCloud: false,
+        useCloud: process.env.CLOUDOT_ENV === 'ci',
       }),
       // Props for webpack-dev-server v4.0.0-beta.2
       //


### PR DESCRIPTION
Updates Webpack to work with both CI and stage/prod environments. Just need to close the browser in order to switch from stage to CI and vice versa, but working now.

> CI was trying to proxy to https://ci.console.redhat.com/ -- Zack

Also updated the Travis custom release script to support ci-beta and ci-stable for a bit longer. Although we still push directly from master to stage-beta.