### PR TITLE
RateInput component not localized

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -28124,6 +28124,12 @@
         "value": "Select the metric you want to assign a price to, and specify a measurement unit and rate. You can optionally set multiple rates for particular tags."
       }
     ],
+    "CostModelsWizardRateAriaLabel": [
+      {
+        "type": 0,
+        "value": "Assign rate"
+      }
+    ],
     "CostModelsWizardReviewMarkDiscount": [
       {
         "type": 0,

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -139,6 +139,7 @@
   "CostModelsWizardOnboardAWS": "Amazon Web Services (AWS)",
   "CostModelsWizardOnboardOCP": "Red Hat OpenShift Container Platform",
   "CostModelsWizardPriceListMetric": "Select the metric you want to assign a price to, and specify a measurement unit and rate. You can optionally set multiple rates for particular tags.",
+  "CostModelsWizardRateAriaLabel": "Assign rate",
   "CostModelsWizardReviewMarkDiscount": "Markup/Discount",
   "CostModelsWizardReviewStatusSubDetails": "Review and confirm your cost model configuration and assignments. Click {create} to create the cost model, or {back} to revise.",
   "CostModelsWizardReviewStatusSubTitle": "Costs for resources connected to the assigned sources will now be calculated using the newly created {value} cost model.",

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -1046,6 +1046,11 @@ export default defineMessages({
       'Select the metric you want to assign a price to, and specify a measurement unit and rate. You can optionally set multiple rates for particular tags.',
     id: 'CostModelsWizardPriceListMetric',
   },
+  CostModelsWizardRateAriaLabel: {
+    defaultMessage: 'Assign rate',
+    description: 'Assign rate',
+    id: 'CostModelsWizardRateAriaLabel',
+  },
   CostModelsWizardReviewMarkDiscount: {
     defaultMessage: 'Markup/Discount',
     description: 'No Markup/Discount',

--- a/src/pages/costModels/components/inputs/rateInput.tsx
+++ b/src/pages/costModels/components/inputs/rateInput.tsx
@@ -55,9 +55,9 @@ const RateInputBase: React.FunctionComponent<RateInputBaseProps> = ({
           onBlur={onBlur}
           isRequired
           type="text"
-          aria-label={`rate input ${fieldId}`}
+          aria-label={intl.formatMessage(messages.CostModelsWizardRateAriaLabel)}
           id={fieldId}
-          placeholder="0.00"
+          placeholder={formatRaw('0.00')}
           value={formatRaw(value as string)}
           onChange={onChange}
           onKeyDown={handleOnKeyDown}

--- a/src/pages/costModels/costModel/markup.tsx
+++ b/src/pages/costModels/costModel/markup.tsx
@@ -20,7 +20,7 @@ import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
 import { rbacSelectors } from 'store/rbac';
-import { formatPercentage } from 'utils/format';
+import { formatRaw } from 'utils/format';
 
 import { styles } from './costCalc.styles';
 import UpdateMarkupDialog from './updateMarkupDialog';
@@ -40,8 +40,7 @@ const MarkupCardBase: React.FunctionComponent<Props> = ({
   isUpdateDialogOpen,
 }) => {
   const [dropdownIsOpen, setDropdownIsOpen] = React.useState(false);
-  const markupValue =
-    current && current.markup && current.markup.value ? formatPercentage(Number(current.markup.value)) : '0.0';
+  const markupValue = formatRaw(current && current.markup && current.markup.value ? current.markup.value : '0');
 
   return (
     <>

--- a/src/pages/costModels/costModel/markup.tsx
+++ b/src/pages/costModels/costModel/markup.tsx
@@ -20,7 +20,7 @@ import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
 import { rbacSelectors } from 'store/rbac';
-import { formatRaw } from 'utils/format';
+import { formatPercentage } from 'utils/format';
 
 import { styles } from './costCalc.styles';
 import UpdateMarkupDialog from './updateMarkupDialog';
@@ -40,7 +40,13 @@ const MarkupCardBase: React.FunctionComponent<Props> = ({
   isUpdateDialogOpen,
 }) => {
   const [dropdownIsOpen, setDropdownIsOpen] = React.useState(false);
-  const markupValue = formatRaw(current && current.markup && current.markup.value ? current.markup.value : '0');
+  const markupValue = formatPercentage(
+    current && current.markup && current.markup.value ? Number(current.markup.value) : 0,
+    {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 10,
+    }
+  );
 
   return (
     <>

--- a/src/pages/costModels/costModel/updateMarkupDialog.tsx
+++ b/src/pages/costModels/costModel/updateMarkupDialog.tsx
@@ -46,7 +46,7 @@ interface State {
 class UpdateMarkupModelBase extends React.Component<Props, State> {
   constructor(props) {
     super(props);
-    const initialMarkup = Number(this.props.current.markup.value); // Drop trailing zeros from API value
+    const initialMarkup = Number(this.props.current.markup.value || 0); // Drop trailing zeros from API value
     const isNegative = initialMarkup < 0;
 
     this.state = {

--- a/src/pages/costModels/costModel/updateMarkupDialog.tsx
+++ b/src/pages/costModels/costModel/updateMarkupDialog.tsx
@@ -117,7 +117,12 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
               };
               updateCostModel(current.uuid, newState, 'updateMarkup');
             }}
-            isDisabled={isLoading || validated === 'error' || Number(markup) === Number(current.markup.value)}
+            isDisabled={
+              isLoading ||
+              validated === 'error' ||
+              markup.trim().length === 0 ||
+              Number(markup) === Number(current.markup.value)
+            }
           >
             {intl.formatMessage(messages.Save)}
           </Button>,
@@ -184,14 +189,16 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
                             : intl.formatMessage(messages.MarkupPlus)}
                         </InputGroupText>
                         <TextInput
-                          style={styles.inputField}
-                          type="text"
                           aria-label={intl.formatMessage(messages.Rate)}
                           id="markup-input-box"
-                          value={formatRaw(this.state.markup)}
+                          isRequired
                           onKeyDown={this.handleOnKeyDown}
                           onChange={this.handleMarkupDiscountChange}
+                          placeholder={formatRaw('0')}
+                          style={styles.inputField}
+                          type="text"
                           validated={validated}
+                          value={formatRaw(this.state.markup)}
                         />
                         <InputGroupText style={styles.percent}>
                           {intl.formatMessage(messages.PercentSymbol)}

--- a/src/pages/costModels/createCostModelWizard/index.tsx
+++ b/src/pages/costModels/createCostModelWizard/index.tsx
@@ -469,7 +469,7 @@ class CostModelWizardBase extends React.Component<Props, State> {
             type: this.state.type,
             description: this.state.description,
             distribution: this.state.distribution,
-            markup: this.state.isDiscount ? '-' + this.state.markup : this.state.markup,
+            markup: `${this.state.isDiscount ? '-' : ''}${this.state.markup}`,
             tiers: this.state.tiers,
             priceListCurrent: this.state.priceListCurrent,
             sources: this.state.sources.filter(src => src.selected),

--- a/src/pages/costModels/createCostModelWizard/markup.tsx
+++ b/src/pages/costModels/createCostModelWizard/markup.tsx
@@ -99,14 +99,16 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
                                 : intl.formatMessage(messages.MarkupPlus)}
                             </InputGroupText>
                             <TextInput
-                              style={styles.inputField}
-                              type="text"
                               aria-label={intl.formatMessage(messages.Rate)}
                               id="markup-input-box"
-                              value={formatRaw(markup)}
+                              isRequired
                               onKeyDown={handleOnKeyDown}
                               onChange={handleMarkupDiscountChange}
+                              placeholder={formatRaw('0')}
+                              style={styles.inputField}
+                              type="text"
                               validated={validated}
+                              value={formatRaw(markup)}
                             />
                             <InputGroupText style={styles.percent}>
                               {intl.formatMessage(messages.PercentSymbol)}

--- a/src/pages/costModels/createCostModelWizard/markup.tsx
+++ b/src/pages/costModels/createCostModelWizard/markup.tsx
@@ -21,6 +21,7 @@ import messages from 'locales/messages';
 import { styles } from 'pages/costModels/costModel/costCalc.styles';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
+import { formatRaw } from 'utils/format';
 
 import { CostModelContext } from './context';
 
@@ -41,6 +42,9 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
           distribution,
           type,
         }) => {
+          const helpText = markupValidator();
+          const validated = helpText ? 'error' : 'default';
+
           return (
             <Stack hasGutter>
               <StackItem>
@@ -81,26 +85,35 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
                   </Flex>
                   <Flex direction={{ default: 'column' }} alignSelf={{ default: 'alignSelfCenter' }}>
                     <FlexItem>
-                      <InputGroup style={styles.rateContainer}>
-                        <InputGroupText style={styles.sign}>
-                          {isDiscount
-                            ? intl.formatMessage(messages.DiscountMinus)
-                            : intl.formatMessage(messages.MarkupPlus)}
-                        </InputGroupText>
-                        <TextInput
-                          style={styles.inputField}
-                          type="text"
-                          aria-label={intl.formatMessage(messages.Rate)}
-                          id="markup-input-box"
-                          value={markup}
-                          onKeyDown={handleOnKeyDown}
-                          onChange={handleMarkupDiscountChange}
-                          validated={markupValidator()}
-                        />
-                        <InputGroupText style={styles.percent}>
-                          {intl.formatMessage(messages.PercentSymbol)}
-                        </InputGroupText>
-                      </InputGroup>
+                      <Form>
+                        <FormGroup
+                          fieldId="markup-input-box"
+                          helperTextInvalid={helpText ? intl.formatMessage(helpText) : undefined}
+                          style={styles.rateContainer}
+                          validated={validated}
+                        >
+                          <InputGroup>
+                            <InputGroupText style={styles.sign}>
+                              {isDiscount
+                                ? intl.formatMessage(messages.DiscountMinus)
+                                : intl.formatMessage(messages.MarkupPlus)}
+                            </InputGroupText>
+                            <TextInput
+                              style={styles.inputField}
+                              type="text"
+                              aria-label={intl.formatMessage(messages.Rate)}
+                              id="markup-input-box"
+                              value={formatRaw(markup)}
+                              onKeyDown={handleOnKeyDown}
+                              onChange={handleMarkupDiscountChange}
+                              validated={validated}
+                            />
+                            <InputGroupText style={styles.percent}>
+                              {intl.formatMessage(messages.PercentSymbol)}
+                            </InputGroupText>
+                          </InputGroup>
+                        </FormGroup>
+                      </Form>
                     </FlexItem>
                   </Flex>
                 </Flex>

--- a/src/pages/costModels/createCostModelWizard/steps.tsx
+++ b/src/pages/costModels/createCostModelWizard/steps.tsx
@@ -1,5 +1,6 @@
 import messages from 'locales/messages';
 import { MessageDescriptor } from 'react-intl';
+import { countDecimals } from 'utils/format';
 
 export const nameErrors = (name: string): MessageDescriptor | null => {
   if (name.length === 0) {
@@ -18,30 +19,45 @@ export const descriptionErrors = (description: string): MessageDescriptor | null
   return null;
 };
 
+const isMarkupValid = value => {
+  if (value.trim() === '') {
+    return false;
+  }
+  if (isNaN(Number(value))) {
+    return false;
+  }
+  // Test number of decimals
+  const decimals = countDecimals(value);
+  if (decimals > 10) {
+    return false;
+  }
+  return true;
+};
+
 export const validatorsHash = {
   '': [() => false],
   AWS: [
     ctx => nameErrors(ctx.name) === null && descriptionErrors(ctx.description) === null && ctx.type !== '',
-    ctx => ctx.markup !== '' && !isNaN(Number(ctx.markup)),
+    ctx => isMarkupValid(ctx.markup),
     () => true,
     () => true,
   ],
   AZURE: [
     ctx => nameErrors(ctx.name) === null && descriptionErrors(ctx.description) === null && ctx.type !== '',
-    ctx => ctx.markup !== '' && !isNaN(Number(ctx.markup)),
+    ctx => isMarkupValid(ctx.markup),
     () => true,
     () => true,
   ],
   GCP: [
     ctx => nameErrors(ctx.name) === null && descriptionErrors(ctx.description) === null && ctx.type !== '',
-    ctx => ctx.markup !== '' && !isNaN(Number(ctx.markup)),
+    ctx => isMarkupValid(ctx.markup),
     () => true,
     () => true,
   ],
   OCP: [
     ctx => nameErrors(ctx.name) === null && descriptionErrors(ctx.description) === null && ctx.type !== '',
     ctx => ctx.priceListCurrent.justSaved,
-    ctx => ctx.markup !== '' && !isNaN(Number(ctx.markup)),
+    ctx => isMarkupValid(ctx.markup),
     () => true,
     () => true,
   ],


### PR DESCRIPTION
Localized the RateInput aria-label and placeholder.

https://issues.redhat.com/browse/COST-1893

In addition, I fixed the wizard step validator to match the markup validator. That is, the next button should not be enabled unless the markup is valid. That should include checking the number of decimal places, white spaces, etc.

**Wizard markup next step button**
![chrome-capture (2)](https://user-images.githubusercontent.com/17481322/134692852-9f3cea7d-4045-46bd-bc86-0226adf853d7.gif)

**Add Rate placeholder**
<img width="1148" alt="Screen Shot 2021-09-24 at 10 37 45 AM" src="https://user-images.githubusercontent.com/17481322/134693140-d25568f4-5508-4358-9082-ff09135edc87.png">


