### PR TITLE
Force "no data" tooltips to display

### DIFF
--- a/src/pages/views/explorer/explorerChart.tsx
+++ b/src/pages/views/explorer/explorerChart.tsx
@@ -98,6 +98,7 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
     return {
       x: xVal,
       y: value === null ? null : yVal, // For displaying "no data" labels in chart tooltips
+      ...(value === null && { _y: 0 }), // Force "no data" tooltips. See https://issues.redhat.com/browse/COST-1765
       date: computedItem.date,
       key: computedItem.id,
       name: computedItem.label ? computedItem.label : computedItem.id, // legend item label


### PR DESCRIPTION
This forces "no data" tooltips to display in the Cost Explorer.

https://issues.redhat.com/browse/COST-1765

<img width="1103" alt="Screen Shot 2021-08-10 at 4 11 52 PM" src="https://user-images.githubusercontent.com/17481322/128928707-357a50c5-0e21-4526-b46a-5555e96d4a00.png">
