### PR TITLE
Cost models percentages are not localized

### DIFF
--- a/src/pages/costModels/costModel/markup.tsx
+++ b/src/pages/costModels/costModel/markup.tsx
@@ -76,7 +76,7 @@ const MarkupCardBase: React.FunctionComponent<Props> = ({
         </CardHeader>
         <CardBody style={styles.cardDescription}>{intl.formatMessage(messages.MarkupOrDiscountDesc)}</CardBody>
         <CardBody isFilled />
-        <CardBody style={styles.cardBody}>{markupValue}%</CardBody>
+        <CardBody style={styles.cardBody}>{intl.formatMessage(messages.Percent, { value: markupValue })}</CardBody>
         <CardBody isFilled />
       </Card>
     </>

--- a/src/pages/costModels/createCostModelWizard/review.tsx
+++ b/src/pages/costModels/createCostModelWizard/review.tsx
@@ -99,7 +99,9 @@ const ReviewDetailsBase: React.SFC<WrappedComponentProps> = ({ intl }) => (
                   <TextListItem component={TextListItemVariants.dt}>
                     {intl.formatMessage(messages.CostModelsWizardReviewMarkDiscount)}
                   </TextListItem>
-                  <TextListItem component={TextListItemVariants.dd}>{isDiscount ? '-' + markup : markup}%</TextListItem>
+                  <TextListItem component={TextListItemVariants.dd}>
+                    {intl.formatMessage(messages.Percent, { value: isDiscount ? '-' + markup : markup })}
+                  </TextListItem>
                   {type === 'OCP' && (
                     <>
                       <TextListItem component={TextListItemVariants.dt}>


### PR DESCRIPTION
Removed the hard coded '%" characters in the wizard review and cost calculations markup.

https://issues.redhat.com/browse/COST-1892

<img width="822" alt="Screen Shot 2021-09-22 at 10 03 32 PM" src="https://user-images.githubusercontent.com/17481322/134444783-9bc82c66-0be2-4dd0-b194-cc677f8d9bfa.png">

<img width="1109" alt="Screen Shot 2021-09-22 at 10 04 08 PM" src="https://user-images.githubusercontent.com/17481322/134444791-debf0ca4-a84a-42c3-9fb8-35a30a9d2b4f.png">


