### PR TITLE
Show new features in beta environment only

### DIFF
--- a/src/components/currency/currency.tsx
+++ b/src/components/currency/currency.tsx
@@ -128,6 +128,10 @@ class CurrencyBase extends React.Component<CurrencyProps> {
   public render() {
     const { intl } = this.props;
 
+    if (!insights.chrome.isBeta()) {
+      return null;
+    }
+
     // Delete currency units if current session is not valid
     invalidateCurrencyUnits();
 

--- a/src/components/currency/currency.tsx
+++ b/src/components/currency/currency.tsx
@@ -128,6 +128,7 @@ class CurrencyBase extends React.Component<CurrencyProps> {
   public render() {
     const { intl } = this.props;
 
+    // Todo: Show new features in beta environment only
     if (!insights.chrome.isBeta()) {
       return null;
     }

--- a/src/components/inactiveSources/inactiveSources.tsx
+++ b/src/components/inactiveSources/inactiveSources.tsx
@@ -18,7 +18,7 @@ import {
   providersActions,
   providersSelectors,
 } from 'store/providers';
-import { deleteInactiveSourcesToken, initInactiveSourcesToken, isInactiveSourcesTokenValid } from 'utils/localStorage';
+import { deleteInactiveSourcesToken, isInactiveSourcesTokenValid, saveInactiveSourcesToken } from 'utils/localStorage';
 import { getReleasePath } from 'utils/pathname';
 
 interface InactiveSourcesOwnProps {
@@ -218,7 +218,7 @@ class InactiveSourcesBase extends React.Component<InactiveSourcesProps> {
   };
 
   private handleOnClose = () => {
-    initInactiveSourcesToken();
+    saveInactiveSourcesToken();
     this.forceUpdate();
   };
 

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -4,6 +4,7 @@ interface Chrome {
   appNavClick: ({ id: string, secondaryNav: boolean }) => void;
   init: () => void;
   identifyApp: (appId: string) => void;
+  isBeta: () => boolean;
   navigation: (navFunc: any) => void;
   on: (event: string, eventFunc: any) => () => void;
   appAction: (pageName: string) => void;

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -60,8 +60,12 @@ export const dateRangeOptions: {
   { label: messages.ExplorerDateRange, value: 'previous_month_to_date' },
   { label: messages.ExplorerDateRange, value: 'last_thirty_days' },
   { label: messages.ExplorerDateRange, value: 'last_sixty_days' },
-  { label: messages.ExplorerDateRange, value: 'last_ninety_days' },
 ];
+
+// Todo: Show new features in beta environment only
+if (insights.chrome.isBeta()) {
+  dateRangeOptions.push({ label: messages.ExplorerDateRange, value: 'last_ninety_days' });
+}
 
 export const groupByAwsOptions: {
   label: string;

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -54,14 +54,14 @@ export const isCurrencyTokenValid = () => {
   return getCurrencyToken() === getPartialTokenCookie();
 };
 
-// Initialize inactive sources token, used by isInactiveSourcesTokenValid
-export const initInactiveSourcesToken = () => {
-  setInactiveSourcesToken(getPartialTokenCookie());
-};
-
 // Returns true if inactive sources token is valid for current session
 export const isInactiveSourcesTokenValid = () => {
   return getInactiveSourcesToken() === getPartialTokenCookie();
+};
+
+// Save inactive sources token, used by isInactiveSourcesTokenValid
+export const saveInactiveSourcesToken = () => {
+  setInactiveSourcesToken(getPartialTokenCookie());
 };
 
 // Set currency token, used by isCurrencyTokenValid


### PR DESCRIPTION
We want to show a couple features based only in the beta environment. Specifically, the Cost Explorer 90 days view and the currency selector in the page headers.

**Stage environment**
<img width="1464" alt="Screen Shot 2021-09-24 at 11 10 15 AM" src="https://user-images.githubusercontent.com/17481322/134699029-046787a0-693f-4ce4-bc53-ba9d784e58a3.png">

**Beta environment**
<img width="1467" alt="Screen Shot 2021-09-24 at 11 10 50 AM" src="https://user-images.githubusercontent.com/17481322/134699076-d4ad93ac-3069-4e58-ac26-72079b1e13e5.png">


