### PR TITLE
Empty strings in type-ahead

### DIFF
--- a/src/pages/views/components/resourceTypeahead/resourceSelect.tsx
+++ b/src/pages/views/components/resourceTypeahead/resourceSelect.tsx
@@ -101,6 +101,9 @@ class ResourceSelectBase extends React.Component<ResourceSelectProps> {
   private handleOnCreateOption = value => {
     const { createdOptions } = this.state;
 
+    if (value.trim() === '') {
+      return;
+    }
     let options = [...createdOptions];
     if (options.length > 4) {
       options = options.slice(1, options.length);
@@ -133,6 +136,9 @@ class ResourceSelectBase extends React.Component<ResourceSelectProps> {
   private handleOnSelect = (event, value) => {
     const { onSelect } = this.props;
 
+    if (value.trim() === '') {
+      return;
+    }
     if (onSelect) {
       onSelect(value);
     }


### PR DESCRIPTION
Empty strings in type-ahead generate bad API requests

https://issues.redhat.com/browse/COST-1812

![chrome-capture (2)](https://user-images.githubusercontent.com/17481322/131225483-8c7db20b-a5d1-43f0-99b1-50774a814244.gif)
