### PR TITLE
Markup shows validation error for German locale (part 2 of 2)

### DIFF
--- a/src/pages/costModels/costModel/markup.tsx
+++ b/src/pages/costModels/costModel/markup.tsx
@@ -20,7 +20,7 @@ import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
 import { rbacSelectors } from 'store/rbac';
-import { formatPercentage } from 'utils/format';
+import { formatRaw } from 'utils/format';
 
 import { styles } from './costCalc.styles';
 import UpdateMarkupDialog from './updateMarkupDialog';
@@ -40,8 +40,7 @@ const MarkupCardBase: React.FunctionComponent<Props> = ({
   isUpdateDialogOpen,
 }) => {
   const [dropdownIsOpen, setDropdownIsOpen] = React.useState(false);
-  const markupValue =
-    current && current.markup && current.markup.value ? formatPercentage(Number(current.markup.value)) : '0.0';
+  const markupValue = formatRaw(current && current.markup && current.markup.value ? current.markup.value : '0');
 
   return (
     <>

--- a/src/pages/costModels/costModel/markup.tsx
+++ b/src/pages/costModels/costModel/markup.tsx
@@ -20,7 +20,7 @@ import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
 import { rbacSelectors } from 'store/rbac';
-import { formatRaw } from 'utils/format';
+import { formatPercentage } from 'utils/format';
 
 import { styles } from './costCalc.styles';
 import UpdateMarkupDialog from './updateMarkupDialog';
@@ -40,7 +40,13 @@ const MarkupCardBase: React.FunctionComponent<Props> = ({
   isUpdateDialogOpen,
 }) => {
   const [dropdownIsOpen, setDropdownIsOpen] = React.useState(false);
-  const markupValue = formatRaw(current && current.markup && current.markup.value ? current.markup.value : '0');
+  const markupValue = formatPercentage(
+    current && current.markup && current.markup.value ? Number(current.markup.value) : 0,
+    {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 10,
+    }
+  );
 
   return (
     <>

--- a/src/pages/costModels/costModel/updateMarkupDialog.tsx
+++ b/src/pages/costModels/costModel/updateMarkupDialog.tsx
@@ -46,7 +46,7 @@ interface State {
 class UpdateMarkupModelBase extends React.Component<Props, State> {
   constructor(props) {
     super(props);
-    const initialMarkup = Number(this.props.current.markup.value); // Drop trailing zeros from API value
+    const initialMarkup = Number(this.props.current.markup.value || 0); // Drop trailing zeros from API value
     const isNegative = initialMarkup < 0;
 
     this.state = {

--- a/src/pages/costModels/createCostModelWizard/markup.tsx
+++ b/src/pages/costModels/createCostModelWizard/markup.tsx
@@ -21,6 +21,7 @@ import messages from 'locales/messages';
 import { styles } from 'pages/costModels/costModel/costCalc.styles';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
+import { formatRaw } from 'utils/format';
 
 import { CostModelContext } from './context';
 
@@ -41,6 +42,9 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
           distribution,
           type,
         }) => {
+          const helpText = markupValidator();
+          const validated = helpText ? 'error' : 'default';
+
           return (
             <Stack hasGutter>
               <StackItem>
@@ -81,26 +85,35 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
                   </Flex>
                   <Flex direction={{ default: 'column' }} alignSelf={{ default: 'alignSelfCenter' }}>
                     <FlexItem>
-                      <InputGroup style={styles.rateContainer}>
-                        <InputGroupText style={styles.sign}>
-                          {isDiscount
-                            ? intl.formatMessage(messages.DiscountMinus)
-                            : intl.formatMessage(messages.MarkupPlus)}
-                        </InputGroupText>
-                        <TextInput
-                          style={styles.inputField}
-                          type="text"
-                          aria-label={intl.formatMessage(messages.Rate)}
-                          id="markup-input-box"
-                          value={markup}
-                          onKeyDown={handleOnKeyDown}
-                          onChange={handleMarkupDiscountChange}
-                          validated={markupValidator()}
-                        />
-                        <InputGroupText style={styles.percent}>
-                          {intl.formatMessage(messages.PercentSymbol)}
-                        </InputGroupText>
-                      </InputGroup>
+                      <Form>
+                        <FormGroup
+                          fieldId="markup-input-box"
+                          helperTextInvalid={helpText ? intl.formatMessage(helpText) : undefined}
+                          style={styles.rateContainer}
+                          validated={validated}
+                        >
+                          <InputGroup>
+                            <InputGroupText style={styles.sign}>
+                              {isDiscount
+                                ? intl.formatMessage(messages.DiscountMinus)
+                                : intl.formatMessage(messages.MarkupPlus)}
+                            </InputGroupText>
+                            <TextInput
+                              style={styles.inputField}
+                              type="text"
+                              aria-label={intl.formatMessage(messages.Rate)}
+                              id="markup-input-box"
+                              value={formatRaw(markup)}
+                              onKeyDown={handleOnKeyDown}
+                              onChange={handleMarkupDiscountChange}
+                              validated={validated}
+                            />
+                            <InputGroupText style={styles.percent}>
+                              {intl.formatMessage(messages.PercentSymbol)}
+                            </InputGroupText>
+                          </InputGroup>
+                        </FormGroup>
+                      </Form>
                     </FlexItem>
                   </Flex>
                 </Flex>


### PR DESCRIPTION
The cost models markup dialog currently shows a validation error for the German locale. One issue is related to the validator, which doesn't account for different decimal separators.

- Updated wizard markup step to match "cost calculations" edit dialog
- Formatted "cost calculations" card to show 10 decimal places 

**Wizard markup step**
![chrome-capture (1)](https://user-images.githubusercontent.com/17481322/134682989-4a7dc553-d263-4230-903b-7006bca3cffe.gif)

**Cost calculations markup card**
<img width="888" alt="Screen Shot 2021-09-24 at 9 22 30 AM" src="https://user-images.githubusercontent.com/17481322/134683026-c820ff05-a678-4e1f-9a5f-a9979a2ddc2d.png">

