### PR TITLE
Remove MarkupWithDistribution functions from CostModelContext

### DIFF
--- a/src/pages/costModels/createCostModelWizard/context.ts
+++ b/src/pages/costModels/createCostModelWizard/context.ts
@@ -22,8 +22,6 @@ export const defaultCostModelContext = {
   handleMarkupDiscountChange: (...args: any[]) => null,
   handleDistributionChange: (...args: any[]) => null,
   handleSignChange: (...args: any[]) => null,
-  markupValidator: (...args: any[]) => null,
-  handleOnKeyDown: (...args: any[]) => null,
   setSources: (value: any) => null,
   dataFetched: false,
   loading: false,

--- a/src/pages/costModels/createCostModelWizard/index.tsx
+++ b/src/pages/costModels/createCostModelWizard/index.tsx
@@ -11,7 +11,7 @@ import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions } from 'store/costModels';
 import { metricsSelectors } from 'store/metrics';
-import { countDecimals, formatRaw } from 'utils/format';
+import { formatRaw } from 'utils/format';
 
 import { fetchSources as apiSources } from './api';
 import { CostModelContext } from './context';
@@ -86,7 +86,7 @@ const InternalWizardBase: React.SFC<InternalWizardBaseProps> = ({
           distribution,
           rates: tiers,
           markup: {
-            value: isDiscount ? '-' + markup : markup,
+            value: `${isDiscount ? '-' : ''}${markup}`,
             unit: 'percent',
           },
           source_uuids: sources.map(src => src.uuid),
@@ -333,25 +333,6 @@ class CostModelWizardBase extends React.Component<Props, State> {
           handleSignChange: (_, event) => {
             const { value } = event.currentTarget;
             this.setState({ isDiscount: value === 'true' });
-          },
-          markupValidator: () => {
-            const { markup } = this.state;
-
-            if (isNaN(Number(markup))) {
-              return messages.MarkupOrDiscountNumber;
-            }
-            // Test number of decimals
-            const decimals = countDecimals(markup);
-            if (decimals > 10) {
-              return messages.MarkupOrDiscountTooLong;
-            }
-            return undefined;
-          },
-          handleOnKeyDown: event => {
-            // Prevent 'enter', '+', and '-'
-            if (event.keyCode === 13 || event.keyCode === 187 || event.keyCode === 189) {
-              event.preventDefault();
-            }
           },
           error: this.state.error,
           apiError: this.state.apiError,

--- a/src/pages/costModels/createCostModelWizard/markup.tsx
+++ b/src/pages/costModels/createCostModelWizard/markup.tsx
@@ -21,7 +21,7 @@ import messages from 'locales/messages';
 import { styles } from 'pages/costModels/costModel/costCalc.styles';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
-import { formatRaw } from 'utils/format';
+import { countDecimals, formatRaw } from 'utils/format';
 
 import { CostModelContext } from './context';
 
@@ -29,20 +29,37 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
   public render() {
     const { intl } = this.props;
 
+    const handleOnKeyDown = event => {
+      // Prevent 'enter', '+', and '-'
+      if (event.keyCode === 13 || event.keyCode === 187 || event.keyCode === 189) {
+        event.preventDefault();
+      }
+    };
+
+    const markupValidator = value => {
+      if (isNaN(Number(value))) {
+        return messages.MarkupOrDiscountNumber;
+      }
+      // Test number of decimals
+      const decimals = countDecimals(value);
+      if (decimals > 10) {
+        return messages.MarkupOrDiscountTooLong;
+      }
+      return undefined;
+    };
+
     return (
       <CostModelContext.Consumer>
         {({
           handleDistributionChange,
           handleSignChange,
-          handleOnKeyDown,
           handleMarkupDiscountChange,
-          markupValidator,
           markup,
           isDiscount,
           distribution,
           type,
         }) => {
-          const helpText = markupValidator();
+          const helpText = markupValidator(markup);
           const validated = helpText ? 'error' : 'default';
 
           return (


### PR DESCRIPTION
The wizard's `CostModelContext` object contains a few functions used by the `MarkupWithDistribution` step. Specifically, `handleOnKeyDown` and `markupValidator`.

Considering this step is never reused, and the functions don't set state, they may be better located in the `MarkupWithDistribution` component.

https://issues.redhat.com/browse/COST-1898