### PR TITLE
Extra cost explorer requests

### DIFF
--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -216,8 +216,18 @@ export const getPerspectiveDefault = ({
   userAccess: UserAccess;
 }) => {
   let result = queryFromRoute.perspective;
+  if (result) {
+    return result;
+  }
 
-  if (!result) {
+  const isLoading =
+    awsProvidersFetchStatus === FetchStatus.inProgress ||
+    azureProvidersFetchStatus === FetchStatus.inProgress ||
+    gcpProvidersFetchStatus === FetchStatus.inProgress ||
+    ibmProvidersFetchStatus === FetchStatus.inProgress ||
+    ocpProvidersFetchStatus === FetchStatus.inProgress;
+
+  if (!isLoading) {
     if (isOcpAvailable(userAccess, ocpProviders, ocpProvidersFetchStatus)) {
       result = PerspectiveType.ocp;
     } else if (isAwsAvailable(userAccess, awsProviders, awsProvidersFetchStatus)) {


### PR DESCRIPTION
Cost explorer is generating extra API requests. Some query params are not valid for the current perspective because it's based on sources API requests which are still in progress.  

We need to wait until those requests have returned before attempting to generate an API request for the cost report.

https://issues.redhat.com/browse/COST-1813