### PR TITLE
Removed unused no-restricted-imports patterns

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -89,7 +89,7 @@
         "no-new-wrappers": "error",
         "no-prototype-builtins": "off",
         "no-restricted-imports": ["error", {
-            "patterns": ["./*/**,", "../*/**", "**.json"]
+            "patterns": ["../*/**"]
         }],
         "no-shadow": "error",
         "no-throw-literal": "error",


### PR DESCRIPTION
Removed no-restricted-imports patterns which appear to be unused. For example, we probably don't want to error on "**.json" files, specifically.