### PR TITLE
Use infrastructure.uuid property for empty states

### DIFF
--- a/src/api/providers.ts
+++ b/src/api/providers.ts
@@ -30,6 +30,11 @@ export interface ProviderCostModel {
   uuid: string;
 }
 
+export interface ProviderInfrastructure {
+  type?: string;
+  uuid?: string;
+}
+
 export interface Provider {
   active?: boolean;
   authentication?: ProviderAuthentication;
@@ -40,6 +45,7 @@ export interface Provider {
   current_month_data?: boolean;
   customer?: ProviderCustomer;
   has_data?: boolean;
+  infrastructure?: ProviderInfrastructure;
   name?: string;
   previous_month_data?: boolean;
   type?: string;

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -30,7 +30,12 @@ import GcpOcpDashboard from 'pages/views/overview/gcpOcpDashboard';
 import IbmDashboard from 'pages/views/overview/ibmDashboard';
 import OcpCloudDashboard from 'pages/views/overview/ocpCloudDashboard';
 import OcpDashboard from 'pages/views/overview/ocpDashboard';
-import { hasCurrentMonthData, hasPreviousMonthData } from 'pages/views/utils/providers';
+import {
+  hasCloudCurrentMonthData,
+  hasCloudPreviousMonthData,
+  hasCurrentMonthData,
+  hasPreviousMonthData,
+} from 'pages/views/utils/providers';
 import React from 'react';
 import { WithTranslation, withTranslation } from 'react-i18next';
 import { connect } from 'react-redux';
@@ -372,13 +377,15 @@ class OverviewBase extends React.Component<OverviewProps> {
         const hasData = hasCurrentMonthData(awsProviders) || hasPreviousMonthData(awsProviders);
         return hasData ? <AwsDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.awsOcp) {
-        const hasData = hasCurrentMonthData(awsProviders) || hasPreviousMonthData(awsProviders);
+        const hasData =
+          hasCloudCurrentMonthData(awsProviders, ocpProviders) || hasCloudPreviousMonthData(awsProviders, ocpProviders);
         return hasData ? <AwsOcpDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.gcp) {
         const hasData = hasCurrentMonthData(gcpProviders) || hasPreviousMonthData(gcpProviders);
         return hasData ? <GcpDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.gcpOcp) {
-        const hasData = hasCurrentMonthData(gcpProviders) || hasPreviousMonthData(gcpProviders);
+        const hasData =
+          hasCloudCurrentMonthData(gcpProviders, ocpProviders) || hasCloudPreviousMonthData(gcpProviders, ocpProviders);
         return hasData ? <GcpOcpDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.ibm) {
         const hasData = hasCurrentMonthData(ibmProviders) || hasPreviousMonthData(ibmProviders);
@@ -387,7 +394,9 @@ class OverviewBase extends React.Component<OverviewProps> {
         const hasData = hasCurrentMonthData(azureProviders) || hasPreviousMonthData(azureProviders);
         return hasData ? <AzureDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.azureOcp) {
-        const hasData = hasCurrentMonthData(azureProviders) || hasPreviousMonthData(azureProviders);
+        const hasData =
+          hasCloudCurrentMonthData(azureProviders, ocpProviders) ||
+          hasCloudPreviousMonthData(azureProviders, ocpProviders);
         return hasData ? <AzureOcpDashboard /> : noData;
       } else {
         return noData;

--- a/src/pages/views/utils/providers.ts
+++ b/src/pages/views/utils/providers.ts
@@ -1,13 +1,20 @@
 import { Providers } from 'api/providers';
 
-// Ensure at least one source provider has data available for the current month
-export const hasCurrentMonthData = (providers: Providers) => {
-  let result = false;
+// eslint-disable-next-line no-shadow
+const enum DataType {
+  currentMonthData = 'current_month_data',
+  hasData = 'has_data',
+  previousMonthData = 'previous_month_data',
+}
 
-  if (providers && providers.data) {
-    for (const provider of providers.data) {
-      if (provider.current_month_data) {
-        result = true;
+// Returns the OCP provider matching the given infrastructure uuid
+const _getOcpProvider = (ocpProviders: Providers, uuid?: string) => {
+  let result;
+
+  if (ocpProviders && ocpProviders.data) {
+    for (const provider of ocpProviders.data) {
+      if (provider.infrastructure && provider.infrastructure.uuid === uuid) {
+        result = provider;
         break;
       }
     }
@@ -16,12 +23,12 @@ export const hasCurrentMonthData = (providers: Providers) => {
 };
 
 // Ensure at least one source provider has data available
-export const hasData = (providers: Providers) => {
+const _hasData = (providers: Providers, dataType: DataType) => {
   let result = false;
 
   if (providers && providers.data) {
     for (const provider of providers.data) {
-      if (provider.has_data) {
+      if (provider[dataType]) {
         result = true;
         break;
       }
@@ -30,17 +37,50 @@ export const hasData = (providers: Providers) => {
   return result;
 };
 
-// Ensure at least one source provider has data available for the previous month
-export const hasPreviousMonthData = (providers: Providers) => {
+// Ensure at least one cloud source provider has data available
+const _hasCloudData = (providers: Providers, ocpProviders: Providers, dataType: DataType) => {
   let result = false;
 
   if (providers && providers.data) {
     for (const provider of providers.data) {
-      if (provider.previous_month_data) {
+      const ocpProvider = _getOcpProvider(ocpProviders, provider.uuid);
+
+      // Ensure AWS provider is filtered by OpenShift and has OCP data
+      if (ocpProvider && ocpProvider[dataType]) {
         result = true;
         break;
       }
     }
   }
   return result;
+};
+
+// Ensure at least one cloud source provider has data available for the current month (e.g., "AWS filtered by OpenShift")
+export const hasCloudCurrentMonthData = (providers: Providers, ocpProviders: Providers) => {
+  return _hasCloudData(providers, ocpProviders, DataType.currentMonthData);
+};
+
+// Ensure at least one cloud source provider has data available (e.g., "AWS filtered by OpenShift")
+export const hasCloudData = (providers: Providers, ocpProviders: Providers) => {
+  return _hasCloudData(providers, ocpProviders, DataType.hasData);
+};
+
+// Ensure at least one cloud source provider has data available for the previous month (e.g., "AWS filtered by OpenShift")
+export const hasCloudPreviousMonthData = (providers: Providers, ocpProviders: Providers) => {
+  return _hasCloudData(providers, ocpProviders, DataType.previousMonthData);
+};
+
+// Ensure at least one source provider has data available for the current month
+export const hasCurrentMonthData = (providers: Providers) => {
+  return _hasData(providers, DataType.currentMonthData);
+};
+
+// Ensure at least one source provider has data available
+export const hasData = (providers: Providers) => {
+  return _hasData(providers, DataType.hasData);
+};
+
+// Ensure at least one source provider has data available for the previous month
+export const hasPreviousMonthData = (providers: Providers) => {
+  return _hasData(providers, DataType.previousMonthData);
 };


### PR DESCRIPTION
Empty states are not being displayed correctly for "xxx filtered by OpenShift" perspectives. For this type of filter, we need to look at its associated OCP source.

A new `infrastructure.uuid` property was added to OCP sources. We can use this to match the uuid of the "AWS filtered by OpenShift" source with the OCP source. Once we have the correct OCP source, we can test its `current_month_data` and `previous_month_data` properties.

https://issues.redhat.com/browse/COST-1776