### PR TITLE
Added space between up arrow and percentage

### DIFF
--- a/src/pages/views/details/awsDetails/awsDetailsTable.scss
+++ b/src/pages/views/details/awsDetails/awsDetailsTable.scss
@@ -12,7 +12,9 @@
       &.increase {
         color: var(--pf-global--danger-color--100);
       }
-      .fa-sort-up {}
+      .fa-sort-up {
+        margin-left: 10px;
+      }
       .fa-sort-down {
         margin-left: 10px;
       }

--- a/src/pages/views/details/azureDetails/azureDetailsTable.scss
+++ b/src/pages/views/details/azureDetails/azureDetailsTable.scss
@@ -12,7 +12,9 @@
       &.increase {
         color: var(--pf-global--danger-color--100);
       }
-      .fa-sort-up {}
+      .fa-sort-up {
+        margin-left: 10px;
+      }
       .fa-sort-down {
         margin-left: 10px;
       }

--- a/src/pages/views/details/gcpDetails/gcpDetailsTable.scss
+++ b/src/pages/views/details/gcpDetails/gcpDetailsTable.scss
@@ -12,7 +12,9 @@
       &.increase {
         color: var(--pf-global--danger-color--100);
       }
-      .fa-sort-up {}
+      .fa-sort-up {
+        margin-left: 10px;
+      }
       .fa-sort-down {
         margin-left: 10px;
       }

--- a/src/pages/views/details/ibmDetails/ibmDetailsTable.scss
+++ b/src/pages/views/details/ibmDetails/ibmDetailsTable.scss
@@ -12,7 +12,9 @@
       &.increase {
         color: var(--pf-global--danger-color--100);
       }
-      .fa-sort-up {}
+      .fa-sort-up {
+        margin-left: 10px;
+      }
       .fa-sort-down {
         margin-left: 10px;
       }

--- a/src/pages/views/explorer/explorerTable.scss
+++ b/src/pages/views/explorer/explorerTable.scss
@@ -12,7 +12,9 @@
       &.increase {
         color: var(--pf-global--danger-color--100);
       }
-      .fa-sort-up {}
+      .fa-sort-up {
+        margin-left: 10px;
+      }
       .fa-sort-down {
         margin-left: 10px;
       }


### PR DESCRIPTION
For the details pages "month over month change", I added space between the up arrow and percentage, matching the down arrow.

https://issues.redhat.com/browse/COST-1858

<img width="836" alt="Screen Shot 2021-09-15 at 6 05 50 PM" src="https://user-images.githubusercontent.com/17481322/133516183-c375276a-5f46-4e56-952b-5e3fc05503af.png">
