### PR TITLE
Snake case keys

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -90,7 +90,7 @@
     "GroupByTopValueProject": "DE Projects",
     "GroupByTopValueRegion": "DE Regions",
     "GroupByTopValueService": "DE Services",
-    "GroupByValues": "{value, select, account {{count, plural, one {DE Account} other {DE Accounts}}} cluster {{count, plural, one {DE Cluster} other {DE Clusters}}} instanceType {{count, plural, one {DE Instance Type} other {DE Instance Types}}} node {{count, plural, one {DE Node} other {DE Node}}} orgUnitId {{count, plural, one {DE Organizational unit} other {DE Organizational units}}} pod {{count, plural, one {DE Pod} other {DE Pods}}} project {{count, plural, one {DE Project} other {DE Projects}}} region {{count, plural, one {DE Region} other {DE Region}}} resourceLocation {{count, plural, one {DE Region} other {DE Region}}} service {{count, plural, one {DE Service} other {DE Services}}} serviceName {{count, plural, one {DE Service} other {DE Services}}} subscriptionGuid {{count, plural, one {DE Account} other {DE Accounts}}} tag {{count, plural, one {DE Tag} other {DE Tags}}} other {}}",
+    "GroupByValues": "{value, select, account {{count, plural, one {DE Account} other {DE Accounts}}} cluster {{count, plural, one {DE Cluster} other {DE Clusters}}} instance_type {{count, plural, one {DE Instance Type} other {DE Instance Types}}} node {{count, plural, one {DE Node} other {DE Node}}} org_unit_id {{count, plural, one {DE Organizational unit} other {DE Organizational units}}} pod {{count, plural, one {DE Pod} other {DE Pods}}} project {{count, plural, one {DE Project} other {DE Projects}}} region {{count, plural, one {DE Region} other {DE Region}}} resource_location {{count, plural, one {DE Region} other {DE Region}}} service {{count, plural, one {DE Service} other {DE Services}}} service_name {{count, plural, one {DE Service} other {DE Services}}} subscription_guid {{count, plural, one {DE Account} other {DE Accounts}}} tag {{count, plural, one {DE Tag} other {DE Tags}}} other {}}",
     "IBM": "DE IBM Cloud",
     "IBMComputeTitle": "DE Compute instances usage",
     "IBMCostTitle": "DE IBM Cloud Services cost",
@@ -145,8 +145,8 @@
     "ToolBarBulkSelectAriaSelect": "DE Select all items",
     "ToolBarBulkSelectNone": "DE Select none (0 items)",
     "ToolBarBulkSelectPage": "DE Select page ({value} items)",
-    "UnitTooltips": "{units, select, coreHours {{value} DE core-hours} gb {{value} DE GB} gbHours {{value} DE GB-hours} gbMo {{value} DE GB-month} gibibyteMonth {{value} DE GiB-month} hour {{value} DE hours} hrs {{value} DE hours} usd {{value} DE} vmHours {{value} DE VM-hours} other {DE {value}}}",
-    "Units": "{units, select, coreHours {DE core-hours} gb {DE GB} gbHours {DE GB-hours} gbMo {DE GB-month} gibibyteMonth {DE GiB-month} hour {DE hours} hrs {DE hours} usd {$USD} vmHours {DE VM-hours} other {}}",
+    "UnitTooltips": "{units, select, core_hours {{value} DE core-hours} gb {{value} DE GB} gb_hours {{value} ES GB-hours} gb_mo {{value} DE GB-month} gibibyte_month {{value} DE GiB-month} hour {{value} DE hours} hrs {{value} DE hours} usd {{value} DE} vm_hours {{value} DE VM-hours} other {DE {value}}}",
+    "Units": "{units, select, core_hours {DE core-hours} gb {DE GB} gb_hours {DE GB-hours} gb_mo {DE GB-month} gibibyte_month {DE GiB-month} hour {DE hours} hrs {DE hours} usd {$USD} vm_hours {DE VM-hours} other {}}",
     "Usage": "DE Usage"
   },
   "fr": {
@@ -240,7 +240,7 @@
     "GroupByTopValueProject": "FR Projects",
     "GroupByTopValueRegion": "FR Regions",
     "GroupByTopValueService": "FR Services",
-    "GroupByValues": "{value, select, account {{count, plural, one {FR Account} other {FR Accounts}}} cluster {{count, plural, one {FR Cluster} other {FR Clusters}}} instanceType {{count, plural, one {FR Instance Type} other {FR Instance Types}}} node {{count, plural, one {FR Node} other {FR Node}}} orgUnitId {{count, plural, one {FR Organizational unit} other {FR Organizational units}}} pod {{count, plural, one {FR Pod} other {FR Pods}}} project {{count, plural, one {FR Project} other {FR Projects}}} region {{count, plural, one {FR Region} other {FR Region}}} resourceLocation {{count, plural, one {FR Region} other {FR Region}}} service {{count, plural, one {FR Service} other {FR Services}}} serviceName {{count, plural, one {FR Service} other {FR Services}}} subscriptionGuid {{count, plural, one {FR Account} other {FR Accounts}}} tag {{count, plural, one {FR Tag} other {FR Tags}}} other {}}",
+    "GroupByValues": "{value, select, account {{count, plural, one {FR Account} other {FR Accounts}}} cluster {{count, plural, one {FR Cluster} other {FR Clusters}}} instance_type {{count, plural, one {FR Instance Type} other {FR Instance Types}}} node {{count, plural, one {FR Node} other {FR Node}}} org_unit_id {{count, plural, one {FR Organizational unit} other {FR Organizational units}}} pod {{count, plural, one {FR Pod} other {FR Pods}}} project {{count, plural, one {FR Project} other {FR Projects}}} region {{count, plural, one {FR Region} other {FR Region}}} resource_location {{count, plural, one {FR Region} other {FR Region}}} service {{count, plural, one {FR Service} other {FR Services}}} service_name {{count, plural, one {FR Service} other {FR Services}}} subscription_guid {{count, plural, one {FR Account} other {FR Accounts}}} tag {{count, plural, one {FR Tag} other {FR Tags}}} other {}}",
     "IBM": "FR IBM Cloud",
     "IBMComputeTitle": "FR Compute instances usage",
     "IBMCostTitle": "FR IBM Cloud Services cost",
@@ -295,8 +295,8 @@
     "ToolBarBulkSelectAriaSelect": "FR Select all items",
     "ToolBarBulkSelectNone": "FR Select none (0 items)",
     "ToolBarBulkSelectPage": "FR Select page ({value} items)",
-    "UnitTooltips": "{units, select, coreHours {{value} FR core-hours} gb {{value} FR GB} gbHours {{value} FR GB-hours} gbMo {{value} FR GB-month} gibibyteMonth {{value} FR GiB-month} hour {{value} FR hours} hrs {{value} FR hours} usd {{value} FR} vmHours {{value} FR VM-hours} other {FR {value}}}",
-    "Units": "{units, select, coreHours {FR core-hours} gb {FR GB} gbHours {FR GB-hours} gbMo {FR GB-month} gibibyteMonth {FR GiB-month} hour {FR hours} hrs {FR hours} usd {$USD} vmHours {FR VM-hours} other {}}",
+    "UnitTooltips": "{units, select, core_hours {{value} FR core-hours} gb {{value} FR GB} gb_hours {{value} ES GB-hours} gb_mo {{value} FR GB-month} gibibyte_month {{value} FR GiB-month} hour {{value} FR hours} hrs {{value} FR hours} usd {{value} FR} vm_hours {{value} FR VM-hours} other {FR {value}}}",
+    "Units": "{units, select, core_hours {FR core-hours} gb {FR GB} gb_hours {FR GB-hours} gb_mo {FR GB-month} gibibyte_month {FR GiB-month} hour {FR hours} hrs {FR hours} usd {$USD} vm_hours {FR VM-hours} other {}}",
     "Usage": "FR Usage"
   },
   "en": {
@@ -390,7 +390,7 @@
     "GroupByTopValueProject": "EN Projects",
     "GroupByTopValueRegion": "EN Regions",
     "GroupByTopValueService": "EN Services",
-    "GroupByValues": "{value, select, account {{count, plural, one {EN Account} other {EN Accounts}}} cluster {{count, plural, one {EN Cluster} other {EN Clusters}}} instanceType {{count, plural, one {EN Instance Type} other {EN Instance Types}}} node {{count, plural, one {EN Node} other {EN Node}}} orgUnitId {{count, plural, one {EN Organizational unit} other {EN Organizational units}}} pod {{count, plural, one {EN Pod} other {EN Pods}}} project {{count, plural, one {EN Project} other {EN Projects}}} region {{count, plural, one {EN Region} other {EN Region}}} resourceLocation {{count, plural, one {EN Region} other {EN Region}}} service {{count, plural, one {EN Service} other {EN Services}}} serviceName {{count, plural, one {EN Service} other {EN Services}}} subscriptionGuid {{count, plural, one {EN Account} other {EN Accounts}}} tag {{count, plural, one {EN Tag} other {EN Tags}}} other {}}",
+    "GroupByValues": "{value, select, account {{count, plural, one {EN Account} other {EN Accounts}}} cluster {{count, plural, one {EN Cluster} other {EN Clusters}}} instance_type {{count, plural, one {EN Instance Type} other {EN Instance Types}}} node {{count, plural, one {EN Node} other {EN Node}}} org_unit_id {{count, plural, one {EN Organizational unit} other {EN Organizational units}}} pod {{count, plural, one {EN Pod} other {EN Pods}}} project {{count, plural, one {EN Project} other {EN Projects}}} region {{count, plural, one {EN Region} other {EN Region}}} resource_location {{count, plural, one {EN Region} other {EN Region}}} service {{count, plural, one {EN Service} other {EN Services}}} service_name {{count, plural, one {EN Service} other {EN Services}}} subscription_guid {{count, plural, one {EN Account} other {EN Accounts}}} tag {{count, plural, one {EN Tag} other {EN Tags}}} other {}}",
     "IBM": "EN IBM Cloud",
     "IBMComputeTitle": "EN Compute instances usage",
     "IBMCostTitle": "EN IBM Cloud Services cost",
@@ -445,8 +445,8 @@
     "ToolBarBulkSelectAriaSelect": "EN Select all items",
     "ToolBarBulkSelectNone": "EN Select none (0 items)",
     "ToolBarBulkSelectPage": "EN Select page ({value} items)",
-    "UnitTooltips": "{units, select, coreHours {{value} EN core-hours} gb {{value} EN GB} gbHours {{value} EN GB-hours} gbMo {{value} EN GB-month} gibibyteMonth {{value} EN GiB-month} hour {{value} EN hours} hrs {{value} EN hours} usd {{value} EN} vmHours {{value} EN VM-hours} other {EN {value}}}",
-    "Units": "{units, select, coreHours {EN core-hours} gb {EN GB} gbHours {EN GB-hours} gbMo {EN GB-month} gibibyteMonth {EN GiB-month} hour {EN hours} hrs {EN hours} usd {$USD} vmHours {EN VM-hours} other {}}",
+    "UnitTooltips": "{units, select, core_hours {{value} EN core-hours} gb {{value} EN GB} gb_hours {{value} ES GB-hours} gb_mo {{value} EN GB-month} gibibyte_month {{value} EN GiB-month} hour {{value} EN hours} hrs {{value} EN hours} usd {{value} EN} vm_hours {{value} EN VM-hours} other {EN {value}}}",
+    "Units": "{units, select, core_hours {EN core-hours} gb {EN GB} gb_hours {EN GB-hours} gb_mo {EN GB-month} gibibyte_month {EN GiB-month} hour {EN hours} hrs {EN hours} usd {$USD} vm_hours {EN VM-hours} other {}}",
     "Usage": "EN Usage"
   }
 }

--- a/locales/de.json
+++ b/locales/de.json
@@ -89,7 +89,7 @@
   "GroupByTopValueProject": "DE Projects",
   "GroupByTopValueRegion": "DE Regions",
   "GroupByTopValueService": "DE Services",
-  "GroupByValues": "{value, select, account {{count, plural, one {DE Account} other {DE Accounts}}} cluster {{count, plural, one {DE Cluster} other {DE Clusters}}} instanceType {{count, plural, one {DE Instance Type} other {DE Instance Types}}} node {{count, plural, one {DE Node} other {DE Node}}} orgUnitId {{count, plural, one {DE Organizational unit} other {DE Organizational units}}} pod {{count, plural, one {DE Pod} other {DE Pods}}} project {{count, plural, one {DE Project} other {DE Projects}}} region {{count, plural, one {DE Region} other {DE Region}}} resourceLocation {{count, plural, one {DE Region} other {DE Region}}} service {{count, plural, one {DE Service} other {DE Services}}} serviceName {{count, plural, one {DE Service} other {DE Services}}} subscriptionGuid {{count, plural, one {DE Account} other {DE Accounts}}} tag {{count, plural, one {DE Tag} other {DE Tags}}} other {}}",
+  "GroupByValues": "{value, select, account {{count, plural, one {DE Account} other {DE Accounts}}} cluster {{count, plural, one {DE Cluster} other {DE Clusters}}} instance_type {{count, plural, one {DE Instance Type} other {DE Instance Types}}} node {{count, plural, one {DE Node} other {DE Node}}} org_unit_id {{count, plural, one {DE Organizational unit} other {DE Organizational units}}} pod {{count, plural, one {DE Pod} other {DE Pods}}} project {{count, plural, one {DE Project} other {DE Projects}}} region {{count, plural, one {DE Region} other {DE Region}}} resource_location {{count, plural, one {DE Region} other {DE Region}}} service {{count, plural, one {DE Service} other {DE Services}}} service_name {{count, plural, one {DE Service} other {DE Services}}} subscription_guid {{count, plural, one {DE Account} other {DE Accounts}}} tag {{count, plural, one {DE Tag} other {DE Tags}}} other {}}",
   "IBM": "DE IBM Cloud",
   "IBMComputeTitle": "DE Compute instances usage",
   "IBMCostTitle": "DE IBM Cloud Services cost",
@@ -144,7 +144,7 @@
   "ToolBarBulkSelectAriaSelect": "DE Select all items",
   "ToolBarBulkSelectNone": "DE Select none (0 items)",
   "ToolBarBulkSelectPage": "DE Select page ({value} items)",
-  "UnitTooltips": "{units, select, coreHours {{value} DE core-hours} gb {{value} DE GB} gbHours {{value} DE GB-hours} gbMo {{value} DE GB-month} gibibyteMonth {{value} DE GiB-month} hour {{value} DE hours} hrs {{value} DE hours} usd {{value} DE} vmHours {{value} DE VM-hours} other {DE {value}}}",
-  "Units": "{units, select, coreHours {DE core-hours} gb {DE GB} gbHours {DE GB-hours} gbMo {DE GB-month} gibibyteMonth {DE GiB-month} hour {DE hours} hrs {DE hours} usd {$USD} vmHours {DE VM-hours} other {}}",
+  "UnitTooltips": "{units, select, core_hours {{value} DE core-hours} gb {{value} DE GB} gb_hours {{value} ES GB-hours} gb_mo {{value} DE GB-month} gibibyte_month {{value} DE GiB-month} hour {{value} DE hours} hrs {{value} DE hours} usd {{value} DE} vm_hours {{value} DE VM-hours} other {DE {value}}}",
+  "Units": "{units, select, core_hours {DE core-hours} gb {DE GB} gb_hours {DE GB-hours} gb_mo {DE GB-month} gibibyte_month {DE GiB-month} hour {DE hours} hrs {DE hours} usd {$USD} vm_hours {DE VM-hours} other {}}",
   "Usage": "DE Usage"
 }

--- a/locales/fr.json
+++ b/locales/fr.json
@@ -89,7 +89,7 @@
   "GroupByTopValueProject": "FR Projects",
   "GroupByTopValueRegion": "FR Regions",
   "GroupByTopValueService": "FR Services",
-  "GroupByValues": "{value, select, account {{count, plural, one {FR Account} other {FR Accounts}}} cluster {{count, plural, one {FR Cluster} other {FR Clusters}}} instanceType {{count, plural, one {FR Instance Type} other {FR Instance Types}}} node {{count, plural, one {FR Node} other {FR Node}}} orgUnitId {{count, plural, one {FR Organizational unit} other {FR Organizational units}}} pod {{count, plural, one {FR Pod} other {FR Pods}}} project {{count, plural, one {FR Project} other {FR Projects}}} region {{count, plural, one {FR Region} other {FR Region}}} resourceLocation {{count, plural, one {FR Region} other {FR Region}}} service {{count, plural, one {FR Service} other {FR Services}}} serviceName {{count, plural, one {FR Service} other {FR Services}}} subscriptionGuid {{count, plural, one {FR Account} other {FR Accounts}}} tag {{count, plural, one {FR Tag} other {FR Tags}}} other {}}",
+  "GroupByValues": "{value, select, account {{count, plural, one {FR Account} other {FR Accounts}}} cluster {{count, plural, one {FR Cluster} other {FR Clusters}}} instance_type {{count, plural, one {FR Instance Type} other {FR Instance Types}}} node {{count, plural, one {FR Node} other {FR Node}}} org_unit_id {{count, plural, one {FR Organizational unit} other {FR Organizational units}}} pod {{count, plural, one {FR Pod} other {FR Pods}}} project {{count, plural, one {FR Project} other {FR Projects}}} region {{count, plural, one {FR Region} other {FR Region}}} resource_location {{count, plural, one {FR Region} other {FR Region}}} service {{count, plural, one {FR Service} other {FR Services}}} service_name {{count, plural, one {FR Service} other {FR Services}}} subscription_guid {{count, plural, one {FR Account} other {FR Accounts}}} tag {{count, plural, one {FR Tag} other {FR Tags}}} other {}}",
   "IBM": "FR IBM Cloud",
   "IBMComputeTitle": "FR Compute instances usage",
   "IBMCostTitle": "FR IBM Cloud Services cost",
@@ -144,7 +144,7 @@
   "ToolBarBulkSelectAriaSelect": "FR Select all items",
   "ToolBarBulkSelectNone": "FR Select none (0 items)",
   "ToolBarBulkSelectPage": "FR Select page ({value} items)",
-  "UnitTooltips": "{units, select, coreHours {{value} FR core-hours} gb {{value} FR GB} gbHours {{value} FR GB-hours} gbMo {{value} FR GB-month} gibibyteMonth {{value} FR GiB-month} hour {{value} FR hours} hrs {{value} FR hours} usd {{value} FR} vmHours {{value} FR VM-hours} other {FR {value}}}",
-  "Units": "{units, select, coreHours {FR core-hours} gb {FR GB} gbHours {FR GB-hours} gbMo {FR GB-month} gibibyteMonth {FR GiB-month} hour {FR hours} hrs {FR hours} usd {$USD} vmHours {FR VM-hours} other {}}",
+  "UnitTooltips": "{units, select, core_hours {{value} FR core-hours} gb {{value} FR GB} gb_hours {{value} ES GB-hours} gb_mo {{value} FR GB-month} gibibyte_month {{value} FR GiB-month} hour {{value} FR hours} hrs {{value} FR hours} usd {{value} FR} vm_hours {{value} FR VM-hours} other {FR {value}}}",
+  "Units": "{units, select, core_hours {FR core-hours} gb {FR GB} gb_hours {FR GB-hours} gb_mo {FR GB-month} gibibyte_month {FR GiB-month} hour {FR hours} hrs {FR hours} usd {$USD} vm_hours {FR VM-hours} other {}}",
   "Usage": "FR Usage"
 }

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -89,7 +89,7 @@
   "GroupByTopValueProject": "EN Projects",
   "GroupByTopValueRegion": "EN Regions",
   "GroupByTopValueService": "EN Services",
-  "GroupByValues": "{value, select, account {{count, plural, one {EN Account} other {EN Accounts}}} cluster {{count, plural, one {EN Cluster} other {EN Clusters}}} instanceType {{count, plural, one {EN Instance Type} other {EN Instance Types}}} node {{count, plural, one {EN Node} other {EN Node}}} orgUnitId {{count, plural, one {EN Organizational unit} other {EN Organizational units}}} pod {{count, plural, one {EN Pod} other {EN Pods}}} project {{count, plural, one {EN Project} other {EN Projects}}} region {{count, plural, one {EN Region} other {EN Region}}} resourceLocation {{count, plural, one {EN Region} other {EN Region}}} service {{count, plural, one {EN Service} other {EN Services}}} serviceName {{count, plural, one {EN Service} other {EN Services}}} subscriptionGuid {{count, plural, one {EN Account} other {EN Accounts}}} tag {{count, plural, one {EN Tag} other {EN Tags}}} other {}}",
+  "GroupByValues": "{value, select, account {{count, plural, one {EN Account} other {EN Accounts}}} cluster {{count, plural, one {EN Cluster} other {EN Clusters}}} instance_type {{count, plural, one {EN Instance Type} other {EN Instance Types}}} node {{count, plural, one {EN Node} other {EN Node}}} org_unit_id {{count, plural, one {EN Organizational unit} other {EN Organizational units}}} pod {{count, plural, one {EN Pod} other {EN Pods}}} project {{count, plural, one {EN Project} other {EN Projects}}} region {{count, plural, one {EN Region} other {EN Region}}} resource_location {{count, plural, one {EN Region} other {EN Region}}} service {{count, plural, one {EN Service} other {EN Services}}} service_name {{count, plural, one {EN Service} other {EN Services}}} subscription_guid {{count, plural, one {EN Account} other {EN Accounts}}} tag {{count, plural, one {EN Tag} other {EN Tags}}} other {}}",
   "IBM": "EN IBM Cloud",
   "IBMComputeTitle": "EN Compute instances usage",
   "IBMCostTitle": "EN IBM Cloud Services cost",
@@ -144,7 +144,7 @@
   "ToolBarBulkSelectAriaSelect": "EN Select all items",
   "ToolBarBulkSelectNone": "EN Select none (0 items)",
   "ToolBarBulkSelectPage": "EN Select page ({value} items)",
-  "UnitTooltips": "{units, select, coreHours {{value} EN core-hours} gb {{value} EN GB} gbHours {{value} EN GB-hours} gbMo {{value} EN GB-month} gibibyteMonth {{value} EN GiB-month} hour {{value} EN hours} hrs {{value} EN hours} usd {{value} EN} vmHours {{value} EN VM-hours} other {EN {value}}}",
-  "Units": "{units, select, coreHours {EN core-hours} gb {EN GB} gbHours {EN GB-hours} gbMo {EN GB-month} gibibyteMonth {EN GiB-month} hour {EN hours} hrs {EN hours} usd {$USD} vmHours {EN VM-hours} other {}}",
+  "UnitTooltips": "{units, select, core_hours {{value} EN core-hours} gb {{value} EN GB} gb_hours {{value} ES GB-hours} gb_mo {{value} EN GB-month} gibibyte_month {{value} EN GiB-month} hour {{value} EN hours} hrs {{value} EN hours} usd {{value} EN} vm_hours {{value} EN VM-hours} other {EN {value}}}",
+  "Units": "{units, select, core_hours {EN core-hours} gb {EN GB} gb_hours {EN GB-hours} gb_mo {EN GB-month} gibibyte_month {EN GiB-month} hour {EN hours} hrs {EN hours} usd {$USD} vm_hours {EN VM-hours} other {}}",
   "Usage": "EN Usage"
 }

--- a/src/components/charts/common/chartDatumUtils.ts
+++ b/src/components/charts/common/chartDatumUtils.ts
@@ -396,13 +396,13 @@ export function getTooltipContent(formatValue) {
   return function labelFormatter(value: number, unit: string = null, options: FormatOptions = {}) {
     const lookup = unitLookupKey(unit);
     switch (lookup) {
-      case 'coreHours':
+      case 'core_hours':
       case 'hour':
       case 'hrs':
       case 'gb':
-      case 'gbHours':
-      case 'gbMo':
-      case 'gibibyteMonth':
+      case 'gb_hours':
+      case 'gb_mo':
+      case 'gibibyte_month':
       case 'vmHours':
         return intlHelper(
           intl.formatMessage(messages.UnitTooltips, { units: lookup, value: formatValue(value, unit, options) })

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -545,16 +545,16 @@ export default defineMessages({
       '{value, select, ' +
       'account {{count, plural, one {EN Account} other {EN Accounts}}} ' +
       'cluster {{count, plural, one {EN Cluster} other {EN Clusters}}} ' +
-      'instanceType {{count, plural, one {EN Instance Type} other {EN Instance Types}}} ' +
+      'instance_type {{count, plural, one {EN Instance Type} other {EN Instance Types}}} ' +
       'node {{count, plural, one {EN Node} other {EN Node}}} ' +
-      'orgUnitId {{count, plural, one {EN Organizational unit} other {EN Organizational units}}} ' +
+      'org_unit_id {{count, plural, one {EN Organizational unit} other {EN Organizational units}}} ' +
       'pod {{count, plural, one {EN Pod} other {EN Pods}}} ' +
       'project {{count, plural, one {EN Project} other {EN Projects}}} ' +
       'region {{count, plural, one {EN Region} other {EN Region}}} ' +
-      'resourceLocation {{count, plural, one {EN Region} other {EN Region}}} ' +
+      'resource_location {{count, plural, one {EN Region} other {EN Region}}} ' +
       'service {{count, plural, one {EN Service} other {EN Services}}} ' +
-      'serviceName {{count, plural, one {EN Service} other {EN Services}}} ' +
-      'subscriptionGuid {{count, plural, one {EN Account} other {EN Accounts}}} ' +
+      'service_name {{count, plural, one {EN Service} other {EN Services}}} ' +
+      'subscription_guid {{count, plural, one {EN Account} other {EN Accounts}}} ' +
       'tag {{count, plural, one {EN Tag} other {EN Tags}}} ' +
       'other {}}',
     description: 'Group by values',
@@ -841,15 +841,15 @@ export default defineMessages({
   UnitTooltips: {
     defaultMessage:
       '{units, select, ' +
-      'coreHours {{value} EN core-hours} ' +
+      'core_hours {{value} EN core-hours} ' +
       'gb {{value} EN GB} ' +
-      'gbHours {{value} EN GB-hours} ' +
-      'gbMo {{value} EN GB-month} ' +
-      'gibibyteMonth {{value} EN GiB-month} ' +
+      'gb_hours {{value} ES GB-hours} ' +
+      'gb_mo {{value} EN GB-month} ' +
+      'gibibyte_month {{value} EN GiB-month} ' +
       'hour {{value} EN hours} ' +
       'hrs {{value} EN hours} ' +
       'usd {{value} EN} ' +
-      'vmHours {{value} EN VM-hours} ' +
+      'vm_hours {{value} EN VM-hours} ' +
       'other {EN {value}}}',
     description: 'return value and unit based on key: "units"',
     id: 'UnitTooltips',
@@ -857,15 +857,15 @@ export default defineMessages({
   Units: {
     defaultMessage:
       '{units, select, ' +
-      'coreHours {EN core-hours} ' +
+      'core_hours {EN core-hours} ' +
       'gb {EN GB} ' +
-      'gbHours {EN GB-hours} ' +
-      'gbMo {EN GB-month} ' +
-      'gibibyteMonth {EN GiB-month} ' +
+      'gb_hours {EN GB-hours} ' +
+      'gb_mo {EN GB-month} ' +
+      'gibibyte_month {EN GiB-month} ' +
       'hour {EN hours} ' +
       'hrs {EN hours} ' +
       'usd {$USD} ' +
-      'vmHours {EN VM-hours} ' +
+      'vm_hours {EN VM-hours} ' +
       'other {}}',
     description: 'return the proper unit label based on key: "units"',
     id: 'Units',

--- a/src/utils/formatValue.test.ts
+++ b/src/utils/formatValue.test.ts
@@ -22,7 +22,7 @@ describe('formatValue', () => {
   });
 
   test('gb unit calls format storage', () => {
-    const unit = 'gbMo';
+    const unit = 'gb_mo';
     format.formatValue(value, 'gb-mo', formatOptions);
     expect(format.formatUsageGb).toBeCalledWith(value, unit, formatOptions);
   });

--- a/src/utils/formatValue.ts
+++ b/src/utils/formatValue.ts
@@ -11,22 +11,22 @@ export const unitLookupKey = unit => {
   const lookup = unit ? unit.toLowerCase() : '';
   switch (lookup) {
     case 'gb-hours':
-      return 'gbHours';
+      return 'gb_hours';
       break;
     case 'gb-mo':
-      return 'gbMo';
+      return 'gb_mo';
       break;
     case 'gibibyte month':
-      return 'gibibyteMonth';
+      return 'gibibyte_month';
       break;
     case 'core-hours':
-      return 'coreHours';
+      return 'core_hours';
       break;
     case 'tag-mo':
-      return 'tagMo';
+      return 'tag_mo';
       break;
     case 'vm-hours':
-      return 'vmHours';
+      return 'vm_hours';
       break;
     case 'usd':
     case '$usd':
@@ -50,6 +50,7 @@ export const formatValue: ValueFormatter = (value: number, unit: string, options
       return formatCurrency(fValue, lookup, options);
     case 'gb':
     case 'gbHours':
+    case 'gb_hours':
     case 'gbMo':
     case 'gibibyteMonth':
     case 'tagMo':

--- a/src/utils/formatValue.ts
+++ b/src/utils/formatValue.ts
@@ -51,10 +51,10 @@ export const formatValue: ValueFormatter = (value: number, unit: string, options
     case 'gb':
     case 'gbHours':
     case 'gb_hours':
-    case 'gbMo':
-    case 'gibibyteMonth':
-    case 'tagMo':
-    case 'vmHours':
+    case 'gb_mo':
+    case 'gibibyte_month':
+    case 'tag_mo':
+    case 'vm_hours':
       return formatUsageGb(fValue, lookup, options);
     case 'coreHours':
     case 'hour':

--- a/src/utils/formatValue.ts
+++ b/src/utils/formatValue.ts
@@ -8,34 +8,22 @@ export interface FormatOptions {
 export type ValueFormatter = (value: number, unit?: string, options?: FormatOptions) => string | number;
 
 export const unitLookupKey = unit => {
-  const lookup = unit ? unit.toLowerCase() : '';
+  const lookup = unit ? unit.replace('-', '_').replace(' ', '_').toLowerCase() : '';
   switch (lookup) {
-    case 'gb-hours':
-      return 'gb_hours';
-      break;
-    case 'gb-mo':
-      return 'gb_mo';
-      break;
-    case 'gibibyte month':
-      return 'gibibyte_month';
-      break;
-    case 'core-hours':
-      return 'core_hours';
-      break;
-    case 'tag-mo':
-      return 'tag_mo';
-      break;
-    case 'vm-hours':
-      return 'vm_hours';
-      break;
+    case 'core_hours':
+    case 'gb':
+    case 'gb_hours':
+    case 'gb_mo':
+    case 'gibibyte_month':
+    case 'hour':
+    case 'hrs':
+    case 'tag_mo':
+    case 'vm_hours':
     case 'usd':
+      return lookup;
     case '$usd':
       return 'usd';
       break;
-    case 'gb':
-    case 'hour':
-    case 'hrs':
-      return lookup;
     default:
       return '';
   }
@@ -49,7 +37,6 @@ export const formatValue: ValueFormatter = (value: number, unit: string, options
     case 'usd':
       return formatCurrency(fValue, lookup, options);
     case 'gb':
-    case 'gbHours':
     case 'gb_hours':
     case 'gb_mo':
     case 'gibibyte_month':

--- a/src/utils/formatValue.ts
+++ b/src/utils/formatValue.ts
@@ -8,7 +8,7 @@ export interface FormatOptions {
 export type ValueFormatter = (value: number, unit?: string, options?: FormatOptions) => string | number;
 
 export const unitLookupKey = unit => {
-  const lookup = unit ? unit.replace('-', '_').replace(' ', '_').toLowerCase() : '';
+  const lookup = unit ? unit.replace(/[- ]/g, '_').toLowerCase() : '';
   switch (lookup) {
     case 'core_hours':
     case 'gb':


### PR DESCRIPTION
Changed message keys to use snake case for group_bys and units

Azure breakdown page, which uses `subscription_guid` as "Accounts"

<img width="1320" alt="Screen Shot 2021-08-18 at 7 01 40 PM" src="https://user-images.githubusercontent.com/17481322/129983257-f054fdf1-30e6-47cd-8e34-26e1b30ac0e8.png">


Overview page, which uses `gb_hours`, `gb_mo`, etc.

<img width="564" alt="Screen Shot 2021-08-18 at 6 35 40 PM" src="https://user-images.githubusercontent.com/17481322/129983334-369a7552-3a24-4dd8-9c24-dadaf4f6e2e5.png">
