### PR TITLE
Markup shows validation error for German locale

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -33768,6 +33768,18 @@
         "value": "Use markup/discount to manipulate how the raw costs are being calculated for your sources. Note, costs calculated from price list rates will not be affected by this."
       }
     ],
+    "MarkupOrDiscountNumber": [
+      {
+        "type": 0,
+        "value": "Markup or discount must be a number"
+      }
+    ],
+    "MarkupOrDiscountTooLong": [
+      {
+        "type": 0,
+        "value": "Should not exceed 10 decimals"
+      }
+    ],
     "MarkupPlus": [
       {
         "type": 0,

--- a/locales/data.json
+++ b/locales/data.json
@@ -1,4 +1,18120 @@
 {
+  "de": {
+    "AWS": [
+      {
+        "type": 0,
+        "value": "DE Amazon Web Services"
+      }
+    ],
+    "AWSComputeTitle": [
+      {
+        "type": 0,
+        "value": "DE Compute (EC2) instances usage"
+      }
+    ],
+    "AWSCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "DE Amazon Web Services cumulative cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "AWSDailyCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "DE Amazon Web Services daily cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "AWSDashboardCostTitle": [
+      {
+        "type": 0,
+        "value": "DE Amazon Web Services cost"
+      }
+    ],
+    "AWSDesc": [
+      {
+        "type": 0,
+        "value": "DE Raw cost from Amazon Web Services infrastructure."
+      }
+    ],
+    "AWSDetailsTable": [
+      {
+        "type": 0,
+        "value": "DE Amazon Web Services details table"
+      }
+    ],
+    "AWSDetailsTitle": [
+      {
+        "type": 0,
+        "value": "DE Amazon Web Services Details"
+      }
+    ],
+    "AWSOcpDashboardCostTitle": [
+      {
+        "type": 0,
+        "value": "DE Amazon Web Services filtered by OpenShift cost"
+      }
+    ],
+    "Azure": [
+      {
+        "type": 0,
+        "value": "DE Microsoft Azure"
+      }
+    ],
+    "AzureComputeTitle": [
+      {
+        "type": 0,
+        "value": "DE Virtual machines usage"
+      }
+    ],
+    "AzureCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "DE Microsoft Azure cumulative cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "AzureDailyCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "DE Microsoft Azure daily cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "AzureDashboardCostTitle": [
+      {
+        "type": 0,
+        "value": "DE Microsoft Azure cost"
+      }
+    ],
+    "AzureDesc": [
+      {
+        "type": 0,
+        "value": "DE Raw cost from Azure infrastructure."
+      }
+    ],
+    "AzureDetailsTable": [
+      {
+        "type": 0,
+        "value": "DE Microsoft Azure details table"
+      }
+    ],
+    "AzureDetailsTitle": [
+      {
+        "type": 0,
+        "value": "DE Microsoft Azure details"
+      }
+    ],
+    "AzureOcpDashboardCostTitle": [
+      {
+        "type": 0,
+        "value": "DE Microsoft Azure filtered by OpenShift cost"
+      }
+    ],
+    "Back": [
+      {
+        "type": 0,
+        "value": "DE Back"
+      }
+    ],
+    "BreakdownBackToDetails": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " account details"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " cluster details"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " instance type details"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " node details"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " organizational unit details"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " project details"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " region details"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " region details"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " service details"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " service details"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " account details"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost by tags"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "groupBy"
+      }
+    ],
+    "BreakdownBackToDetailsAriaLabel": [
+      {
+        "type": 0,
+        "value": "DE Back to details"
+      }
+    ],
+    "BreakdownCostBreakdownAriaLabel": [
+      {
+        "type": 0,
+        "value": "DE A description of markup, raw cost and usage cost"
+      }
+    ],
+    "BreakdownCostBreakdownTitle": [
+      {
+        "type": 0,
+        "value": "DE Cost breakdown"
+      }
+    ],
+    "BreakdownCostChartAriaDesc": [
+      {
+        "type": 0,
+        "value": "DE Breakdown of markup, raw, and usage costs"
+      }
+    ],
+    "BreakdownCostChartTooltip": [
+      {
+        "type": 1,
+        "value": "name"
+      },
+      {
+        "type": 0,
+        "value": "DE : "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      }
+    ],
+    "BreakdownCostOverviewTitle": [
+      {
+        "type": 0,
+        "value": "DE Cost overview"
+      }
+    ],
+    "BreakdownHistoricalDataTitle": [
+      {
+        "type": 0,
+        "value": "DE Historical data"
+      }
+    ],
+    "BreakdownSummaryTitle": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost by accounts"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost by clusters"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost by instance types"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost by Node"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost by organizational units"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost by projects"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost by regions"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost by regions"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost by services"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost by services"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost by accounts"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost by tags"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "BreakdownTitle": [
+      {
+        "type": 1,
+        "value": "value"
+      }
+    ],
+    "BreakdownTotalCostDate": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (January "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (January "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (February "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (February "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (March "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (March "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (April "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (April "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (June "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (June "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (July "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (July "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (August "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (August "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (September "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (September "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (October "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (October "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (November "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (November "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (December "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  total cost (December "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "CPUTitle": [
+      {
+        "type": 0,
+        "value": "DE CPU"
+      }
+    ],
+    "CalculationType": [
+      {
+        "type": 0,
+        "value": "DE Calculation type"
+      }
+    ],
+    "Cancel": [
+      {
+        "type": 0,
+        "value": "DE Cancel"
+      }
+    ],
+    "ChartCostForecastConeLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost confidence (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostForecastConeLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "DE Cost confidence (no data)"
+      }
+    ],
+    "ChartCostForecastConeLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost confidence (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost confidence (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost confidence (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost confidence (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost confidence (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost confidence (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost confidence (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost confidence (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost confidence (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost confidence (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost confidence (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost confidence (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostForecastConeTooltip": [
+      {
+        "type": 1,
+        "value": "value0"
+      },
+      {
+        "type": 0,
+        "value": "DE  - "
+      },
+      {
+        "type": 1,
+        "value": "value1"
+      }
+    ],
+    "ChartCostForecastLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost forecast (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostForecastLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "DE Cost forecast (no data)"
+      }
+    ],
+    "ChartCostForecastLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost forecast (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost forecast (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost forecast (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost forecast (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost forecast (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost forecast (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost forecast (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost forecast (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost forecast (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost forecast (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost forecast (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost forecast (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostInfrastructureForecastConeLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure confidence (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostInfrastructureForecastConeLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "DE Infrastructure confidence (no data)"
+      }
+    ],
+    "ChartCostInfrastructureForecastConeLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure confidence (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure confidence (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure confidence (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure confidence (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure confidence (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure confidence (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure confidence (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure confidence (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure confidence (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure confidence (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure confidence (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure confidence (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostInfrastructureForecastLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure forecast (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostInfrastructureForecastLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "DE Infrastructure forecast (no data)"
+      }
+    ],
+    "ChartCostInfrastructureForecastLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure forecast (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure forecast (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure forecast (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure forecast (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure forecast (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure forecast (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure forecast (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure forecast (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure forecast (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure forecast (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure forecast (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure forecast (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostInfrastructureLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Infrastructure cost (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostInfrastructureLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "DE Infrastructure cost (no data)"
+      }
+    ],
+    "ChartCostInfrastructureLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure cost (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure cost (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure cost (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure cost (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure cost (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure cost (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure cost (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure cost (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure cost (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure cost (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure cost (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Infrastructure cost (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cost (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "DE Cost (no data)"
+      }
+    ],
+    "ChartCostLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostSupplementaryLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Supplementary cost (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostSupplementaryLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "DE Supplementary cost (no data)"
+      }
+    ],
+    "ChartCostSupplementaryLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Supplementary cost (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Supplementary cost (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Supplementary cost (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Supplementary cost (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Supplementary cost (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Supplementary cost (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Supplementary cost (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Supplementary cost (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Supplementary cost (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Supplementary cost (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Supplementary cost (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Supplementary cost (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartDateRange": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartDayOfTheMonth": [
+      {
+        "type": 0,
+        "value": "DE Day "
+      },
+      {
+        "type": 1,
+        "value": "day"
+      }
+    ],
+    "ChartLimitLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Limit (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartLimitLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "DE Limit (no data)"
+      }
+    ],
+    "ChartLimitLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Limit (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Limit (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Limit (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Limit (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Limit (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Limit (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Limit (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Limit (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Limit (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Limit (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Limit (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Limit (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartNoData": [
+      {
+        "type": 0,
+        "value": "DE no data"
+      }
+    ],
+    "ChartOthers": [
+      {
+        "offset": 0,
+        "options": {
+          "one": {
+            "value": [
+              {
+                "type": 1,
+                "value": "count"
+              },
+              {
+                "type": 0,
+                "value": "DE  Other"
+              }
+            ]
+          },
+          "other": {
+            "value": [
+              {
+                "type": 1,
+                "value": "count"
+              },
+              {
+                "type": 0,
+                "value": "DE  Others"
+              }
+            ]
+          }
+        },
+        "pluralType": "cardinal",
+        "type": 6,
+        "value": "count"
+      }
+    ],
+    "ChartRequestLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Requests (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartRequestLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Requests (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Requests (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Requests (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Requests (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Requests (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Requests (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Requests (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Requests (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Requests (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Requests (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Requests (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Requests (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartRequestsLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "DE Requests (no data)"
+      }
+    ],
+    "ChartUsageLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartUsageLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "DE Usage (no data)"
+      }
+    ],
+    "ChartUsageLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Usage (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Usage (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Usage (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Usage (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Usage (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Usage (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Usage (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Usage (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Usage (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Usage (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Usage (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Usage (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "Close": [
+      {
+        "type": 0,
+        "value": "DE Close"
+      }
+    ],
+    "Clusters": [
+      {
+        "type": 0,
+        "value": "DE Clusters"
+      }
+    ],
+    "Cost": [
+      {
+        "type": 0,
+        "value": "DE Cost"
+      }
+    ],
+    "CostCalculations": [
+      {
+        "type": 0,
+        "value": "DE Cost calculations"
+      }
+    ],
+    "CostManagement": [
+      {
+        "type": 0,
+        "value": "DE Cost Management"
+      }
+    ],
+    "CostModels": [
+      {
+        "type": 0,
+        "value": "DE Cost Models"
+      }
+    ],
+    "CostModelsAddTagValues": [
+      {
+        "type": 0,
+        "value": "DE Add more tag values"
+      }
+    ],
+    "CostModelsAssignSources": [
+      {
+        "offset": 0,
+        "options": {
+          "one": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Assign source"
+              }
+            ]
+          },
+          "other": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Assign sources"
+              }
+            ]
+          }
+        },
+        "pluralType": "cardinal",
+        "type": 6,
+        "value": "count"
+      }
+    ],
+    "CostModelsAssignSourcesErrorDescription": [
+      {
+        "type": 0,
+        "value": "DE You cannot assign a source at this time. Try refreshing this page. If the problem persists, contact your organization administrator or visit our "
+      },
+      {
+        "type": 1,
+        "value": "url"
+      },
+      {
+        "type": 0,
+        "value": " for known outages."
+      }
+    ],
+    "CostModelsAssignSourcesErrorTitle": [
+      {
+        "type": 0,
+        "value": "DE This action is temporarily unavailable"
+      }
+    ],
+    "CostModelsAssignSourcesParen": [
+      {
+        "type": 0,
+        "value": "DE Assign source(s)"
+      }
+    ],
+    "CostModelsAssignedSources": [
+      {
+        "type": 0,
+        "value": "DE Assigned sources"
+      }
+    ],
+    "CostModelsAvailableSources": [
+      {
+        "type": 0,
+        "value": "DE The following sources are assigned to my production cost model:"
+      }
+    ],
+    "CostModelsCanDelete": [
+      {
+        "type": 0,
+        "value": "DE This action will delete "
+      },
+      {
+        "type": 1,
+        "value": "name"
+      },
+      {
+        "type": 0,
+        "value": " cost model from the system. This action cannot be undone"
+      }
+    ],
+    "CostModelsCanNotDelete": [
+      {
+        "type": 0,
+        "value": "DE The following sources are assigned to "
+      },
+      {
+        "type": 1,
+        "value": "name"
+      },
+      {
+        "type": 0,
+        "value": " cost model:"
+      }
+    ],
+    "CostModelsDelete": [
+      {
+        "type": 0,
+        "value": "DE Delete cost model"
+      }
+    ],
+    "CostModelsDeleteDesc": [
+      {
+        "type": 0,
+        "value": "DE This action will delete "
+      },
+      {
+        "type": 1,
+        "value": "costModel"
+      },
+      {
+        "type": 0,
+        "value": " cost model from the system. This action cannot be undone."
+      }
+    ],
+    "CostModelsDeleteSource": [
+      {
+        "type": 0,
+        "value": "DE You must unassign any sources before you can delete this cost model."
+      }
+    ],
+    "CostModelsDescTooLong": [
+      {
+        "type": 0,
+        "value": "DE Should not exceed 500 characters"
+      }
+    ],
+    "CostModelsDetailsAssignSourcesTitle": [
+      {
+        "type": 0,
+        "value": "DE Assign sources"
+      }
+    ],
+    "CostModelsDistributionDesc": [
+      {
+        "type": 0,
+        "value": "DE The following is the type of metric that is set to be used when distributing costs to the project level breakdowns."
+      }
+    ],
+    "CostModelsDistributionEdit": [
+      {
+        "type": 0,
+        "value": "DE Edit distribution"
+      }
+    ],
+    "CostModelsEmptyState": [
+      {
+        "type": 0,
+        "value": "DE What is your hybrid cloud costing you?"
+      }
+    ],
+    "CostModelsEmptyStateDesc": [
+      {
+        "type": 0,
+        "value": "DE Create a cost model to start calculating your hybrid cloud costs using custom price lists, markups, or both. Click on the button below to begin the journey."
+      }
+    ],
+    "CostModelsEmptyStateLearnMore": [
+      {
+        "type": 0,
+        "value": "DE Read about setting up a cost model"
+      }
+    ],
+    "CostModelsEnterTagKey": [
+      {
+        "type": 0,
+        "value": "DE Enter a tag key"
+      }
+    ],
+    "CostModelsEnterTagRate": [
+      {
+        "type": 0,
+        "value": "DE Enter rate by tag"
+      }
+    ],
+    "CostModelsEnterTagValue": [
+      {
+        "type": 0,
+        "value": "DE Enter a tag value"
+      }
+    ],
+    "CostModelsExamplesDoubleMarkup": [
+      {
+        "type": 0,
+        "value": "DE A markup rate of (+) 100% doubles the base costs of your source(s)."
+      }
+    ],
+    "CostModelsExamplesNoAdjust": [
+      {
+        "type": 0,
+        "value": "DE A markup or discount rate of (+/-) 0% (the default) makes no adjustments to the base costs of your source(s)."
+      }
+    ],
+    "CostModelsExamplesReduceSeventyfive": [
+      {
+        "type": 0,
+        "value": "DE A discount rate of (-) 25% reduces the base costs of your source(s) to 75% of the original value."
+      }
+    ],
+    "CostModelsExamplesReduceZero": [
+      {
+        "type": 0,
+        "value": "DE A discount rate of (-) 100% reduces the base costs of your source(s) to 0."
+      }
+    ],
+    "CostModelsFilterPlaceholder": [
+      {
+        "type": 0,
+        "value": "DE Filter by name..."
+      }
+    ],
+    "CostModelsFilterTagKey": [
+      {
+        "type": 0,
+        "value": "DE Filter by tag key"
+      }
+    ],
+    "CostModelsInfoTooLong": [
+      {
+        "type": 0,
+        "value": "DE Should not exceed 100 characters"
+      }
+    ],
+    "CostModelsLastChange": [
+      {
+        "type": 0,
+        "value": "DE Last change"
+      }
+    ],
+    "CostModelsPopover": [
+      {
+        "type": 0,
+        "value": "DE A cost model allows you to associate a price to metrics provided by your sources to charge for utilization of resources. "
+      },
+      {
+        "type": 1,
+        "value": "learnMore"
+      }
+    ],
+    "CostModelsPopoverAriaLabel": [
+      {
+        "type": 0,
+        "value": "DE Cost model info popover"
+      }
+    ],
+    "CostModelsRateTooLong": [
+      {
+        "type": 0,
+        "value": "DE Should not exceed 10 decimals"
+      }
+    ],
+    "CostModelsReadOnly": [
+      {
+        "type": 0,
+        "value": "DE You have read only permissions"
+      }
+    ],
+    "CostModelsRefreshDialog": [
+      {
+        "type": 0,
+        "value": "DE Refresh this dialog"
+      }
+    ],
+    "CostModelsRequiredField": [
+      {
+        "type": 0,
+        "value": "DE This field is required"
+      }
+    ],
+    "CostModelsRouterErrorTitle": [
+      {
+        "type": 0,
+        "value": "DE Fail routing to cost model"
+      }
+    ],
+    "CostModelsRouterServerError": [
+      {
+        "type": 0,
+        "value": "DE Server error: could not get the cost model."
+      }
+    ],
+    "CostModelsSourceDelete": [
+      {
+        "type": 0,
+        "value": "DE Unassign"
+      }
+    ],
+    "CostModelsSourceDeleteSource": [
+      {
+        "type": 0,
+        "value": "DE Unassign source"
+      }
+    ],
+    "CostModelsSourceDeleteSourceDesc": [
+      {
+        "type": 0,
+        "value": "DE This will remove the assignment of "
+      },
+      {
+        "type": 1,
+        "value": "source"
+      },
+      {
+        "type": 0,
+        "value": " from the "
+      },
+      {
+        "type": 1,
+        "value": "costModel"
+      },
+      {
+        "type": 0,
+        "value": " cost model. You can then assign the cost model to a new source."
+      }
+    ],
+    "CostModelsSourceEmptyStateDesc": [
+      {
+        "type": 0,
+        "value": "DE Select the source(s) you want to apply this cost model to."
+      }
+    ],
+    "CostModelsSourceEmptyStateTitle": [
+      {
+        "type": 0,
+        "value": "DE No sources are assigned"
+      }
+    ],
+    "CostModelsSourceTablePaginationAriaLabel": [
+      {
+        "type": 0,
+        "value": "DE Sources table pagination controls"
+      }
+    ],
+    "CostModelsSourceType": [
+      {
+        "type": 0,
+        "value": "DE Source type"
+      }
+    ],
+    "CostModelsSourcesTableAriaLabel": [
+      {
+        "type": 0,
+        "value": "DE Sources table"
+      }
+    ],
+    "CostModelsTableAriaLabel": [
+      {
+        "type": 0,
+        "value": "DE Cost models table"
+      }
+    ],
+    "CostModelsTagRateTableAriaLabel": [
+      {
+        "type": 0,
+        "value": "DE Tag rates"
+      }
+    ],
+    "CostModelsTagRateTableDefault": [
+      {
+        "type": 0,
+        "value": "DE Default"
+      }
+    ],
+    "CostModelsTagRateTableKey": [
+      {
+        "type": 0,
+        "value": "DE Tag key"
+      }
+    ],
+    "CostModelsTagRateTableRate": [
+      {
+        "type": 0,
+        "value": "DE Rate"
+      }
+    ],
+    "CostModelsTagRateTableValue": [
+      {
+        "type": 0,
+        "value": "DE Tag value"
+      }
+    ],
+    "CostModelsUUIDEmptyState": [
+      {
+        "type": 0,
+        "value": "DE Cost model can not be found"
+      }
+    ],
+    "CostModelsUUIDEmptyStateDesc": [
+      {
+        "type": 0,
+        "value": "DE Cost model with uuid: "
+      },
+      {
+        "type": 1,
+        "value": "uuid"
+      },
+      {
+        "type": 0,
+        "value": " does not exist."
+      }
+    ],
+    "CostModelsWizardCreateCostModel": [
+      {
+        "type": 0,
+        "value": "DE Create cost model"
+      }
+    ],
+    "CostModelsWizardCreatePriceList": [
+      {
+        "type": 0,
+        "value": "DE Create a price list"
+      }
+    ],
+    "CostModelsWizardEmptySourceTypeLabel": [
+      {
+        "type": 0,
+        "value": "DE Select source type"
+      }
+    ],
+    "CostModelsWizardEmptyStateCreate": [
+      {
+        "type": 0,
+        "value": "DE To create a price list, begin by clicking the "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " button."
+      }
+    ],
+    "CostModelsWizardEmptyStateOtherTime": [
+      {
+        "type": 0,
+        "value": "DE You can create a price list or modify one at a later time."
+      }
+    ],
+    "CostModelsWizardEmptyStateSkipStep": [
+      {
+        "type": 0,
+        "value": "DE To skip this step, click the "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " button."
+      }
+    ],
+    "CostModelsWizardEmptyStateTitle": [
+      {
+        "type": 0,
+        "value": "DE A price list has not been created."
+      }
+    ],
+    "CostModelsWizardGeneralInfoTitle": [
+      {
+        "type": 0,
+        "value": "DE Enter general information"
+      }
+    ],
+    "CostModelsWizardNoRatesAdded": [
+      {
+        "type": 0,
+        "value": "DE No rates were added to the price list"
+      }
+    ],
+    "CostModelsWizardOnboardAWS": [
+      {
+        "type": 0,
+        "value": "DE Amazon Web Services (AWS)"
+      }
+    ],
+    "CostModelsWizardOnboardOCP": [
+      {
+        "type": 0,
+        "value": "DE Red Hat OpenShift Container Platform"
+      }
+    ],
+    "CostModelsWizardPriceListMetric": [
+      {
+        "type": 0,
+        "value": "DE Select the metric you want to assign a price to, and specify a measurement unit and rate. You can optionally set multiple rates for particular tags."
+      }
+    ],
+    "CostModelsWizardReviewMarkDiscount": [
+      {
+        "type": 0,
+        "value": "DE Markup/Discount"
+      }
+    ],
+    "CostModelsWizardReviewStatusSubDetails": [
+      {
+        "type": 0,
+        "value": "DE Review and confirm your cost model configuration and assignments. Click "
+      },
+      {
+        "type": 1,
+        "value": "create"
+      },
+      {
+        "type": 0,
+        "value": " to create the cost model, or "
+      },
+      {
+        "type": 1,
+        "value": "back"
+      },
+      {
+        "type": 0,
+        "value": " to revise."
+      }
+    ],
+    "CostModelsWizardReviewStatusSubTitle": [
+      {
+        "type": 0,
+        "value": "DE Costs for resources connected to the assigned sources will now be calculated using the newly created "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " cost model."
+      }
+    ],
+    "CostModelsWizardReviewStatusTitle": [
+      {
+        "type": 0,
+        "value": "DE Creation successful"
+      }
+    ],
+    "CostModelsWizardSourceCaption": [
+      {
+        "options": {
+          "aws": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Select from the following Amazon Web Services sources:"
+              }
+            ]
+          },
+          "azure": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Select from the following Microsoft Azure sources:"
+              }
+            ]
+          },
+          "gcp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Select from the following Google Cloud Platform sources:"
+              }
+            ]
+          },
+          "ocp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Select from the following Red Hat OpenShift sources:"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "CostModelsWizardSourceErrorDescription": [
+      {
+        "type": 0,
+        "value": "DE Try refreshing this step or you can skip this step (as it is optional) and assign the source to the cost model at a later time. If the problem persists, contact your organization administrator or visit our "
+      },
+      {
+        "type": 1,
+        "value": "url"
+      },
+      {
+        "type": 0,
+        "value": " for known outages."
+      }
+    ],
+    "CostModelsWizardSourceErrorTitle": [
+      {
+        "type": 0,
+        "value": "DE This step is temporarily unavailable"
+      }
+    ],
+    "CostModelsWizardSourceSubtitle": [
+      {
+        "type": 0,
+        "value": "DE Select one or more sources to this cost model. You can skip this step and assign the cost model to a source at a later time. A source will be unavailable for selection if a cost model is already assigned to it."
+      }
+    ],
+    "CostModelsWizardSourceTableAriaLabel": [
+      {
+        "type": 0,
+        "value": "DE Assign sources to cost model table"
+      }
+    ],
+    "CostModelsWizardSourceTableCostModel": [
+      {
+        "type": 0,
+        "value": "DE Cost model assigned"
+      }
+    ],
+    "CostModelsWizardSourceTableDefaultCostModel": [
+      {
+        "type": 0,
+        "value": "DE Default cost model"
+      }
+    ],
+    "CostModelsWizardSourceTitle": [
+      {
+        "type": 0,
+        "value": "DE Assign sources to the cost model (optional)"
+      }
+    ],
+    "CostModelsWizardSourceWarning": [
+      {
+        "type": 0,
+        "value": "DE This source is assigned to "
+      },
+      {
+        "type": 1,
+        "value": "costModel"
+      },
+      {
+        "type": 0,
+        "value": " cost model. You will have to unassigned it first"
+      }
+    ],
+    "CostModelsWizardStepsGenInfo": [
+      {
+        "type": 0,
+        "value": "DE Enter information"
+      }
+    ],
+    "CostModelsWizardStepsPriceList": [
+      {
+        "type": 0,
+        "value": "DE Price list"
+      }
+    ],
+    "CostModelsWizardStepsReview": [
+      {
+        "type": 0,
+        "value": "DE Review details"
+      }
+    ],
+    "CostModelsWizardStepsSources": [
+      {
+        "type": 0,
+        "value": "DE Assign a source to the cost model"
+      }
+    ],
+    "CostModelsWizardSubTitleTable": [
+      {
+        "type": 0,
+        "value": "DE The following is a list of rates you have set so far for this price list."
+      }
+    ],
+    "CostModelsWizardWarningSources": [
+      {
+        "type": 0,
+        "value": "DE Cannot assign cost model to a source that is already assigned to another one"
+      }
+    ],
+    "Create": [
+      {
+        "type": 0,
+        "value": "DE Create"
+      }
+    ],
+    "CreateCostModelConfirmMsg": [
+      {
+        "type": 0,
+        "value": "DE Are you sure you want to stop creating a cost model? All settings will be discarded."
+      }
+    ],
+    "CreateCostModelDesc": [
+      {
+        "type": 0,
+        "value": "DE A cost model allows you to associate a price to metrics provided by your sources to charge for utilization of resources."
+      }
+    ],
+    "CreateCostModelExit": [
+      {
+        "type": 0,
+        "value": "DE Exit cost model creation"
+      }
+    ],
+    "CreateCostModelExitYes": [
+      {
+        "type": 0,
+        "value": "DE Yes, I want to exit"
+      }
+    ],
+    "CreateCostModelNoContinue": [
+      {
+        "type": 0,
+        "value": "DE No, I want to continue"
+      }
+    ],
+    "CreateCostModelTitle": [
+      {
+        "type": 0,
+        "value": "DE Create a cost model"
+      }
+    ],
+    "CreateRate": [
+      {
+        "type": 0,
+        "value": "DE Create rate"
+      }
+    ],
+    "Currency": [
+      {
+        "type": 0,
+        "value": "DE Currency"
+      }
+    ],
+    "CurrencyAbbreviations": [
+      {
+        "options": {
+          "billion": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "DE  B"
+              }
+            ]
+          },
+          "million": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "DE  M"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "quadrillion": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "DE  q"
+              }
+            ]
+          },
+          "thousand": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "DE  K"
+              }
+            ]
+          },
+          "trillion": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "DE  t"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "symbol"
+      }
+    ],
+    "CurrencyOptions": [
+      {
+        "options": {
+          "AUD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE AUD (AU$) - Australian Dollar"
+              }
+            ]
+          },
+          "CAD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE CAD (C$) - Canadian Dollar"
+              }
+            ]
+          },
+          "CHF": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE CHF (CHF) - Swiss Franc"
+              }
+            ]
+          },
+          "CNY": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE CNY (CN¥) - Chinese Yuan"
+              }
+            ]
+          },
+          "DKK": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE DKK (Dkr) - Danish Krone"
+              }
+            ]
+          },
+          "EUR": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE EUR (€) - Euro"
+              }
+            ]
+          },
+          "GBP": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE GBP (£) - British Pound"
+              }
+            ]
+          },
+          "HKD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE HKD (HK$) - Hong Kong Dollar"
+              }
+            ]
+          },
+          "JPY": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE JPY (¥) - Japanese Yen"
+              }
+            ]
+          },
+          "NOK": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE NOK (Nkr) - Norwegian Krone"
+              }
+            ]
+          },
+          "NZD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE NZD (NZ$) - New Zealand Dollar"
+              }
+            ]
+          },
+          "SEK": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE SEK (Skr) - Swedish Krona"
+              }
+            ]
+          },
+          "SGD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE SGD (S$) - Singapore Dollar"
+              }
+            ]
+          },
+          "USD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE USD ($) - United States Dollar"
+              }
+            ]
+          },
+          "ZAR": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE ZAR (R) - South African Rand"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "units"
+      }
+    ],
+    "CurrencyUnits": [
+      {
+        "options": {
+          "AUD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE AU$"
+              }
+            ]
+          },
+          "CAD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE C$"
+              }
+            ]
+          },
+          "CHF": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE CHF"
+              }
+            ]
+          },
+          "CNY": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE CN¥"
+              }
+            ]
+          },
+          "DKK": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Dkr"
+              }
+            ]
+          },
+          "EUR": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE €"
+              }
+            ]
+          },
+          "GBP": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE £"
+              }
+            ]
+          },
+          "HKD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE HK$"
+              }
+            ]
+          },
+          "JPY": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE ¥"
+              }
+            ]
+          },
+          "NOK": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Nkr"
+              }
+            ]
+          },
+          "NZD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE NZ$"
+              }
+            ]
+          },
+          "SEK": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Skr"
+              }
+            ]
+          },
+          "SGD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE S$"
+              }
+            ]
+          },
+          "USD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE $USD"
+              }
+            ]
+          },
+          "ZAR": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE R"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "units"
+      }
+    ],
+    "DashboardCumulativeCostComparison": [
+      {
+        "type": 0,
+        "value": "DE Cumulative cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "DashboardDailyUsageComparison": [
+      {
+        "type": 0,
+        "value": "DE Daily usage comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "DashboardDatabaseTitle": [
+      {
+        "type": 0,
+        "value": "DE Database services cost"
+      }
+    ],
+    "DashboardNetworkTitle": [
+      {
+        "type": 0,
+        "value": "DE Network services cost"
+      }
+    ],
+    "DashboardStorageTitle": [
+      {
+        "type": 0,
+        "value": "DE Storage services usage"
+      }
+    ],
+    "DashboardTotalCostTooltip": [
+      {
+        "type": 0,
+        "value": "DE This total cost is the sum of the infrastructure cost "
+      },
+      {
+        "type": 1,
+        "value": "infrastructureCost"
+      },
+      {
+        "type": 0,
+        "value": " and supplementary cost "
+      },
+      {
+        "type": 1,
+        "value": "supplementaryCost"
+      }
+    ],
+    "Delete": [
+      {
+        "type": 0,
+        "value": "DE Delete"
+      }
+    ],
+    "Description": [
+      {
+        "type": 0,
+        "value": "DE Description"
+      }
+    ],
+    "DetailsActionsExport": [
+      {
+        "type": 0,
+        "value": "DE Export data"
+      }
+    ],
+    "DetailsActionsPriceList": [
+      {
+        "type": 0,
+        "value": "DE View all price lists"
+      }
+    ],
+    "DetailsClustersModalTitle": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE account "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE cluster "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE instance type "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE node "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE organizational unit "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE project "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE region "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE region "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE service "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE service "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE account "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE tags "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "groupBy"
+      }
+    ],
+    "DetailsColumnManagementTitle": [
+      {
+        "type": 0,
+        "value": "DE Manage columns"
+      }
+    ],
+    "DetailsCostValue": [
+      {
+        "type": 0,
+        "value": "DE Cost: "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      }
+    ],
+    "DetailsEmptyState": [
+      {
+        "type": 0,
+        "value": "DE Processing data to generate a list of all services that sums to a total cost..."
+      }
+    ],
+    "DetailsMoreClusters": [
+      {
+        "type": 0,
+        "value": "DE , "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " more..."
+      }
+    ],
+    "DetailsResourceNames": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Account names"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cluster names"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Instance type names"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Node names"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Organizational unit names"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Project names"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Region names"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Region names"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Service names"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Service names"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Account names"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Tag names"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "DetailsSummaryModalTitle": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "DE  accounts"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "DE  clusters"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "DE  instance types"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "DE  nodes"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "DE  organizational units"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "DE  projects"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "DE  regions"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "DE  regions"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "DE  services"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "DE  services"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "DE  accounts"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "DE  tags"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "groupBy"
+      }
+    ],
+    "DetailsUnusedRequestsLabel": [
+      {
+        "type": 0,
+        "value": "DE Unrequested capacity"
+      }
+    ],
+    "DetailsUnusedUsageLabel": [
+      {
+        "type": 0,
+        "value": "DE Unused capacity"
+      }
+    ],
+    "DetailsUnusedUsageUnits": [
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": "DE  ("
+      },
+      {
+        "type": 1,
+        "value": "percentage"
+      },
+      {
+        "type": 0,
+        "value": "% of capacity)"
+      }
+    ],
+    "DetailsUsageCapacity": [
+      {
+        "type": 0,
+        "value": "DE Capacity - "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " "
+      },
+      {
+        "type": 1,
+        "value": "units"
+      }
+    ],
+    "DetailsUsageLimit": [
+      {
+        "type": 0,
+        "value": "DE Limit - "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " "
+      },
+      {
+        "type": 1,
+        "value": "units"
+      }
+    ],
+    "DetailsUsageRequests": [
+      {
+        "type": 0,
+        "value": "DE Requests - "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " "
+      },
+      {
+        "type": 1,
+        "value": "units"
+      }
+    ],
+    "DetailsUsageUsage": [
+      {
+        "type": 0,
+        "value": "DE Usage - "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " "
+      },
+      {
+        "type": 1,
+        "value": "units"
+      }
+    ],
+    "DetailsViewAll": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE View all accounts"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE View all clusters"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE View all instance types"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE View all nodes"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE View all organizational units"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE View all projects"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE View all regions"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE View all regions"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE View all Services"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE View all services"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE View all accounts"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE View all tags"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "DiscountMinus": [
+      {
+        "type": 0,
+        "value": "DE Discount (-)"
+      }
+    ],
+    "DistributionModelDesc": [
+      {
+        "type": 0,
+        "value": "DE This choice is for users to direct how their raw costs are distributed either by CPU or Memory on the project level breakdowns."
+      }
+    ],
+    "DistributionType": [
+      {
+        "type": 0,
+        "value": "DE Distribution type"
+      }
+    ],
+    "DocsAddOcpSources": [
+      {
+        "type": 0,
+        "value": "DE https://access.redhat.com/documentation/en-us/cost_management_service/2021/html-single/adding_an_openshift_container_platform_source_to_cost_management"
+      }
+    ],
+    "DocsConfigCostModels": [
+      {
+        "type": 0,
+        "value": "DE https://access.redhat.com/documentation/en-us/cost_management_service/2021/html-single/using_cost_models/index#assembly-setting-up-cost-models"
+      }
+    ],
+    "DocsCostModelTerminology": [
+      {
+        "type": 0,
+        "value": "DE https://access.redhat.com/documentation/en-us/cost_management_service/2021/html-single/using_cost_models/index#cost-model-terminology"
+      }
+    ],
+    "DocsUsingCostModels": [
+      {
+        "type": 0,
+        "value": "DE https://access.redhat.com/documentation/en-us/cost_management_service/2021/html-single/using_cost_models"
+      }
+    ],
+    "Edit": [
+      {
+        "type": 0,
+        "value": "DE Edit"
+      }
+    ],
+    "EditCostModel": [
+      {
+        "type": 0,
+        "value": "DE Edit cost model"
+      }
+    ],
+    "EditMarkup": [
+      {
+        "type": 0,
+        "value": "DE Edit markup"
+      }
+    ],
+    "EditMarkupOrDiscount": [
+      {
+        "type": 0,
+        "value": "DE Edit markup or discount"
+      }
+    ],
+    "EmptyFilterSourceStateSubtitle": [
+      {
+        "type": 0,
+        "value": "DE Sorry, no source with the given filter was found."
+      }
+    ],
+    "EmptyFilterStateSubtitle": [
+      {
+        "type": 0,
+        "value": "DE Sorry, no data with the given filter was found."
+      }
+    ],
+    "EmptyFilterStateTitle": [
+      {
+        "type": 0,
+        "value": "DE No match found"
+      }
+    ],
+    "ErrorStateNotAuthorizedDesc": [
+      {
+        "type": 0,
+        "value": "DE Contact the cost management administrator to provide access to this application"
+      }
+    ],
+    "ErrorStateNotAuthorizedTitle": [
+      {
+        "type": 0,
+        "value": "DE You don't have access to the Cost management application"
+      }
+    ],
+    "ErrorStateUnexpectedDesc": [
+      {
+        "type": 0,
+        "value": "DE We encountered an unexpected error. Contact your administrator."
+      }
+    ],
+    "ErrorStateUnexpectedTitle": [
+      {
+        "type": 0,
+        "value": "DE Oops!"
+      }
+    ],
+    "ExamplesTitle": [
+      {
+        "type": 0,
+        "value": "DE Examples"
+      }
+    ],
+    "ExplorerChartTitle": [
+      {
+        "options": {
+          "aws": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Amazon Web Services - Top 5 Costliest"
+              }
+            ]
+          },
+          "aws_ocp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Amazon Web Services filtered by OpenShift - Top 5 Costliest"
+              }
+            ]
+          },
+          "azure": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Microsoft Azure - Top 5 Costliest"
+              }
+            ]
+          },
+          "azure_ocp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Microsoft Azure filtered by OpenShift - Top 5 Costliest"
+              }
+            ]
+          },
+          "gcp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Google Cloud Platform - Top 5 Costliest"
+              }
+            ]
+          },
+          "gcp_ocp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Google Cloud Platform filtered by OpenShift - Top 5 Costliest"
+              }
+            ]
+          },
+          "ibm": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE IBM Cloud - Top 5 Costliest"
+              }
+            ]
+          },
+          "ocp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE All OpenShift - Top 5 Costliest"
+              }
+            ]
+          },
+          "ocp_cloud": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE All cloud filtered by OpenShift - Top 5 Costliest"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "ExplorerDateColumn": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Jan "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Feb "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Mar "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Apr "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE May "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Jun "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Jul "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Aug "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Sep "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Oct "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Nov "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Dec "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ExplorerDateRange": [
+      {
+        "options": {
+          "current_month_to_date": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Month to date"
+              }
+            ]
+          },
+          "last_ninety_days": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Last 90 days"
+              }
+            ]
+          },
+          "last_sixty_days": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Last 60 days"
+              }
+            ]
+          },
+          "last_thirty_days": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Last 30 days"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "previous_month_to_date": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Previous month and month to date"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "ExplorerMonthDate": [
+      {
+        "type": 1,
+        "value": "month"
+      },
+      {
+        "type": 0,
+        "value": "DE  "
+      },
+      {
+        "type": 1,
+        "value": "date"
+      }
+    ],
+    "ExplorerTableAriaLabel": [
+      {
+        "type": 0,
+        "value": "DE Cost Explorer table"
+      }
+    ],
+    "ExplorerTitle": [
+      {
+        "type": 0,
+        "value": "DE Cost Explorer"
+      }
+    ],
+    "ExportAggregateType": [
+      {
+        "type": 0,
+        "value": "DE Select aggregate type"
+      }
+    ],
+    "ExportAll": [
+      {
+        "type": 0,
+        "value": "DE All"
+      }
+    ],
+    "ExportDownload": [
+      {
+        "type": 0,
+        "value": "DE Generate and download"
+      }
+    ],
+    "ExportError": [
+      {
+        "type": 0,
+        "value": "DE Something went wrong, please try fewer selections"
+      }
+    ],
+    "ExportFileName": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -accounts-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -accounts-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -clusters-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -clusters-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -instances-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -instances-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -node-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -node-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -org_units-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -org_units-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -projects-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -projects-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -regions-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -regions-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -regions-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -regions-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -services-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -services-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -services-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -services-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -accounts-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -accounts-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -tags-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE -tags-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "groupBy"
+      }
+    ],
+    "ExportHeading": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Aggregates of the following accounts will be exported to a .csv file."
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Aggregates of the following clusters will be exported to a .csv file."
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Aggregates of the following instance types will be exported to a .csv file."
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Aggregates of the following nodes will be exported to a .csv file."
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Aggregates of the following organizational units will be exported to a .csv file."
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Aggregates of the following projects will be exported to a .csv file."
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Aggregates of the following regions will be exported to a .csv file."
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Aggregates of the regions will be exported to a .csv file."
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Aggregates of the following services will be exported to a .csv file."
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Aggregates of the following services will be exported to a .csv file."
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Aggregates of the following accounts will be exported to a .csv file."
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Aggregates of the following tags will be exported to a .csv file."
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "groupBy"
+      }
+    ],
+    "ExportResolution": [
+      {
+        "options": {
+          "daily": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Daily"
+              }
+            ]
+          },
+          "monthly": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Monthly"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "ExportSelected": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Selected accounts"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Selected clusters"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Selected instance types"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Selected nodes"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Selected organizational units"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Selected projects"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Selected regions"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Selected regions"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Selected services"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Selected services"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Selected accounts"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Selected tags"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "groupBy"
+      }
+    ],
+    "ExportTimeScope": [
+      {
+        "options": {
+          "current": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Current "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "previous": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Previous "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "ExportTimeScopeTitle": [
+      {
+        "type": 0,
+        "value": "DE Select month"
+      }
+    ],
+    "ExportTitle": [
+      {
+        "type": 0,
+        "value": "DE Export"
+      }
+    ],
+    "FilterByButtonAriaLabel": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter button for account name"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter button for cluster name"
+              }
+            ]
+          },
+          "name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter button for name name"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter button for node name"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter button for organizational unit name"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter button for project name"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter button for region name"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter button for region name"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter button for service name"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter button for service_name name"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter button for account name"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter button for tag name"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "FilterByInputAriaLabel": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Input for account name"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Input for cluster name"
+              }
+            ]
+          },
+          "name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Input for name name"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Input for node name"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Input for organizational unit name"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Input for project name"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Input for region name"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Input for region name"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Input for service name"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Input for service_name name"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Input for account name"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Input for tag name"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "FilterByOrgUnitAriaLabel": [
+      {
+        "type": 0,
+        "value": "DE Organizational units"
+      }
+    ],
+    "FilterByOrgUnitPlaceholder": [
+      {
+        "type": 0,
+        "value": "DE Choose unit"
+      }
+    ],
+    "FilterByPlaceholder": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter by account"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter by cluster"
+              }
+            ]
+          },
+          "description": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter by description"
+              }
+            ]
+          },
+          "name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter by name"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter by node"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter by organizational unit"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter by project"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter by region"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter by region"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter by service"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter by service"
+              }
+            ]
+          },
+          "source_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter by source type"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter by account"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Filter by tag"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "FilterByTagKeyAriaLabel": [
+      {
+        "type": 0,
+        "value": "DE Tag keys"
+      }
+    ],
+    "FilterByTagKeyPlaceholder": [
+      {
+        "type": 0,
+        "value": "DE Choose key"
+      }
+    ],
+    "FilterByTagValueAriaLabel": [
+      {
+        "type": 0,
+        "value": "DE Tag values"
+      }
+    ],
+    "FilterByTagValueButtonAriaLabel": [
+      {
+        "type": 0,
+        "value": "DE Filter button for tag value"
+      }
+    ],
+    "FilterByTagValueInputPlaceholder": [
+      {
+        "type": 0,
+        "value": "DE Filter by value"
+      }
+    ],
+    "FilterByTagValuePlaceholder": [
+      {
+        "type": 0,
+        "value": "DE Choose value"
+      }
+    ],
+    "FilterByValues": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Account"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cluster"
+              }
+            ]
+          },
+          "name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Name"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Node"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Organizational unit"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Project"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Region"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Region"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Service"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Service"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Account"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Tag"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "ForDate": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for January "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for January "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for February "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for February "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for March "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for March "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for April "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for April "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for June "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for June "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for July "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for July "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for August "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for August "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for September "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for September "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for October "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for October "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for November "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for November "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for December "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "DE  for December "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "GCP": [
+      {
+        "type": 0,
+        "value": "DE Google Cloud Platform"
+      }
+    ],
+    "GCPComputeTitle": [
+      {
+        "type": 0,
+        "value": "DE Compute instances usage"
+      }
+    ],
+    "GCPCostTitle": [
+      {
+        "type": 0,
+        "value": "DE Google Cloud Platform Services cost"
+      }
+    ],
+    "GCPCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "DE Google Cloud Platform Services cumulative cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "GCPDailyCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "DE Google Cloud Platform Services daily cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "GCPDesc": [
+      {
+        "type": 0,
+        "value": "DE Raw cost from Google Cloud Platform infrastructure."
+      }
+    ],
+    "GCPDetailsTable": [
+      {
+        "type": 0,
+        "value": "DE Google Cloud Platform details table"
+      }
+    ],
+    "GCPDetailsTitle": [
+      {
+        "type": 0,
+        "value": "DE Google Cloud Platform Details"
+      }
+    ],
+    "GroupByAll": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Account"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Accounts"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Cluster"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Clusters"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Instance type"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Instance types"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Node"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Node"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Organizational unit"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Organizational units"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Project"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Projects"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Region"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Regions"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Region"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Regions"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Service"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Services"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Service"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Services"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Account"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Accounts"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Tag"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE All Tags"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "GroupByLabel": [
+      {
+        "type": 0,
+        "value": "DE Group by"
+      }
+    ],
+    "GroupByTop": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top account"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top accounts"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top cluster"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top clusters"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top instance type"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top instance types"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top node"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top node"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top organizational unit"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top organizational units"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top project"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top projects"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top region"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top regions"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top region"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top regions"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top service"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top services"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top service"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top services"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top account"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top accounts"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top tag"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Top tags"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "GroupByValueNames": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Account names"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cluster names"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Instance type names"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Node names"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Organizational unit names"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Project names"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Region names"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Region names"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Service names"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Service names"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Account names"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Tag names"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "groupBy"
+      }
+    ],
+    "GroupByValues": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE account"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE accounts"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE cluster"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE clusters"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE instance type"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE instance types"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE node"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE node"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE organizational unit"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE organizational units"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE project"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE projects"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE region"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE regions"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE region"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE regions"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE service"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE services"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE service"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE services"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE account"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE accounts"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE tag"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE tags"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "GroupByValuesTitleCase": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Account"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Accounts"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Cluster"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Clusters"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Instance type"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Instance types"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Node"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Node"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Organizational unit"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Organizational units"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Project"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Projects"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Region"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Regions"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Region"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Regions"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Service"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Services"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Service"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Services"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Account"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Accounts"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Tag"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Tags"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "HistoricalChartCostLabel": [
+      {
+        "type": 0,
+        "value": "DE Cost ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "HistoricalChartDayOfMonthLabel": [
+      {
+        "type": 0,
+        "value": "DE Day of Month"
+      }
+    ],
+    "HistoricalChartTitle": [
+      {
+        "options": {
+          "cost": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cost comparison"
+              }
+            ]
+          },
+          "cpu": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE CPU usage, request, and limit comparison"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Compute usage comparison"
+              }
+            ]
+          },
+          "memory": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Memory usage, request, and limit comparison"
+              }
+            ]
+          },
+          "modal": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "DE  daily usage comparison"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "storage": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Storage usage comparison"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "HistoricalChartUsageLabel": [
+      {
+        "options": {
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE hrs"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "storage": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE gb-mo"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "IBM": [
+      {
+        "type": 0,
+        "value": "DE IBM Cloud"
+      }
+    ],
+    "IBMComputeTitle": [
+      {
+        "type": 0,
+        "value": "DE Compute instances usage"
+      }
+    ],
+    "IBMCostTitle": [
+      {
+        "type": 0,
+        "value": "DE IBM Cloud Services cost"
+      }
+    ],
+    "IBMCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "DE IBM Cloud Services cumulative cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "IBMDailyCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "DE IBM Cloud Services daily cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "IBMDesc": [
+      {
+        "type": 0,
+        "value": "DE Raw cost from IBM Cloud infrastructure."
+      }
+    ],
+    "IBMDetailsTable": [
+      {
+        "type": 0,
+        "value": "DE IBM Cloud details table"
+      }
+    ],
+    "IBMDetailsTitle": [
+      {
+        "type": 0,
+        "value": "DE IBM Cloud Details"
+      }
+    ],
+    "InactiveSourcesGoTitle": [
+      {
+        "type": 0,
+        "value": "DE A problem was detected with "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      }
+    ],
+    "InactiveSourcesGoTo": [
+      {
+        "type": 0,
+        "value": "DE Go to Sources for more information"
+      }
+    ],
+    "InactiveSourcesTitleMultiplier": [
+      {
+        "type": 0,
+        "value": "DE A problem was detected with the following sources"
+      }
+    ],
+    "Infrastructure": [
+      {
+        "type": 0,
+        "value": "DE Infrastructure"
+      }
+    ],
+    "LearnMore": [
+      {
+        "type": 0,
+        "value": "DE Learn more"
+      }
+    ],
+    "LoadingStateDesc": [
+      {
+        "type": 0,
+        "value": "DE Searching for your sources. Do not refresh the browser"
+      }
+    ],
+    "LoadingStateTitle": [
+      {
+        "type": 0,
+        "value": "DE Looking for sources..."
+      }
+    ],
+    "MaintenanceEmptyStateDesc": [
+      {
+        "type": 0,
+        "value": "DE Cost Management is currently undergoing scheduled maintenance and will be unavailable from 13:00 - 19:00 UTC (09:00 AM - 03:00 PM EDT)."
+      }
+    ],
+    "MaintenanceEmptyStateInfo": [
+      {
+        "type": 0,
+        "value": "DE For more information visit "
+      },
+      {
+        "type": 1,
+        "value": "url"
+      }
+    ],
+    "MaintenanceEmptyStateThanks": [
+      {
+        "type": 0,
+        "value": "DE We will be back soon. Thank you for your patience!"
+      }
+    ],
+    "ManageColumnsAriaLabel": [
+      {
+        "type": 0,
+        "value": "DE Table column management"
+      }
+    ],
+    "ManageColumnsDesc": [
+      {
+        "type": 0,
+        "value": "DE Selected categories will be displayed in the table"
+      }
+    ],
+    "ManageColumnsTitle": [
+      {
+        "type": 0,
+        "value": "DE Manage columns"
+      }
+    ],
+    "MarkupDescription": [
+      {
+        "type": 0,
+        "value": "DE The portion of cost calculated by applying markup or discount to infrastructure raw cost in the cost management application"
+      }
+    ],
+    "MarkupOrDiscount": [
+      {
+        "type": 0,
+        "value": "DE Markup or Discount"
+      }
+    ],
+    "MarkupOrDiscountDesc": [
+      {
+        "type": 0,
+        "value": "DE This Percentage is applied to raw cost calculations by multiplying the cost with this percentage. Costs calculated from price list rates will not be effected."
+      }
+    ],
+    "MarkupOrDiscountModalDesc": [
+      {
+        "type": 0,
+        "value": "DE Use markup/discount to manipulate how the raw costs are being calculated for your sources. Note, costs calculated from price list rates will not be affected by this."
+      }
+    ],
+    "MarkupPlus": [
+      {
+        "type": 0,
+        "value": "DE Markup (+)"
+      }
+    ],
+    "MarkupTitle": [
+      {
+        "type": 0,
+        "value": "DE Markup"
+      }
+    ],
+    "Measurement": [
+      {
+        "type": 0,
+        "value": "DE Measurement"
+      }
+    ],
+    "MeasurementPlaceholder": [
+      {
+        "type": 0,
+        "value": "DE Filter by measurements"
+      }
+    ],
+    "MeasurementValues": [
+      {
+        "options": {
+          "count": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Count"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Count ("
+                      },
+                      {
+                        "type": 1,
+                        "value": "units"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "request": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Request"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Request ("
+                      },
+                      {
+                        "type": 1,
+                        "value": "units"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "usage": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE Usage ("
+                      },
+                      {
+                        "type": 1,
+                        "value": "units"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "MemoryTitle": [
+      {
+        "type": 0,
+        "value": "DE Memory"
+      }
+    ],
+    "Metric": [
+      {
+        "type": 0,
+        "value": "DE Metric"
+      }
+    ],
+    "MetricPlaceholder": [
+      {
+        "type": 0,
+        "value": "DE Filter by metrics"
+      }
+    ],
+    "MetricValues": [
+      {
+        "options": {
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Cluster"
+              }
+            ]
+          },
+          "cpu": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE CPU"
+              }
+            ]
+          },
+          "memory": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Memory"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Node"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "persistent_volume_claims": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Persistent volume claims"
+              }
+            ]
+          },
+          "storage": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Storage"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "MonthOverMonthChange": [
+      {
+        "type": 0,
+        "value": "DE Month over month change"
+      }
+    ],
+    "Name": [
+      {
+        "offset": 0,
+        "options": {
+          "one": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Name"
+              }
+            ]
+          },
+          "other": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Names"
+              }
+            ]
+          }
+        },
+        "pluralType": "cardinal",
+        "type": 6,
+        "value": "count"
+      }
+    ],
+    "Next": [
+      {
+        "type": 0,
+        "value": "DE next"
+      }
+    ],
+    "No": [
+      {
+        "type": 0,
+        "value": "DE no"
+      }
+    ],
+    "NoAuthorizedStateAws": [
+      {
+        "type": 0,
+        "value": "DE Amazon Web Services in Cost Management"
+      }
+    ],
+    "NoDataForDate": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE No data available for Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "NoDataStateDesc": [
+      {
+        "type": 0,
+        "value": "DE We have detected a source, but we are not done processing the incoming data. The time to process could take up to 24 hours. Try refreshing the page at a later time."
+      }
+    ],
+    "NoDataStateRefresh": [
+      {
+        "type": 0,
+        "value": "DE Refresh this page"
+      }
+    ],
+    "NoDataStateTitle": [
+      {
+        "type": 0,
+        "value": "DE Still processing the data"
+      }
+    ],
+    "NoProvidersStateAwsDesc": [
+      {
+        "type": 0,
+        "value": "DE Add an Amazon Web Services account to see a total cost breakdown of your spend by accounts, organizational units, services, regions, or tags."
+      }
+    ],
+    "NoProvidersStateAwsTitle": [
+      {
+        "type": 0,
+        "value": "DE Track your Amazon Web Services spending!"
+      }
+    ],
+    "NoProvidersStateAzureDesc": [
+      {
+        "type": 0,
+        "value": "DE Add a Microsoft Azure account to see a total cost breakdown of your spend by accounts, services, regions, or tags."
+      }
+    ],
+    "NoProvidersStateAzureTitle": [
+      {
+        "type": 0,
+        "value": "DE Track your Microsoft Azure spending!"
+      }
+    ],
+    "NoProvidersStateGcpDesc": [
+      {
+        "type": 0,
+        "value": "DE Add a Google Cloud Platform account to see a total cost breakdown of your spend by accounts, services, regions, or tags."
+      }
+    ],
+    "NoProvidersStateGcpTitle": [
+      {
+        "type": 0,
+        "value": "DE Track your Google Cloud Platform spending!"
+      }
+    ],
+    "NoProvidersStateGetStarted": [
+      {
+        "type": 0,
+        "value": "DE Get started with Sources"
+      }
+    ],
+    "NoProvidersStateIbmDesc": [
+      {
+        "type": 0,
+        "value": "DE Add an IBM Cloud account to see a total cost breakdown of your spend by accounts, services, regions, or tags."
+      }
+    ],
+    "NoProvidersStateIbmTitle": [
+      {
+        "type": 0,
+        "value": "DE Track your IBM Cloud spending!"
+      }
+    ],
+    "NoProvidersStateOcpAddSources": [
+      {
+        "type": 0,
+        "value": "DE Add an OpenShift cluster to Cost Management"
+      }
+    ],
+    "NoProvidersStateOcpDesc": [
+      {
+        "type": 0,
+        "value": "DE Add an OpenShift Container Platform cluster to see a total cost breakdown of your pods by cluster, node, project, or labels."
+      }
+    ],
+    "NoProvidersStateOcpTitle": [
+      {
+        "type": 0,
+        "value": "DE Track your OpenShift spending!"
+      }
+    ],
+    "NoProvidersStateOverviewDesc": [
+      {
+        "type": 0,
+        "value": "DE Add a source, like an OpenShift Container Platform cluster or a cloud services account, to see a total cost breakdown as well as usage information like instance counts and storage."
+      }
+    ],
+    "NoProvidersStateOverviewTitle": [
+      {
+        "type": 0,
+        "value": "DE Track your spending!"
+      }
+    ],
+    "NotAuthorizedStateAzure": [
+      {
+        "type": 0,
+        "value": "DE Microsoft Azure in Cost Management"
+      }
+    ],
+    "NotAuthorizedStateCostModels": [
+      {
+        "type": 0,
+        "value": "DE Cost Models in Cost Management"
+      }
+    ],
+    "NotAuthorizedStateGcp": [
+      {
+        "type": 0,
+        "value": "DE Google Cloud Platform in Cost Management"
+      }
+    ],
+    "NotAuthorizedStateIbm": [
+      {
+        "type": 0,
+        "value": "DE IBM Cloud in Cost Management"
+      }
+    ],
+    "NotAuthorizedStateOcp": [
+      {
+        "type": 0,
+        "value": "DE OpenShift in Cost Management"
+      }
+    ],
+    "OCPCPUUsageAndRequests": [
+      {
+        "type": 0,
+        "value": "DE CPU usage and requests"
+      }
+    ],
+    "OCPCloudDashboardComputeTitle": [
+      {
+        "type": 0,
+        "value": "DE Compute services usage"
+      }
+    ],
+    "OCPCloudDashboardCostTitle": [
+      {
+        "type": 0,
+        "value": "DE All cloud filtered by OpenShift cost"
+      }
+    ],
+    "OCPCloudDashboardCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "DE All cloud filtered by OpenShift cumulative cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPCloudDashboardDailyCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "DE All cloud filtered by OpenShift daily cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPDailyUsageAndRequestComparison": [
+      {
+        "type": 0,
+        "value": "DE Daily usage and requests comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPDashboardCPUUsageAndRequests": [
+      {
+        "type": 0,
+        "value": "DE OpenShift CPU usage and requests"
+      }
+    ],
+    "OCPDashboardCostTitle": [
+      {
+        "type": 0,
+        "value": "DE All OpenShift cost"
+      }
+    ],
+    "OCPDashboardCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "DE All OpenShift cumulative cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPDashboardDailyCostTitle": [
+      {
+        "type": 0,
+        "value": "DE All OpenShift daily cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPDashboardMemoryUsageAndRequests": [
+      {
+        "type": 0,
+        "value": "DE OpenShift Memory usage and requests"
+      }
+    ],
+    "OCPDetailsInfrastructureCost": [
+      {
+        "type": 0,
+        "value": "DE Infrastructure cost"
+      }
+    ],
+    "OCPDetailsInfrastructureCostDesc": [
+      {
+        "type": 0,
+        "value": "DE The cost based on raw usage data from the underlying infrastructure."
+      }
+    ],
+    "OCPDetailsSupplementaryCost": [
+      {
+        "type": 0,
+        "value": "DE Infrastructure cost"
+      }
+    ],
+    "OCPDetailsSupplementaryCostDesc": [
+      {
+        "type": 0,
+        "value": "DE All costs not directly attributed to the infrastructure. These costs are determined by applying a price list within a cost model to OpenShift cluster metrics."
+      }
+    ],
+    "OCPDetailsTable": [
+      {
+        "type": 0,
+        "value": "DE OpenShift details table"
+      }
+    ],
+    "OCPDetailsTitle": [
+      {
+        "type": 0,
+        "value": "DE OpenShift details"
+      }
+    ],
+    "OCPInfrastructureCostTitle": [
+      {
+        "type": 0,
+        "value": "DE OpenShift infrastructure cost"
+      }
+    ],
+    "OCPInfrastructureCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "DE OpenShift cumulative infrastructure cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPInfrastructureDailyCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "DE OpenShift daily infrastructure cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPMemoryUsageAndRequests": [
+      {
+        "type": 0,
+        "value": "DE Memory usage and requests"
+      }
+    ],
+    "OCPSupplementaryCostTitle": [
+      {
+        "type": 0,
+        "value": "DE OpenShift supplementary cost"
+      }
+    ],
+    "OCPSupplementaryCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "DE OpenShift cumulative supplementary cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPSupplementaryDailyCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "DE OpenShift daily supplementary cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPUsageAndRequests": [
+      {
+        "type": 0,
+        "value": "DE OpenShift Volume usage and requests"
+      }
+    ],
+    "OCPUsageCostTitle": [
+      {
+        "type": 0,
+        "value": "DE OpenShift usage cost"
+      }
+    ],
+    "OCPUsageDashboardCPUTitle": [
+      {
+        "type": 0,
+        "value": "DE OpenShift CPU usage and requests"
+      }
+    ],
+    "OCPUsageDashboardCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "DE Metering cumulative cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPVolumeUsageAndRequests": [
+      {
+        "type": 0,
+        "value": "DE Volume usage and requests"
+      }
+    ],
+    "OpenShift": [
+      {
+        "type": 0,
+        "value": "DE OpenShift"
+      }
+    ],
+    "OpenShiftCloudInfrastructure": [
+      {
+        "type": 0,
+        "value": "DE OpenShift cloud infrastructure"
+      }
+    ],
+    "OpenShiftCloudInfrastructureDesc": [
+      {
+        "type": 0,
+        "value": "DE Infrastructure cost attributed to OpenShift Container Platform, based on a subset of cloud cost data."
+      }
+    ],
+    "OpenShiftDesc": [
+      {
+        "type": 0,
+        "value": "DE Total cost for OpenShift Container Platform, comprising the infrastructure cost and cost calculated from metrics."
+      }
+    ],
+    "OverviewInfoArialLabel": [
+      {
+        "type": 0,
+        "value": "DE A description of perspectives"
+      }
+    ],
+    "OverviewTitle": [
+      {
+        "type": 0,
+        "value": "DE Cost Management Overview"
+      }
+    ],
+    "PageTitleAWS": [
+      {
+        "type": 0,
+        "value": "DE Amazon Web Services - Cost Management | Red Hat OpenShift Cluster Manager"
+      }
+    ],
+    "PageTitleAzure": [
+      {
+        "type": 0,
+        "value": "DE Microsoft Azure - Cost Management | Red Hat OpenShift Cluster Manager"
+      }
+    ],
+    "PageTitleCostModels": [
+      {
+        "type": 0,
+        "value": "DE Cost Models - Cost Management | Red Hat OpenShift Cluster Manager"
+      }
+    ],
+    "PageTitleDefault": [
+      {
+        "type": 0,
+        "value": "DE Cost Management | Red Hat OpenShift Cluster Manager"
+      }
+    ],
+    "PageTitleExplorer": [
+      {
+        "type": 0,
+        "value": "DE Cost Explorer - Cost Management | Red Hat OpenShift Cluster Manager"
+      }
+    ],
+    "PageTitleGCP": [
+      {
+        "type": 0,
+        "value": "DE Google Cloud Platform - Cost Management | Red Hat OpenShift Cluster Manager"
+      }
+    ],
+    "PageTitleIBM": [
+      {
+        "type": 0,
+        "value": "DE IBM Cloud - Cost Management | Red Hat OpenShift Cluster Manager"
+      }
+    ],
+    "PageTitleOpenShift": [
+      {
+        "type": 0,
+        "value": "DE OpenShift - Cost Management | Red Hat OpenShift Cluster Manager"
+      }
+    ],
+    "PageTitleOverview": [
+      {
+        "type": 0,
+        "value": "DE Overview - Cost Management | Red Hat OpenShift Cluster Manager"
+      }
+    ],
+    "Percent": [
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": "DE  %"
+      }
+    ],
+    "PercentOfCost": [
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": "DE  % of cost"
+      }
+    ],
+    "PercentSymbol": [
+      {
+        "type": 0,
+        "value": "DE %"
+      }
+    ],
+    "PercentTotalCost": [
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": "DE  "
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": " ("
+      },
+      {
+        "type": 1,
+        "value": "percent"
+      },
+      {
+        "type": 0,
+        "value": " %)"
+      }
+    ],
+    "Perspective": [
+      {
+        "type": 0,
+        "value": "DE Perspective"
+      }
+    ],
+    "PerspectiveValues": [
+      {
+        "options": {
+          "aws": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Amazon Web Services"
+              }
+            ]
+          },
+          "aws_ocp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Amazon Web Services filtered by OpenShift"
+              }
+            ]
+          },
+          "azure": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Microsoft Azure"
+              }
+            ]
+          },
+          "azure_ocp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Microsoft Azure filtered by OpenShift"
+              }
+            ]
+          },
+          "gcp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Google Cloud Platform"
+              }
+            ]
+          },
+          "gcp_ocp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE Google Cloud Platform filtered by OpenShift"
+              }
+            ]
+          },
+          "ibm": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE IBM Cloud"
+              }
+            ]
+          },
+          "ocp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE All OpenShift"
+              }
+            ]
+          },
+          "ocp_cloud": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE All cloud filtered by OpenShift"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "PriceList": [
+      {
+        "type": 0,
+        "value": "DE Price list"
+      }
+    ],
+    "PriceListAddRate": [
+      {
+        "type": 0,
+        "value": "DE Add rate"
+      }
+    ],
+    "PriceListDeleteRate": [
+      {
+        "type": 0,
+        "value": "DE Delete rate"
+      }
+    ],
+    "PriceListDesc": [
+      {
+        "offset": 0,
+        "options": {
+          "one": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE This action will remove "
+              },
+              {
+                "type": 1,
+                "value": "metric"
+              },
+              {
+                "type": 0,
+                "value": " rate from "
+              },
+              {
+                "type": 1,
+                "value": "costModel"
+              }
+            ]
+          },
+          "other": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE This action will remove "
+              },
+              {
+                "type": 1,
+                "value": "metric"
+              },
+              {
+                "type": 0,
+                "value": " rate from "
+              },
+              {
+                "type": 1,
+                "value": "costModel"
+              },
+              {
+                "type": 0,
+                "value": ", which is assigned to the following sources:"
+              }
+            ]
+          }
+        },
+        "pluralType": "cardinal",
+        "type": 6,
+        "value": "count"
+      }
+    ],
+    "PriceListDuplicate": [
+      {
+        "type": 0,
+        "value": "DE This tag key is already in use"
+      }
+    ],
+    "PriceListEditRate": [
+      {
+        "type": 0,
+        "value": "DE Edit rate"
+      }
+    ],
+    "PriceListEmptyRate": [
+      {
+        "type": 0,
+        "value": "DE No rates are set"
+      }
+    ],
+    "PriceListEmptyRateDesc": [
+      {
+        "type": 0,
+        "value": "DE To add rates to the price list, click on the \"Add\" rate button above."
+      }
+    ],
+    "PriceListNumberRate": [
+      {
+        "type": 0,
+        "value": "DE Rate must be a number"
+      }
+    ],
+    "PriceListPosNumberRate": [
+      {
+        "type": 0,
+        "value": "DE Rate must be a positive number"
+      }
+    ],
+    "Rate": [
+      {
+        "type": 0,
+        "value": "DE Rate"
+      }
+    ],
+    "RawCostDescription": [
+      {
+        "type": 0,
+        "value": "DE The costs reported by a cloud provider without any cost model calculations applied."
+      }
+    ],
+    "RawCostTitle": [
+      {
+        "type": 0,
+        "value": "DE Raw cost"
+      }
+    ],
+    "RbacErrorDescription": [
+      {
+        "type": 0,
+        "value": "DE There was a problem receiving user permissions. Refreshing this page may fix it. If it does not, please contact your admin."
+      }
+    ],
+    "RbacErrorTitle": [
+      {
+        "type": 0,
+        "value": "DE Failed to get RBAC information"
+      }
+    ],
+    "RedHatStatusUrl": [
+      {
+        "type": 0,
+        "value": "DE https://status.redhat.com"
+      }
+    ],
+    "Requests": [
+      {
+        "type": 0,
+        "value": "DE Requests"
+      }
+    ],
+    "Save": [
+      {
+        "type": 0,
+        "value": "DE Save"
+      }
+    ],
+    "Select": [
+      {
+        "type": 0,
+        "value": "DE Select..."
+      }
+    ],
+    "SelectAll": [
+      {
+        "type": 0,
+        "value": "DE Select all"
+      }
+    ],
+    "Selected": [
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": "DE  selected"
+      }
+    ],
+    "SinceDate": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE January "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE January "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE February "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE February "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE March "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE March "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE April "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE April "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE June "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE June "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE July "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE July "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE August "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE August "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE September "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE September "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE October "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE October "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE November "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE November "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE December "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "DE December "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "Sources": [
+      {
+        "type": 0,
+        "value": "DE Sources"
+      }
+    ],
+    "Supplementary": [
+      {
+        "type": 0,
+        "value": "DE Supplementary"
+      }
+    ],
+    "TagHeadingKey": [
+      {
+        "type": 0,
+        "value": "DE Key"
+      }
+    ],
+    "TagHeadingTitle": [
+      {
+        "type": 0,
+        "value": "DE Tags ("
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "TagHeadingValue": [
+      {
+        "type": 0,
+        "value": "DE Value"
+      }
+    ],
+    "TagNames": [
+      {
+        "type": 0,
+        "value": "DE Tag names"
+      }
+    ],
+    "ToolBarBulkSelectAll": [
+      {
+        "type": 0,
+        "value": "DE Select all ("
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " items)"
+      }
+    ],
+    "ToolBarBulkSelectAriaDeselect": [
+      {
+        "type": 0,
+        "value": "DE Deselect all items"
+      }
+    ],
+    "ToolBarBulkSelectAriaSelect": [
+      {
+        "type": 0,
+        "value": "DE Select all items"
+      }
+    ],
+    "ToolBarBulkSelectNone": [
+      {
+        "type": 0,
+        "value": "DE Select none (0 items)"
+      }
+    ],
+    "ToolBarBulkSelectPage": [
+      {
+        "type": 0,
+        "value": "DE Select page ("
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " items)"
+      }
+    ],
+    "ToolBarPriceListMeasurementPlaceHolder": [
+      {
+        "type": 0,
+        "value": "DE Filter by measurements"
+      }
+    ],
+    "ToolBarPriceListMetricPlaceHolder": [
+      {
+        "type": 0,
+        "value": "DE Filter by metrics"
+      }
+    ],
+    "UnitTooltips": [
+      {
+        "options": {
+          "core_hours": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "DE  core-hours"
+              }
+            ]
+          },
+          "gb": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "DE  GB"
+              }
+            ]
+          },
+          "gb_hours": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "DE  GB-hours"
+              }
+            ]
+          },
+          "gb_mo": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "DE  GB-month"
+              }
+            ]
+          },
+          "gibibyte_month": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "DE  GiB-month"
+              }
+            ]
+          },
+          "hour": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "DE  hours"
+              }
+            ]
+          },
+          "hrs": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "DE  hours"
+              }
+            ]
+          },
+          "other": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              }
+            ]
+          },
+          "vm_hours": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "DE  VM-hours"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "units"
+      }
+    ],
+    "Units": [
+      {
+        "options": {
+          "core_hours": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE core-hours"
+              }
+            ]
+          },
+          "gb": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE GB"
+              }
+            ]
+          },
+          "gb_hours": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE GB-hours"
+              }
+            ]
+          },
+          "gb_mo": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE GB-month"
+              }
+            ]
+          },
+          "gibibyte_month": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE GiB-month"
+              }
+            ]
+          },
+          "hour": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE hours"
+              }
+            ]
+          },
+          "hrs": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE hours"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "vm_hours": {
+            "value": [
+              {
+                "type": 0,
+                "value": "DE VM-hours"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "units"
+      }
+    ],
+    "Usage": [
+      {
+        "type": 0,
+        "value": "DE Usage"
+      }
+    ],
+    "UsageCostDescription": [
+      {
+        "type": 0,
+        "value": "DE The portion of cost calculated by applying hourly and/or monthly price list rates to metrics."
+      }
+    ],
+    "UsageCostTitle": [
+      {
+        "type": 0,
+        "value": "DE Usage cost"
+      }
+    ],
+    "Various": [
+      {
+        "type": 0,
+        "value": "DE Various"
+      }
+    ],
+    "Yes": [
+      {
+        "type": 0,
+        "value": "DE Yes"
+      }
+    ]
+  },
   "en": {
     "AWS": [
       {
@@ -18112,6 +36228,18122 @@
       {
         "type": 0,
         "value": "Yes"
+      }
+    ]
+  },
+  "fr": {
+    "AWS": [
+      {
+        "type": 0,
+        "value": "FR Amazon Web Services"
+      }
+    ],
+    "AWSComputeTitle": [
+      {
+        "type": 0,
+        "value": "FR Compute (EC2) instances usage"
+      }
+    ],
+    "AWSCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "FR Amazon Web Services cumulative cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "AWSDailyCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "FR Amazon Web Services daily cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "AWSDashboardCostTitle": [
+      {
+        "type": 0,
+        "value": "FR Amazon Web Services cost"
+      }
+    ],
+    "AWSDesc": [
+      {
+        "type": 0,
+        "value": "FR Raw cost from Amazon Web Services infrastructure."
+      }
+    ],
+    "AWSDetailsTable": [
+      {
+        "type": 0,
+        "value": "FR Amazon Web Services details table"
+      }
+    ],
+    "AWSDetailsTitle": [
+      {
+        "type": 0,
+        "value": "FR Amazon Web Services Details"
+      }
+    ],
+    "AWSOcpDashboardCostTitle": [
+      {
+        "type": 0,
+        "value": "FR Amazon Web Services filtered by OpenShift cost"
+      }
+    ],
+    "Azure": [
+      {
+        "type": 0,
+        "value": "FR Microsoft Azure"
+      }
+    ],
+    "AzureComputeTitle": [
+      {
+        "type": 0,
+        "value": "FR Virtual machines usage"
+      }
+    ],
+    "AzureCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "FR Microsoft Azure cumulative cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "AzureDailyCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "FR Microsoft Azure daily cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "AzureDashboardCostTitle": [
+      {
+        "type": 0,
+        "value": "FR Microsoft Azure cost"
+      }
+    ],
+    "AzureDesc": [
+      {
+        "type": 0,
+        "value": "FR Raw cost from Azure infrastructure."
+      }
+    ],
+    "AzureDetailsTable": [
+      {
+        "type": 0,
+        "value": "FR Microsoft Azure details table"
+      }
+    ],
+    "AzureDetailsTitle": [
+      {
+        "type": 0,
+        "value": "FR Microsoft Azure details"
+      }
+    ],
+    "AzureOcpDashboardCostTitle": [
+      {
+        "type": 0,
+        "value": "FR Microsoft Azure filtered by OpenShift cost"
+      }
+    ],
+    "Back": [
+      {
+        "type": 0,
+        "value": "FR Back"
+      }
+    ],
+    "BreakdownBackToDetails": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " account details"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " cluster details"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " instance type details"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " node details"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " organizational unit details"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " project details"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " region details"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " region details"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " service details"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " service details"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " account details"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost by tags"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "groupBy"
+      }
+    ],
+    "BreakdownBackToDetailsAriaLabel": [
+      {
+        "type": 0,
+        "value": "FR Back to details"
+      }
+    ],
+    "BreakdownCostBreakdownAriaLabel": [
+      {
+        "type": 0,
+        "value": "FR A description of markup, raw cost and usage cost"
+      }
+    ],
+    "BreakdownCostBreakdownTitle": [
+      {
+        "type": 0,
+        "value": "FR Cost breakdown"
+      }
+    ],
+    "BreakdownCostChartAriaDesc": [
+      {
+        "type": 0,
+        "value": "FR Breakdown of markup, raw, and usage costs"
+      }
+    ],
+    "BreakdownCostChartTooltip": [
+      {
+        "type": 1,
+        "value": "name"
+      },
+      {
+        "type": 0,
+        "value": "FR : "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      }
+    ],
+    "BreakdownCostOverviewTitle": [
+      {
+        "type": 0,
+        "value": "FR Cost overview"
+      }
+    ],
+    "BreakdownHistoricalDataTitle": [
+      {
+        "type": 0,
+        "value": "FR Historical data"
+      }
+    ],
+    "BreakdownSummaryTitle": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost by accounts"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost by clusters"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost by instance types"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost by Node"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost by organizational units"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost by projects"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost by regions"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost by regions"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost by services"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost by services"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost by accounts"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost by tags"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "BreakdownTitle": [
+      {
+        "type": 1,
+        "value": "value"
+      }
+    ],
+    "BreakdownTotalCostDate": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (January "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (January "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (February "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (February "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (March "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (March "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (April "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (April "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (June "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (June "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (July "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (July "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (August "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (August "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (September "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (September "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (October "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (October "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (November "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (November "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (December "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  total cost (December "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "CPUTitle": [
+      {
+        "type": 0,
+        "value": "FR CPU"
+      }
+    ],
+    "CalculationType": [
+      {
+        "type": 0,
+        "value": "FR Calculation type"
+      }
+    ],
+    "Cancel": [
+      {
+        "type": 0,
+        "value": "FR Cancel"
+      }
+    ],
+    "ChartCostForecastConeLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost confidence (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostForecastConeLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "FR Cost confidence (no data)"
+      }
+    ],
+    "ChartCostForecastConeLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost confidence (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost confidence (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost confidence (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost confidence (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost confidence (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost confidence (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost confidence (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost confidence (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost confidence (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost confidence (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost confidence (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost confidence (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostForecastConeTooltip": [
+      {
+        "type": 1,
+        "value": "value0"
+      },
+      {
+        "type": 0,
+        "value": "FR  - "
+      },
+      {
+        "type": 1,
+        "value": "value1"
+      }
+    ],
+    "ChartCostForecastLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost forecast (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostForecastLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "FR Cost forecast (no data)"
+      }
+    ],
+    "ChartCostForecastLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost forecast (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost forecast (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost forecast (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost forecast (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost forecast (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost forecast (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost forecast (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost forecast (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost forecast (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost forecast (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost forecast (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost forecast (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostInfrastructureForecastConeLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure confidence (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostInfrastructureForecastConeLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "FR Infrastructure confidence (no data)"
+      }
+    ],
+    "ChartCostInfrastructureForecastConeLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure confidence (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure confidence (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure confidence (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure confidence (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure confidence (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure confidence (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure confidence (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure confidence (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure confidence (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure confidence (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure confidence (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure confidence (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostInfrastructureForecastLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure forecast (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostInfrastructureForecastLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "FR Infrastructure forecast (no data)"
+      }
+    ],
+    "ChartCostInfrastructureForecastLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure forecast (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure forecast (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure forecast (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure forecast (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure forecast (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure forecast (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure forecast (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure forecast (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure forecast (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure forecast (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure forecast (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure forecast (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostInfrastructureLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Infrastructure cost (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostInfrastructureLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "FR Infrastructure cost (no data)"
+      }
+    ],
+    "ChartCostInfrastructureLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure cost (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure cost (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure cost (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure cost (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure cost (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure cost (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure cost (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure cost (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure cost (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure cost (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure cost (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Infrastructure cost (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cost (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "FR Cost (no data)"
+      }
+    ],
+    "ChartCostLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostSupplementaryLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Supplementary cost (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartCostSupplementaryLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "FR Supplementary cost (no data)"
+      }
+    ],
+    "ChartCostSupplementaryLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Supplementary cost (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Supplementary cost (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Supplementary cost (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Supplementary cost (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Supplementary cost (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Supplementary cost (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Supplementary cost (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Supplementary cost (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Supplementary cost (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Supplementary cost (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Supplementary cost (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Supplementary cost (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartDateRange": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": " Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "year"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartDayOfTheMonth": [
+      {
+        "type": 0,
+        "value": "FR Day "
+      },
+      {
+        "type": 1,
+        "value": "day"
+      }
+    ],
+    "ChartLimitLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Limit (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartLimitLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "FR Limit (no data)"
+      }
+    ],
+    "ChartLimitLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Limit (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Limit (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Limit (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Limit (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Limit (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Limit (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Limit (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Limit (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Limit (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Limit (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Limit (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Limit (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartNoData": [
+      {
+        "type": 0,
+        "value": "FR no data"
+      }
+    ],
+    "ChartOthers": [
+      {
+        "offset": 0,
+        "options": {
+          "one": {
+            "value": [
+              {
+                "type": 1,
+                "value": "count"
+              },
+              {
+                "type": 0,
+                "value": "FR  Other"
+              }
+            ]
+          },
+          "other": {
+            "value": [
+              {
+                "type": 1,
+                "value": "count"
+              },
+              {
+                "type": 0,
+                "value": "FR  Others"
+              }
+            ]
+          }
+        },
+        "pluralType": "cardinal",
+        "type": 6,
+        "value": "count"
+      }
+    ],
+    "ChartRequestLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Requests (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartRequestLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Requests (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Requests (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Requests (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Requests (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Requests (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Requests (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Requests (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Requests (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Requests (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Requests (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Requests (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Requests (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartRequestsLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "FR Requests (no data)"
+      }
+    ],
+    "ChartUsageLegendLabel": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage (Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ChartUsageLegendNoDataLabel": [
+      {
+        "type": 0,
+        "value": "FR Usage (no data)"
+      }
+    ],
+    "ChartUsageLegendTooltip": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Usage (Jan)"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Usage (Feb)"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Usage (Mar)"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Usage (Apr)"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Usage (May)"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Usage (Jun)"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Usage (Jul)"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Usage (Aug)"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Usage (Sep)"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Usage (Oct)"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Usage (Nov)"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Usage (Dec)"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "Close": [
+      {
+        "type": 0,
+        "value": "FR Close"
+      }
+    ],
+    "Clusters": [
+      {
+        "type": 0,
+        "value": "FR Clusters"
+      }
+    ],
+    "Cost": [
+      {
+        "type": 0,
+        "value": "FR Cost"
+      }
+    ],
+    "CostCalculations": [
+      {
+        "type": 0,
+        "value": "FR Cost calculations"
+      }
+    ],
+    "CostManagement": [
+      {
+        "type": 0,
+        "value": "FR Cost Management"
+      }
+    ],
+    "CostModels": [
+      {
+        "type": 0,
+        "value": "FR Cost Models"
+      }
+    ],
+    "CostModelsAddTagValues": [
+      {
+        "type": 0,
+        "value": "FR Add more tag values"
+      }
+    ],
+    "CostModelsAssignSources": [
+      {
+        "offset": 0,
+        "options": {
+          "one": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Assign source"
+              }
+            ]
+          },
+          "other": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Assign sources"
+              }
+            ]
+          }
+        },
+        "pluralType": "cardinal",
+        "type": 6,
+        "value": "count"
+      }
+    ],
+    "CostModelsAssignSourcesErrorDescription": [
+      {
+        "type": 0,
+        "value": "FR You cannot assign a source at this time. Try refreshing this page. If the problem persists, contact your organization administrator or visit our "
+      },
+      {
+        "type": 1,
+        "value": "url"
+      },
+      {
+        "type": 0,
+        "value": " for known outages."
+      }
+    ],
+    "CostModelsAssignSourcesErrorTitle": [
+      {
+        "type": 0,
+        "value": "FR This action is temporarily unavailable"
+      }
+    ],
+    "CostModelsAssignSourcesParen": [
+      {
+        "type": 0,
+        "value": "FR Assign source(s)"
+      }
+    ],
+    "CostModelsAssignedSources": [
+      {
+        "type": 0,
+        "value": "FR Assigned sources"
+      }
+    ],
+    "CostModelsAvailableSources": [
+      {
+        "type": 0,
+        "value": "FR The following sources are assigned to my production cost model:"
+      }
+    ],
+    "CostModelsCanDelete": [
+      {
+        "type": 0,
+        "value": "FR This action will delete "
+      },
+      {
+        "type": 1,
+        "value": "name"
+      },
+      {
+        "type": 0,
+        "value": " cost model from the system. This action cannot be undone"
+      }
+    ],
+    "CostModelsCanNotDelete": [
+      {
+        "type": 0,
+        "value": "FR The following sources are assigned to "
+      },
+      {
+        "type": 1,
+        "value": "name"
+      },
+      {
+        "type": 0,
+        "value": " cost model:"
+      }
+    ],
+    "CostModelsDelete": [
+      {
+        "type": 0,
+        "value": "FR Delete cost model"
+      }
+    ],
+    "CostModelsDeleteDesc": [
+      {
+        "type": 0,
+        "value": "FR This action will delete "
+      },
+      {
+        "type": 1,
+        "value": "costModel"
+      },
+      {
+        "type": 0,
+        "value": " cost model from the system. This action cannot be undone."
+      }
+    ],
+    "CostModelsDeleteSource": [
+      {
+        "type": 0,
+        "value": "FR You must unassign any sources before you can delete this cost model."
+      }
+    ],
+    "CostModelsDescTooLong": [
+      {
+        "type": 0,
+        "value": "FR Should not exceed 500 characters"
+      }
+    ],
+    "CostModelsDetailsAssignSourcesTitle": [
+      {
+        "type": 0,
+        "value": "FR Assign sources"
+      }
+    ],
+    "CostModelsDistributionDesc": [
+      {
+        "type": 0,
+        "value": "FR The following is the type of metric that is set to be used when distributing costs to the project level breakdowns."
+      }
+    ],
+    "CostModelsDistributionEdit": [
+      {
+        "type": 0,
+        "value": "FR Edit distribution"
+      }
+    ],
+    "CostModelsEmptyState": [
+      {
+        "type": 0,
+        "value": "FR What is your hybrid cloud costing you?"
+      }
+    ],
+    "CostModelsEmptyStateDesc": [
+      {
+        "type": 0,
+        "value": "FR Create a cost model to start calculating your hybrid cloud costs using custom price lists, markups, or both. Click on the button below to begin the journey."
+      }
+    ],
+    "CostModelsEmptyStateLearnMore": [
+      {
+        "type": 0,
+        "value": "FR Read about setting up a cost model"
+      }
+    ],
+    "CostModelsEnterTagKey": [
+      {
+        "type": 0,
+        "value": "FR Enter a tag key"
+      }
+    ],
+    "CostModelsEnterTagRate": [
+      {
+        "type": 0,
+        "value": "FR Enter rate by tag"
+      }
+    ],
+    "CostModelsEnterTagValue": [
+      {
+        "type": 0,
+        "value": "FR Enter a tag value"
+      }
+    ],
+    "CostModelsExamplesDoubleMarkup": [
+      {
+        "type": 0,
+        "value": "FR A markup rate of (+) 100% doubles the base costs of your source(s)."
+      }
+    ],
+    "CostModelsExamplesNoAdjust": [
+      {
+        "type": 0,
+        "value": "FR A markup or discount rate of (+/-) 0% (the default) makes no adjustments to the base costs of your source(s)."
+      }
+    ],
+    "CostModelsExamplesReduceSeventyfive": [
+      {
+        "type": 0,
+        "value": "FR A discount rate of (-) 25% reduces the base costs of your source(s) to 75% of the original value."
+      }
+    ],
+    "CostModelsExamplesReduceZero": [
+      {
+        "type": 0,
+        "value": "FR A discount rate of (-) 100% reduces the base costs of your source(s) to 0."
+      }
+    ],
+    "CostModelsFilterPlaceholder": [
+      {
+        "type": 0,
+        "value": "FR Filter by name..."
+      }
+    ],
+    "CostModelsFilterTagKey": [
+      {
+        "type": 0,
+        "value": "FR Filter by tag key"
+      }
+    ],
+    "CostModelsInfoTooLong": [
+      {
+        "type": 0,
+        "value": "FR Should not exceed 100 characters"
+      }
+    ],
+    "CostModelsLastChange": [
+      {
+        "type": 0,
+        "value": "FR Last change"
+      }
+    ],
+    "CostModelsPopover": [
+      {
+        "type": 0,
+        "value": "FR A cost model allows you to associate a price to metrics provided by your sources to charge for utilization of resources. "
+      },
+      {
+        "type": 1,
+        "value": "learnMore"
+      }
+    ],
+    "CostModelsPopoverAriaLabel": [
+      {
+        "type": 0,
+        "value": "FR Cost model info popover"
+      }
+    ],
+    "CostModelsRateTooLong": [
+      {
+        "type": 0,
+        "value": "FR Should not exceed 10 decimals"
+      }
+    ],
+    "CostModelsReadOnly": [
+      {
+        "type": 0,
+        "value": "FR You have read only permissions"
+      }
+    ],
+    "CostModelsRefreshDialog": [
+      {
+        "type": 0,
+        "value": "FR Refresh this dialog"
+      }
+    ],
+    "CostModelsRequiredField": [
+      {
+        "type": 0,
+        "value": "FR This field is required"
+      }
+    ],
+    "CostModelsRouterErrorTitle": [
+      {
+        "type": 0,
+        "value": "FR Fail routing to cost model"
+      }
+    ],
+    "CostModelsRouterServerError": [
+      {
+        "type": 0,
+        "value": "FR Server error: could not get the cost model."
+      }
+    ],
+    "CostModelsSourceDelete": [
+      {
+        "type": 0,
+        "value": "FR Unassign"
+      }
+    ],
+    "CostModelsSourceDeleteSource": [
+      {
+        "type": 0,
+        "value": "FR Unassign source"
+      }
+    ],
+    "CostModelsSourceDeleteSourceDesc": [
+      {
+        "type": 0,
+        "value": "FR This will remove the assignment of "
+      },
+      {
+        "type": 1,
+        "value": "source"
+      },
+      {
+        "type": 0,
+        "value": " from the "
+      },
+      {
+        "type": 1,
+        "value": "costModel"
+      },
+      {
+        "type": 0,
+        "value": " cost model. You can then assign the cost model to a new source."
+      }
+    ],
+    "CostModelsSourceEmptyStateDesc": [
+      {
+        "type": 0,
+        "value": "FR Select the source(s) you want to apply this cost model to."
+      }
+    ],
+    "CostModelsSourceEmptyStateTitle": [
+      {
+        "type": 0,
+        "value": "FR No sources are assigned"
+      }
+    ],
+    "CostModelsSourceTablePaginationAriaLabel": [
+      {
+        "type": 0,
+        "value": "FR Sources table pagination controls"
+      }
+    ],
+    "CostModelsSourceType": [
+      {
+        "type": 0,
+        "value": "FR Source type"
+      }
+    ],
+    "CostModelsSourcesTableAriaLabel": [
+      {
+        "type": 0,
+        "value": "FR Sources table"
+      }
+    ],
+    "CostModelsTableAriaLabel": [
+      {
+        "type": 0,
+        "value": "FR Cost models table"
+      }
+    ],
+    "CostModelsTagRateTableAriaLabel": [
+      {
+        "type": 0,
+        "value": "FR Tag rates"
+      }
+    ],
+    "CostModelsTagRateTableDefault": [
+      {
+        "type": 0,
+        "value": "FR Default"
+      }
+    ],
+    "CostModelsTagRateTableKey": [
+      {
+        "type": 0,
+        "value": "FR Tag key"
+      }
+    ],
+    "CostModelsTagRateTableRate": [
+      {
+        "type": 0,
+        "value": "FR Rate"
+      }
+    ],
+    "CostModelsTagRateTableValue": [
+      {
+        "type": 0,
+        "value": "FR Tag value"
+      }
+    ],
+    "CostModelsUUIDEmptyState": [
+      {
+        "type": 0,
+        "value": "FR Cost model can not be found"
+      }
+    ],
+    "CostModelsUUIDEmptyStateDesc": [
+      {
+        "type": 0,
+        "value": "FR Cost model with uuid: "
+      },
+      {
+        "type": 1,
+        "value": "uuid"
+      },
+      {
+        "type": 0,
+        "value": " does not exist."
+      }
+    ],
+    "CostModelsWizardCreateCostModel": [
+      {
+        "type": 0,
+        "value": "FR Create cost model"
+      }
+    ],
+    "CostModelsWizardCreatePriceList": [
+      {
+        "type": 0,
+        "value": "FR Create a price list"
+      }
+    ],
+    "CostModelsWizardEmptySourceTypeLabel": [
+      {
+        "type": 0,
+        "value": "FR Select source type"
+      }
+    ],
+    "CostModelsWizardEmptyStateCreate": [
+      {
+        "type": 0,
+        "value": "FR To create a price list, begin by clicking the "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " button."
+      }
+    ],
+    "CostModelsWizardEmptyStateOtherTime": [
+      {
+        "type": 0,
+        "value": "FR You can create a price list or modify one at a later time."
+      }
+    ],
+    "CostModelsWizardEmptyStateSkipStep": [
+      {
+        "type": 0,
+        "value": "FR To skip this step, click the "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " button."
+      }
+    ],
+    "CostModelsWizardEmptyStateTitle": [
+      {
+        "type": 0,
+        "value": "FR A price list has not been created."
+      }
+    ],
+    "CostModelsWizardGeneralInfoTitle": [
+      {
+        "type": 0,
+        "value": "FR Enter general information"
+      }
+    ],
+    "CostModelsWizardNoRatesAdded": [
+      {
+        "type": 0,
+        "value": "FR No rates were added to the price list"
+      }
+    ],
+    "CostModelsWizardOnboardAWS": [
+      {
+        "type": 0,
+        "value": "FR Amazon Web Services (AWS)"
+      }
+    ],
+    "CostModelsWizardOnboardOCP": [
+      {
+        "type": 0,
+        "value": "FR Red Hat OpenShift Container Platform"
+      }
+    ],
+    "CostModelsWizardPriceListMetric": [
+      {
+        "type": 0,
+        "value": "FR Select the metric you want to assign a price to, and specify a measurement unit and rate. You can optionally set multiple rates for particular tags."
+      }
+    ],
+    "CostModelsWizardReviewMarkDiscount": [
+      {
+        "type": 0,
+        "value": "FR Markup/Discount"
+      }
+    ],
+    "CostModelsWizardReviewStatusSubDetails": [
+      {
+        "type": 0,
+        "value": "FR Review and confirm your cost model configuration and assignments. Click "
+      },
+      {
+        "type": 1,
+        "value": "create"
+      },
+      {
+        "type": 0,
+        "value": " to create the cost model, or "
+      },
+      {
+        "type": 1,
+        "value": "back"
+      },
+      {
+        "type": 0,
+        "value": " to revise."
+      }
+    ],
+    "CostModelsWizardReviewStatusSubTitle": [
+      {
+        "type": 0,
+        "value": "FR Costs for resources connected to the assigned sources will now be calculated using the newly created "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " cost model."
+      }
+    ],
+    "CostModelsWizardReviewStatusTitle": [
+      {
+        "type": 0,
+        "value": "FR Creation successful"
+      }
+    ],
+    "CostModelsWizardSourceCaption": [
+      {
+        "options": {
+          "aws": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Select from the following Amazon Web Services sources:"
+              }
+            ]
+          },
+          "azure": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Select from the following Microsoft Azure sources:"
+              }
+            ]
+          },
+          "gcp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Select from the following Google Cloud Platform sources:"
+              }
+            ]
+          },
+          "ocp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Select from the following Red Hat OpenShift sources:"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "CostModelsWizardSourceErrorDescription": [
+      {
+        "type": 0,
+        "value": "FR Try refreshing this step or you can skip this step (as it is optional) and assign the source to the cost model at a later time. If the problem persists, contact your organization administrator or visit our "
+      },
+      {
+        "type": 1,
+        "value": "url"
+      },
+      {
+        "type": 0,
+        "value": " for known outages."
+      }
+    ],
+    "CostModelsWizardSourceErrorTitle": [
+      {
+        "type": 0,
+        "value": "FR This step is temporarily unavailable"
+      }
+    ],
+    "CostModelsWizardSourceSubtitle": [
+      {
+        "type": 0,
+        "value": "FR Select one or more sources to this cost model. You can skip this step and assign the cost model to a source at a later time. A source will be unavailable for selection if a cost model is already assigned to it."
+      }
+    ],
+    "CostModelsWizardSourceTableAriaLabel": [
+      {
+        "type": 0,
+        "value": "FR Assign sources to cost model table"
+      }
+    ],
+    "CostModelsWizardSourceTableCostModel": [
+      {
+        "type": 0,
+        "value": "FR Cost model assigned"
+      }
+    ],
+    "CostModelsWizardSourceTableDefaultCostModel": [
+      {
+        "type": 0,
+        "value": "FR Default cost model"
+      }
+    ],
+    "CostModelsWizardSourceTitle": [
+      {
+        "type": 0,
+        "value": "FR Assign sources to the cost model (optional)"
+      }
+    ],
+    "CostModelsWizardSourceWarning": [
+      {
+        "type": 0,
+        "value": "FR This source is assigned to "
+      },
+      {
+        "type": 1,
+        "value": "costModel"
+      },
+      {
+        "type": 0,
+        "value": " cost model. You will have to unassigned it first"
+      }
+    ],
+    "CostModelsWizardStepsGenInfo": [
+      {
+        "type": 0,
+        "value": "FR Enter information"
+      }
+    ],
+    "CostModelsWizardStepsPriceList": [
+      {
+        "type": 0,
+        "value": "FR Price list"
+      }
+    ],
+    "CostModelsWizardStepsReview": [
+      {
+        "type": 0,
+        "value": "FR Review details"
+      }
+    ],
+    "CostModelsWizardStepsSources": [
+      {
+        "type": 0,
+        "value": "FR Assign a source to the cost model"
+      }
+    ],
+    "CostModelsWizardSubTitleTable": [
+      {
+        "type": 0,
+        "value": "FR The following is a list of rates you have set so far for this price list."
+      }
+    ],
+    "CostModelsWizardWarningSources": [
+      {
+        "type": 0,
+        "value": "FR Cannot assign cost model to a source that is already assigned to another one"
+      }
+    ],
+    "Create": [
+      {
+        "type": 0,
+        "value": "FR Create"
+      }
+    ],
+    "CreateCostModelConfirmMsg": [
+      {
+        "type": 0,
+        "value": "FR Are you sure you want to stop creating a cost model? All settings will be discarded."
+      }
+    ],
+    "CreateCostModelDesc": [
+      {
+        "type": 0,
+        "value": "FR A cost model allows you to associate a price to metrics provided by your sources to charge for utilization of resources."
+      }
+    ],
+    "CreateCostModelExit": [
+      {
+        "type": 0,
+        "value": "FR Exit cost model creation"
+      }
+    ],
+    "CreateCostModelExitYes": [
+      {
+        "type": 0,
+        "value": "FR Yes, I want to exit"
+      }
+    ],
+    "CreateCostModelNoContinue": [
+      {
+        "type": 0,
+        "value": "FR No, I want to continue"
+      }
+    ],
+    "CreateCostModelTitle": [
+      {
+        "type": 0,
+        "value": "FR Create a cost model"
+      }
+    ],
+    "CreateRate": [
+      {
+        "type": 0,
+        "value": "FR Create rate"
+      }
+    ],
+    "Currency": [
+      {
+        "type": 0,
+        "value": "FR Currency"
+      }
+    ],
+    "CurrencyAbbreviations": [
+      {
+        "options": {
+          "billion": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "FR  B"
+              }
+            ]
+          },
+          "million": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "FR  M"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "quadrillion": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "FR  q"
+              }
+            ]
+          },
+          "thousand": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "FR  K"
+              }
+            ]
+          },
+          "trillion": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "FR  t"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "symbol"
+      }
+    ],
+    "CurrencyOptions": [
+      {
+        "options": {
+          "AUD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR AUD (AU$) - Australian Dollar"
+              }
+            ]
+          },
+          "CAD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR CAD (C$) - Canadian Dollar"
+              }
+            ]
+          },
+          "CHF": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR CHF (CHF) - Swiss Franc"
+              }
+            ]
+          },
+          "CNY": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR CNY (CN¥) - Chinese Yuan"
+              }
+            ]
+          },
+          "DKK": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR DKK (Dkr) - Danish Krone"
+              }
+            ]
+          },
+          "EUR": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR EUR (€) - Euro"
+              }
+            ]
+          },
+          "GBP": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR GBP (£) - British Pound"
+              }
+            ]
+          },
+          "HKD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR HKD (HK$) - Hong Kong Dollar"
+              }
+            ]
+          },
+          "JPY": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR JPY (¥) - Japanese Yen"
+              }
+            ]
+          },
+          "NOK": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR NOK (Nkr) - Norwegian Krone"
+              }
+            ]
+          },
+          "NZD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR NZD (NZ$) - New Zealand Dollar"
+              }
+            ]
+          },
+          "SEK": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR SEK (Skr) - Swedish Krona"
+              }
+            ]
+          },
+          "SGD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR SGD (S$) - Singapore Dollar"
+              }
+            ]
+          },
+          "USD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR USD ($) - United States Dollar"
+              }
+            ]
+          },
+          "ZAR": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR ZAR (R) - South African Rand"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "units"
+      }
+    ],
+    "CurrencyUnits": [
+      {
+        "options": {
+          "AUD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR AU$"
+              }
+            ]
+          },
+          "CAD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR C$"
+              }
+            ]
+          },
+          "CHF": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR CHF"
+              }
+            ]
+          },
+          "CNY": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR CN¥"
+              }
+            ]
+          },
+          "DKK": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Dkr"
+              }
+            ]
+          },
+          "EUR": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR €"
+              }
+            ]
+          },
+          "GBP": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR £"
+              }
+            ]
+          },
+          "HKD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR HK$"
+              }
+            ]
+          },
+          "JPY": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR ¥"
+              }
+            ]
+          },
+          "NOK": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Nkr"
+              }
+            ]
+          },
+          "NZD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR NZ$"
+              }
+            ]
+          },
+          "SEK": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Skr"
+              }
+            ]
+          },
+          "SGD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR S$"
+              }
+            ]
+          },
+          "USD": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR $USD"
+              }
+            ]
+          },
+          "ZAR": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR R"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "units"
+      }
+    ],
+    "DashboardCumulativeCostComparison": [
+      {
+        "type": 0,
+        "value": "FR Cumulative cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "DashboardDailyUsageComparison": [
+      {
+        "type": 0,
+        "value": "FR Daily usage comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "DashboardDatabaseTitle": [
+      {
+        "type": 0,
+        "value": "FR Database services cost"
+      }
+    ],
+    "DashboardNetworkTitle": [
+      {
+        "type": 0,
+        "value": "FR Network services cost"
+      }
+    ],
+    "DashboardStorageTitle": [
+      {
+        "type": 0,
+        "value": "FR Storage services usage"
+      }
+    ],
+    "DashboardTotalCostTooltip": [
+      {
+        "type": 0,
+        "value": "FR This total cost is the sum of the infrastructure cost "
+      },
+      {
+        "type": 1,
+        "value": "infrastructureCost"
+      },
+      {
+        "type": 0,
+        "value": " and supplementary cost "
+      },
+      {
+        "type": 1,
+        "value": "supplementaryCost"
+      }
+    ],
+    "Delete": [
+      {
+        "type": 0,
+        "value": "FR Delete"
+      }
+    ],
+    "Description": [
+      {
+        "type": 0,
+        "value": "FR Description"
+      }
+    ],
+    "DetailsActionsExport": [
+      {
+        "type": 0,
+        "value": "FR Export data"
+      }
+    ],
+    "DetailsActionsPriceList": [
+      {
+        "type": 0,
+        "value": "FR View all price lists"
+      }
+    ],
+    "DetailsClustersModalTitle": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR account "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR cluster "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR instance type "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR node "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR organizational unit "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR project "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR region "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR region "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR service "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR service "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR account "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR tags "
+              },
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": " clusters"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "groupBy"
+      }
+    ],
+    "DetailsColumnManagementTitle": [
+      {
+        "type": 0,
+        "value": "FR Manage columns"
+      }
+    ],
+    "DetailsCostValue": [
+      {
+        "type": 0,
+        "value": "FR Cost: "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      }
+    ],
+    "DetailsEmptyState": [
+      {
+        "type": 0,
+        "value": "FR Processing data to generate a list of all services that sums to a total cost..."
+      }
+    ],
+    "DetailsMoreClusters": [
+      {
+        "type": 0,
+        "value": "FR , "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " more..."
+      }
+    ],
+    "DetailsResourceNames": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Account names"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cluster names"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Instance type names"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Node names"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Organizational unit names"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Project names"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Region names"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Region names"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Service names"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Service names"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Account names"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Tag names"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "DetailsSummaryModalTitle": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "FR  accounts"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "FR  clusters"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "FR  instance types"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "FR  nodes"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "FR  organizational units"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "FR  projects"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "FR  regions"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "FR  regions"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "FR  services"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "FR  services"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "FR  accounts"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "FR  tags"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "groupBy"
+      }
+    ],
+    "DetailsUnusedRequestsLabel": [
+      {
+        "type": 0,
+        "value": "FR Unrequested capacity"
+      }
+    ],
+    "DetailsUnusedUsageLabel": [
+      {
+        "type": 0,
+        "value": "FR Unused capacity"
+      }
+    ],
+    "DetailsUnusedUsageUnits": [
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": "FR  ("
+      },
+      {
+        "type": 1,
+        "value": "percentage"
+      },
+      {
+        "type": 0,
+        "value": "% of capacity)"
+      }
+    ],
+    "DetailsUsageCapacity": [
+      {
+        "type": 0,
+        "value": "FR Capacity - "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " "
+      },
+      {
+        "type": 1,
+        "value": "units"
+      }
+    ],
+    "DetailsUsageLimit": [
+      {
+        "type": 0,
+        "value": "FR Limit - "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " "
+      },
+      {
+        "type": 1,
+        "value": "units"
+      }
+    ],
+    "DetailsUsageRequests": [
+      {
+        "type": 0,
+        "value": "FR Requests - "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " "
+      },
+      {
+        "type": 1,
+        "value": "units"
+      }
+    ],
+    "DetailsUsageUsage": [
+      {
+        "type": 0,
+        "value": "FR Usage - "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " "
+      },
+      {
+        "type": 1,
+        "value": "units"
+      }
+    ],
+    "DetailsViewAll": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR View all accounts"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR View all clusters"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR View all instance types"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR View all nodes"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR View all organizational units"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR View all projects"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR View all regions"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR View all regions"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR View all Services"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR View all services"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR View all accounts"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR View all tags"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "DiscountMinus": [
+      {
+        "type": 0,
+        "value": "FR Discount (-)"
+      }
+    ],
+    "DistributionModelDesc": [
+      {
+        "type": 0,
+        "value": "FR This choice is for users to direct how their raw costs are distributed either by CPU or Memory on the project level breakdowns."
+      }
+    ],
+    "DistributionType": [
+      {
+        "type": 0,
+        "value": "FR Distribution type"
+      }
+    ],
+    "DocsAddOcpSources": [
+      {
+        "type": 0,
+        "value": "FR https://access.redhat.com/documentation/en-us/cost_management_service/2021/html-single/adding_an_openshift_container_platform_source_to_cost_management"
+      }
+    ],
+    "DocsConfigCostModels": [
+      {
+        "type": 0,
+        "value": "FR https://access.redhat.com/documentation/en-us/cost_management_service/2021/html-single/using_cost_models/index#assembly-setting-up-cost-models"
+      }
+    ],
+    "DocsCostModelTerminology": [
+      {
+        "type": 0,
+        "value": "FR https://access.redhat.com/documentation/en-us/cost_management_service/2021/html-single/using_cost_models/index#cost-model-terminology"
+      }
+    ],
+    "DocsUsingCostModels": [
+      {
+        "type": 0,
+        "value": "FR https://access.redhat.com/documentation/en-us/cost_management_service/2021/html-single/using_cost_models"
+      }
+    ],
+    "Edit": [
+      {
+        "type": 0,
+        "value": "FR Edit"
+      }
+    ],
+    "EditCostModel": [
+      {
+        "type": 0,
+        "value": "FR Edit cost model"
+      }
+    ],
+    "EditMarkup": [
+      {
+        "type": 0,
+        "value": "FR Edit markup"
+      }
+    ],
+    "EditMarkupOrDiscount": [
+      {
+        "type": 0,
+        "value": "FR Edit markup or discount"
+      }
+    ],
+    "EmptyFilterSourceStateSubtitle": [
+      {
+        "type": 0,
+        "value": "FR Sorry, no source with the given filter was found."
+      }
+    ],
+    "EmptyFilterStateSubtitle": [
+      {
+        "type": 0,
+        "value": "FR Sorry, no data with the given filter was found."
+      }
+    ],
+    "EmptyFilterStateTitle": [
+      {
+        "type": 0,
+        "value": "FR No match found"
+      }
+    ],
+    "ErrorStateNotAuthorizedDesc": [
+      {
+        "type": 0,
+        "value": "FR Contact the cost management administrator to provide access to this application"
+      }
+    ],
+    "ErrorStateNotAuthorizedTitle": [
+      {
+        "type": 0,
+        "value": "FR You don't have access to the Cost management application"
+      }
+    ],
+    "ErrorStateUnexpectedDesc": [
+      {
+        "type": 0,
+        "value": "FR We encountered an unexpected error. Contact your administrator."
+      }
+    ],
+    "ErrorStateUnexpectedTitle": [
+      {
+        "type": 0,
+        "value": "FR Oops!"
+      }
+    ],
+    "ExamplesTitle": [
+      {
+        "type": 0,
+        "value": "FR Examples"
+      }
+    ],
+    "ExplorerChartTitle": [
+      {
+        "options": {
+          "aws": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Amazon Web Services - Top 5 Costliest"
+              }
+            ]
+          },
+          "aws_ocp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Amazon Web Services filtered by OpenShift - Top 5 Costliest"
+              }
+            ]
+          },
+          "azure": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Microsoft Azure - Top 5 Costliest"
+              }
+            ]
+          },
+          "azure_ocp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Microsoft Azure filtered by OpenShift - Top 5 Costliest"
+              }
+            ]
+          },
+          "gcp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Google Cloud Platform - Top 5 Costliest"
+              }
+            ]
+          },
+          "gcp_ocp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Google Cloud Platform filtered by OpenShift - Top 5 Costliest"
+              }
+            ]
+          },
+          "ibm": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR IBM Cloud - Top 5 Costliest"
+              }
+            ]
+          },
+          "ocp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR All OpenShift - Top 5 Costliest"
+              }
+            ]
+          },
+          "ocp_cloud": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR All cloud filtered by OpenShift - Top 5 Costliest"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "ExplorerDateColumn": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Jan "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Feb "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Mar "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Apr "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR May "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Jun "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Jul "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Aug "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Sep "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Oct "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Nov "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Dec "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "ExplorerDateRange": [
+      {
+        "options": {
+          "current_month_to_date": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Month to date"
+              }
+            ]
+          },
+          "last_ninety_days": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Last 90 days"
+              }
+            ]
+          },
+          "last_sixty_days": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Last 60 days"
+              }
+            ]
+          },
+          "last_thirty_days": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Last 30 days"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "previous_month_to_date": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Previous month and month to date"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "ExplorerMonthDate": [
+      {
+        "type": 1,
+        "value": "month"
+      },
+      {
+        "type": 0,
+        "value": "FR  "
+      },
+      {
+        "type": 1,
+        "value": "date"
+      }
+    ],
+    "ExplorerTableAriaLabel": [
+      {
+        "type": 0,
+        "value": "FR Cost Explorer table"
+      }
+    ],
+    "ExplorerTitle": [
+      {
+        "type": 0,
+        "value": "FR Cost Explorer"
+      }
+    ],
+    "ExportAggregateType": [
+      {
+        "type": 0,
+        "value": "FR Select aggregate type"
+      }
+    ],
+    "ExportAll": [
+      {
+        "type": 0,
+        "value": "FR All"
+      }
+    ],
+    "ExportDownload": [
+      {
+        "type": 0,
+        "value": "FR Generate and download"
+      }
+    ],
+    "ExportError": [
+      {
+        "type": 0,
+        "value": "FR Something went wrong, please try fewer selections"
+      }
+    ],
+    "ExportFileName": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -accounts-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -accounts-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -clusters-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -clusters-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -instances-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -instances-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -node-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -node-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -org_units-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -org_units-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -projects-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -projects-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -regions-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -regions-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -regions-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -regions-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -services-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -services-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -services-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -services-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -accounts-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -accounts-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "options": {
+                  "daily": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -tags-daily-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "monthly": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "provider"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR -tags-monthly-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "date"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": []
+                  }
+                },
+                "type": 5,
+                "value": "resolution"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "groupBy"
+      }
+    ],
+    "ExportHeading": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Aggregates of the following accounts will be exported to a .csv file."
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Aggregates of the following clusters will be exported to a .csv file."
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Aggregates of the following instance types will be exported to a .csv file."
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Aggregates of the following nodes will be exported to a .csv file."
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Aggregates of the following organizational units will be exported to a .csv file."
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Aggregates of the following projects will be exported to a .csv file."
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Aggregates of the following regions will be exported to a .csv file."
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Aggregates of the regions will be exported to a .csv file."
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Aggregates of the following services will be exported to a .csv file."
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Aggregates of the following services will be exported to a .csv file."
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Aggregates of the following accounts will be exported to a .csv file."
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Aggregates of the following tags will be exported to a .csv file."
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "groupBy"
+      }
+    ],
+    "ExportResolution": [
+      {
+        "options": {
+          "daily": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Daily"
+              }
+            ]
+          },
+          "monthly": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Monthly"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "ExportSelected": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Selected accounts"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Selected clusters"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Selected instance types"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Selected nodes"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Selected organizational units"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Selected projects"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Selected regions"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Selected regions"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Selected services"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Selected services"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Selected accounts"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Selected tags"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "groupBy"
+      }
+    ],
+    "ExportTimeScope": [
+      {
+        "options": {
+          "current": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Current "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "previous": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Previous "
+              },
+              {
+                "type": 1,
+                "value": "date"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "ExportTimeScopeTitle": [
+      {
+        "type": 0,
+        "value": "FR Select month"
+      }
+    ],
+    "ExportTitle": [
+      {
+        "type": 0,
+        "value": "FR Export"
+      }
+    ],
+    "FilterByButtonAriaLabel": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter button for account name"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter button for cluster name"
+              }
+            ]
+          },
+          "name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter button for name name"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter button for node name"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter button for organizational unit name"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter button for project name"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter button for region name"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter button for region name"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter button for service name"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter button for service_name name"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter button for account name"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter button for tag name"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "FilterByInputAriaLabel": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Input for account name"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Input for cluster name"
+              }
+            ]
+          },
+          "name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Input for name name"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Input for node name"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Input for organizational unit name"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Input for project name"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Input for region name"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Input for region name"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Input for service name"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Input for service_name name"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Input for account name"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Input for tag name"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "FilterByOrgUnitAriaLabel": [
+      {
+        "type": 0,
+        "value": "FR Organizational units"
+      }
+    ],
+    "FilterByOrgUnitPlaceholder": [
+      {
+        "type": 0,
+        "value": "FR Choose unit"
+      }
+    ],
+    "FilterByPlaceholder": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter by account"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter by cluster"
+              }
+            ]
+          },
+          "description": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter by description"
+              }
+            ]
+          },
+          "name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter by name"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter by node"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter by organizational unit"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter by project"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter by region"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter by region"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter by service"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter by service"
+              }
+            ]
+          },
+          "source_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter by source type"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter by account"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Filter by tag"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "FilterByTagKeyAriaLabel": [
+      {
+        "type": 0,
+        "value": "FR Tag keys"
+      }
+    ],
+    "FilterByTagKeyPlaceholder": [
+      {
+        "type": 0,
+        "value": "FR Choose key"
+      }
+    ],
+    "FilterByTagValueAriaLabel": [
+      {
+        "type": 0,
+        "value": "FR Tag values"
+      }
+    ],
+    "FilterByTagValueButtonAriaLabel": [
+      {
+        "type": 0,
+        "value": "FR Filter button for tag value"
+      }
+    ],
+    "FilterByTagValueInputPlaceholder": [
+      {
+        "type": 0,
+        "value": "FR Filter by value"
+      }
+    ],
+    "FilterByTagValuePlaceholder": [
+      {
+        "type": 0,
+        "value": "FR Choose value"
+      }
+    ],
+    "FilterByValues": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Account"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cluster"
+              }
+            ]
+          },
+          "name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Name"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Node"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Organizational unit"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Project"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Region"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Region"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Service"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Service"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Account"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Tag"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "ForDate": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for January "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for January "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for February "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for February "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for March "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for March "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for April "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for April "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for June "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for June "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for July "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for July "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for August "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for August "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for September "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for September "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for October "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for October "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for November "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for November "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for December "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 1,
+                        "value": "value"
+                      },
+                      {
+                        "type": 0,
+                        "value": "FR  for December "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "GCP": [
+      {
+        "type": 0,
+        "value": "FR Google Cloud Platform"
+      }
+    ],
+    "GCPComputeTitle": [
+      {
+        "type": 0,
+        "value": "FR Compute instances usage"
+      }
+    ],
+    "GCPCostTitle": [
+      {
+        "type": 0,
+        "value": "FR Google Cloud Platform Services cost"
+      }
+    ],
+    "GCPCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "FR Google Cloud Platform Services cumulative cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "GCPDailyCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "FR Google Cloud Platform Services daily cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "GCPDesc": [
+      {
+        "type": 0,
+        "value": "FR Raw cost from Google Cloud Platform infrastructure."
+      }
+    ],
+    "GCPDetailsTable": [
+      {
+        "type": 0,
+        "value": "FR Google Cloud Platform details table"
+      }
+    ],
+    "GCPDetailsTitle": [
+      {
+        "type": 0,
+        "value": "FR Google Cloud Platform Details"
+      }
+    ],
+    "GroupByAll": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Account"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Accounts"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Cluster"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Clusters"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Instance type"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Instance types"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Node"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Node"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Organizational unit"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Organizational units"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Project"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Projects"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Region"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Regions"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Region"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Regions"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Service"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Services"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Service"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Services"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Account"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Accounts"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Tag"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR All Tags"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "GroupByLabel": [
+      {
+        "type": 0,
+        "value": "FR Group by"
+      }
+    ],
+    "GroupByTop": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top account"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top accounts"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top cluster"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top clusters"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top instance type"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top instance types"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top node"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top node"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top organizational unit"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top organizational units"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top project"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top projects"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top region"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top regions"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top region"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top regions"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top service"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top services"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top service"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top services"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top account"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top accounts"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top tag"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Top tags"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "GroupByValueNames": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Account names"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cluster names"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Instance type names"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Node names"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Organizational unit names"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Project names"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Region names"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Region names"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Service names"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Service names"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Account names"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Tag names"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "groupBy"
+      }
+    ],
+    "GroupByValues": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR account"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR accounts"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR cluster"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR clusters"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR instance type"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR instance types"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR node"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR node"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR organizational unit"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR organizational units"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR project"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR projects"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR region"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR regions"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR region"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR regions"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR service"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR services"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR service"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR services"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR account"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR accounts"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR tag"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR tags"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "GroupByValuesTitleCase": [
+      {
+        "options": {
+          "account": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Account"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Accounts"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "cluster": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Cluster"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Clusters"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Instance type"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Instance types"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Node"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Node"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "org_unit_id": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Organizational unit"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Organizational units"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "project": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Project"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Projects"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "region": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Region"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Regions"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "resource_location": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Region"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Regions"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "service": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Service"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Services"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "service_name": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Service"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Services"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "subscription_guid": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Account"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Accounts"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "tag": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Tag"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Tags"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "HistoricalChartCostLabel": [
+      {
+        "type": 0,
+        "value": "FR Cost ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "HistoricalChartDayOfMonthLabel": [
+      {
+        "type": 0,
+        "value": "FR Day of Month"
+      }
+    ],
+    "HistoricalChartTitle": [
+      {
+        "options": {
+          "cost": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cost comparison"
+              }
+            ]
+          },
+          "cpu": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR CPU usage, request, and limit comparison"
+              }
+            ]
+          },
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Compute usage comparison"
+              }
+            ]
+          },
+          "memory": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Memory usage, request, and limit comparison"
+              }
+            ]
+          },
+          "modal": {
+            "value": [
+              {
+                "type": 1,
+                "value": "name"
+              },
+              {
+                "type": 0,
+                "value": "FR  daily usage comparison"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "storage": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Storage usage comparison"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "HistoricalChartUsageLabel": [
+      {
+        "options": {
+          "instance_type": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR hrs"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "storage": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR gb-mo"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "IBM": [
+      {
+        "type": 0,
+        "value": "FR IBM Cloud"
+      }
+    ],
+    "IBMComputeTitle": [
+      {
+        "type": 0,
+        "value": "FR Compute instances usage"
+      }
+    ],
+    "IBMCostTitle": [
+      {
+        "type": 0,
+        "value": "FR IBM Cloud Services cost"
+      }
+    ],
+    "IBMCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "FR IBM Cloud Services cumulative cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "IBMDailyCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "FR IBM Cloud Services daily cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "IBMDesc": [
+      {
+        "type": 0,
+        "value": "FR Raw cost from IBM Cloud infrastructure."
+      }
+    ],
+    "IBMDetailsTable": [
+      {
+        "type": 0,
+        "value": "FR IBM Cloud details table"
+      }
+    ],
+    "IBMDetailsTitle": [
+      {
+        "type": 0,
+        "value": "FR IBM Cloud Details"
+      }
+    ],
+    "InactiveSourcesGoTitle": [
+      {
+        "type": 0,
+        "value": "FR A problem was detected with "
+      },
+      {
+        "type": 1,
+        "value": "value"
+      }
+    ],
+    "InactiveSourcesGoTo": [
+      {
+        "type": 0,
+        "value": "FR Go to Sources for more information"
+      }
+    ],
+    "InactiveSourcesTitleMultiplier": [
+      {
+        "type": 0,
+        "value": "FR A problem was detected with the following sources"
+      }
+    ],
+    "Infrastructure": [
+      {
+        "type": 0,
+        "value": "FR Infrastructure"
+      }
+    ],
+    "LearnMore": [
+      {
+        "type": 0,
+        "value": "FR Learn more"
+      }
+    ],
+    "LoadingStateDesc": [
+      {
+        "type": 0,
+        "value": "FR Searching for your sources. Do not refresh the browser"
+      }
+    ],
+    "LoadingStateTitle": [
+      {
+        "type": 0,
+        "value": "FR Looking for sources..."
+      }
+    ],
+    "MaintenanceEmptyStateDesc": [
+      {
+        "type": 0,
+        "value": "FR Cost Management is currently undergoing scheduled maintenance and will be unavailable from 13:00 - 19:00 UTC (09:00 AM - 03:00 PM EDT)."
+      }
+    ],
+    "MaintenanceEmptyStateInfo": [
+      {
+        "type": 0,
+        "value": "FR For more information visit "
+      },
+      {
+        "type": 1,
+        "value": "url"
+      }
+    ],
+    "MaintenanceEmptyStateThanks": [
+      {
+        "type": 0,
+        "value": "FR We will be back soon. Thank you for your patience!"
+      }
+    ],
+    "ManageColumnsAriaLabel": [
+      {
+        "type": 0,
+        "value": "FR Table column management"
+      }
+    ],
+    "ManageColumnsDesc": [
+      {
+        "type": 0,
+        "value": "FR Selected categories will be displayed in the table"
+      }
+    ],
+    "ManageColumnsTitle": [
+      {
+        "type": 0,
+        "value": "FR Manage columns"
+      }
+    ],
+    "MarkupDescription": [
+      {
+        "type": 0,
+        "value": "FR The portion of cost calculated by applying markup or discount to infrastructure raw cost in the cost management application"
+      }
+    ],
+    "MarkupOrDiscount": [
+      {
+        "type": 0,
+        "value": "FR Markup or Discount"
+      }
+    ],
+    "MarkupOrDiscountDesc": [
+      {
+        "type": 0,
+        "value": "FR This Percentage is applied to raw cost calculations by multiplying the cost with this percentage. Costs calculated from price list rates will not be effected."
+      }
+    ],
+    "MarkupOrDiscountModalDesc": [
+      {
+        "type": 0,
+        "value": "FR Use markup/discount to manipulate how the raw costs are being calculated for your sources. Note, costs calculated from price list rates will not be affected by this."
+      }
+    ],
+    "MarkupPlus": [
+      {
+        "type": 0,
+        "value": "FR Markup (+)"
+      }
+    ],
+    "MarkupTitle": [
+      {
+        "type": 0,
+        "value": "FR Markup"
+      }
+    ],
+    "Measurement": [
+      {
+        "type": 0,
+        "value": "FR Measurement"
+      }
+    ],
+    "MeasurementPlaceholder": [
+      {
+        "type": 0,
+        "value": "FR Filter by measurements"
+      }
+    ],
+    "MeasurementValues": [
+      {
+        "options": {
+          "count": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Count"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Count ("
+                      },
+                      {
+                        "type": 1,
+                        "value": "units"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "request": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Request"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Request ("
+                      },
+                      {
+                        "type": 1,
+                        "value": "units"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "usage": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR Usage ("
+                      },
+                      {
+                        "type": 1,
+                        "value": "units"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "MemoryTitle": [
+      {
+        "type": 0,
+        "value": "FR Memory"
+      }
+    ],
+    "Metric": [
+      {
+        "type": 0,
+        "value": "FR Metric"
+      }
+    ],
+    "MetricPlaceholder": [
+      {
+        "type": 0,
+        "value": "FR Filter by metrics"
+      }
+    ],
+    "MetricValues": [
+      {
+        "options": {
+          "cluster": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Cluster"
+              }
+            ]
+          },
+          "cpu": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR CPU"
+              }
+            ]
+          },
+          "memory": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Memory"
+              }
+            ]
+          },
+          "node": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Node"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "persistent_volume_claims": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Persistent volume claims"
+              }
+            ]
+          },
+          "storage": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Storage"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "MonthOverMonthChange": [
+      {
+        "type": 0,
+        "value": "FR Month over month change"
+      }
+    ],
+    "Name": [
+      {
+        "offset": 0,
+        "options": {
+          "one": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Name"
+              }
+            ]
+          },
+          "other": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Names"
+              }
+            ]
+          }
+        },
+        "pluralType": "cardinal",
+        "type": 6,
+        "value": "count"
+      }
+    ],
+    "Next": [
+      {
+        "type": 0,
+        "value": "FR next"
+      }
+    ],
+    "No": [
+      {
+        "type": 0,
+        "value": "FR no"
+      }
+    ],
+    "NoAuthorizedStateAws": [
+      {
+        "type": 0,
+        "value": "FR Amazon Web Services in Cost Management"
+      }
+    ],
+    "NoDataForDate": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Jan "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Feb "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Mar "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Apr "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Jun "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Jul "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Aug "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Sep "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Oct "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Nov "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR No data available for Dec "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "NoDataStateDesc": [
+      {
+        "type": 0,
+        "value": "FR We have detected a source, but we are not done processing the incoming data. The time to process could take up to 24 hours. Try refreshing the page at a later time."
+      }
+    ],
+    "NoDataStateRefresh": [
+      {
+        "type": 0,
+        "value": "FR Refresh this page"
+      }
+    ],
+    "NoDataStateTitle": [
+      {
+        "type": 0,
+        "value": "FR Still processing the data"
+      }
+    ],
+    "NoProvidersStateAwsDesc": [
+      {
+        "type": 0,
+        "value": "FR Add an Amazon Web Services account to see a total cost breakdown of your spend by accounts, organizational units, services, regions, or tags."
+      }
+    ],
+    "NoProvidersStateAwsTitle": [
+      {
+        "type": 0,
+        "value": "FR Track your Amazon Web Services spending!"
+      }
+    ],
+    "NoProvidersStateAzureDesc": [
+      {
+        "type": 0,
+        "value": "FR Add a Microsoft Azure account to see a total cost breakdown of your spend by accounts, services, regions, or tags."
+      }
+    ],
+    "NoProvidersStateAzureTitle": [
+      {
+        "type": 0,
+        "value": "FR Track your Microsoft Azure spending!"
+      }
+    ],
+    "NoProvidersStateGcpDesc": [
+      {
+        "type": 0,
+        "value": "FR Add a Google Cloud Platform account to see a total cost breakdown of your spend by accounts, services, regions, or tags."
+      }
+    ],
+    "NoProvidersStateGcpTitle": [
+      {
+        "type": 0,
+        "value": "FR Track your Google Cloud Platform spending!"
+      }
+    ],
+    "NoProvidersStateGetStarted": [
+      {
+        "type": 0,
+        "value": "FR Get started with Sources"
+      }
+    ],
+    "NoProvidersStateIbmDesc": [
+      {
+        "type": 0,
+        "value": "FR Add an IBM Cloud account to see a total cost breakdown of your spend by accounts, services, regions, or tags."
+      }
+    ],
+    "NoProvidersStateIbmTitle": [
+      {
+        "type": 0,
+        "value": "FR Track your IBM Cloud spending!"
+      }
+    ],
+    "NoProvidersStateOcpAddSources": [
+      {
+        "type": 0,
+        "value": "FR Add an OpenShift cluster to Cost Management"
+      }
+    ],
+    "NoProvidersStateOcpDesc": [
+      {
+        "type": 0,
+        "value": "FR Add an OpenShift Container Platform cluster to see a total cost breakdown of your pods by cluster, node, project, or labels."
+      }
+    ],
+    "NoProvidersStateOcpTitle": [
+      {
+        "type": 0,
+        "value": "FR Track your OpenShift spending!"
+      }
+    ],
+    "NoProvidersStateOverviewDesc": [
+      {
+        "type": 0,
+        "value": "FR Add a source, like an OpenShift Container Platform cluster or a cloud services account, to see a total cost breakdown as well as usage information like instance counts and storage."
+      }
+    ],
+    "NoProvidersStateOverviewTitle": [
+      {
+        "type": 0,
+        "value": "FR Track your spending!"
+      }
+    ],
+    "NotAuthorizedStateAzure": [
+      {
+        "type": 0,
+        "value": "FR Microsoft Azure in Cost Management"
+      }
+    ],
+    "NotAuthorizedStateCostModels": [
+      {
+        "type": 0,
+        "value": "FR Cost Models in Cost Management"
+      }
+    ],
+    "NotAuthorizedStateGcp": [
+      {
+        "type": 0,
+        "value": "FR Google Cloud Platform in Cost Management"
+      }
+    ],
+    "NotAuthorizedStateIbm": [
+      {
+        "type": 0,
+        "value": "FR IBM Cloud in Cost Management"
+      }
+    ],
+    "NotAuthorizedStateOcp": [
+      {
+        "type": 0,
+        "value": "FR OpenShift in Cost Management"
+      }
+    ],
+    "OCPCPUUsageAndRequests": [
+      {
+        "type": 0,
+        "value": "FR CPU usage and requests"
+      }
+    ],
+    "OCPCloudDashboardComputeTitle": [
+      {
+        "type": 0,
+        "value": "FR Compute services usage"
+      }
+    ],
+    "OCPCloudDashboardCostTitle": [
+      {
+        "type": 0,
+        "value": "FR All cloud filtered by OpenShift cost"
+      }
+    ],
+    "OCPCloudDashboardCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "FR All cloud filtered by OpenShift cumulative cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPCloudDashboardDailyCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "FR All cloud filtered by OpenShift daily cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPDailyUsageAndRequestComparison": [
+      {
+        "type": 0,
+        "value": "FR Daily usage and requests comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPDashboardCPUUsageAndRequests": [
+      {
+        "type": 0,
+        "value": "FR OpenShift CPU usage and requests"
+      }
+    ],
+    "OCPDashboardCostTitle": [
+      {
+        "type": 0,
+        "value": "FR All OpenShift cost"
+      }
+    ],
+    "OCPDashboardCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "FR All OpenShift cumulative cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPDashboardDailyCostTitle": [
+      {
+        "type": 0,
+        "value": "FR All OpenShift daily cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPDashboardMemoryUsageAndRequests": [
+      {
+        "type": 0,
+        "value": "FR OpenShift Memory usage and requests"
+      }
+    ],
+    "OCPDetailsInfrastructureCost": [
+      {
+        "type": 0,
+        "value": "FR Infrastructure cost"
+      }
+    ],
+    "OCPDetailsInfrastructureCostDesc": [
+      {
+        "type": 0,
+        "value": "FR The cost based on raw usage data from the underlying infrastructure."
+      }
+    ],
+    "OCPDetailsSupplementaryCost": [
+      {
+        "type": 0,
+        "value": "FR Infrastructure cost"
+      }
+    ],
+    "OCPDetailsSupplementaryCostDesc": [
+      {
+        "type": 0,
+        "value": "FR All costs not directly attributed to the infrastructure. These costs are determined by applying a price list within a cost model to OpenShift cluster metrics."
+      }
+    ],
+    "OCPDetailsTable": [
+      {
+        "type": 0,
+        "value": "FR OpenShift details table"
+      }
+    ],
+    "OCPDetailsTitle": [
+      {
+        "type": 0,
+        "value": "FR OpenShift details"
+      }
+    ],
+    "OCPInfrastructureCostTitle": [
+      {
+        "type": 0,
+        "value": "FR OpenShift infrastructure cost"
+      }
+    ],
+    "OCPInfrastructureCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "FR OpenShift cumulative infrastructure cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPInfrastructureDailyCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "FR OpenShift daily infrastructure cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPMemoryUsageAndRequests": [
+      {
+        "type": 0,
+        "value": "FR Memory usage and requests"
+      }
+    ],
+    "OCPSupplementaryCostTitle": [
+      {
+        "type": 0,
+        "value": "FR OpenShift supplementary cost"
+      }
+    ],
+    "OCPSupplementaryCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "FR OpenShift cumulative supplementary cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPSupplementaryDailyCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "FR OpenShift daily supplementary cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPUsageAndRequests": [
+      {
+        "type": 0,
+        "value": "FR OpenShift Volume usage and requests"
+      }
+    ],
+    "OCPUsageCostTitle": [
+      {
+        "type": 0,
+        "value": "FR OpenShift usage cost"
+      }
+    ],
+    "OCPUsageDashboardCPUTitle": [
+      {
+        "type": 0,
+        "value": "FR OpenShift CPU usage and requests"
+      }
+    ],
+    "OCPUsageDashboardCostTrendTitle": [
+      {
+        "type": 0,
+        "value": "FR Metering cumulative cost comparison ("
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "OCPVolumeUsageAndRequests": [
+      {
+        "type": 0,
+        "value": "FR Volume usage and requests"
+      }
+    ],
+    "OpenShift": [
+      {
+        "type": 0,
+        "value": "FR OpenShift"
+      }
+    ],
+    "OpenShiftCloudInfrastructure": [
+      {
+        "type": 0,
+        "value": "FR OpenShift cloud infrastructure"
+      }
+    ],
+    "OpenShiftCloudInfrastructureDesc": [
+      {
+        "type": 0,
+        "value": "FR Infrastructure cost attributed to OpenShift Container Platform, based on a subset of cloud cost data."
+      }
+    ],
+    "OpenShiftDesc": [
+      {
+        "type": 0,
+        "value": "FR Total cost for OpenShift Container Platform, comprising the infrastructure cost and cost calculated from metrics."
+      }
+    ],
+    "OverviewInfoArialLabel": [
+      {
+        "type": 0,
+        "value": "FR A description of perspectives"
+      }
+    ],
+    "OverviewTitle": [
+      {
+        "type": 0,
+        "value": "FR Cost Management Overview"
+      }
+    ],
+    "PageTitleAWS": [
+      {
+        "type": 0,
+        "value": "FR Amazon Web Services - Cost Management | Red Hat OpenShift Cluster Manager"
+      }
+    ],
+    "PageTitleAzure": [
+      {
+        "type": 0,
+        "value": "FR Microsoft Azure - Cost Management | Red Hat OpenShift Cluster Manager"
+      }
+    ],
+    "PageTitleCostModels": [
+      {
+        "type": 0,
+        "value": "FR Cost Models - Cost Management | Red Hat OpenShift Cluster Manager"
+      }
+    ],
+    "PageTitleDefault": [
+      {
+        "type": 0,
+        "value": "FR Cost Management | Red Hat OpenShift Cluster Manager"
+      }
+    ],
+    "PageTitleExplorer": [
+      {
+        "type": 0,
+        "value": "FR Cost Explorer - Cost Management | Red Hat OpenShift Cluster Manager"
+      }
+    ],
+    "PageTitleGCP": [
+      {
+        "type": 0,
+        "value": "FR Google Cloud Platform - Cost Management | Red Hat OpenShift Cluster Manager"
+      }
+    ],
+    "PageTitleIBM": [
+      {
+        "type": 0,
+        "value": "FR IBM Cloud - Cost Management | Red Hat OpenShift Cluster Manager"
+      }
+    ],
+    "PageTitleOpenShift": [
+      {
+        "type": 0,
+        "value": "FR OpenShift - Cost Management | Red Hat OpenShift Cluster Manager"
+      }
+    ],
+    "PageTitleOverview": [
+      {
+        "type": 0,
+        "value": "FR Overview - Cost Management | Red Hat OpenShift Cluster Manager"
+      }
+    ],
+    "Percent": [
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": "FR  %"
+      }
+    ],
+    "PercentOfCost": [
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": "FR  % of cost"
+      }
+    ],
+    "PercentSymbol": [
+      {
+        "type": 0,
+        "value": "FR %"
+      }
+    ],
+    "PercentTotalCost": [
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": "FR  "
+      },
+      {
+        "type": 1,
+        "value": "units"
+      },
+      {
+        "type": 0,
+        "value": " ("
+      },
+      {
+        "type": 1,
+        "value": "percent"
+      },
+      {
+        "type": 0,
+        "value": " %)"
+      }
+    ],
+    "Perspective": [
+      {
+        "type": 0,
+        "value": "FR Perspective"
+      }
+    ],
+    "PerspectiveValues": [
+      {
+        "options": {
+          "aws": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Amazon Web Services"
+              }
+            ]
+          },
+          "aws_ocp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Amazon Web Services filtered by OpenShift"
+              }
+            ]
+          },
+          "azure": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Microsoft Azure"
+              }
+            ]
+          },
+          "azure_ocp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Microsoft Azure filtered by OpenShift"
+              }
+            ]
+          },
+          "gcp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Google Cloud Platform"
+              }
+            ]
+          },
+          "gcp_ocp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR Google Cloud Platform filtered by OpenShift"
+              }
+            ]
+          },
+          "ibm": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR IBM Cloud"
+              }
+            ]
+          },
+          "ocp": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR All OpenShift"
+              }
+            ]
+          },
+          "ocp_cloud": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR All cloud filtered by OpenShift"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "value"
+      }
+    ],
+    "PriceList": [
+      {
+        "type": 0,
+        "value": "FR Price list"
+      }
+    ],
+    "PriceListAddRate": [
+      {
+        "type": 0,
+        "value": "FR Add rate"
+      }
+    ],
+    "PriceListDeleteRate": [
+      {
+        "type": 0,
+        "value": "FR Delete rate"
+      }
+    ],
+    "PriceListDesc": [
+      {
+        "offset": 0,
+        "options": {
+          "one": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR This action will remove "
+              },
+              {
+                "type": 1,
+                "value": "metric"
+              },
+              {
+                "type": 0,
+                "value": " rate from "
+              },
+              {
+                "type": 1,
+                "value": "costModel"
+              }
+            ]
+          },
+          "other": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR This action will remove "
+              },
+              {
+                "type": 1,
+                "value": "metric"
+              },
+              {
+                "type": 0,
+                "value": " rate from "
+              },
+              {
+                "type": 1,
+                "value": "costModel"
+              },
+              {
+                "type": 0,
+                "value": ", which is assigned to the following sources:"
+              }
+            ]
+          }
+        },
+        "pluralType": "cardinal",
+        "type": 6,
+        "value": "count"
+      }
+    ],
+    "PriceListDuplicate": [
+      {
+        "type": 0,
+        "value": "FR This tag key is already in use"
+      }
+    ],
+    "PriceListEditRate": [
+      {
+        "type": 0,
+        "value": "FR Edit rate"
+      }
+    ],
+    "PriceListEmptyRate": [
+      {
+        "type": 0,
+        "value": "FR No rates are set"
+      }
+    ],
+    "PriceListEmptyRateDesc": [
+      {
+        "type": 0,
+        "value": "FR To add rates to the price list, click on the \"Add\" rate button above."
+      }
+    ],
+    "PriceListNumberRate": [
+      {
+        "type": 0,
+        "value": "FR Rate must be a number"
+      }
+    ],
+    "PriceListPosNumberRate": [
+      {
+        "type": 0,
+        "value": "FR Rate must be a positive number"
+      }
+    ],
+    "Rate": [
+      {
+        "type": 0,
+        "value": "FR Rate"
+      }
+    ],
+    "RawCostDescription": [
+      {
+        "type": 0,
+        "value": "FR The costs reported by a cloud provider without any cost model calculations applied."
+      }
+    ],
+    "RawCostTitle": [
+      {
+        "type": 0,
+        "value": "FR Raw cost"
+      }
+    ],
+    "RbacErrorDescription": [
+      {
+        "type": 0,
+        "value": "FR There was a problem receiving user permissions. Refreshing this page may fix it. If it does not, please contact your admin."
+      }
+    ],
+    "RbacErrorTitle": [
+      {
+        "type": 0,
+        "value": "FR Failed to get RBAC information"
+      }
+    ],
+    "RedHatStatusUrl": [
+      {
+        "type": 0,
+        "value": "FR https://status.redhat.com"
+      }
+    ],
+    "Requests": [
+      {
+        "type": 0,
+        "value": "FR Requests"
+      }
+    ],
+    "Save": [
+      {
+        "type": 0,
+        "value": "FR Save"
+      }
+    ],
+    "Select": [
+      {
+        "type": 0,
+        "value": "FR Select..."
+      }
+    ],
+    "SelectAll": [
+      {
+        "type": 0,
+        "value": "FR Select all"
+      }
+    ],
+    "Selected": [
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": "FR  selected"
+      }
+    ],
+    "SinceDate": [
+      {
+        "options": {
+          "0": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR January "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR January "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "1": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR February "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR February "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "2": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR March "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR March "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "3": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR April "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR April "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "4": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR May "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "5": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR June "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR June "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "6": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR July "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR July "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "7": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR August "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR August "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "8": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR September "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR September "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "9": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR October "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR October "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "10": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR November "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR November "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "11": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR December "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "FR December "
+                      },
+                      {
+                        "type": 1,
+                        "value": "startDate"
+                      },
+                      {
+                        "type": 0,
+                        "value": "-"
+                      },
+                      {
+                        "type": 1,
+                        "value": "endDate"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          }
+        },
+        "type": 5,
+        "value": "month"
+      }
+    ],
+    "Sources": [
+      {
+        "type": 0,
+        "value": "FR Sources"
+      }
+    ],
+    "Supplementary": [
+      {
+        "type": 0,
+        "value": "FR Supplementary"
+      }
+    ],
+    "TagHeadingKey": [
+      {
+        "type": 0,
+        "value": "FR Key"
+      }
+    ],
+    "TagHeadingTitle": [
+      {
+        "type": 0,
+        "value": "FR Tags ("
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": ")"
+      }
+    ],
+    "TagHeadingValue": [
+      {
+        "type": 0,
+        "value": "FR Value"
+      }
+    ],
+    "TagNames": [
+      {
+        "type": 0,
+        "value": "FR Tag names"
+      }
+    ],
+    "ToolBarBulkSelectAll": [
+      {
+        "type": 0,
+        "value": "FR Select all ("
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " items)"
+      }
+    ],
+    "ToolBarBulkSelectAriaDeselect": [
+      {
+        "type": 0,
+        "value": "FR Deselect all items"
+      }
+    ],
+    "ToolBarBulkSelectAriaSelect": [
+      {
+        "type": 0,
+        "value": "FR Select all items"
+      }
+    ],
+    "ToolBarBulkSelectNone": [
+      {
+        "type": 0,
+        "value": "FR Select none (0 items)"
+      }
+    ],
+    "ToolBarBulkSelectPage": [
+      {
+        "type": 0,
+        "value": "FR Select page ("
+      },
+      {
+        "type": 1,
+        "value": "value"
+      },
+      {
+        "type": 0,
+        "value": " items)"
+      }
+    ],
+    "ToolBarPriceListMeasurementPlaceHolder": [
+      {
+        "type": 0,
+        "value": "FR Filter by measurements"
+      }
+    ],
+    "ToolBarPriceListMetricPlaceHolder": [
+      {
+        "type": 0,
+        "value": "FR Filter by metrics"
+      }
+    ],
+    "UnitTooltips": [
+      {
+        "options": {
+          "core_hours": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "FR  core-hours"
+              }
+            ]
+          },
+          "gb": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "FR  GB"
+              }
+            ]
+          },
+          "gb_hours": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "FR  GB-hours"
+              }
+            ]
+          },
+          "gb_mo": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "FR  GB-month"
+              }
+            ]
+          },
+          "gibibyte_month": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "FR  GiB-month"
+              }
+            ]
+          },
+          "hour": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "FR  hours"
+              }
+            ]
+          },
+          "hrs": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "FR  hours"
+              }
+            ]
+          },
+          "other": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              }
+            ]
+          },
+          "vm_hours": {
+            "value": [
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": "FR  VM-hours"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "units"
+      }
+    ],
+    "Units": [
+      {
+        "options": {
+          "core_hours": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR core-hours"
+              }
+            ]
+          },
+          "gb": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR GB"
+              }
+            ]
+          },
+          "gb_hours": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR GB-hours"
+              }
+            ]
+          },
+          "gb_mo": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR GB-month"
+              }
+            ]
+          },
+          "gibibyte_month": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR GiB-month"
+              }
+            ]
+          },
+          "hour": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR hours"
+              }
+            ]
+          },
+          "hrs": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR hours"
+              }
+            ]
+          },
+          "other": {
+            "value": []
+          },
+          "vm_hours": {
+            "value": [
+              {
+                "type": 0,
+                "value": "FR VM-hours"
+              }
+            ]
+          }
+        },
+        "type": 5,
+        "value": "units"
+      }
+    ],
+    "Usage": [
+      {
+        "type": 0,
+        "value": "FR Usage"
+      }
+    ],
+    "UsageCostDescription": [
+      {
+        "type": 0,
+        "value": "FR The portion of cost calculated by applying hourly and/or monthly price list rates to metrics."
+      }
+    ],
+    "UsageCostTitle": [
+      {
+        "type": 0,
+        "value": "FR Usage cost"
+      }
+    ],
+    "Various": [
+      {
+        "type": 0,
+        "value": "FR Various"
+      }
+    ],
+    "Yes": [
+      {
+        "type": 0,
+        "value": "FR Yes"
       }
     ]
   }

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -287,6 +287,8 @@
   "MarkupOrDiscount": "Markup or Discount",
   "MarkupOrDiscountDesc": "This Percentage is applied to raw cost calculations by multiplying the cost with this percentage. Costs calculated from price list rates will not be effected.",
   "MarkupOrDiscountModalDesc": "Use markup/discount to manipulate how the raw costs are being calculated for your sources. Note, costs calculated from price list rates will not be affected by this.",
+  "MarkupOrDiscountNumber": "Markup or discount must be a number",
+  "MarkupOrDiscountTooLong": "Should not exceed 10 decimals",
   "MarkupPlus": "Markup (+)",
   "MarkupTitle": "Markup",
   "Measurement": "Measurement",

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -2145,6 +2145,16 @@ export default defineMessages({
       'Use markup/discount to manipulate how the raw costs are being calculated for your sources. Note, costs calculated from price list rates will not be affected by this.',
     id: 'MarkupOrDiscountModalDesc',
   },
+  MarkupOrDiscountNumber: {
+    defaultMessage: 'Markup or discount must be a number',
+    description: 'Markup or discount must be a number',
+    id: 'MarkupOrDiscountNumber',
+  },
+  MarkupOrDiscountTooLong: {
+    defaultMessage: 'Should not exceed 10 decimals',
+    description: 'Should not exceed 10 decimals',
+    id: 'MarkupOrDiscountTooLong',
+  },
   MarkupPlus: {
     defaultMessage: 'Markup (+)',
     description: 'Markup (+)',

--- a/src/pages/costModels/components/inputs/rateInput.tsx
+++ b/src/pages/costModels/components/inputs/rateInput.tsx
@@ -12,7 +12,7 @@ import { intl as defaultIntl } from 'components/i18n';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
-import { formatRateRaw } from 'utils/format';
+import { formatRaw } from 'utils/format';
 type RateFormGroup = Pick<FormGroupProps, 'fieldId' | 'style'>;
 interface UniqueProps {
   label?: MessageDescriptor | string;
@@ -58,7 +58,7 @@ const RateInputBase: React.FunctionComponent<RateInputBaseProps> = ({
           aria-label={`rate input ${fieldId}`}
           id={fieldId}
           placeholder="0.00"
-          value={formatRateRaw(value as string)}
+          value={formatRaw(value as string)}
           onChange={onChange}
           onKeyDown={handleOnKeyDown}
           validated={validated}

--- a/src/pages/costModels/components/inputs/rateInput.tsx
+++ b/src/pages/costModels/components/inputs/rateInput.tsx
@@ -12,6 +12,7 @@ import { intl as defaultIntl } from 'components/i18n';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
+import { formatRateRaw } from 'utils/format';
 type RateFormGroup = Pick<FormGroupProps, 'fieldId' | 'style'>;
 interface UniqueProps {
   label?: MessageDescriptor | string;
@@ -31,6 +32,12 @@ const RateInputBase: React.FunctionComponent<RateInputBaseProps> = ({
   validated,
   value,
 }) => {
+  const handleOnKeyDown = event => {
+    // Prevent 'enter' and '+'
+    if (event.keyCode === 13 || event.keyCode === 187) {
+      event.preventDefault();
+    }
+  };
   return (
     <FormGroup
       isRequired
@@ -51,8 +58,9 @@ const RateInputBase: React.FunctionComponent<RateInputBaseProps> = ({
           aria-label={`rate input ${fieldId}`}
           id={fieldId}
           placeholder="0.00"
-          value={value}
+          value={formatRateRaw(value as string)}
           onChange={onChange}
+          onKeyDown={handleOnKeyDown}
           validated={validated}
         />
       </InputGroup>

--- a/src/pages/costModels/components/rateForm/useRateForm.tsx
+++ b/src/pages/costModels/components/rateForm/useRateForm.tsx
@@ -1,6 +1,7 @@
 import { MetricHash } from 'api/metrics';
 import { Rate } from 'api/rates';
 import React from 'react';
+import { formatRateRaw } from 'utils/format';
 
 import { textHelpers } from './constants';
 import {
@@ -124,10 +125,10 @@ export function rateFormReducer(state = initialRateFormData, action: Actions) {
     case 'UPDATE_REGULAR': {
       return {
         ...state,
-        tieredRates: [{ value: action.value, isDirty: true }],
+        tieredRates: [{ value: formatRateRaw(action.value, 'en'), isDirty: true }],
         errors: {
           ...state.errors,
-          tieredRates: checkRateOnChange(action.value),
+          tieredRates: checkRateOnChange(formatRateRaw(action.value, 'en')),
         },
       };
     }

--- a/src/pages/costModels/components/rateForm/useRateForm.tsx
+++ b/src/pages/costModels/components/rateForm/useRateForm.tsx
@@ -1,7 +1,7 @@
 import { MetricHash } from 'api/metrics';
 import { Rate } from 'api/rates';
 import React from 'react';
-import { formatRateRaw } from 'utils/format';
+import { formatRaw } from 'utils/format';
 
 import { textHelpers } from './constants';
 import {
@@ -125,10 +125,10 @@ export function rateFormReducer(state = initialRateFormData, action: Actions) {
     case 'UPDATE_REGULAR': {
       return {
         ...state,
-        tieredRates: [{ value: formatRateRaw(action.value, 'en'), isDirty: true }],
+        tieredRates: [{ value: formatRaw(action.value, 'en'), isDirty: true }],
         errors: {
           ...state.errors,
-          tieredRates: checkRateOnChange(formatRateRaw(action.value, 'en')),
+          tieredRates: checkRateOnChange(formatRaw(action.value, 'en')),
         },
       };
     }

--- a/src/pages/costModels/components/rateForm/utils.tsx
+++ b/src/pages/costModels/components/rateForm/utils.tsx
@@ -2,7 +2,7 @@ import { SortByDirection } from '@patternfly/react-table';
 import { CostModel, CostModelRequest } from 'api/costModels';
 import { MetricHash } from 'api/metrics';
 import { Rate, RateRequest, TagRates } from 'api/rates';
-import { countDecimals, formatRateRaw } from 'utils/format';
+import { countDecimals, formatRaw } from 'utils/format';
 
 import { textHelpers } from './constants';
 
@@ -176,7 +176,7 @@ export const transformFormDataToRequest = (rateFormData: RateFormData, metricsHa
             return {
               tag_value: tvalue.tagValue,
               unit: 'USD',
-              value: formatRateRaw(tvalue.value, 'en'),
+              value: formatRaw(tvalue.value, 'en'),
               description: tvalue.description,
               default: ix === rateFormData.taggingRates.defaultTag,
             };
@@ -184,7 +184,7 @@ export const transformFormDataToRequest = (rateFormData: RateFormData, metricsHa
         }
       : rateFormData.tieredRates.map(tiered => {
           return {
-            value: formatRateRaw(tiered.value, 'en'),
+            value: formatRaw(tiered.value, 'en'),
             unit: 'USD',
             usage: { unit: 'USD' },
           };

--- a/src/pages/costModels/components/rateForm/utils.tsx
+++ b/src/pages/costModels/components/rateForm/utils.tsx
@@ -2,7 +2,7 @@ import { SortByDirection } from '@patternfly/react-table';
 import { CostModel, CostModelRequest } from 'api/costModels';
 import { MetricHash } from 'api/metrics';
 import { Rate, RateRequest, TagRates } from 'api/rates';
-import { getLocale } from 'components/i18n';
+import { countDecimals, formatRateRaw } from 'utils/format';
 
 import { textHelpers } from './constants';
 
@@ -52,32 +52,19 @@ export type RateFormTagValue = typeof initialRateFormData['taggingRates']['tagVa
 export type taggingRates = typeof initialRateFormData['taggingRates'];
 export type RateFormErrors = typeof initialRateFormData['errors'];
 
-// Parse localized rates with a comma decimal separator (e.g., 1.234,56 in German is 1,234.56 USD)
-const parseLocalizedRate = (rate: string) => {
-  // Get decimal separator used by current browser locale
-  const decimalSeparator = Number('1.1').toLocaleString(getLocale(), {}).substring(1, 2);
-
-  // Remove thousands separator and normalize decimal separator (to USD for now)
-  const thousandsSeparator = decimalSeparator === ',' ? /\./g : /,/g;
-  const result = rate.replace(thousandsSeparator, '').replace(decimalSeparator, '.');
-  return result;
-};
-
 export const checkRateOnChange = (regular: string) => {
-  const rate = parseLocalizedRate(regular);
-
-  if (rate.length === 0) {
+  if (regular.length === 0) {
     return textHelpers.required;
   }
-  if (isNaN(Number(rate))) {
+  if (isNaN(Number(regular))) {
     return textHelpers.not_number;
   }
-  if (Number(rate) < 0) {
+  if (Number(regular) < 0) {
     return textHelpers.not_positive;
   }
   // Test number of decimals
-  const decimals = rate.split('.');
-  if (decimals[1] && decimals[1].length > 10) {
+  const decimals = countDecimals(regular);
+  if (decimals > 10) {
     return textHelpers.rate_too_long;
   }
   return null;
@@ -189,7 +176,7 @@ export const transformFormDataToRequest = (rateFormData: RateFormData, metricsHa
             return {
               tag_value: tvalue.tagValue,
               unit: 'USD',
-              value: Number(parseLocalizedRate(tvalue.value)),
+              value: formatRateRaw(tvalue.value, 'en'),
               description: tvalue.description,
               default: ix === rateFormData.taggingRates.defaultTag,
             };
@@ -197,7 +184,7 @@ export const transformFormDataToRequest = (rateFormData: RateFormData, metricsHa
         }
       : rateFormData.tieredRates.map(tiered => {
           return {
-            value: Number(parseLocalizedRate(tiered.value)),
+            value: formatRateRaw(tiered.value, 'en'),
             unit: 'USD',
             usage: { unit: 'USD' },
           };

--- a/src/pages/costModels/costModel/costCalc.styles.ts
+++ b/src/pages/costModels/costModel/costCalc.styles.ts
@@ -18,7 +18,7 @@ export const styles = {
   },
   inputField: {
     borderLeft: 0,
-    width: 150,
+    width: 175,
   },
   markupRadio: {
     marginBottom: 6,

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -113,7 +113,7 @@ export const formatRate: Formatter = (
 // For example, if the user enters "1,234,56" or "1.234.56", a validator should generate an isNaN error.
 //
 // Note: Use locale='en' to format as USD when submitting API values.
-export const formatRateRaw = (value: string, locale = getLocale()) => {
+export const formatRaw = (value: string, locale = getLocale()) => {
   // Get decimal separator used by current browser locale
   const decimalSeparator = Number('1.1').toLocaleString(locale, {}).substring(1, 2);
 
@@ -172,6 +172,6 @@ const formatUsageHrs: UnitsFormatter = (
   return value.toLocaleString(getLocale(), options);
 };
 
-const unknownTypeFormatter = (value, options) => {
+const unknownTypeFormatter = (value: number, options: FormatOptions) => {
   return value.toLocaleString(getLocale(), options);
 };


### PR DESCRIPTION
The cost models markup dialog currently shows a validation error for the German locale. One issue is related to the validator, which doesn't account for different decimal separators.

I refactored to format markup based on the browser's locale. In addition, I've added validation messages, similar to the rate input field. This also simplifies the modal logic a bit. 

Note: The wizard will be update via a separate PR.

**After**
![chrome-capture](https://user-images.githubusercontent.com/17481322/134616553-ee34e741-aab6-466e-a77c-854526f9c3f5.gif)


**Before**
<img width="873" alt="Screen Shot 2021-09-24 at 12 23 34 AM" src="https://user-images.githubusercontent.com/17481322/134617935-736d8031-aef8-4fbe-916e-e32160d2e57a.png">

