### PR TITLE
Export limit

### DIFF
--- a/src/api/exports/awsOcpExport.ts
+++ b/src/api/exports/awsOcpExport.ts
@@ -1,0 +1,12 @@
+import { ReportTypePaths } from 'api/reports/awsOcpReports';
+import { ReportType } from 'api/reports/report';
+import axios from 'axios';
+
+export function runExport(reportType: ReportType, query: string) {
+  const path = ReportTypePaths[reportType];
+  return axios.get<string>(`${path}?${query}`, {
+    headers: {
+      Accept: 'text/csv',
+    },
+  });
+}

--- a/src/api/exports/azureOcpExport.ts
+++ b/src/api/exports/azureOcpExport.ts
@@ -1,0 +1,12 @@
+import { ReportTypePaths } from 'api/reports/azureOcpReports';
+import { ReportType } from 'api/reports/report';
+import axios from 'axios';
+
+export function runExport(reportType: ReportType, query: string) {
+  const path = ReportTypePaths[reportType];
+  return axios.get<string>(`${path}?${query}`, {
+    headers: {
+      Accept: 'text/csv',
+    },
+  });
+}

--- a/src/api/exports/exportUtils.ts
+++ b/src/api/exports/exportUtils.ts
@@ -1,8 +1,11 @@
 import { ReportPathsType, ReportType } from 'api/reports/report';
 
 import { runExport as runAwsExport } from './awsExport';
+import { runExport as runAwsOcpExport } from './awsOcpExport';
 import { runExport as runAzureExport } from './azureExport';
+import { runExport as runAzureOcpExport } from './azureOcpExport';
 import { runExport as runGcpExport } from './gcpExport';
+import { runExport as runGcpOcpExport } from './gcpOcpExport';
 import { runExport as runIbmExport } from './ibmExport';
 import { runExport as runOcpCloudExport } from './ocpCloudExport';
 import { runExport as runOcpExport } from './ocpExport';
@@ -13,11 +16,20 @@ export function runExport(reportPathsType: ReportPathsType, reportType: ReportTy
     case ReportPathsType.aws:
       report = runAwsExport(reportType, query);
       break;
+    case ReportPathsType.awsOcp:
+      report = runAwsOcpExport(reportType, query);
+      break;
     case ReportPathsType.azure:
       report = runAzureExport(reportType, query);
       break;
+    case ReportPathsType.azureOcp:
+      report = runAzureOcpExport(reportType, query);
+      break;
     case ReportPathsType.gcp:
       report = runGcpExport(reportType, query);
+      break;
+    case ReportPathsType.gcpOcp:
+      report = runGcpOcpExport(reportType, query);
       break;
     case ReportPathsType.ibm:
       report = runIbmExport(reportType, query);

--- a/src/api/exports/gcpOcpExport.ts
+++ b/src/api/exports/gcpOcpExport.ts
@@ -1,0 +1,12 @@
+import { ReportTypePaths } from 'api/reports/gcpOcpReports';
+import { ReportType } from 'api/reports/report';
+import axios from 'axios';
+
+export function runExport(reportType: ReportType, query: string) {
+  const path = ReportTypePaths[reportType];
+  return axios.get<string>(`${path}?${query}`, {
+    headers: {
+      Accept: 'text/csv',
+    },
+  });
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -496,6 +496,7 @@
     "cancel": "Cancel",
     "confirm": "Generate and download",
     "daily": "Daily",
+    "error": "Something went wrong, try fewer selections",
     "file": {
       "daily": "daily",
       "monthly": "monthly",

--- a/src/pages/views/components/export/exportModal.styles.ts
+++ b/src/pages/views/components/export/exportModal.styles.ts
@@ -4,6 +4,9 @@ import global_spacer_xs from '@patternfly/react-tokens/dist/js/global_spacer_xs'
 import React from 'react';
 
 export const styles = {
+  alert: {
+    marginBottom: global_spacer_md.var,
+  },
   form: {
     marginLeft: global_spacer_sm.var,
   },

--- a/src/pages/views/components/export/exportModal.tsx
+++ b/src/pages/views/components/export/exportModal.tsx
@@ -1,4 +1,4 @@
-import { Button, ButtonVariant, Form, FormGroup, Modal, Radio } from '@patternfly/react-core';
+import { Alert, Button, ButtonVariant, Form, FormGroup, Modal, Radio } from '@patternfly/react-core';
 import { Query, tagPrefix } from 'api/queries/query';
 import { ReportPathsType } from 'api/reports/report';
 import { AxiosError } from 'axios';
@@ -16,8 +16,6 @@ import { styles } from './exportModal.styles';
 import { ExportSubmit } from './exportSubmit';
 
 export interface ExportModalOwnProps extends WithTranslation {
-  error?: AxiosError;
-  export?: string;
   groupBy?: string;
   isAllItems?: boolean;
   isOpen: boolean;
@@ -40,6 +38,7 @@ interface ExportModalDispatchProps {
 }
 
 interface ExportModalState {
+  error?: AxiosError;
   timeScope: number;
   resolution: string;
 }
@@ -64,6 +63,7 @@ const timeScopeOptions: {
 
 export class ExportModalBase extends React.Component<ExportModalProps, ExportModalState> {
   protected defaultState: ExportModalState = {
+    error: undefined,
     timeScope: -1,
     resolution: this.props.resolution || 'monthly',
   };
@@ -80,6 +80,10 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
     this.setState({ ...this.defaultState }, () => {
       this.props.onClose(false);
     });
+  };
+
+  private handleError = (error: AxiosError) => {
+    this.setState({ error });
   };
 
   public handleMonthChange = (_, event) => {
@@ -101,7 +105,7 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
       showTimeScope = true,
       t,
     } = this.props;
-    const { resolution, timeScope } = this.state;
+    const { error, resolution, timeScope } = this.state;
 
     let sortedItems = [...items];
     if (this.props.isOpen) {
@@ -141,6 +145,7 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
             key="confirm"
             timeScope={showTimeScope ? timeScope : undefined}
             onClose={this.handleClose}
+            onError={this.handleError}
             query={query}
             reportPathsType={reportPathsType}
             resolution={resolution}
@@ -155,6 +160,7 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
           </Button>,
         ]}
       >
+        {error && <Alert variant="danger" style={styles.alert} title={t('export.error')} />}
         <div style={styles.title}>
           <span>{t('export.heading', { groupBy })}</span>
         </div>

--- a/src/pages/views/components/export/exportSubmit.tsx
+++ b/src/pages/views/components/export/exportSubmit.tsx
@@ -18,14 +18,11 @@ export interface ExportSubmitOwnProps extends WithTranslation {
   isAllItems?: boolean;
   items?: ComputedReportItem[];
   onClose(isOpen: boolean);
+  onError(error: AxiosError);
   query?: Query;
   reportPathsType: ReportPathsType;
   resolution: string;
   timeScope: number;
-}
-
-interface ExportSubmitStateProps {
-  // TBD...
 }
 
 interface ExportSubmitDispatchProps {
@@ -58,11 +55,14 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
   }
 
   public componentDidUpdate(prevProps: ExportSubmitProps) {
-    const { report } = this.props;
+    const { report, reportError } = this.props;
     const { fetchReportClicked } = this.state;
 
     if (prevProps.report !== report && fetchReportClicked) {
       this.getExport();
+    }
+    if (reportError) {
+      this.props.onError(reportError);
     }
   }
 
@@ -94,8 +94,12 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
   };
 
   private handleClose = () => {
+    const { reportError } = this.props;
+
     this.setState({ ...this.defaultState }, () => {
-      this.props.onClose(false);
+      if (!reportError) {
+        this.props.onClose(false);
+      }
     });
   };
 
@@ -144,6 +148,7 @@ const mapStateToProps = createMapStateToProps<ExportSubmitOwnProps, ExportSubmit
         time_scope_value: timeScope ? timeScope : undefined,
       },
       filter_by: {},
+      limit: 0,
       order_by: undefined,
       perspective: undefined,
       dateRange: undefined,


### PR DESCRIPTION
1. Increased the number of items in exported csv files using the `limit=0` query parameter.
2. Added a generic error message.
3. Fixed missing exports for "filtered by OpenShift" perspectives for Cost Explorer.

https://issues.redhat.com/browse/COST-1690

<img width="593" alt="Screen Shot 2021-08-11 at 12 00 05 AM" src="https://user-images.githubusercontent.com/17481322/128970171-45282955-3bba-4398-8c01-d9a7bed953ff.png">
