### PR TITLE
Convert Dropdown components to use Select (1 of many)

### DIFF
--- a/src/components/costType/costType.styles.ts
+++ b/src/components/costType/costType.styles.ts
@@ -9,5 +9,6 @@ export const styles = {
   costLabel: {
     marginBottom: 0,
     marginRight: global_spacer_md.var,
+    whiteSpace: 'nowrap',
   },
 } as { [className: string]: React.CSSProperties };

--- a/src/components/costType/costType.tsx
+++ b/src/components/costType/costType.tsx
@@ -1,5 +1,4 @@
-import { MessageDescriptor } from '@formatjs/intl/src/types';
-import { Dropdown, DropdownItem, DropdownToggle, Title } from '@patternfly/react-core';
+import { Select, SelectOption, SelectOptionObject, SelectVariant, Title } from '@patternfly/react-core';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
@@ -13,7 +12,13 @@ interface CostTypeOwnProps {
 
 interface CostTypeState {
   currentItem: string;
-  isCostTypeOpen: boolean;
+  isSelectOpen: boolean;
+}
+
+interface CostTypeOption extends SelectOptionObject {
+  desc?: string;
+  id?: string;
+  toString(): string;
 }
 
 type CostTypeProps = CostTypeOwnProps & WrappedComponentProps;
@@ -25,90 +30,78 @@ const enum CostTypes {
   unblended = 'unblended',
 }
 
-export const costTypeOptions: {
-  desc: MessageDescriptor;
-  label: MessageDescriptor;
-  value: string;
-}[] = [
-  { desc: messages.CostTypeUnblendedDesc, label: messages.CostTypeUnblended, value: CostTypes.unblended },
-  { desc: messages.CostTypeAmortizedDesc, label: messages.CostTypeAmortized, value: CostTypes.amortized },
-  { desc: messages.CostTypeBlendedDesc, label: messages.CostTypeBlended, value: CostTypes.blended },
-];
-
 class CostTypeBase extends React.Component<CostTypeProps> {
   protected defaultState: CostTypeState = {
     currentItem: CostTypes.unblended,
-    isCostTypeOpen: false,
+    isSelectOpen: false,
   };
   public state: CostTypeState = { ...this.defaultState };
 
-  private getDropDownItems = () => {
+  private getOptions = (): CostTypeOption[] => {
     const { intl } = this.props;
 
-    return costTypeOptions.map(option => (
-      <DropdownItem
-        component="button"
-        description={intl.formatMessage(option.desc)}
-        key={option.value}
-        onClick={() => this.handleClick(option.value)}
-      >
-        {intl.formatMessage(option.label)}
-      </DropdownItem>
-    ));
+    const options: CostTypeOption[] = [
+      {
+        desc: intl.formatMessage(messages.CostTypeUnblendedDesc),
+        id: CostTypes.unblended,
+        toString: () => intl.formatMessage(messages.CostTypeUnblended),
+      },
+      {
+        id: CostTypes.amortized,
+        desc: intl.formatMessage(messages.CostTypeAmortizedDesc),
+        toString: () => intl.formatMessage(messages.CostTypeAmortized),
+      },
+      {
+        id: CostTypes.blended,
+        desc: intl.formatMessage(messages.CostTypeBlendedDesc),
+        toString: () => intl.formatMessage(messages.CostTypeBlended),
+      },
+    ];
+    return options;
   };
 
-  private getCurrentLabel = () => {
-    const { intl } = this.props;
+  private getCurrentItem = () => {
     const { currentItem } = this.state;
 
-    const costType = getCostType() || currentItem; // Get cost type from local storage
-
-    switch (costType) {
-      case 'amortized':
-        return intl.formatMessage(messages.CostTypeAmortized);
-      case 'blended':
-        return intl.formatMessage(messages.CostTypeBlended);
-      default:
-      case 'unblended':
-        return intl.formatMessage(messages.CostTypeUnblended);
-    }
+    const costType = getCostType(); // Get currency units from local storage
+    return costType ? costType : currentItem;
   };
 
-  private getDropDown = () => {
+  private getSelect = () => {
     const { isDisabled } = this.props;
-    const { isCostTypeOpen } = this.state;
-    const dropdownItems = this.getDropDownItems();
+    const { isSelectOpen } = this.state;
+
+    const currentItem = this.getCurrentItem();
+    const selections = this.getOptions();
+    const selection = selections.find((item: CostTypeOption) => item.id === currentItem);
 
     return (
-      <Dropdown
-        id="costTypeDropdown"
+      <Select
+        id="costTypeSelect"
+        isDisabled={isDisabled}
+        isOpen={isSelectOpen}
         onSelect={this.handleSelect}
-        toggle={
-          <DropdownToggle isDisabled={isDisabled} onToggle={this.handleToggle}>
-            {this.getCurrentLabel()}
-          </DropdownToggle>
-        }
-        isOpen={isCostTypeOpen}
-        dropdownItems={dropdownItems}
-      />
+        onToggle={this.handleToggle}
+        selections={selection}
+        variant={SelectVariant.single}
+      >
+        {selections.map(item => (
+          <SelectOption key={item.id} value={item} />
+        ))}
+      </Select>
     );
   };
 
-  private handleClick = value => {
-    setCostType(value); // Set cost type via local storage
-    this.setState({ currentItem: value });
+  private handleSelect = (event, selection: CostTypeOption) => {
+    this.setState({
+      currentItem: selection.id,
+      isSelectOpen: false,
+    });
+    setCostType(selection.id); // Set currency units via local storage
   };
 
-  private handleSelect = () => {
-    this.setState({
-      isCostTypeOpen: !this.state.isCostTypeOpen,
-    });
-  };
-
-  private handleToggle = isCostTypeOpen => {
-    this.setState({
-      isCostTypeOpen,
-    });
+  private handleToggle = isSelectOpen => {
+    this.setState({ isSelectOpen });
   };
 
   public render() {
@@ -127,7 +120,7 @@ class CostTypeBase extends React.Component<CostTypeProps> {
         <Title headingLevel="h3" size="md" style={styles.costLabel}>
           {intl.formatMessage(messages.CostTypeLabel)}
         </Title>
-        {this.getDropDown()}
+        {this.getSelect()}
       </div>
     );
   }

--- a/src/components/costType/costType.tsx
+++ b/src/components/costType/costType.tsx
@@ -17,8 +17,8 @@ interface CostTypeState {
 
 interface CostTypeOption extends SelectOptionObject {
   desc?: string;
-  id?: string;
-  toString(): string;
+  toString(): string; // label
+  value?: string;
 }
 
 type CostTypeProps = CostTypeOwnProps & WrappedComponentProps;
@@ -37,24 +37,24 @@ class CostTypeBase extends React.Component<CostTypeProps> {
   };
   public state: CostTypeState = { ...this.defaultState };
 
-  private getOptions = (): CostTypeOption[] => {
+  private getSelectOptions = (): CostTypeOption[] => {
     const { intl } = this.props;
 
     const options: CostTypeOption[] = [
       {
         desc: intl.formatMessage(messages.CostTypeUnblendedDesc),
-        id: CostTypes.unblended,
         toString: () => intl.formatMessage(messages.CostTypeUnblended),
+        value: CostTypes.unblended,
       },
       {
-        id: CostTypes.amortized,
         desc: intl.formatMessage(messages.CostTypeAmortizedDesc),
         toString: () => intl.formatMessage(messages.CostTypeAmortized),
+        value: CostTypes.amortized,
       },
       {
-        id: CostTypes.blended,
         desc: intl.formatMessage(messages.CostTypeBlendedDesc),
         toString: () => intl.formatMessage(messages.CostTypeBlended),
+        value: CostTypes.blended,
       },
     ];
     return options;
@@ -72,8 +72,8 @@ class CostTypeBase extends React.Component<CostTypeProps> {
     const { isSelectOpen } = this.state;
 
     const currentItem = this.getCurrentItem();
-    const selections = this.getOptions();
-    const selection = selections.find((item: CostTypeOption) => item.id === currentItem);
+    const selectOptions = this.getSelectOptions();
+    const selection = selectOptions.find((item: CostTypeOption) => item.value === currentItem);
 
     return (
       <Select
@@ -85,8 +85,8 @@ class CostTypeBase extends React.Component<CostTypeProps> {
         selections={selection}
         variant={SelectVariant.single}
       >
-        {selections.map(item => (
-          <SelectOption key={item.id} value={item} />
+        {selectOptions.map(item => (
+          <SelectOption key={item.value} value={item} />
         ))}
       </Select>
     );
@@ -94,10 +94,10 @@ class CostTypeBase extends React.Component<CostTypeProps> {
 
   private handleSelect = (event, selection: CostTypeOption) => {
     this.setState({
-      currentItem: selection.id,
+      currentItem: selection.value,
       isSelectOpen: false,
     });
-    setCostType(selection.id); // Set currency units via local storage
+    setCostType(selection.value); // Set currency units via local storage
   };
 
   private handleToggle = isSelectOpen => {

--- a/src/components/currency/currency.scss
+++ b/src/components/currency/currency.scss
@@ -1,0 +1,8 @@
+@import url("~@patternfly/patternfly/base/patternfly-variables.css");
+
+// Workaround for missing "position" property
+.currencyOverride {
+  .pf-c-select__menu {
+    right: 0;
+  }
+}

--- a/src/components/currency/currency.styles.ts
+++ b/src/components/currency/currency.styles.ts
@@ -9,5 +9,6 @@ export const styles = {
   currencyLabel: {
     marginBottom: 0,
     marginRight: global_spacer_md.var,
+    whiteSpace: 'nowrap',
   },
 } as { [className: string]: React.CSSProperties };

--- a/src/components/currency/currency.tsx
+++ b/src/components/currency/currency.tsx
@@ -33,8 +33,8 @@ interface CurrencyState {
 }
 
 interface CurrencyOption extends SelectOptionObject {
-  id?: string;
-  toString(): string;
+  toString(): string; // label
+  value?: string;
 }
 
 type CurrencyProps = CurrencyOwnProps & CurrencyDispatchProps & CurrencyStateProps & WrappedComponentProps;
@@ -52,7 +52,7 @@ class CurrencyBase extends React.Component<CurrencyProps> {
     fetchCurrency();
   }
 
-  private getOptions = (): CurrencyOption[] => {
+  private getSelectOptions = (): CurrencyOption[] => {
     const { currency, intl } = this.props;
 
     const options: CurrencyOption[] = [];
@@ -60,14 +60,14 @@ class CurrencyBase extends React.Component<CurrencyProps> {
     if (currency) {
       currency.data.map(val => {
         options.push({
-          id: val.code,
           toString: () => intl.formatMessage(messages.CurrencyOptions, { units: val.code }),
+          value: val.code,
         });
       });
     } else {
       options.push({
-        id: 'USD',
         toString: () => intl.formatMessage(messages.CurrencyOptions, { units: 'USD' }),
+        value: 'USD',
       });
     }
     return options;
@@ -85,8 +85,8 @@ class CurrencyBase extends React.Component<CurrencyProps> {
     const { isSelectOpen } = this.state;
 
     const currentItem = this.getCurrentItem();
-    const selections = this.getOptions();
-    const selection = selections.find((item: CurrencyOption) => item.id === currentItem);
+    const selectOptions = this.getSelectOptions();
+    const selection = selectOptions.find((item: CurrencyOption) => item.value === currentItem);
 
     return (
       <Select
@@ -99,8 +99,8 @@ class CurrencyBase extends React.Component<CurrencyProps> {
         selections={selection}
         variant={SelectVariant.single}
       >
-        {selections.map(item => (
-          <SelectOption key={item.id} value={item} />
+        {selectOptions.map(item => (
+          <SelectOption key={item.value} value={item} />
         ))}
       </Select>
     );
@@ -108,10 +108,10 @@ class CurrencyBase extends React.Component<CurrencyProps> {
 
   private handleSelect = (event, selection: CurrencyOption) => {
     this.setState({
-      currentItem: selection.id,
+      currentItem: selection.value,
       isSelectOpen: false,
     });
-    setCurrency(selection.id); // Set currency units via local storage
+    setCurrency(selection.value); // Set currency units via local storage
   };
 
   private handleToggle = isSelectOpen => {

--- a/src/components/currency/currency.tsx
+++ b/src/components/currency/currency.tsx
@@ -1,5 +1,6 @@
-import { MessageDescriptor } from '@formatjs/intl/src/types';
-import { Dropdown, DropdownItem, DropdownPosition, DropdownToggle, Title } from '@patternfly/react-core';
+import './currency.scss';
+
+import { Select, SelectOption, SelectOptionObject, SelectVariant, Title } from '@patternfly/react-core';
 import { Currency } from 'api/currency';
 import { AxiosError } from 'axios';
 import messages from 'locales/messages';
@@ -28,12 +29,12 @@ interface CurrencyStateProps {
 
 interface CurrencyState {
   currentItem: string;
-  isCurrencyOpen: boolean;
+  isSelectOpen: boolean;
 }
 
-interface CurrencyOptions {
-  label: MessageDescriptor;
-  value: string;
+interface CurrencyOption extends SelectOptionObject {
+  id?: string;
+  toString(): string;
 }
 
 type CurrencyProps = CurrencyOwnProps & CurrencyDispatchProps & CurrencyStateProps & WrappedComponentProps;
@@ -41,7 +42,7 @@ type CurrencyProps = CurrencyOwnProps & CurrencyDispatchProps & CurrencyStatePro
 class CurrencyBase extends React.Component<CurrencyProps> {
   protected defaultState: CurrencyState = {
     currentItem: 'USD',
-    isCurrencyOpen: false,
+    isSelectOpen: false,
   };
   public state: CurrencyState = { ...this.defaultState };
 
@@ -51,79 +52,70 @@ class CurrencyBase extends React.Component<CurrencyProps> {
     fetchCurrency();
   }
 
-  private getOptions = () => {
-    const { currency } = this.props;
+  private getOptions = (): CurrencyOption[] => {
+    const { currency, intl } = this.props;
 
-    const options: CurrencyOptions[] = [];
+    const options: CurrencyOption[] = [];
 
     if (currency) {
       currency.data.map(val => {
         options.push({
-          label: messages.CurrencyOptions,
-          value: val.code,
+          id: val.code,
+          toString: () => intl.formatMessage(messages.CurrencyOptions, { units: val.code }),
         });
+      });
+    } else {
+      options.push({
+        id: 'USD',
+        toString: () => intl.formatMessage(messages.CurrencyOptions, { units: 'USD' }),
       });
     }
     return options;
   };
 
-  private getDropDownItems = () => {
-    const { intl } = this.props;
-
-    const options = this.getOptions();
-    return options.map(option => (
-      <DropdownItem component="button" key={option.value} onClick={() => this.handleClick(option.value)}>
-        {intl.formatMessage(option.label, { units: option.value })}
-      </DropdownItem>
-    ));
-  };
-
-  private getCurrentLabel = () => {
-    const { intl } = this.props;
+  private getCurrentItem = () => {
     const { currentItem } = this.state;
 
     const currencyUnits = getCurrency(); // Get currency units from local storage
-    const units = currencyUnits ? currencyUnits : currentItem;
-
-    return intl.formatMessage(messages.CurrencyOptions, { units });
+    return currencyUnits ? currencyUnits : currentItem;
   };
 
-  private getDropDown = () => {
+  private getSelect = () => {
     const { isDisabled } = this.props;
-    const { isCurrencyOpen } = this.state;
-    const dropdownItems = this.getDropDownItems();
+    const { isSelectOpen } = this.state;
+
+    const currentItem = this.getCurrentItem();
+    const selections = this.getOptions();
+    const selection = selections.find((item: CurrencyOption) => item.id === currentItem);
 
     return (
-      <Dropdown
-        id="currencyDropdown"
+      <Select
+        className="currencyOverride"
+        id="currencySelect"
+        isDisabled={isDisabled}
+        isOpen={isSelectOpen}
         onSelect={this.handleSelect}
-        position={DropdownPosition.right}
-        toggle={
-          <DropdownToggle isDisabled={isDisabled} onToggle={this.handleToggle}>
-            {this.getCurrentLabel()}
-          </DropdownToggle>
-        }
-        isOpen={isCurrencyOpen}
-        dropdownItems={dropdownItems}
-      />
+        onToggle={this.handleToggle}
+        selections={selection}
+        variant={SelectVariant.single}
+      >
+        {selections.map(item => (
+          <SelectOption key={item.id} value={item} />
+        ))}
+      </Select>
     );
   };
 
-  private handleClick = value => {
-    setCurrency(value); // Set currency units via local storage
-    this.setState({ currentItem: value });
+  private handleSelect = (event, selection: CurrencyOption) => {
+    this.setState({
+      currentItem: selection.id,
+      isSelectOpen: false,
+    });
+    setCurrency(selection.id); // Set currency units via local storage
   };
 
-  private handleSelect = () => {
-    this.setState({
-      isCurrencyOpen: !this.state.isCurrencyOpen,
-    });
-  };
-
-  private handleToggle = isCurrencyOpen => {
-    this.setState({
-      isCurrencyOpen,
-    });
+  private handleToggle = isSelectOpen => {
+    this.setState({ isSelectOpen });
   };
 
   public render() {
@@ -142,7 +134,7 @@ class CurrencyBase extends React.Component<CurrencyProps> {
         <Title headingLevel="h2" size="md" style={styles.currencyLabel}>
           {intl.formatMessage(messages.Currency)}
         </Title>
-        {this.getDropDown()}
+        {this.getSelect()}
       </div>
     );
   }

--- a/src/pages/views/components/dataToolbar/dataToolbar.scss
+++ b/src/pages/views/components/dataToolbar/dataToolbar.scss
@@ -1,6 +1,7 @@
 @import url("~@patternfly/patternfly/base/patternfly-variables.css");
 
 // Workaround for https://github.com/patternfly/patternfly-react/issues/4477
+// and https://github.com/patternfly/patternfly-react/issues/6371
 .selectOverride {
   &.pf-c-select {
     min-width: 250px;

--- a/src/pages/views/components/dataToolbar/dataToolbar.tsx
+++ b/src/pages/views/components/dataToolbar/dataToolbar.tsx
@@ -510,6 +510,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
     }
 
     // Todo: selectOverride is a workaround for https://github.com/patternfly/patternfly-react/issues/4477
+    // and https://github.com/patternfly/patternfly-react/issues/6371
     return (
       <ToolbarFilter
         categoryName={{

--- a/src/pages/views/components/perspective/perspective.styles.ts
+++ b/src/pages/views/components/perspective/perspective.styles.ts
@@ -9,6 +9,7 @@ export const styles = {
   perspectiveLabel: {
     marginBottom: 0,
     marginRight: global_spacer_md.var,
+    whiteSpace: 'nowrap',
   },
   perspectiveOptionLabel: {
     marginBottom: 6,

--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -168,13 +168,13 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
       <Perspective
         currentItem={currentPerspective || options[0].value}
         isDisabled={isDisabled}
-        onItemClicked={this.handlePerspectiveClick}
+        onSelected={this.handlePerspectiveSelected}
         options={options}
       />
     );
   };
 
-  private handlePerspectiveClick = (value: string) => {
+  private handlePerspectiveSelected = (value: string) => {
     const { history, onPerspectiveClicked, query } = this.props;
 
     const newQuery = {

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -350,7 +350,7 @@ class OverviewBase extends React.Component<OverviewProps> {
     return (
       <Perspective
         currentItem={currentItem || options[0].value}
-        onItemClicked={this.handlePerspectiveClick}
+        onSelected={this.handlePerspectiveSelected}
         options={options}
       />
     );
@@ -457,7 +457,7 @@ class OverviewBase extends React.Component<OverviewProps> {
     }
   };
 
-  private handlePerspectiveClick = (value: string) => {
+  private handlePerspectiveSelected = (value: string) => {
     const currentTab = this.getCurrentTab();
     this.setState({
       ...(currentTab === OverviewTab.infrastructure && {


### PR DESCRIPTION
Per the PatternFly guidelines, and after speaking with Natalie, we should be using PatternFly Select components instead of Dropdown for our overview and details pages.

This updates dropdowns for currency, "show cost as", and perspective.

https://issues.redhat.com/browse/COST-1914

![chrome-capture (1)](https://user-images.githubusercontent.com/17481322/135291266-2430d17d-8bb9-4a5e-8961-5f45dad258a5.gif)

