### PR TITLE
Cost Explorer: Sort daily cost

### DIFF
--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -381,11 +381,15 @@ class Explorer extends React.Component<ExplorerProps> {
     history.replace(filteredQuery);
   };
 
-  private handleSort = (sortType: string, isSortAscending: boolean) => {
+  private handleSort = (sortType: string, date: string, isSortAscending: boolean) => {
     const { history, query } = this.props;
     const newQuery = { ...JSON.parse(JSON.stringify(query)) };
     newQuery.order_by = {};
     newQuery.order_by[sortType] = isSortAscending ? 'asc' : 'desc';
+
+    if (date) {
+      newQuery.order_by.date = date;
+    }
     const filteredQuery = getRouteForQuery(history, newQuery);
     history.replace(filteredQuery);
   };

--- a/src/pages/views/explorer/explorerTable.scss
+++ b/src/pages/views/explorer/explorerTable.scss
@@ -34,7 +34,7 @@
 .explorerTableOverride {
   &.pf-c-table {
     thead th + th + th {
-      min-width: 100px;
+      min-width: 125px;
     }
     thead th:first-child, tbody td:first-child {
       background-clip: padding-box;

--- a/src/pages/views/explorer/explorerTable.tsx
+++ b/src/pages/views/explorer/explorerTable.tsx
@@ -29,7 +29,7 @@ interface ExplorerTableOwnProps {
   isAllSelected?: boolean;
   isLoading?: boolean;
   onSelected(items: ComputedReportItem[], isSelected: boolean);
-  onSort(value: string, isSortAscending: boolean);
+  onSort(value: string, date: string, isSortAscending: boolean);
   perspective: PerspectiveType;
   query: AwsQuery;
   report: AwsReport;
@@ -120,6 +120,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
         : [
             {
               cellTransforms: [nowrap],
+              date: undefined,
               orderBy: groupById === 'account' && perspective === PerspectiveType.aws ? 'account_alias' : groupById,
               title: intl.formatMessage(messages.GroupByValueNames, { groupBy: groupById }),
               transforms: [sortable],
@@ -146,9 +147,10 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
       const month = getMonth(mapIdDate);
       columns.push({
         cellTransforms: [nowrap],
-        orderBy: undefined, // TBD...
+        date: mapId,
+        orderBy: 'cost',
         title: intl.formatMessage(messages.ExplorerChartDate, { date, month }),
-        transforms: undefined,
+        transforms: [sortable],
       });
 
       computedItems.map(rowItem => {
@@ -311,9 +313,9 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
     const { columns } = this.state;
 
     if (onSort) {
-      const orderBy = columns[index - 1].orderBy;
+      const column = columns[index - 1];
       const isSortAscending = direction === SortByDirection.asc;
-      onSort(orderBy, isSortAscending);
+      onSort(column.orderBy, column.date, isSortAscending);
     }
   };
 

--- a/src/pages/views/explorer/explorerTable.tsx
+++ b/src/pages/views/explorer/explorerTable.tsx
@@ -141,25 +141,29 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
     ) {
       const mapId = format(currentDate, 'yyyy-MM-dd');
 
+      let isSortable = true;
+      computedItems.map(rowItem => {
+        const item = rowItem.get(mapId);
+        if (!item) {
+          isSortable = false;
+          rowItem.set(mapId, {
+            date: mapId,
+          });
+        }
+      });
+
       // Add column headings
       const mapIdDate = new Date(mapId + 'T00:00:00');
       const date = getDate(mapIdDate);
       const month = getMonth(mapIdDate);
       columns.push({
         cellTransforms: [nowrap],
-        date: mapId,
-        orderBy: 'cost',
         title: intl.formatMessage(messages.ExplorerChartDate, { date, month }),
-        transforms: [sortable],
-      });
-
-      computedItems.map(rowItem => {
-        const item = rowItem.get(mapId);
-        if (!item) {
-          rowItem.set(mapId, {
-            date: mapId,
-          });
-        }
+        ...(isSortable && {
+          date: mapId,
+          orderBy: 'cost',
+          transforms: [sortable],
+        }),
       });
     }
 
@@ -274,8 +278,12 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
       for (const key of Object.keys(query.order_by)) {
         let c = 0;
         for (const column of columns) {
-          if (column.orderBy === key) {
+          if (column.orderBy === key && !column.date) {
             direction = query.order_by[key] === 'asc' ? SortByDirection.asc : SortByDirection.desc;
+            index = c + 1;
+            break;
+          } else if (column.date === query.order_by[key]) {
+            direction = query.order_by.cost === 'asc' ? SortByDirection.asc : SortByDirection.desc;
             index = c + 1;
             break;
           }


### PR DESCRIPTION
This adds daily sorting to the Cost Explorer's table.

Blocked by https://github.com/project-koku/koku/pull/3081

https://issues.redhat.com/browse/COST-1689

<img width="1401" alt="Screen Shot 2021-08-25 at 5 22 58 PM" src="https://user-images.githubusercontent.com/17481322/130866654-422fb0fa-04de-4e32-afb2-bb8a45fd5c31.png">
