### PR TITLE
Show "All cloud filtered by OpenShift" for beta environment only

### DIFF
--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -44,7 +44,7 @@ import {
   // infrastructureGcpOcpOptions, // Todo: Temp disabled -- see https://issues.redhat.com/browse/COST-1705
   infrastructureGcpOptions,
   infrastructureIbmOptions,
-  // infrastructureOcpCloudOptions, // Todo: Temp disabled -- see https://issues.redhat.com/browse/COST-1483
+  infrastructureOcpCloudOptions,
   ocpOptions,
   PerspectiveType,
 } from './explorerUtils';
@@ -134,9 +134,11 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
     const options = [];
     if (ocp) {
       options.push(...ocpOptions);
-      // Todo: Temp disabled -- see https://issues.redhat.com/browse/COST-1483
-      //
-      // options.push(...infrastructureOcpCloudOptions);
+
+      // Todo: Show new features in beta environment only
+      if (insights.chrome.isBeta()) {
+        options.push(...infrastructureOcpCloudOptions);
+      }
     }
     if (aws) {
       options.push(...infrastructureAwsOptions);

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -163,10 +163,7 @@ const infrastructureGcpOptions = [{ label: messages.PerspectiveValues, value: 'g
 const infrastructureIbmOptions = [{ label: messages.PerspectiveValues, value: 'ibm' }];
 
 // Infrastructure Ocp cloud options
-//
-// Todo: Temp disabled -- see https://issues.redhat.com/browse/COST-1483
-//
-// const infrastructureOcpCloudOptions = [{ label: 'overview.perspective.ocp_cloud', value: 'ocp_cloud' }];
+const infrastructureOcpCloudOptions = [{ label: messages.PerspectiveValues, value: 'ocp_cloud' }];
 
 class OverviewBase extends React.Component<OverviewProps> {
   protected defaultState: OverviewState = {
@@ -251,11 +248,12 @@ class OverviewBase extends React.Component<OverviewProps> {
   };
 
   private getDefaultInfrastructurePerspective = () => {
-    // Todo: Temp disabled -- see https://issues.redhat.com/browse/COST-1483
-    //
-    // if (this.isOcpAvailable()) {
-    //   return InfrastructurePerspective.ocpCloud;
-    // }
+    if (this.isOcpAvailable()) {
+      // Todo: Show new features in beta environment only
+      if (insights.chrome.isBeta()) {
+        return InfrastructurePerspective.ocpCloud;
+      }
+    }
     if (this.isAwsAvailable()) {
       return InfrastructurePerspective.aws;
     }
@@ -296,11 +294,12 @@ class OverviewBase extends React.Component<OverviewProps> {
     // Dynamically show options if providers are available
     const options = [];
     if (this.getCurrentTab() === OverviewTab.infrastructure) {
-      // Todo: Temp disabled -- see https://issues.redhat.com/browse/COST-1483
-      //
-      // if (ocp) {
-      //   options.push(...infrastructureOcpCloudOptions);
-      // }
+      if (ocp) {
+        // Todo: Show new features in beta environment only
+        if (insights.chrome.isBeta()) {
+          options.push(...infrastructureOcpCloudOptions);
+        }
+      }
       if (aws) {
         options.push(...infrastructureAwsOptions);
       }


### PR DESCRIPTION
Show "All cloud filtered by OpenShift" feature in beta environment only. Specifically re-enables the "All cloud filtered by OpenShift" perspective option for the overview and cost explorer pages.

https://issues.redhat.com/browse/COST-1899

**Overview in stage-beta environment**
<img width="1407" alt="Screen Shot 2021-09-24 at 12 48 25 PM" src="https://user-images.githubusercontent.com/17481322/134712240-79c067f5-758e-4036-96af-af10978afad1.png">


**Cost explorer in stage-beta environment**
<img width="1410" alt="Screen Shot 2021-09-24 at 12 48 10 PM" src="https://user-images.githubusercontent.com/17481322/134712227-d177c627-b7cc-4fff-9fa3-cadef249a806.png">



**Overview in stage environment**
<img width="1413" alt="Screen Shot 2021-09-24 at 12 55 21 PM" src="https://user-images.githubusercontent.com/17481322/134712841-71dea4c0-6239-4a82-b606-6edabb71b120.png">


**Cost explorer in stage environment**
<img width="1413" alt="Screen Shot 2021-09-24 at 12 55 34 PM" src="https://user-images.githubusercontent.com/17481322/134712857-542b0bc4-c687-4bb0-8017-e06c7ccdd5d4.png">

