### PR TITLE
Added formatPercentage utils

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -34757,6 +34757,12 @@
         "value": " % of cost"
       }
     ],
+    "PercentSymbol": [
+      {
+        "type": 0,
+        "value": "%"
+      }
+    ],
     "PercentTotalCost": [
       {
         "type": 1,

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -360,6 +360,7 @@
   "OverviewTitle": "Cost Management Overview",
   "Percent": "{value} %",
   "PercentOfCost": "{value} % of cost",
+  "PercentSymbol": "%",
   "PercentTotalCost": "{value} {units} ({percent} %)",
   "Perspective": "Perspective",
   "PerspectiveValues": "{value, select, aws {Amazon Web Services} aws_ocp {Amazon Web Services filtered by OpenShift} azure {Microsoft Azure} azure_ocp {Microsoft Azure filtered by OpenShift} gcp {Google Cloud Platform} gcp_ocp {Google Cloud Platform filtered by OpenShift} ibm {IBM Cloud} ocp {All OpenShift} ocp_cloud {All cloud filtered by OpenShift} other {}}",

--- a/src/components/charts/common/chartDatumUtils.ts
+++ b/src/components/charts/common/chartDatumUtils.ts
@@ -6,8 +6,8 @@ import { endOfMonth, format, getDate, getYear, startOfMonth } from 'date-fns';
 import messages from 'locales/messages';
 import { ComputedForecastItem, getComputedForecastItems } from 'utils/computedForecast/getComputedForecastItems';
 import { ComputedReportItem, getComputedReportItems } from 'utils/computedReport/getComputedReportItems';
+import { formatCurrency, FormatOptions, unitsLookupKey } from 'utils/format';
 import { SortDirection } from 'utils/sort';
-import { formatCurrency, unitsLookupKey, ValueFormatterOptions } from 'utils/valueFormatter';
 
 export interface ChartDatum {
   childName?: string;
@@ -392,13 +392,13 @@ export function getMaxMinValues(datums: ChartDatum[]) {
   return { max, min };
 }
 
-export function getTooltipContent(valueFormatter) {
-  return function labelFormatter(value: number, unit: string = null, options: ValueFormatterOptions = {}) {
+export function getTooltipContent(formatter) {
+  return function labelFormatter(value: number, unit: string = null, options: FormatOptions = {}) {
     const lookup = unitsLookupKey(unit);
     if (lookup) {
       return intl.formatMessage(messages.UnitTooltips, {
         units: lookup,
-        value: valueFormatter(value, unit, options),
+        value: formatter(value, unit, options),
       });
     }
     return formatCurrency(value, unit, options);

--- a/src/components/charts/common/chartUtils.ts
+++ b/src/components/charts/common/chartUtils.ts
@@ -1,7 +1,7 @@
 import { getInteractiveLegendItemStyles } from '@patternfly/react-charts';
 import { intl } from 'components/i18n';
 import messages from 'locales/messages';
-import { ValueFormatter, ValueFormatterOptions } from 'utils/valueFormatter';
+import { FormatOptions, Formatter } from 'utils/format';
 import { DomainTuple, VictoryStyleInterface } from 'victory-core';
 
 import { getMaxMinValues, getTooltipContent } from './chartDatumUtils';
@@ -89,16 +89,12 @@ export const getLegendData = (series: ChartSeries[], hiddenSeries: Set<number>, 
 };
 
 // Note: Forecast is expected to use both datum.y and datum.y0
-export const getTooltipLabel = (
-  datum: any,
-  valueFormatter: ValueFormatter,
-  valueFormatterOptions: ValueFormatterOptions
-) => {
-  const formatter = getTooltipContent(valueFormatter);
+export const getTooltipLabel = (datum: any, formatter: Formatter, formatOptions: FormatOptions) => {
+  const tooltipFormatter = getTooltipContent(formatter);
   const dy =
-    datum.y !== undefined && datum.y !== null ? formatter(datum.y, datum.units, valueFormatterOptions) : undefined;
+    datum.y !== undefined && datum.y !== null ? tooltipFormatter(datum.y, datum.units, formatOptions) : undefined;
   const dy0 =
-    datum.y0 !== undefined && datum.y0 !== null ? formatter(datum.y0, datum.units, valueFormatterOptions) : undefined;
+    datum.y0 !== undefined && datum.y0 !== null ? tooltipFormatter(datum.y0, datum.units, formatOptions) : undefined;
 
   if (dy !== undefined && dy0 !== undefined) {
     return intl.formatMessage(messages.ChartCostForecastConeTooltip, { value0: dy0, value1: dy });

--- a/src/components/charts/costChart/costChart.tsx
+++ b/src/components/charts/costChart/costChart.tsx
@@ -27,8 +27,8 @@ import { getDate } from 'date-fns';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
+import { FormatOptions, Formatter } from 'utils/format';
 import { noop } from 'utils/noop';
-import { ValueFormatter, ValueFormatterOptions } from 'utils/valueFormatter';
 
 import { chartStyles } from './costChart.styles';
 
@@ -48,8 +48,8 @@ interface CostChartOwnProps {
   previousCostData?: any;
   showForecast?: boolean; // Show forecast legend regardless if data is available
   title?: string;
-  valueFormatter?: ValueFormatter;
-  valueFormatterOptions?: ValueFormatterOptions;
+  formatter?: Formatter;
+  formatOptions?: FormatOptions;
 }
 
 interface State {
@@ -367,7 +367,7 @@ class CostChartBase extends React.Component<CostChartProps, State> {
 
   // Returns CursorVoronoiContainer component
   private getCursorVoronoiContainer = () => {
-    const { valueFormatter, valueFormatterOptions } = this.props;
+    const { formatter, formatOptions } = this.props;
 
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
@@ -375,7 +375,7 @@ class CostChartBase extends React.Component<CostChartProps, State> {
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={({ datum }) => getTooltipLabel(datum, valueFormatter, valueFormatterOptions)}
+        labels={({ datum }) => getTooltipLabel(datum, formatter, formatOptions)}
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{

--- a/src/components/charts/costExplorerChart/costExplorerChart.tsx
+++ b/src/components/charts/costExplorerChart/costExplorerChart.tsx
@@ -27,14 +27,16 @@ import {
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
+import { formatCurrencyAbbreviation, FormatOptions, Formatter } from 'utils/format';
 import { noop } from 'utils/noop';
-import { formatCurrencyAbbreviation, ValueFormatter, ValueFormatterOptions } from 'utils/valueFormatter';
 
 import { chartStyles } from './costExplorerChart.styles';
 
 interface CostExplorerChartOwnProps {
   adjustContainerHeight?: boolean;
   containerHeight?: number;
+  formatOptions?: FormatOptions;
+  formatter?: Formatter;
   height?: number;
   legendItemsPerRow?: number;
   padding?: any;
@@ -44,8 +46,6 @@ interface CostExplorerChartOwnProps {
   top4thData: any;
   top5thData: any;
   top6thData: any;
-  valueFormatter?: ValueFormatter;
-  valueFormatterOptions?: ValueFormatterOptions;
 }
 
 interface State {
@@ -276,7 +276,7 @@ class CostExplorerChartBase extends React.Component<CostExplorerChartProps, Stat
 
   // Returns CursorVoronoiContainer component
   private getCursorVoronoiContainer = () => {
-    const { valueFormatter, valueFormatterOptions } = this.props;
+    const { formatter, formatOptions } = this.props;
 
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
@@ -284,7 +284,7 @@ class CostExplorerChartBase extends React.Component<CostExplorerChartProps, Stat
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={({ datum }) => getTooltipLabel(datum, valueFormatter, valueFormatterOptions)}
+        labels={({ datum }) => getTooltipLabel(datum, formatter, formatOptions)}
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{

--- a/src/components/charts/dailyCostChart/dailyCostChart.tsx
+++ b/src/components/charts/dailyCostChart/dailyCostChart.tsx
@@ -30,8 +30,8 @@ import { getDate } from 'date-fns';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
+import { FormatOptions, Formatter } from 'utils/format';
 import { noop } from 'utils/noop';
-import { ValueFormatter, ValueFormatterOptions } from 'utils/valueFormatter';
 
 import { chartStyles } from './dailyCostChart.styles';
 
@@ -51,8 +51,8 @@ interface DailyCostChartOwnProps {
   previousCostData?: any;
   showForecast?: boolean; // Show forecast legend regardless if data is available
   title?: string;
-  valueFormatter?: ValueFormatter;
-  valueFormatterOptions?: ValueFormatterOptions;
+  formatter?: Formatter;
+  formatOptions?: FormatOptions;
 }
 
 interface State {
@@ -414,7 +414,7 @@ class DailyCostChartBase extends React.Component<DailyCostChartProps, State> {
 
   // Returns CursorVoronoiContainer component
   private getCursorVoronoiContainer = () => {
-    const { valueFormatter, valueFormatterOptions } = this.props;
+    const { formatter, formatOptions } = this.props;
 
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
@@ -422,7 +422,7 @@ class DailyCostChartBase extends React.Component<DailyCostChartProps, State> {
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={({ datum }) => getTooltipLabel(datum, valueFormatter, valueFormatterOptions)}
+        labels={({ datum }) => getTooltipLabel(datum, formatter, formatOptions)}
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{

--- a/src/components/charts/dailyTrendChart/dailyTrendChart.tsx
+++ b/src/components/charts/dailyTrendChart/dailyTrendChart.tsx
@@ -30,8 +30,8 @@ import { getDate } from 'date-fns';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
+import { FormatOptions, Formatter } from 'utils/format';
 import { noop } from 'utils/noop';
-import { ValueFormatter, ValueFormatterOptions } from 'utils/valueFormatter';
 
 import { chartStyles } from './dailyTrendChart.styles';
 
@@ -41,6 +41,8 @@ interface DailyTrendChartOwnProps {
   currentData: any;
   forecastData?: any;
   forecastConeData?: any;
+  formatOptions?: FormatOptions;
+  formatter: Formatter;
   height?: number;
   legendItemsPerRow?: number;
   previousData?: any;
@@ -51,8 +53,6 @@ interface DailyTrendChartOwnProps {
   showUsageLegendLabel?: boolean; // The cost legend label is shown by default
   title?: string;
   units?: string;
-  valueFormatter: ValueFormatter;
-  valueFormatterOptions?: ValueFormatterOptions;
 }
 
 interface State {
@@ -315,7 +315,7 @@ class DailyTrendChartBase extends React.Component<DailyTrendChartProps, State> {
 
   // Returns CursorVoronoiContainer component
   private getCursorVoronoiContainer = () => {
-    const { valueFormatter, valueFormatterOptions } = this.props;
+    const { formatter, formatOptions } = this.props;
 
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
@@ -323,7 +323,7 @@ class DailyTrendChartBase extends React.Component<DailyTrendChartProps, State> {
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={({ datum }) => getTooltipLabel(datum, valueFormatter, valueFormatterOptions)}
+        labels={({ datum }) => getTooltipLabel(datum, formatter, formatOptions)}
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{

--- a/src/components/charts/historicalCostChart/historicalCostChart.test.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.test.tsx
@@ -33,8 +33,8 @@ const props: HistoricalCostChartProps = {
   previousCostData,
   previousInfrastructureCostData,
   title: 'Usage Title',
-  valueFormatter: jest.fn(),
-  valueFormatterOptions: {},
+  formatter: jest.fn(),
+  formatOptions: {},
 };
 
 test('reports are formatted to datums', () => {
@@ -76,7 +76,7 @@ test('labels formats with datum and value formatted from props', () => {
   };
   const group = view.find(Chart);
   group.props().containerComponent.props.labels({ datum });
-  expect(props.valueFormatter).toBeCalledWith(datum.y, datum.units, props.valueFormatterOptions);
+  expect(props.formatter).toBeCalledWith(datum.y, datum.units, props.formatOptions);
   expect(view.find(Chart).prop('height')).toBe(props.height);
 });
 

--- a/src/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -28,8 +28,8 @@ import { getDate } from 'date-fns';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
+import { FormatOptions, Formatter } from 'utils/format';
 import { noop } from 'utils/noop';
-import { ValueFormatter, ValueFormatterOptions } from 'utils/valueFormatter';
 
 import { chartStyles, styles } from './historicalCostChart.styles';
 
@@ -38,14 +38,14 @@ interface HistoricalCostChartOwnProps {
   containerHeight?: number;
   currentCostData?: any;
   currentInfrastructureCostData?: any;
+  formatOptions?: FormatOptions;
+  formatter?: Formatter;
   height: number;
   legendItemsPerRow?: number;
   padding?: any;
   previousCostData?: any;
   previousInfrastructureCostData?: any;
   title?: string;
-  valueFormatter?: ValueFormatter;
-  valueFormatterOptions?: ValueFormatterOptions;
   xAxisLabel?: string;
   yAxisLabel?: string;
 }
@@ -208,7 +208,7 @@ class HistoricalCostChartBase extends React.Component<HistoricalCostChartProps, 
 
   // Returns CursorVoronoiContainer component
   private getCursorVoronoiContainer = () => {
-    const { valueFormatter, valueFormatterOptions } = this.props;
+    const { formatter, formatOptions } = this.props;
 
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
@@ -216,7 +216,7 @@ class HistoricalCostChartBase extends React.Component<HistoricalCostChartProps, 
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={({ datum }) => getTooltipLabel(datum, valueFormatter, valueFormatterOptions)}
+        labels={({ datum }) => getTooltipLabel(datum, formatter, formatOptions)}
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.test.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.test.tsx
@@ -19,8 +19,8 @@ const props: HistoricalTrendChartProps = {
   height: 100,
   currentData,
   previousData,
-  valueFormatter: jest.fn(),
-  valueFormatterOptions: {},
+  formatter: jest.fn(),
+  formatOptions: {},
 };
 
 test('reports are formatted to datums', () => {
@@ -56,7 +56,7 @@ test('labels formats with datum and value formatted from props', () => {
   };
   const group = view.find(Chart);
   group.props().containerComponent.props.labels({ datum });
-  expect(formatLabel).toBeCalledWith(datum.y, datum.units, props.valueFormatterOptions);
+  expect(formatLabel).toBeCalledWith(datum.y, datum.units, props.formatOptions);
   expect(view.find(Chart).prop('height')).toBe(props.height);
 });
 

--- a/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -27,14 +27,16 @@ import { getDate } from 'date-fns';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
+import { FormatOptions, Formatter } from 'utils/format';
 import { noop } from 'utils/noop';
-import { ValueFormatter, ValueFormatterOptions } from 'utils/valueFormatter';
 
 import { chartStyles, styles } from './historicalTrendChart.styles';
 
 interface HistoricalTrendChartOwnProps {
   containerHeight?: number;
   currentData: any;
+  formatOptions?: FormatOptions;
+  formatter: Formatter;
   height: number;
   padding?: any;
   previousData?: any;
@@ -42,8 +44,6 @@ interface HistoricalTrendChartOwnProps {
   title?: string;
   showUsageLegendLabel?: boolean;
   units?: string;
-  valueFormatter: ValueFormatter;
-  valueFormatterOptions?: ValueFormatterOptions;
   xAxisLabel?: string;
   yAxisLabel?: string;
 }
@@ -148,7 +148,7 @@ class HistoricalTrendChartBase extends React.Component<HistoricalTrendChartProps
 
   // Returns CursorVoronoiContainer component
   private getCursorVoronoiContainer = () => {
-    const { valueFormatter, valueFormatterOptions } = this.props;
+    const { formatter, formatOptions } = this.props;
 
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
@@ -156,7 +156,7 @@ class HistoricalTrendChartBase extends React.Component<HistoricalTrendChartProps
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={({ datum }) => getTooltipLabel(datum, valueFormatter, valueFormatterOptions)}
+        labels={({ datum }) => getTooltipLabel(datum, formatter, formatOptions)}
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.test.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.test.tsx
@@ -23,8 +23,8 @@ const props: HistoricalUsageChartProps = {
   previousRequestData,
   previousUsageData,
   title: 'Usage Title',
-  valueFormatter: jest.fn(),
-  valueFormatterOptions: {},
+  formatter: jest.fn(),
+  formatOptions: {},
 };
 
 test('reports are formatted to datums', () => {
@@ -66,7 +66,7 @@ test('labels formats with datum and value formatted from props', () => {
   };
   const group = view.find(Chart);
   group.props().containerComponent.props.labels({ datum });
-  expect(props.valueFormatter).toBeCalledWith(datum.y, datum.units, props.valueFormatterOptions);
+  expect(props.formatter).toBeCalledWith(datum.y, datum.units, props.formatOptions);
   expect(view.find(Chart).prop('height')).toBe(props.height);
 });
 

--- a/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -28,8 +28,8 @@ import { getDate } from 'date-fns';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
+import { FormatOptions, Formatter } from 'utils/format';
 import { noop } from 'utils/noop';
-import { ValueFormatter, ValueFormatterOptions } from 'utils/valueFormatter';
 
 import { chartStyles, styles } from './historicalUsageChart.styles';
 
@@ -39,6 +39,8 @@ interface HistoricalUsageChartOwnProps {
   currentLimitData?: any;
   currentRequestData?: any;
   currentUsageData: any;
+  formatOptions?: FormatOptions;
+  formatter?: Formatter;
   height: number;
   legendItemsPerRow?: number;
   padding?: any;
@@ -46,8 +48,6 @@ interface HistoricalUsageChartOwnProps {
   previousRequestData?: any;
   previousUsageData?: any;
   title?: string;
-  valueFormatter?: ValueFormatter;
-  valueFormatterOptions?: ValueFormatterOptions;
   xAxisLabel?: string;
   yAxisLabel?: string;
 }
@@ -256,7 +256,7 @@ class HistoricalUsageChartBase extends React.Component<HistoricalUsageChartProps
 
   // Returns CursorVoronoiContainer component
   private getCursorVoronoiContainer = () => {
-    const { valueFormatter, valueFormatterOptions } = this.props;
+    const { formatter, formatOptions } = this.props;
 
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
@@ -264,7 +264,7 @@ class HistoricalUsageChartBase extends React.Component<HistoricalUsageChartProps
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={({ datum }) => getTooltipLabel(datum, valueFormatter, valueFormatterOptions)}
+        labels={({ datum }) => getTooltipLabel(datum, formatter, formatOptions)}
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{

--- a/src/components/charts/trendChart/trendChart.test.tsx
+++ b/src/components/charts/trendChart/trendChart.test.tsx
@@ -19,8 +19,8 @@ const props: TrendChartProps = {
   height: 100,
   currentData,
   previousData,
-  valueFormatter: jest.fn(),
-  valueFormatterOptions: {},
+  formatter: jest.fn(),
+  formatOptions: {},
 };
 
 test('reports are formatted to datums', () => {
@@ -56,7 +56,7 @@ test('labels formats with datum and value formatted from props', () => {
   };
   const group = view.find(Chart);
   group.props().containerComponent.props.labels({ datum });
-  expect(formatLabel).toBeCalledWith(datum.y, datum.units, props.valueFormatterOptions);
+  expect(formatLabel).toBeCalledWith(datum.y, datum.units, props.formatOptions);
   expect(view.find(Chart).prop('height')).toBe(props.height);
 });
 

--- a/src/components/charts/trendChart/trendChart.tsx
+++ b/src/components/charts/trendChart/trendChart.tsx
@@ -27,8 +27,8 @@ import { getDate } from 'date-fns';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
+import { FormatOptions, Formatter } from 'utils/format';
 import { noop } from 'utils/noop';
-import { ValueFormatter, ValueFormatterOptions } from 'utils/valueFormatter';
 
 import { chartStyles } from './trendChart.styles';
 
@@ -38,6 +38,8 @@ interface TrendChartOwnProps {
   currentData: any;
   forecastData?: any;
   forecastConeData?: any;
+  formatOptions?: FormatOptions;
+  formatter: Formatter;
   height?: number;
   legendItemsPerRow?: number;
   previousData?: any;
@@ -48,8 +50,6 @@ interface TrendChartOwnProps {
   showUsageLegendLabel?: boolean; // The cost legend label is shown by default
   title?: string;
   units?: string;
-  valueFormatter: ValueFormatter;
-  valueFormatterOptions?: ValueFormatterOptions;
 }
 
 interface State {
@@ -264,7 +264,7 @@ class TrendChartBase extends React.Component<TrendChartProps, State> {
 
   // Returns CursorVoronoiContainer component
   private getCursorVoronoiContainer = () => {
-    const { valueFormatter, valueFormatterOptions } = this.props;
+    const { formatter, formatOptions } = this.props;
 
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
@@ -272,7 +272,7 @@ class TrendChartBase extends React.Component<TrendChartProps, State> {
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={({ datum }) => getTooltipLabel(datum, valueFormatter, valueFormatterOptions)}
+        labels={({ datum }) => getTooltipLabel(datum, formatter, formatOptions)}
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{

--- a/src/components/charts/usageChart/usageChart.test.tsx
+++ b/src/components/charts/usageChart/usageChart.test.tsx
@@ -22,8 +22,8 @@ const props: UsageChartProps = {
   height: 100,
   previousRequestData,
   previousUsageData,
-  valueFormatter: jest.fn(),
-  valueFormatterOptions: {},
+  formatter: jest.fn(),
+  formatOptions: {},
 };
 
 test('reports are formatted to datums', () => {
@@ -65,7 +65,7 @@ test('labels formats with datum and value formatted from props', () => {
   };
   const group = view.find(Chart);
   group.props().containerComponent.props.labels({ datum });
-  expect(props.valueFormatter).toBeCalledWith(datum.y, datum.units, props.valueFormatterOptions);
+  expect(props.formatter).toBeCalledWith(datum.y, datum.units, props.formatOptions);
   expect(view.find(Chart).prop('height')).toBe(props.height);
 });
 

--- a/src/components/charts/usageChart/usageChart.tsx
+++ b/src/components/charts/usageChart/usageChart.tsx
@@ -27,8 +27,8 @@ import { getDate } from 'date-fns';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
+import { FormatOptions, Formatter } from 'utils/format';
 import { noop } from 'utils/noop';
-import { ValueFormatter, ValueFormatterOptions } from 'utils/valueFormatter';
 
 import { chartStyles } from './usageChart.styles';
 
@@ -43,8 +43,8 @@ interface UsageChartOwnProps {
   previousRequestData?: any;
   previousUsageData?: any;
   title?: string;
-  valueFormatter?: ValueFormatter;
-  valueFormatterOptions?: ValueFormatterOptions;
+  formatter?: Formatter;
+  formatOptions?: FormatOptions;
 }
 
 interface State {
@@ -197,7 +197,7 @@ class UsageChartBase extends React.Component<UsageChartProps, State> {
 
   // Returns CursorVoronoiContainer component
   private getCursorVoronoiContainer = () => {
-    const { valueFormatter, valueFormatterOptions } = this.props;
+    const { formatter, formatOptions } = this.props;
 
     // Note: Container order is important
     const CursorVoronoiContainer: any = createContainer('voronoi', 'cursor');
@@ -205,7 +205,7 @@ class UsageChartBase extends React.Component<UsageChartProps, State> {
     return (
       <CursorVoronoiContainer
         cursorDimension="x"
-        labels={({ datum }) => getTooltipLabel(datum, valueFormatter, valueFormatterOptions)}
+        labels={({ datum }) => getTooltipLabel(datum, formatter, formatOptions)}
         mouseFollowTooltips
         voronoiDimension="x"
         voronoiPadding={{

--- a/src/components/reports/reportSummary/reportSummaryDetails.tsx
+++ b/src/components/reports/reportSummary/reportSummaryDetails.tsx
@@ -8,24 +8,24 @@ import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
-import { formatCurrency, formatValue, unitsLookupKey, ValueFormatterOptions } from 'utils/valueFormatter';
+import { formatCurrency, FormatOptions, formatUnits, unitsLookupKey } from 'utils/format';
 
 interface ReportSummaryDetailsOwnProps {
   chartType?: DashboardChartType;
   computedReportItem?: string;
   computedReportItemValue?: string;
   costLabel?: string;
+  formatOptions?: FormatOptions;
   report: Report;
-  requestValueFormatterOptions?: ValueFormatterOptions;
+  requestFormatOptions?: FormatOptions;
   requestLabel?: string;
   reportType?: ReportType;
   showTooltip?: boolean;
   showUnits?: boolean;
   showUsageFirst?: boolean;
   units?: string;
-  usageValueFormatterOptions?: ValueFormatterOptions;
+  usageFormatOptions?: FormatOptions;
   usageLabel?: string;
-  valueFormatterOptions?: ValueFormatterOptions;
 }
 
 type ReportSummaryDetailsProps = ReportSummaryDetailsOwnProps & WrappedComponentProps;
@@ -35,18 +35,18 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
   computedReportItem = 'cost',
   computedReportItemValue = 'total',
   costLabel,
+  formatOptions,
   intl,
   report,
-  requestValueFormatterOptions,
+  requestFormatOptions,
   requestLabel,
   reportType,
   showTooltip = false,
   showUnits = false,
   showUsageFirst = false,
   units,
-  usageValueFormatterOptions,
+  usageFormatOptions,
   usageLabel,
-  valueFormatterOptions,
 }) => {
   let cost: string | React.ReactNode = <EmptyValueState />;
   let supplementaryCost: string | React.ReactNode = <EmptyValueState />;
@@ -74,36 +74,36 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
     cost = formatCurrency(
       hasCost ? report.meta.total.cost.total.value : 0,
       hasCost ? report.meta.total.cost.total.units : 'USD',
-      valueFormatterOptions
+      formatOptions
     );
     supplementaryCost = formatCurrency(
       hasSupplementaryCost ? report.meta.total.supplementary.total.value : 0,
       hasSupplementaryCost ? report.meta.total.supplementary.total.units : 'USD',
-      valueFormatterOptions
+      formatOptions
     );
     infrastructureCost = formatCurrency(
       hasInfrastructureCost ? report.meta.total.infrastructure[computedReportItemValue].value : 0,
       hasInfrastructureCost ? report.meta.total.infrastructure[computedReportItemValue].units : 'USD',
-      valueFormatterOptions
+      formatOptions
     );
-    request = formatValue(
+    request = formatUnits(
       hasRequest ? report.meta.total.request.value : 0,
       hasRequest ? report.meta.total.request.units : undefined,
-      requestValueFormatterOptions ? usageValueFormatterOptions : valueFormatterOptions
+      requestFormatOptions ? usageFormatOptions : formatOptions
     );
 
     if (hasUsage && report.meta.total.usage.value >= 0) {
-      usage = formatValue(
+      usage = formatUnits(
         hasUsage ? report.meta.total.usage.value : 0,
         hasUsage ? report.meta.total.usage.units : undefined,
-        usageValueFormatterOptions ? usageValueFormatterOptions : valueFormatterOptions
+        usageFormatOptions ? usageFormatOptions : formatOptions
       );
     } else {
       // Workaround for https://github.com/project-koku/koku-ui/issues/1058
-      usage = formatValue(
+      usage = formatUnits(
         hasUsage ? (report.meta.total.usage as any) : 0,
         hasCount ? report.meta.total.count.units : undefined,
-        usageValueFormatterOptions ? usageValueFormatterOptions : valueFormatterOptions
+        usageFormatOptions ? usageFormatOptions : formatOptions
       );
     }
   }

--- a/src/components/reports/reportSummary/reportSummaryItem.test.tsx
+++ b/src/components/reports/reportSummary/reportSummaryItem.test.tsx
@@ -12,14 +12,14 @@ const props: ReportSummaryItemProps = {
   totalValue: 1000,
   units: 'units',
   value: 100,
-  valueFormatterOptions: {},
-  valueFormatter: jest.fn(v => `formatted ${v}`),
+  formatOptions: {},
+  formatter: jest.fn(v => `formatted ${v}`),
 };
 
-// Temporarily disabled formatValue test until PF4 progress bar supports custom labels
+// Temporarily disabled formatUnits test until PF4 progress bar supports custom labels
 xtest('formats value', () => {
   shallow(<ReportSummaryItem {...props} />);
-  expect(props.valueFormatter).toBeCalledWith(props.value, props.units, props.valueFormatterOptions);
+  expect(props.formatter).toBeCalledWith(props.value, props.units, props.formatOptions);
 });
 
 test('gets percentage from value and total value', () => {

--- a/src/components/reports/reportSummary/reportSummaryItem.tsx
+++ b/src/components/reports/reportSummary/reportSummaryItem.tsx
@@ -4,15 +4,15 @@ import { Progress, ProgressSize } from '@patternfly/react-core';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
-import { ValueFormatterOptions } from 'utils/valueFormatter';
-import { formatCurrency, unitsLookupKey } from 'utils/valueFormatter';
+import { FormatOptions } from 'utils/format';
+import { formatCurrency, formatPercentage, unitsLookupKey } from 'utils/format';
 
 interface ReportSummaryItemOwnProps {
   label: string;
   totalValue: number;
   units: string;
   value: number;
-  valueFormatterOptions?: ValueFormatterOptions;
+  formatOptions?: FormatOptions;
 }
 
 type ReportSummaryItemProps = ReportSummaryItemOwnProps & WrappedComponentProps;
@@ -23,20 +23,20 @@ const ReportSummaryItemBase: React.SFC<ReportSummaryItemProps> = ({
   totalValue,
   units,
   value,
-  valueFormatterOptions,
+  formatOptions,
 }) => {
   const unitsLabel = intl.formatMessage(messages.Units, { units: unitsLookupKey(units) });
   const percent = !totalValue ? 0 : (value / totalValue) * 100;
-  const percentVal = Number(percent.toFixed(2));
+  const percentVal = formatPercentage(percent);
   const percentLabel = intl.formatMessage(messages.PercentTotalCost, {
     percent: percentVal,
     units: unitsLabel,
-    value: formatCurrency(value, units, valueFormatterOptions),
+    value: formatCurrency(value, units, formatOptions),
   });
 
   return (
     <li className="reportSummaryItem">
-      <Progress label={percentLabel} value={percentVal} title={label} size={ProgressSize.sm} />
+      <Progress label={percentLabel} value={Number(percentVal)} title={label} size={ProgressSize.sm} />
     </li>
   );
 };

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -2555,6 +2555,11 @@ export default defineMessages({
     description: '{value} % of cost',
     id: 'PercentOfCost',
   },
+  PercentSymbol: {
+    defaultMessage: '%',
+    description: 'percent symbol',
+    id: 'PercentSymbol',
+  },
   PercentTotalCost: {
     defaultMessage: '{value} {units} ({percent} %)',
     description: '{value} {units} ({percent} %)',

--- a/src/modules/ocpOverviewWidget/ocpOverviewChart.tsx
+++ b/src/modules/ocpOverviewWidget/ocpOverviewChart.tsx
@@ -13,9 +13,9 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
+import { unitsLookupKey } from 'utils/format';
+import { formatUnits } from 'utils/format';
 import { skeletonWidth } from 'utils/skeleton';
-import { unitsLookupKey } from 'utils/valueFormatter';
-import { formatValue } from 'utils/valueFormatter';
 
 import { chartStyles, styles } from './ocpOverviewChart.styles';
 
@@ -107,7 +107,7 @@ class OcpOverviewChartBase extends React.Component<OcpOverviewChartProps> {
         adjustContainerHeight
         containerHeight={chartStyles.chartContainerHeight}
         currentData={currentData}
-        valueFormatter={formatValue}
+        formatter={formatUnits}
         height={chartStyles.chartHeight}
         previousData={previousData}
         units={units}

--- a/src/pages/costModels/components/rateForm/rateForm.tsx
+++ b/src/pages/costModels/components/rateForm/rateForm.tsx
@@ -8,7 +8,7 @@ import { Selector } from 'pages/costModels/components/inputs/selector';
 import { SimpleInput } from 'pages/costModels/components/inputs/simpleInput';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
-import { unitsLookupKey } from 'utils/valueFormatter';
+import { unitsLookupKey } from 'utils/format';
 
 import { TaggingRatesForm } from './taggingRatesForm';
 import { UseRateData } from './useRateForm';

--- a/src/pages/costModels/components/rateTable.tsx
+++ b/src/pages/costModels/components/rateTable.tsx
@@ -14,7 +14,7 @@ import { intl as defaultIntl } from 'components/i18n';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
-import { formatCurrency } from 'utils/valueFormatter';
+import { formatCurrency } from 'utils/format';
 
 import { compareBy } from './rateForm/utils';
 import TagRateTable from './tagRateTable';

--- a/src/pages/costModels/components/tagRateTable.tsx
+++ b/src/pages/costModels/components/tagRateTable.tsx
@@ -4,7 +4,7 @@ import { intl as defaultIntl } from 'components/i18n';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
-import { formatCurrency } from 'utils/valueFormatter';
+import { formatCurrency } from 'utils/format';
 
 interface TagRateTableProps extends WrappedComponentProps {
   tagRates: TagRates;

--- a/src/pages/costModels/costModel/markup.tsx
+++ b/src/pages/costModels/costModel/markup.tsx
@@ -20,7 +20,7 @@ import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
 import { rbacSelectors } from 'store/rbac';
-import { formatValue } from 'utils/valueFormatter';
+import { formatPercentage } from 'utils/format';
 
 import { styles } from './costCalc.styles';
 import UpdateMarkupDialog from './updateMarkupDialog';
@@ -41,11 +41,7 @@ const MarkupCardBase: React.FunctionComponent<Props> = ({
 }) => {
   const [dropdownIsOpen, setDropdownIsOpen] = React.useState(false);
   const markupValue =
-    current && current.markup && current.markup.value
-      ? formatValue(Number(current.markup.value), current.markup.unit, {
-          fractionDigits: 2,
-        })
-      : '0.0';
+    current && current.markup && current.markup.value ? formatPercentage(Number(current.markup.value)) : '0.0';
 
   return (
     <>

--- a/src/pages/costModels/costModel/updateMarkupDialog.tsx
+++ b/src/pages/costModels/costModel/updateMarkupDialog.tsx
@@ -24,7 +24,7 @@ import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
-import { formatValue } from 'utils/valueFormatter';
+import { formatPercentage } from 'utils/format';
 
 import { styles } from './costCalc.styles';
 
@@ -50,10 +50,7 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
     const noSignValue = isNegative ? initialMarkup.substring(1) : initialMarkup;
 
     this.state = {
-      markup:
-        (formatValue(Number(noSignValue), 'unknown', {
-          fractionDigits: 2,
-        }) as string) || '0.00',
+      markup: (formatPercentage(Number(noSignValue)) as string) || '0.00',
       origIsDiscount: isNegative,
       isDiscount: isNegative,
     };
@@ -168,7 +165,11 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
               <Flex direction={{ default: 'column' }} alignSelf={{ default: 'alignSelfCenter' }}>
                 <FlexItem>
                   <InputGroup style={styles.rateContainer}>
-                    <InputGroupText style={styles.sign}>{isDiscount ? '-' : '+'}</InputGroupText>
+                    <InputGroupText style={styles.sign}>
+                      {isDiscount
+                        ? intl.formatMessage(messages.DiscountMinus)
+                        : intl.formatMessage(messages.MarkupPlus)}
+                    </InputGroupText>
                     <TextInput
                       style={styles.inputField}
                       type="text"
@@ -179,7 +180,7 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
                       onChange={this.handleMarkupDiscountChange}
                       validated={this.markupValidator()}
                     />
-                    <InputGroupText style={styles.percent}>%</InputGroupText>
+                    <InputGroupText style={styles.percent}>{intl.formatMessage(messages.PercentSymbol)}</InputGroupText>
                   </InputGroup>
                 </FlexItem>
               </Flex>

--- a/src/pages/costModels/createCostModelWizard/markup.tsx
+++ b/src/pages/costModels/createCostModelWizard/markup.tsx
@@ -82,7 +82,11 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
                   <Flex direction={{ default: 'column' }} alignSelf={{ default: 'alignSelfCenter' }}>
                     <FlexItem>
                       <InputGroup style={styles.rateContainer}>
-                        <InputGroupText style={styles.sign}>{isDiscount ? '-' : '+'}</InputGroupText>
+                        <InputGroupText style={styles.sign}>
+                          {isDiscount
+                            ? intl.formatMessage(messages.DiscountMinus)
+                            : intl.formatMessage(messages.MarkupPlus)}
+                        </InputGroupText>
                         <TextInput
                           style={styles.inputField}
                           type="text"
@@ -93,7 +97,9 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
                           onChange={handleMarkupDiscountChange}
                           validated={markupValidator()}
                         />
-                        <InputGroupText style={styles.percent}>%</InputGroupText>
+                        <InputGroupText style={styles.percent}>
+                          {intl.formatMessage(messages.PercentSymbol)}
+                        </InputGroupText>
                       </InputGroup>
                     </FlexItem>
                   </Flex>

--- a/src/pages/views/details/awsDetails/detailsHeader.tsx
+++ b/src/pages/views/details/awsDetails/detailsHeader.tsx
@@ -16,7 +16,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { awsProvidersQuery, providersSelectors } from 'store/providers';
 import { ComputedAwsReportItemsParams, getIdKeyForGroupBy } from 'utils/computedReport/getComputedAwsReportItems';
 import { getSinceDateRangeString } from 'utils/dateRange';
-import { formatCurrency } from 'utils/valueFormatter';
+import { formatCurrency } from 'utils/format';
 
 import { styles } from './detailsHeader.styles';
 

--- a/src/pages/views/details/awsDetails/detailsTable.tsx
+++ b/src/pages/views/details/awsDetails/detailsTable.tsx
@@ -20,7 +20,7 @@ import { paths } from 'routes';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedAwsReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dateRange';
-import { formatCurrency } from 'utils/valueFormatter';
+import { formatCurrency, formatPercentage } from 'utils/format';
 
 import { styles } from './detailsTable.styles';
 
@@ -234,7 +234,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   private getMonthOverMonthCost = (item: ComputedReportItem, index: number) => {
     const { intl } = this.props;
     const value = formatCurrency(Math.abs(item.cost.total.value - item.delta_value), item.cost.total.units);
-    const percentage = item.delta_percent !== null ? Math.abs(item.delta_percent).toFixed(2) : 0;
+    const percentage = item.delta_percent !== null ? formatPercentage(Math.abs(item.delta_percent)) : 0;
 
     const showPercentage = !(percentage === 0 || percentage === '0.00');
     const showValue = item.delta_percent !== null; // Workaround for https://github.com/project-koku/koku/issues/1395

--- a/src/pages/views/details/azureDetails/detailsHeader.tsx
+++ b/src/pages/views/details/azureDetails/detailsHeader.tsx
@@ -15,7 +15,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { azureProvidersQuery, providersSelectors } from 'store/providers';
 import { ComputedAzureReportItemsParams, getIdKeyForGroupBy } from 'utils/computedReport/getComputedAzureReportItems';
 import { getSinceDateRangeString } from 'utils/dateRange';
-import { formatCurrency } from 'utils/valueFormatter';
+import { formatCurrency } from 'utils/format';
 
 import { styles } from './detailsHeader.styles';
 

--- a/src/pages/views/details/azureDetails/detailsTable.tsx
+++ b/src/pages/views/details/azureDetails/detailsTable.tsx
@@ -19,7 +19,7 @@ import { paths } from 'routes';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedAzureReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dateRange';
-import { formatCurrency } from 'utils/valueFormatter';
+import { formatCurrency, formatPercentage } from 'utils/format';
 
 import { styles } from './detailsTable.styles';
 
@@ -238,7 +238,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   private getMonthOverMonthCost = (item: ComputedReportItem, index: number) => {
     const { intl } = this.props;
     const value = formatCurrency(Math.abs(item.cost.total.value - item.delta_value), item.cost.total.units);
-    const percentage = item.delta_percent !== null ? Math.abs(item.delta_percent).toFixed(2) : 0;
+    const percentage = item.delta_percent !== null ? formatPercentage(Math.abs(item.delta_percent)) : 0;
 
     const showPercentage = !(percentage === 0 || percentage === '0.00');
     const showValue = item.delta_percent !== null; // Workaround for https://github.com/project-koku/koku/issues/1395

--- a/src/pages/views/details/components/breakdown/breakdownHeader.tsx
+++ b/src/pages/views/details/components/breakdown/breakdownHeader.tsx
@@ -13,7 +13,7 @@ import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { getForDateRangeString } from 'utils/dateRange';
-import { formatCurrency } from 'utils/valueFormatter';
+import { formatCurrency } from 'utils/format';
 
 import { styles } from './breakdownHeader.styles';
 

--- a/src/pages/views/details/components/costChart/costChart.tsx
+++ b/src/pages/views/details/components/costChart/costChart.tsx
@@ -6,8 +6,8 @@ import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { FetchStatus } from 'store/common';
 import { reportActions } from 'store/reports';
+import { formatCurrency } from 'utils/format';
 import { skeletonWidth } from 'utils/skeleton';
-import { formatCurrency } from 'utils/valueFormatter';
 
 import { chartStyles, styles } from './costChart.styles';
 

--- a/src/pages/views/details/components/historicalData/historicalDataCostChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataCostChart.tsx
@@ -10,8 +10,8 @@ import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
+import { formatUnits } from 'utils/format';
 import { skeletonWidth } from 'utils/skeleton';
-import { formatValue } from 'utils/valueFormatter';
 
 import { chartStyles, styles } from './historicalChart.styles';
 
@@ -98,8 +98,8 @@ class HistoricalDataCostChartBase extends React.Component<HistoricalDataCostChar
               containerHeight={chartStyles.chartContainerHeight - 25}
               currentCostData={currentData}
               currentInfrastructureCostData={currentInfrastructureCostData}
-              valueFormatter={formatValue}
-              valueFormatterOptions={{}}
+              formatOptions={{}}
+              formatter={formatUnits}
               height={chartStyles.chartHeight}
               previousCostData={previousData}
               previousInfrastructureCostData={previousInfrastructureCostData}

--- a/src/pages/views/details/components/historicalData/historicalDataTrendChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataTrendChart.tsx
@@ -10,8 +10,8 @@ import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
+import { formatUnits, unitsLookupKey } from 'utils/format';
 import { skeletonWidth } from 'utils/skeleton';
-import { formatValue, unitsLookupKey } from 'utils/valueFormatter';
 
 import { chartStyles, styles } from './historicalChart.styles';
 
@@ -119,8 +119,8 @@ class HistoricalDataTrendChartBase extends React.Component<HistoricalDataTrendCh
             <HistoricalTrendChart
               containerHeight={chartStyles.chartContainerHeight - 50}
               currentData={currentData}
-              valueFormatter={formatValue}
-              valueFormatterOptions={{}}
+              formatOptions={{}}
+              formatter={formatUnits}
               height={chartStyles.chartHeight}
               previousData={previousData}
               units={isCostChart ? costUnits : usageUnits}

--- a/src/pages/views/details/components/historicalData/historicalDataUsageChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataUsageChart.tsx
@@ -10,8 +10,8 @@ import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
+import { formatUnits, unitsLookupKey } from 'utils/format';
 import { skeletonWidth } from 'utils/skeleton';
-import { formatValue, unitsLookupKey } from 'utils/valueFormatter';
 
 import { chartStyles, styles } from './historicalChart.styles';
 
@@ -99,8 +99,8 @@ class HistoricalDataUsageChartBase extends React.Component<HistoricalDataUsageCh
               currentLimitData={currentLimitData}
               currentRequestData={currentRequestData}
               currentUsageData={currentUsageData}
-              valueFormatter={formatValue}
-              valueFormatterOptions={{}}
+              formatter={formatUnits}
+              formatOptions={{}}
               height={chartStyles.chartHeight}
               previousLimitData={previousLimitData}
               previousRequestData={previousRequestData}

--- a/src/pages/views/details/components/summary/summaryCard.tsx
+++ b/src/pages/views/details/components/summary/summaryCard.tsx
@@ -87,8 +87,8 @@ class SummaryBase extends React.Component<SummaryProps> {
         {({ items }) =>
           items.map(reportItem => (
             <ReportSummaryItem
+              formatOptions={{}}
               key={`${reportItem.id}-item`}
-              valueFormatterOptions={{}}
               label={reportItem.label ? reportItem.label.toString() : undefined}
               totalValue={report.meta.total.cost.total.value}
               units={report.meta.total.cost.total.units}

--- a/src/pages/views/details/components/summary/summaryModalView.tsx
+++ b/src/pages/views/details/components/summary/summaryModalView.tsx
@@ -9,7 +9,7 @@ import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
-import { formatCurrency } from 'utils/valueFormatter';
+import { formatCurrency } from 'utils/format';
 
 import { styles } from './summaryModal.styles';
 
@@ -74,7 +74,7 @@ class SummaryModalViewBase extends React.Component<SummaryModalViewProps> {
               items.map(_item => (
                 <ReportSummaryItem
                   key={_item.id}
-                  valueFormatterOptions={{}}
+                  formatOptions={{}}
                   label={_item.label ? _item.label.toString() : ''}
                   totalValue={report.meta.total.cost.total.value}
                   units={report.meta.total.cost.total.units}

--- a/src/pages/views/details/components/usageChart/usageChart.tsx
+++ b/src/pages/views/details/components/usageChart/usageChart.tsx
@@ -14,9 +14,9 @@ import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
+import { formatPercentage, formatUnits, unitsLookupKey } from 'utils/format';
 import { noop } from 'utils/noop';
 import { skeletonWidth } from 'utils/skeleton';
-import { formatValue, unitsLookupKey } from 'utils/valueFormatter';
 
 import { styles } from './usageChart.styles';
 
@@ -349,21 +349,21 @@ class UsageChartBase extends React.Component<UsageChartProps> {
       <Grid hasGutter>
         <GridItem md={12} lg={6}>
           <div>{intl.formatMessage(messages.DetailsUnusedUsageLabel)}</div>
-          <div style={styles.capacity}>{formatValue(unusedUsageCapacity, usageUnits)}</div>
+          <div style={styles.capacity}>{formatUnits(unusedUsageCapacity, usageUnits)}</div>
           <div>
             {intl.formatMessage(messages.DetailsUnusedUnits, {
-              percentage: formatValue(unusedUsageCapacityPercentage, usageUnits),
+              percentage: formatPercentage(unusedUsageCapacityPercentage, { fractionDigits: 0 }),
               units: usageUnits,
             })}
           </div>
         </GridItem>
         <GridItem md={12} lg={6}>
           <div>{intl.formatMessage(messages.DetailsUnusedRequestsLabel)}</div>
-          <div style={styles.capacity}>{formatValue(unusedRequestCapacity, requestUnits)}</div>
+          <div style={styles.capacity}>{formatUnits(unusedRequestCapacity, requestUnits)}</div>
           <div>
             {intl.formatMessage(messages.DetailsUnusedUnits, {
-              percentage: formatValue(unusedRequestCapacityPercentage, requestUnits),
-              units: usageUnits,
+              percentage: formatPercentage(unusedRequestCapacityPercentage, { fractionDigits: 0 }),
+              units: requestUnits,
             })}
           </div>
         </GridItem>

--- a/src/pages/views/details/gcpDetails/detailsHeader.tsx
+++ b/src/pages/views/details/gcpDetails/detailsHeader.tsx
@@ -15,7 +15,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { gcpProvidersQuery, providersSelectors } from 'store/providers';
 import { ComputedGcpReportItemsParams, getIdKeyForGroupBy } from 'utils/computedReport/getComputedGcpReportItems';
 import { getSinceDateRangeString } from 'utils/dateRange';
-import { formatCurrency } from 'utils/valueFormatter';
+import { formatCurrency } from 'utils/format';
 
 import { styles } from './detailsHeader.styles';
 

--- a/src/pages/views/details/gcpDetails/detailsTable.tsx
+++ b/src/pages/views/details/gcpDetails/detailsTable.tsx
@@ -19,7 +19,7 @@ import { paths } from 'routes';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedGcpReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dateRange';
-import { formatCurrency } from 'utils/valueFormatter';
+import { formatCurrency, formatPercentage } from 'utils/format';
 
 import { styles } from './detailsTable.styles';
 
@@ -238,7 +238,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   private getMonthOverMonthCost = (item: ComputedReportItem, index: number) => {
     const { intl } = this.props;
     const value = formatCurrency(Math.abs(item.cost.total.value - item.delta_value), item.cost.total.units);
-    const percentage = item.delta_percent !== null ? Math.abs(item.delta_percent).toFixed(2) : 0;
+    const percentage = item.delta_percent !== null ? formatPercentage(Math.abs(item.delta_percent)) : 0;
 
     const showPercentage = !(percentage === 0 || percentage === '0.00');
     const showValue = item.delta_percent !== null; // Workaround for https://github.com/project-koku/koku/issues/1395

--- a/src/pages/views/details/ibmDetails/detailsHeader.tsx
+++ b/src/pages/views/details/ibmDetails/detailsHeader.tsx
@@ -15,7 +15,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { ibmProvidersQuery, providersSelectors } from 'store/providers';
 import { ComputedIbmReportItemsParams, getIdKeyForGroupBy } from 'utils/computedReport/getComputedIbmReportItems';
 import { getSinceDateRangeString } from 'utils/dateRange';
-import { formatCurrency } from 'utils/valueFormatter';
+import { formatCurrency } from 'utils/format';
 
 import { styles } from './detailsHeader.styles';
 

--- a/src/pages/views/details/ibmDetails/detailsTable.tsx
+++ b/src/pages/views/details/ibmDetails/detailsTable.tsx
@@ -19,7 +19,7 @@ import { paths } from 'routes';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedIbmReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dateRange';
-import { formatCurrency } from 'utils/valueFormatter';
+import { formatCurrency, formatPercentage } from 'utils/format';
 
 import { styles } from './detailsTable.styles';
 
@@ -238,7 +238,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   private getMonthOverMonthCost = (item: ComputedReportItem, index: number) => {
     const { intl } = this.props;
     const value = formatCurrency(Math.abs(item.cost.total.value - item.delta_value), item.cost.total.units);
-    const percentage = item.delta_percent !== null ? Math.abs(item.delta_percent).toFixed(2) : 0;
+    const percentage = item.delta_percent !== null ? formatPercentage(Math.abs(item.delta_percent)) : 0;
 
     const showPercentage = !(percentage === 0 || percentage === '0.00');
     const showValue = item.delta_percent !== null; // Workaround for https://github.com/project-koku/koku/issues/1395

--- a/src/pages/views/details/ocpDetails/detailsHeader.tsx
+++ b/src/pages/views/details/ocpDetails/detailsHeader.tsx
@@ -16,7 +16,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { ocpProvidersQuery, providersSelectors } from 'store/providers';
 import { ComputedOcpReportItemsParams, getIdKeyForGroupBy } from 'utils/computedReport/getComputedOcpReportItems';
 import { getSinceDateRangeString } from 'utils/dateRange';
-import { formatCurrency } from 'utils/valueFormatter';
+import { formatCurrency } from 'utils/format';
 
 import { styles } from './detailsHeader.styles';
 

--- a/src/pages/views/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/views/details/ocpDetails/detailsTable.tsx
@@ -20,7 +20,7 @@ import { paths } from 'routes';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedOcpReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dateRange';
-import { formatCurrency } from 'utils/valueFormatter';
+import { formatCurrency, formatPercentage } from 'utils/format';
 
 import { styles } from './detailsTable.styles';
 
@@ -326,7 +326,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   private getMonthOverMonthCost = (item: ComputedReportItem, index: number) => {
     const { intl } = this.props;
     const value = formatCurrency(Math.abs(item.cost.total.value - item.delta_value), item.cost.total.units);
-    const percentage = item.delta_percent !== null ? Math.abs(item.delta_percent).toFixed(2) : 0;
+    const percentage = item.delta_percent !== null ? formatPercentage(Math.abs(item.delta_percent)) : 0;
 
     const showPercentage = !(percentage === 0 || percentage === '0.00');
     const showValue = item.delta_percent !== null; // Workaround for https://github.com/project-koku/koku/issues/1395

--- a/src/pages/views/explorer/explorerChart.tsx
+++ b/src/pages/views/explorer/explorerChart.tsx
@@ -21,8 +21,8 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
+import { formatUnits } from 'utils/format';
 import { skeletonWidth } from 'utils/skeleton';
-import { formatValue } from 'utils/valueFormatter';
 
 import { chartStyles, styles } from './explorerChart.styles';
 import {
@@ -231,8 +231,8 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
               <CostExplorerChart
                 adjustContainerHeight
                 containerHeight={chartStyles.chartContainerHeight}
-                valueFormatter={formatValue}
-                valueFormatterOptions={{}}
+                formatOptions={{}}
+                formatter={formatUnits}
                 height={chartStyles.chartHeight}
                 top1stData={datums.length > 0 ? datums[0] : []}
                 top2ndData={datums.length > 1 ? datums[1] : []}

--- a/src/pages/views/explorer/explorerTable.tsx
+++ b/src/pages/views/explorer/explorerTable.tsx
@@ -17,7 +17,7 @@ import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
-import { formatCurrency } from 'utils/valueFormatter';
+import { formatCurrency } from 'utils/format';
 
 import { styles } from './explorerTable.styles';
 import { DateRangeType, getDateRange, getDateRangeDefault, PerspectiveType } from './explorerUtils';

--- a/src/pages/views/overview/components/dashboardWidget.test.tsx
+++ b/src/pages/views/overview/components/dashboardWidget.test.tsx
@@ -39,7 +39,7 @@ const props: DashboardWidgetProps = {
   trend: {
     type: ChartType.rolling,
     titleKey: tmessages.TestTrendTitle,
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   status: FetchStatus.none,
   currentQuery: '',
@@ -48,9 +48,9 @@ const props: DashboardWidgetProps = {
   details: {
     breakdownDescKeyRange: 'detail description range',
     breakdownDescKeySingle: 'detail description single',
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
-  topItems: { valueFormatterOptions: {} },
+  topItems: { formatOptions: {} },
 } as any;
 
 const getDateMock = getDate as jest.Mock;

--- a/src/pages/views/overview/components/dashboardWidgetBase.tsx
+++ b/src/pages/views/overview/components/dashboardWidgetBase.tsx
@@ -28,7 +28,7 @@ import React from 'react';
 import { WrappedComponentProps } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { DashboardChartType, DashboardWidget } from 'store/dashboard/common/dashboardCommon';
-import { formatCurrency, formatValue, unitsLookupKey } from 'utils/valueFormatter';
+import { formatCurrency, formatUnits, unitsLookupKey } from 'utils/format';
 
 import { ChartComparison } from './chartComparison';
 import { chartStyles, styles } from './dashboardWidget.styles';
@@ -198,12 +198,12 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
           forecastData={forecastData.forecastData}
           forecastInfrastructureConeData={forecastInfrastructureData.forecastConeData}
           forecastInfrastructureData={forecastInfrastructureData.forecastData}
+          formatOptions={trend.formatOptions}
+          formatter={formatCurrency}
           height={height}
           previousCostData={previousCostData}
           previousInfrastructureCostData={previousInfrastructureData}
           showForecast={trend.computedForecastItem !== undefined}
-          valueFormatter={formatCurrency}
-          valueFormatterOptions={trend.valueFormatterOptions}
         />
       </>
     );
@@ -243,14 +243,14 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
           currentData={currentData}
           forecastData={forecastData}
           forecastConeData={forecastConeData}
+          formatOptions={trend.formatOptions}
+          formatter={formatCurrency}
           height={height}
           previousData={previousData}
           showForecast={trend.computedForecastItem !== undefined}
           showInfrastructureLabel={showInfrastructureLabel}
           showSupplementaryLabel={showSupplementaryLabel}
           showUsageLegendLabel={details.showUsageLegendLabel}
-          valueFormatter={formatCurrency}
-          valueFormatterOptions={trend.valueFormatterOptions}
           units={this.getUnits()}
         />
       </>
@@ -415,6 +415,8 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         currentData={currentData}
         forecastData={forecastData}
         forecastConeData={forecastConeData}
+        formatOptions={trend.formatOptions}
+        formatter={formatCurrency}
         height={height}
         previousData={previousData}
         showForecast={trend.computedForecastItem !== undefined}
@@ -423,8 +425,6 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         showUsageLegendLabel={details.showUsageLegendLabel}
         title={title}
         units={this.getUnits()}
-        valueFormatter={formatCurrency}
-        valueFormatterOptions={trend.valueFormatterOptions}
       />
     );
   };
@@ -451,12 +451,12 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         containerHeight={chartStyles.containerUsageHeight}
         currentRequestData={currentRequestData}
         currentUsageData={currentUsageData}
+        formatOptions={trend.formatOptions}
+        formatter={formatUnits}
         height={height}
         previousRequestData={previousRequestData}
         previousUsageData={previousUsageData}
         title={title}
-        valueFormatter={formatValue}
-        valueFormatterOptions={trend.valueFormatterOptions}
       />
     );
   };
@@ -472,6 +472,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         computedReportItem={computedReportItem}
         computedReportItemValue={computedReportItemValue}
         costLabel={this.getDetailsLabel(details.costKey)}
+        formatOptions={details.formatOptions}
         report={currentReport}
         reportType={reportType}
         requestLabel={this.getDetailsLabel(details.requestKey)}
@@ -479,9 +480,8 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         showUnits={details.showUnits}
         showUsageFirst={details.showUsageFirst}
         units={this.getUnits()}
-        usageValueFormatterOptions={details.usageValueFormatterOptions}
+        usageFormatOptions={details.usageFormatOptions}
         usageLabel={this.getDetailsLabel(details.usageKey)}
-        valueFormatterOptions={details.valueFormatterOptions}
       />
     );
   };
@@ -592,12 +592,12 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     if (activeTab === currentTab) {
       return (
         <ReportSummaryItem
+          formatOptions={topItems.formatOptions}
           key={`${reportItem.id}-item`}
           label={reportItem.label ? reportItem.label.toString() : ''}
           totalValue={totalValue}
           units={this.getUnits()}
           value={reportItem[computedReportItem][computedReportItemValue].value}
-          valueFormatterOptions={topItems.valueFormatterOptions}
         />
       );
     } else {

--- a/src/store/dashboard/awsDashboard/awsDashboard.test.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboard.test.ts
@@ -77,14 +77,14 @@ test('getQueryForWidget', () => {
     reportType: ReportType.cost,
     availableTabs: [AwsDashboardTab.accounts],
     currentTab: AwsDashboardTab.accounts,
-    details: { valueFormatterOptions: {} },
+    details: { formatOptions: {} },
     trend: {
       titleKey: '',
       type: ChartType.daily,
-      valueFormatterOptions: {},
+      formatOptions: {},
     },
     topItems: {
-      valueFormatterOptions: {},
+      formatOptions: {},
     },
   };
 

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -26,10 +26,10 @@ export const computeWidget: AwsDashboardWidget = {
     showUsageFirst: true,
     showUsageLegendLabel: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
     },
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -44,12 +44,12 @@ export const computeWidget: AwsDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   AwsDashboardTab.instanceType,
@@ -71,7 +71,7 @@ export const costSummaryWidget: AwsDashboardWidget = {
     adjustContainerHeight: true,
     costKey: messages.Cost,
     showHorizontal: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
     viewAllPath: paths.awsDetails,
@@ -86,10 +86,10 @@ export const costSummaryWidget: AwsDashboardWidget = {
     dailyTitleKey: messages.AWSDailyCostTrendTitle,
     titleKey: messages.AWSCostTrendTitle,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   availableTabs: [AwsDashboardTab.services, AwsDashboardTab.accounts, AwsDashboardTab.regions],
   chartType: DashboardChartType.dailyTrend,
@@ -104,7 +104,7 @@ export const databaseWidget: AwsDashboardWidget = {
   details: {
     costKey: messages.Cost,
     showUnits: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -119,10 +119,10 @@ export const databaseWidget: AwsDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   AwsDashboardTab.services,
@@ -141,7 +141,7 @@ export const networkWidget: AwsDashboardWidget = {
   details: {
     costKey: messages.Cost,
     showUnits: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -156,10 +156,10 @@ export const networkWidget: AwsDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   AwsDashboardTab.services,
@@ -182,10 +182,10 @@ export const storageWidget: AwsDashboardWidget = {
     showUsageFirst: true,
     showUsageLegendLabel: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
     },
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -194,12 +194,12 @@ export const storageWidget: AwsDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   AwsDashboardTab.services,

--- a/src/store/dashboard/awsOcpDashboard/awsOcpDashboardWidgets.ts
+++ b/src/store/dashboard/awsOcpDashboard/awsOcpDashboardWidgets.ts
@@ -21,15 +21,15 @@ export const computeWidget: AwsOcpDashboardWidget = {
   reportType: ReportType.instanceType,
   details: {
     costKey: messages.Cost,
+    formatOptions: {
+      fractionDigits: 2,
+    },
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
-    },
-    valueFormatterOptions: {
-      fractionDigits: 2,
     },
   },
   filter: {
@@ -41,14 +41,14 @@ export const computeWidget: AwsOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
-    type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
+    titleKey: messages.DashboardDailyUsageComparison,
+    type: ChartType.daily,
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   AwsOcpDashboardTab.instanceType,
@@ -68,10 +68,10 @@ export const costSummaryWidget: AwsOcpDashboardWidget = {
   reportType: ReportType.cost,
   details: {
     costKey: messages.Cost,
-    showHorizontal: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
+    showHorizontal: true,
   },
   tabsFilter: {
     limit: 3,
@@ -81,12 +81,12 @@ export const costSummaryWidget: AwsOcpDashboardWidget = {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
     dailyTitleKey: messages.AWSDailyCostTrendTitle,
+    formatOptions: {},
     titleKey: messages.AWSCostTrendTitle,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   availableTabs: [AwsOcpDashboardTab.services, AwsOcpDashboardTab.accounts, AwsOcpDashboardTab.regions],
   chartType: DashboardChartType.dailyTrend,
@@ -100,10 +100,10 @@ export const databaseWidget: AwsOcpDashboardWidget = {
   reportType: ReportType.database,
   details: {
     costKey: messages.Cost,
-    showUnits: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
+    showUnits: true,
   },
   filter: {
     service: 'AmazonRDS,AmazonDynamoDB,AmazonElastiCache,AmazonNeptune,AmazonRedshift,AmazonDocumentDB',
@@ -114,12 +114,12 @@ export const databaseWidget: AwsOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    formatOptions: {},
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   AwsOcpDashboardTab.services,
@@ -137,10 +137,10 @@ export const networkWidget: AwsOcpDashboardWidget = {
   reportType: ReportType.network,
   details: {
     costKey: messages.Cost,
-    showUnits: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
+    showUnits: true,
   },
   filter: {
     service: 'AmazonVPC,AmazonOcpFront,AmazonRoute53,AmazonAPIGateway',
@@ -151,12 +151,12 @@ export const networkWidget: AwsOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    formatOptions: {},
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   AwsOcpDashboardTab.services,
@@ -174,28 +174,28 @@ export const storageWidget: AwsOcpDashboardWidget = {
   reportType: ReportType.storage,
   details: {
     costKey: messages.Cost,
+    formatOptions: {
+      fractionDigits: 2,
+    },
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
-    },
-    valueFormatterOptions: {
-      fractionDigits: 2,
     },
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
-    type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
+    titleKey: messages.DashboardDailyUsageComparison,
+    type: ChartType.daily,
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   AwsOcpDashboardTab.services,

--- a/src/store/dashboard/azureDashboard/azureDashboard.test.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboard.test.ts
@@ -88,14 +88,14 @@ test('getQueryForWidget', () => {
     reportType: ReportType.cost,
     availableTabs: [AzureDashboardTab.subscription_guids],
     currentTab: AzureDashboardTab.subscription_guids,
-    details: { valueFormatterOptions: {} },
+    details: { formatOptions: {} },
     trend: {
+      formatOptions: {},
       titleKey: '',
       type: ChartType.daily,
-      valueFormatterOptions: {},
     },
     topItems: {
-      valueFormatterOptions: {},
+      formatOptions: {},
     },
   };
 

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -25,10 +25,10 @@ export const costSummaryWidget: AzureDashboardWidget = {
   details: {
     adjustContainerHeight: true,
     costKey: messages.Cost,
-    showHorizontal: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
+    showHorizontal: true,
     viewAllPath: paths.azureDetails,
   },
   tabsFilter: {
@@ -39,12 +39,12 @@ export const costSummaryWidget: AzureDashboardWidget = {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
     dailyTitleKey: messages.AzureDailyCostTrendTitle,
+    formatOptions: {},
     titleKey: messages.AzureCostTrendTitle,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   availableTabs: [
     AzureDashboardTab.service_names,
@@ -62,10 +62,10 @@ export const databaseWidget: AzureDashboardWidget = {
   reportType: ReportType.database,
   details: {
     costKey: messages.Cost,
-    showUnits: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
+    showUnits: true,
   },
   filter: {
     service_name: 'Database,Cosmos DB,Cache for Redis',
@@ -76,12 +76,12 @@ export const databaseWidget: AzureDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    formatOptions: {},
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   AzureDashboardTab.service_names,
@@ -99,10 +99,10 @@ export const networkWidget: AzureDashboardWidget = {
   reportType: ReportType.network,
   details: {
     costKey: messages.Cost,
-    showUnits: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
+    showUnits: true,
   },
   filter: {
     service_name: 'Virtual Network,VPN,DNS,Traffic Manager,ExpressRoute,Load Balancer,Application Gateway',
@@ -113,12 +113,12 @@ export const networkWidget: AzureDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    formatOptions: {},
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   AzureDashboardTab.service_names,
@@ -136,15 +136,15 @@ export const storageWidget: AzureDashboardWidget = {
   reportType: ReportType.storage,
   details: {
     costKey: messages.Cost,
+    formatOptions: {
+      fractionDigits: 2,
+    },
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
-    },
-    valueFormatterOptions: {
-      fractionDigits: 2,
     },
   },
   filter: {
@@ -156,14 +156,14 @@ export const storageWidget: AzureDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
-    type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
+    titleKey: messages.DashboardDailyUsageComparison,
+    type: ChartType.daily,
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   AzureDashboardTab.service_names,
@@ -181,15 +181,15 @@ export const virtualMachineWidget: AzureDashboardWidget = {
   reportType: ReportType.instanceType,
   details: {
     costKey: messages.Cost,
+    formatOptions: {
+      fractionDigits: 2,
+    },
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
-    },
-    valueFormatterOptions: {
-      fractionDigits: 2,
     },
   },
   filter: {
@@ -201,14 +201,14 @@ export const virtualMachineWidget: AzureDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
-    type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
+    titleKey: messages.DashboardDailyUsageComparison,
+    type: ChartType.daily,
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   AzureDashboardTab.instanceType,

--- a/src/store/dashboard/azureOcpDashboard/azureOcpDashboardWidgets.ts
+++ b/src/store/dashboard/azureOcpDashboard/azureOcpDashboardWidgets.ts
@@ -24,7 +24,7 @@ export const costSummaryWidget: AzureOcpDashboardWidget = {
   details: {
     costKey: messages.Cost,
     showHorizontal: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -38,10 +38,10 @@ export const costSummaryWidget: AzureOcpDashboardWidget = {
     dailyTitleKey: messages.AzureDailyCostTrendTitle,
     titleKey: messages.AzureCostTrendTitle,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   availableTabs: [
     AzureOcpDashboardTab.service_names,
@@ -60,7 +60,7 @@ export const databaseWidget: AzureOcpDashboardWidget = {
   details: {
     costKey: messages.Cost,
     showUnits: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -75,10 +75,10 @@ export const databaseWidget: AzureOcpDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   AzureOcpDashboardTab.service_names,
@@ -97,7 +97,7 @@ export const networkWidget: AzureOcpDashboardWidget = {
   details: {
     costKey: messages.Cost,
     showUnits: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -112,10 +112,10 @@ export const networkWidget: AzureOcpDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   AzureOcpDashboardTab.service_names,
@@ -137,10 +137,10 @@ export const storageWidget: AzureOcpDashboardWidget = {
     showUsageFirst: true,
     showUsageLegendLabel: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
     },
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -155,12 +155,12 @@ export const storageWidget: AzureOcpDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   AzureOcpDashboardTab.service_names,
@@ -182,10 +182,10 @@ export const virtualMachineWidget: AzureOcpDashboardWidget = {
     showUsageFirst: true,
     showUsageLegendLabel: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
     },
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -200,12 +200,12 @@ export const virtualMachineWidget: AzureOcpDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   AzureOcpDashboardTab.instanceType,

--- a/src/store/dashboard/common/dashboardCommon.ts
+++ b/src/store/dashboard/common/dashboardCommon.ts
@@ -1,6 +1,7 @@
 import { MessageDescriptor } from '@formatjs/intl/src/types';
 import { ForecastPathsType, ForecastType } from 'api/forecasts/forecast';
 import { ReportPathsType, ReportType } from 'api/reports/report';
+import { FormatOptions } from 'utils/format';
 
 // eslint-disable-next-line no-shadow
 export const enum DashboardChartType {
@@ -11,10 +12,6 @@ export const enum DashboardChartType {
   usage = 'usage', // This displays daily usage and requests
 }
 
-export interface ValueValueFormatterOptions {
-  fractionDigits?: number;
-}
-
 export interface DashboardWidget<T> {
   availableTabs?: T[];
   chartType?: DashboardChartType;
@@ -22,7 +19,8 @@ export interface DashboardWidget<T> {
   details: {
     adjustContainerHeight?: boolean; // Adjust chart container height for responsiveness
     costKey?: MessageDescriptor; // i18n key
-    requestValueFormatterOptions?: {
+    formatOptions: FormatOptions;
+    requestFormatOptions?: {
       fractionDigits?: number;
     };
     requestKey?: MessageDescriptor;
@@ -32,10 +30,9 @@ export interface DashboardWidget<T> {
     showUsageFirst?: boolean; // Show usage before cost
     showUsageLegendLabel?: boolean;
     usageKey?: MessageDescriptor; // i18n key
-    valueFormatterOptions: ValueValueFormatterOptions;
     viewAllPath?: string; // View all link to details page
     units?: string; // Override units shown as workaround for missing Azure API units
-    usageValueFormatterOptions?: ValueValueFormatterOptions;
+    usageFormatOptions?: FormatOptions;
   };
   filter?: {
     limit?: number;
@@ -59,14 +56,14 @@ export interface DashboardWidget<T> {
     computedForecastInfrastructureItem?: string; // The computed forecast infrastructure item to use in charts.
     computedReportItem: string; // The computed report item to use in charts, summary, etc.
     computedReportItemValue: string; // The computed report value (e.g., raw, markup, total, or usage)
+    formatOptions: FormatOptions;
     dailyTitleKey?: MessageDescriptor;
     showInfrastructureLabel?: boolean; // Trend chart legend items show "Infrastructure cost" instead of "cost"
     showSupplementaryLabel?: boolean; // Trend chart legend items show "Supplementary cost" instead of "cost"
     titleKey: MessageDescriptor;
     type: number;
-    valueFormatterOptions: ValueValueFormatterOptions;
   };
   topItems?: {
-    valueFormatterOptions: any;
+    formatOptions: any;
   };
 }

--- a/src/store/dashboard/gcpDashboard/gcpDashboard.test.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboard.test.ts
@@ -77,14 +77,14 @@ test('getQueryForWidget', () => {
     reportType: ReportType.cost,
     availableTabs: [GcpDashboardTab.accounts],
     currentTab: GcpDashboardTab.accounts,
-    details: { valueFormatterOptions: {} },
+    details: { formatOptions: {} },
     trend: {
       titleKey: '',
       type: ChartType.daily,
-      valueFormatterOptions: {},
+      formatOptions: {},
     },
     topItems: {
-      valueFormatterOptions: {},
+      formatOptions: {},
     },
   };
 

--- a/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
@@ -27,10 +27,10 @@ export const computeWidget: GcpDashboardWidget = {
     showUsageFirst: true,
     showUsageLegendLabel: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
     },
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -45,12 +45,12 @@ export const computeWidget: GcpDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   GcpDashboardTab.instanceType,
@@ -72,7 +72,7 @@ export const costSummaryWidget: GcpDashboardWidget = {
     adjustContainerHeight: true,
     costKey: messages.Cost,
     showHorizontal: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
     viewAllPath: paths.gcpDetails,
@@ -87,10 +87,10 @@ export const costSummaryWidget: GcpDashboardWidget = {
     dailyTitleKey: messages.GCPDailyCostTrendTitle,
     titleKey: messages.GCPCostTrendTitle,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   availableTabs: [GcpDashboardTab.services, GcpDashboardTab.projects, GcpDashboardTab.regions],
   chartType: DashboardChartType.dailyTrend,
@@ -105,7 +105,7 @@ export const databaseWidget: GcpDashboardWidget = {
   details: {
     costKey: messages.Cost,
     showUnits: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -120,10 +120,10 @@ export const databaseWidget: GcpDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   GcpDashboardTab.services,
@@ -142,7 +142,7 @@ export const networkWidget: GcpDashboardWidget = {
   details: {
     costKey: messages.Cost,
     showUnits: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -159,10 +159,10 @@ export const networkWidget: GcpDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   GcpDashboardTab.services,
@@ -184,10 +184,10 @@ export const storageWidget: GcpDashboardWidget = {
     showUsageFirst: true,
     showUsageLegendLabel: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
     },
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -196,12 +196,12 @@ export const storageWidget: GcpDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   GcpDashboardTab.services,

--- a/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboard.test.ts
+++ b/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboard.test.ts
@@ -88,14 +88,14 @@ test('getQueryForWidget', () => {
     reportType: ReportType.cost,
     availableTabs: [GcpOcpDashboardTab.accounts],
     currentTab: GcpOcpDashboardTab.accounts,
-    details: { valueFormatterOptions: {} },
+    details: { formatOptions: {} },
     trend: {
       titleKey: '',
       type: ChartType.daily,
-      valueFormatterOptions: {},
+      formatOptions: {},
     },
     topItems: {
-      valueFormatterOptions: {},
+      formatOptions: {},
     },
   };
 

--- a/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardWidgets.ts
@@ -26,10 +26,10 @@ export const computeWidget: GcpOcpDashboardWidget = {
     showUsageFirst: true,
     showUsageLegendLabel: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
     },
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -44,12 +44,12 @@ export const computeWidget: GcpOcpDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   GcpOcpDashboardTab.instanceType,
@@ -71,7 +71,7 @@ export const costSummaryWidget: GcpOcpDashboardWidget = {
     adjustContainerHeight: true,
     costKey: messages.Cost,
     showHorizontal: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -85,10 +85,10 @@ export const costSummaryWidget: GcpOcpDashboardWidget = {
     dailyTitleKey: messages.GCPDailyCostTrendTitle,
     titleKey: messages.GCPCostTrendTitle,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   availableTabs: [GcpOcpDashboardTab.services, GcpOcpDashboardTab.projects, GcpOcpDashboardTab.regions],
   chartType: DashboardChartType.dailyTrend,
@@ -103,7 +103,7 @@ export const databaseWidget: GcpOcpDashboardWidget = {
   details: {
     costKey: messages.Cost,
     showUnits: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -118,10 +118,10 @@ export const databaseWidget: GcpOcpDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   GcpOcpDashboardTab.services,
@@ -140,7 +140,7 @@ export const networkWidget: GcpOcpDashboardWidget = {
   details: {
     costKey: messages.Cost,
     showUnits: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -157,10 +157,10 @@ export const networkWidget: GcpOcpDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   GcpOcpDashboardTab.services,
@@ -182,10 +182,10 @@ export const storageWidget: GcpOcpDashboardWidget = {
     showUsageFirst: true,
     showUsageLegendLabel: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
     },
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -194,12 +194,12 @@ export const storageWidget: GcpOcpDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   GcpOcpDashboardTab.services,

--- a/src/store/dashboard/ibmDashboard/ibmDashboard.test.ts
+++ b/src/store/dashboard/ibmDashboard/ibmDashboard.test.ts
@@ -77,14 +77,14 @@ test('getQueryForWidget', () => {
     reportType: ReportType.cost,
     availableTabs: [IbmDashboardTab.accounts],
     currentTab: IbmDashboardTab.accounts,
-    details: { valueFormatterOptions: {} },
+    details: { formatOptions: {} },
     trend: {
       titleKey: '',
       type: ChartType.daily,
-      valueFormatterOptions: {},
+      formatOptions: {},
     },
     topItems: {
-      valueFormatterOptions: {},
+      formatOptions: {},
     },
   };
 

--- a/src/store/dashboard/ibmDashboard/ibmDashboardWidgets.ts
+++ b/src/store/dashboard/ibmDashboard/ibmDashboardWidgets.ts
@@ -27,10 +27,10 @@ export const computeWidget: IbmDashboardWidget = {
     showUsageFirst: true,
     showUsageLegendLabel: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
     },
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -45,12 +45,12 @@ export const computeWidget: IbmDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   IbmDashboardTab.instanceType,
@@ -72,7 +72,7 @@ export const costSummaryWidget: IbmDashboardWidget = {
     adjustContainerHeight: true,
     costKey: messages.Cost,
     showHorizontal: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
     viewAllPath: paths.ibmDetails,
@@ -87,10 +87,10 @@ export const costSummaryWidget: IbmDashboardWidget = {
     dailyTitleKey: messages.IBMDailyCostTrendTitle,
     titleKey: messages.IBMCostTrendTitle,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   availableTabs: [IbmDashboardTab.services, IbmDashboardTab.projects, IbmDashboardTab.regions],
   chartType: DashboardChartType.dailyTrend,
@@ -105,7 +105,7 @@ export const databaseWidget: IbmDashboardWidget = {
   details: {
     costKey: messages.Cost,
     showUnits: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -120,10 +120,10 @@ export const databaseWidget: IbmDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   IbmDashboardTab.services,
@@ -142,7 +142,7 @@ export const networkWidget: IbmDashboardWidget = {
   details: {
     costKey: messages.Cost,
     showUnits: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -159,10 +159,10 @@ export const networkWidget: IbmDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   IbmDashboardTab.services,
@@ -184,10 +184,10 @@ export const storageWidget: IbmDashboardWidget = {
     showUsageFirst: true,
     showUsageLegendLabel: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
     },
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -196,12 +196,12 @@ export const storageWidget: IbmDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [
   //   IbmDashboardTab.services,

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboard.test.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboard.test.ts
@@ -84,15 +84,15 @@ test('getQueryForWidget', () => {
     reportType: ReportType.cost,
     availableTabs: [OcpCloudDashboardTab.accounts],
     currentTab: OcpCloudDashboardTab.accounts,
-    details: { valueFormatterOptions: {} },
+    details: { formatOptions: {} },
     trend: {
       computedReportItem: ComputedReportItemType.cost,
+      formatOptions: {},
       titleKey: '',
       type: ChartType.daily,
-      valueFormatterOptions: {},
     },
     topItems: {
-      valueFormatterOptions: {},
+      formatOptions: {},
     },
   };
 

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
@@ -23,10 +23,10 @@ export const costSummaryWidget: OcpCloudDashboardWidget = {
   reportType: ReportType.cost,
   details: {
     costKey: messages.Cost,
-    showHorizontal: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
+    showHorizontal: true,
   },
   tabsFilter: {
     limit: 3,
@@ -36,12 +36,12 @@ export const costSummaryWidget: OcpCloudDashboardWidget = {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
     dailyTitleKey: messages.OCPCloudDashboardDailyCostTrendTitle,
+    formatOptions: {},
     titleKey: messages.OCPCloudDashboardCostTrendTitle,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   availableTabs: [OcpCloudDashboardTab.services, OcpCloudDashboardTab.accounts, OcpCloudDashboardTab.regions],
   chartType: DashboardChartType.dailyTrend,
@@ -57,15 +57,15 @@ export const computeWidget: OcpCloudDashboardWidget = {
   reportType: ReportType.instanceType,
   details: {
     costKey: messages.Cost,
+    formatOptions: {
+      fractionDigits: 2,
+    },
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
-    },
-    valueFormatterOptions: {
-      fractionDigits: 2,
     },
   },
   filter: {
@@ -76,7 +76,7 @@ export const computeWidget: OcpCloudDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -91,7 +91,7 @@ export const databaseWidget: OcpCloudDashboardWidget = {
   details: {
     costKey: messages.Cost,
     showUnits: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -105,7 +105,7 @@ export const databaseWidget: OcpCloudDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   chartType: DashboardChartType.trend,
 };
@@ -118,7 +118,7 @@ export const networkWidget: OcpCloudDashboardWidget = {
   details: {
     costKey: messages.Cost,
     showUnits: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -132,7 +132,7 @@ export const networkWidget: OcpCloudDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   chartType: DashboardChartType.trend,
 };
@@ -148,10 +148,10 @@ export const storageWidget: OcpCloudDashboardWidget = {
     showUsageFirst: true,
     showUsageLegendLabel: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
     },
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },
@@ -160,7 +160,7 @@ export const storageWidget: OcpCloudDashboardWidget = {
     computedReportItemValue: ComputedReportItemValueType.total,
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
   },

--- a/src/store/dashboard/ocpDashboard/ocpDashboard.test.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboard.test.ts
@@ -72,15 +72,15 @@ test('getQueryForWidget', () => {
     reportType: ReportType.cost,
     availableTabs: [OcpDashboardTab.projects],
     currentTab: OcpDashboardTab.projects,
-    details: { valueFormatterOptions: {} },
+    details: { formatOptions: {} },
     trend: {
       computedReportItem: ComputedReportItemType.cost,
+      formatOptions: {},
       titleKey: '',
       type: ChartType.daily,
-      valueFormatterOptions: {},
     },
     topItems: {
-      valueFormatterOptions: {},
+      formatOptions: {},
     },
   };
 

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -25,11 +25,11 @@ export const costSummaryWidget: OcpDashboardWidget = {
   details: {
     adjustContainerHeight: true,
     costKey: messages.Cost,
-    showHorizontal: true,
-    showTooltip: true,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
+    showHorizontal: true,
+    showTooltip: true,
     viewAllPath: paths.ocpDetails,
   },
   trend: {
@@ -38,15 +38,15 @@ export const costSummaryWidget: OcpDashboardWidget = {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
     dailyTitleKey: messages.OCPDashboardDailyCostTitle,
+    formatOptions: {},
     titleKey: messages.OCPDashboardCostTrendTitle,
     type: ChartType.rolling,
-    valueFormatterOptions: {},
   },
   tabsFilter: {
     limit: 3,
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   availableTabs: [OcpDashboardTab.projects, OcpDashboardTab.clusters],
   chartType: DashboardChartType.dailyTrend, // No longer showing infrastructure via DashboardChartType.dailyCost
@@ -59,31 +59,31 @@ export const cpuWidget: OcpDashboardWidget = {
   reportPathsType: ReportPathsType.ocp,
   reportType: ReportType.cpu,
   details: {
-    requestValueFormatterOptions: {
+    formatOptions: {
+      fractionDigits: 0,
+    },
+    requestFormatOptions: {
       fractionDigits: 0,
     },
     requestKey: messages.Requests,
     showUnits: true,
     showUsageFirst: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
-      fractionDigits: 0,
-    },
-    valueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
     },
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.OCPDailyUsageAndRequestComparison,
-    type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
+    titleKey: messages.OCPDailyUsageAndRequestComparison,
+    type: ChartType.daily,
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [OcpDashboardTab.projects, OcpDashboardTab.clusters],
   chartType: DashboardChartType.usage,
@@ -96,31 +96,31 @@ export const memoryWidget: OcpDashboardWidget = {
   reportPathsType: ReportPathsType.ocp,
   reportType: ReportType.memory,
   details: {
-    requestValueFormatterOptions: {
+    formatOptions: {
+      fractionDigits: 0,
+    },
+    requestFormatOptions: {
       fractionDigits: 0,
     },
     requestKey: messages.Requests,
     showUnits: true,
     showUsageFirst: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
-      fractionDigits: 0,
-    },
-    valueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
     },
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.OCPDailyUsageAndRequestComparison,
-    type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
+    titleKey: messages.OCPDailyUsageAndRequestComparison,
+    type: ChartType.daily,
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [OcpDashboardTab.projects, OcpDashboardTab.clusters],
   chartType: DashboardChartType.usage,
@@ -133,31 +133,31 @@ export const volumeWidget: OcpDashboardWidget = {
   reportPathsType: ReportPathsType.ocp,
   reportType: ReportType.volume,
   details: {
-    requestValueFormatterOptions: {
+    formatOptions: {
+      fractionDigits: 0,
+    },
+    requestFormatOptions: {
       fractionDigits: 0,
     },
     requestKey: messages.Requests,
     showUnits: true,
     showUsageFirst: true,
     usageKey: messages.Usage,
-    usageValueFormatterOptions: {
-      fractionDigits: 0,
-    },
-    valueFormatterOptions: {
+    usageFormatOptions: {
       fractionDigits: 0,
     },
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.OCPDailyUsageAndRequestComparison,
-    type: ChartType.daily,
-    valueFormatterOptions: {
+    formatOptions: {
       fractionDigits: 2,
     },
+    titleKey: messages.OCPDailyUsageAndRequestComparison,
+    type: ChartType.daily,
   },
   topItems: {
-    valueFormatterOptions: {},
+    formatOptions: {},
   },
   // availableTabs: [OcpDashboardTab.projects, OcpDashboardTab.clusters],
   chartType: DashboardChartType.usage,

--- a/src/utils/__snapshots__/format.test.ts.snap
+++ b/src/utils/__snapshots__/format.test.ts.snap
@@ -4,6 +4,6 @@ exports[`formatCurrency defaults fractionDigits 1`] = `100.11`;
 
 exports[`formatCurrency uses specified fractionDigits 1`] = `100.11`;
 
-exports[`formatValue null unit returns value fixed to fractionDigits 1`] = `"100.1"`;
+exports[`formatUnits null unit returns value fixed to fractionDigits 1`] = `"100.1"`;
 
-exports[`formatValue unknown unit returns value fixed to fractionDigits 1`] = `"100"`;
+exports[`formatUnits unknown unit returns value fixed to fractionDigits 1`] = `"100"`;

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,28 +1,28 @@
-import * as format from './valueFormatter';
+import * as format from './format';
 
 jest.spyOn(format, 'formatCurrency');
 
-describe('formatValue', () => {
-  const valueFormatterOptions: format.ValueFormatterOptions = {};
+describe('formatUnits', () => {
+  const formatOptions: format.FormatOptions = {};
   const value = 100.11;
 
   test('null value returns 0', () => {
-    expect(format.formatValue(null, 'unknownUnit')).toBe('0');
+    expect(format.formatUnits(null, 'unknownUnit')).toBe('0');
   });
   test('unknown unit returns value fixed to fractionDigits', () => {
-    const formatted = format.formatValue(value, 'unknownUnit');
+    const formatted = format.formatUnits(value, 'unknownUnit');
     expect(formatted).toMatchSnapshot();
   });
 
   test('USD unit calls formatCurrency', () => {
     const units = 'USD';
-    format.formatCurrency(value, units, valueFormatterOptions);
-    expect(format.formatCurrency).toBeCalledWith(value, units, valueFormatterOptions);
+    format.formatCurrency(value, units, formatOptions);
+    expect(format.formatCurrency).toBeCalledWith(value, units, formatOptions);
   });
 
   test('null unit returns value fixed to fractionDigits', () => {
     const units = null;
-    const formatted = format.formatValue(value, units, { fractionDigits: 1 });
+    const formatted = format.formatUnits(value, units, { fractionDigits: 1 });
     expect(formatted).toMatchSnapshot();
   });
 });


### PR DESCRIPTION
- Updated components to call `formatPercentage` instead of `formatUnits`
- Renamed `ValueFormatter` and `ValueFormatterOptions` as `Formatter` and `FormatOptions`
- Localized percent symbol shown by cost models markup

https://issues.redhat.com/browse/COST-1858