### PR TITLE
Localized cost explorer chart

### DIFF
--- a/src/components/charts/costExplorerChart/costExplorerChart.tsx
+++ b/src/components/charts/costExplorerChart/costExplorerChart.tsx
@@ -24,14 +24,15 @@ import {
   isDataHidden,
   isSeriesHidden,
 } from 'components/charts/common/chartUtils';
-import i18next from 'i18next';
+import messages from 'locales/messages';
 import React from 'react';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { formatCurrencyAbbreviation, FormatOptions, ValueFormatter } from 'utils/formatValue';
 import { noop } from 'utils/noop';
 
 import { chartStyles } from './costExplorerChart.styles';
 
-interface CostExplorerChartProps {
+interface CostExplorerChartOwnProps {
   adjustContainerHeight?: boolean;
   containerHeight?: number;
   formatDatumValue?: ValueFormatter;
@@ -55,7 +56,9 @@ interface State {
   units?: string;
 }
 
-class CostExplorerChart extends React.Component<CostExplorerChartProps, State> {
+type CostExplorerChartProps = CostExplorerChartOwnProps & WrappedComponentProps;
+
+class CostExplorerChartBase extends React.Component<CostExplorerChartProps, State> {
   private containerRef = React.createRef<HTMLDivElement>();
   private observer: any = noop;
 
@@ -418,6 +421,7 @@ class CostExplorerChart extends React.Component<CostExplorerChartProps, State> {
   public render() {
     const {
       height,
+      intl,
       padding = {
         bottom: 50,
         left: 40,
@@ -434,7 +438,7 @@ class CostExplorerChart extends React.Component<CostExplorerChartProps, State> {
           labelComponent: (
             <ChartLegendTooltip
               legendData={getLegendData(series, hiddenSeries, true)}
-              title={datum => i18next.t('chart.day_of_month_title', { day: datum.x })}
+              title={datum => intl.formatMessage(messages.ChartDayOfTheMonth, { day: datum.x })}
             />
           ),
         })
@@ -472,5 +476,7 @@ class CostExplorerChart extends React.Component<CostExplorerChartProps, State> {
     );
   }
 }
+
+const CostExplorerChart = injectIntl(CostExplorerChartBase);
 
 export { CostExplorerChart, CostExplorerChartProps };


### PR DESCRIPTION
Localized cost explorer chart

<img width="1307" alt="Screen Shot 2021-09-05 at 2 50 03 AM" src="https://user-images.githubusercontent.com/17481322/132118235-fc47ee62-9e6d-44a1-8d5d-e97e4faa3633.png">
