### PR TITLE
Clean up react-int testing

### DIFF
--- a/src/__mocks__/react-intl.tsx
+++ b/src/__mocks__/react-intl.tsx
@@ -5,11 +5,8 @@ const intl = {
 };
 
 mockedReactIntl.createIntl = () => intl;
-mockedReactIntl.createIntlCache = () => undefined;
 mockedReactIntl.defineMessages = jest.fn(v => v);
-// mockedReactIntl.injectIntl = Component => props => <Component {...props} intl={intl} />;
 mockedReactIntl.injectIntl = jest.fn(v => v);
-mockedReactIntl.useIntl = () => intl;
-mockedReactIntl.intl = intl;
+// mockedReactIntl.injectIntl = Component => props => <Component {...props} intl={intl} />;
 
 module.exports = mockedReactIntl;

--- a/src/components/i18n/index.ts
+++ b/src/components/i18n/index.ts
@@ -1,3 +1,3 @@
 export { I18nProvider } from './i18nProvider';
 export { i18nInit } from './i18init';
-export { getLocale, intl, intlMock } from './intl';
+export { getLocale, intl } from './intl';

--- a/src/components/i18n/intl.ts
+++ b/src/components/i18n/intl.ts
@@ -20,8 +20,3 @@ export const intl = createIntl(
   },
   cache
 );
-
-// Default object for testing
-export const intlMock: any = {
-  formatMessage: ({ defaultMessage }) => defaultMessage,
-};

--- a/src/components/state/emptyFilterState/emptyFilterState.tsx
+++ b/src/components/state/emptyFilterState/emptyFilterState.tsx
@@ -2,7 +2,7 @@ import { MessageDescriptor } from '@formatjs/intl/src/types';
 import { EmptyState, EmptyStateBody, EmptyStateIcon, Title, TitleSizes } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import { OcpCloudQuery, parseQuery } from 'api/queries/ocpCloudQuery';
-import { intlMock } from 'components/i18n';
+import { intl as defaultIntl} from 'components/i18n';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
@@ -20,7 +20,7 @@ interface EmptyFilterStateProps extends WrappedComponentProps {
 const EmptyFilterStateBase: React.SFC<EmptyFilterStateProps> = ({
   filter,
   icon = SearchIcon,
-  intl = intlMock,
+  intl = defaultIntl, // Default required for testing
   showMargin = true,
 
   // destructure last

--- a/src/components/state/emptyFilterState/emptyFilterState.tsx
+++ b/src/components/state/emptyFilterState/emptyFilterState.tsx
@@ -2,7 +2,7 @@ import { MessageDescriptor } from '@formatjs/intl/src/types';
 import { EmptyState, EmptyStateBody, EmptyStateIcon, Title, TitleSizes } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import { OcpCloudQuery, parseQuery } from 'api/queries/ocpCloudQuery';
-import { intl as defaultIntl} from 'components/i18n';
+import { intl as defaultIntl } from 'components/i18n';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';

--- a/src/components/state/loadingState/loadingState.tsx
+++ b/src/components/state/loadingState/loadingState.tsx
@@ -1,5 +1,5 @@
 import { EmptyState, EmptyStateBody, EmptyStateVariant, Spinner, Title } from '@patternfly/react-core';
-import { intlMock } from 'components/i18n';
+import { intl as defaultIntl } from 'components/i18n';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
@@ -8,7 +8,8 @@ interface LoadingStateProps extends WrappedComponentProps {
   icon?: string;
 }
 
-const LoadingStateBase: React.SFC<LoadingStateProps> = ({ intl = intlMock }) => {
+// defaultIntl required for testing
+const LoadingStateBase: React.SFC<LoadingStateProps> = ({ intl = defaultIntl }) => {
   const title = intl.formatMessage(messages.LoadingStateTitle);
   const subTitle = intl.formatMessage(messages.LoadingStateDesc);
 

--- a/src/pages/costModels/costModel/dialog.tsx
+++ b/src/pages/costModels/costModel/dialog.tsx
@@ -1,6 +1,6 @@
 import { Alert, Button, Modal, Title, TitleSizes } from '@patternfly/react-core';
 import { ExclamationTriangleIcon } from '@patternfly/react-icons/dist/esm/icons/exclamation-triangle-icon';
-import { intlMock } from 'components/i18n';
+import { intl as defaultIntl } from 'components/i18n';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
@@ -18,7 +18,7 @@ interface Props extends WrappedComponentProps {
 }
 
 const DialogBase: React.SFC<Props> = ({
-  intl = intlMock,
+  intl = defaultIntl, // Default required for testing
   onClose,
   onProceed,
   title,

--- a/src/pages/costModels/costModelsDetails/createCostModelButton.tsx
+++ b/src/pages/costModels/costModelsDetails/createCostModelButton.tsx
@@ -1,5 +1,5 @@
 import { Button } from '@patternfly/react-core';
-import { intlMock } from 'components/i18n';
+import { intl as defaultIntl } from 'components/i18n';
 import messages from 'locales/messages';
 import { ReadOnlyTooltip } from 'pages/costModels/components/readOnlyTooltip';
 import { CostModelWizard } from 'pages/costModels/createCostModelWizard';
@@ -29,7 +29,7 @@ const buttonMergeProps = (
   dispatchProps: ReturnType<typeof buttonMapDispatchToProps>,
   ownProps: WrappedComponentProps
 ) => {
-  const { intl = intlMock } = ownProps;
+  const { intl = defaultIntl } = ownProps; // Default required for testing
   const { canWrite } = stateProps;
   const { openWizard } = dispatchProps;
 

--- a/src/pages/costModels/costModelsDetails/table.tsx
+++ b/src/pages/costModels/costModelsDetails/table.tsx
@@ -1,7 +1,7 @@
 import { PageSection, PageSectionVariants } from '@patternfly/react-core';
 import { ICell, IRowData, sortable, Table, TableBody, TableGridBreakpoint, TableHeader } from '@patternfly/react-table';
 import { CostModel } from 'api/costModels';
-import { intlMock } from 'components/i18n';
+import { intl as defaultIntl } from 'components/i18n';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
@@ -38,7 +38,7 @@ class CostModelsTableBase extends React.Component<CostModelsTableProps> {
   public render() {
     const {
       actionResolver,
-      intl = intlMock,
+      intl = defaultIntl, // Default required for testing
       canWrite,
       costData,
       history: { push },


### PR DESCRIPTION
Cleaned up react-int testing. 

Instead of using a mock as the intl default, we can use the actual intl instance.