### PR TITLE
Update css-loader

### DIFF
--- a/koku-ui-manifest
+++ b/koku-ui-manifest
@@ -469,7 +469,7 @@ mgmt_services/cost-mgmt:koku-ui/cross-spawn:7.0.3.yarnlock
 mgmt_services/cost-mgmt:koku-ui/cross-spawn:7.0.3.yarnlock
 mgmt_services/cost-mgmt:koku-ui/cross-spawn:7.0.3.yarnlock
 mgmt_services/cost-mgmt:koku-ui/css-in-js-utils:2.0.1.yarnlock
-mgmt_services/cost-mgmt:koku-ui/css-loader:6.2.0.yarnlock
+mgmt_services/cost-mgmt:koku-ui/css-loader:6.3.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/css-select:4.1.3.yarnlock
 mgmt_services/cost-mgmt:koku-ui/css-what:5.0.1.yarnlock
 mgmt_services/cost-mgmt:koku-ui/css-what:5.0.1.yarnlock

--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "aphrodite": "2.4.0",
     "commander": "^8.1.0",
     "copy-webpack-plugin": "7.0.0",
-    "css-loader": "6.2.0",
+    "css-loader": "6.3.0",
     "enzyme": "3.11.0",
     "enzyme-adapter-react-16": "1.15.6",
     "enzyme-to-json": "3.6.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2877,10 +2877,10 @@ css-in-js-utils@^2.0.0:
     hyphenate-style-name "^1.0.2"
     isobject "^3.0.1"
 
-css-loader@6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.2.0.tgz#9663d9443841de957a3cb9bcea2eda65b3377071"
-  integrity sha512-/rvHfYRjIpymZblf49w8jYcRo2y9gj6rV8UroHGmBxKrIyGLokpycyKzp9OkitvqT29ZSpzJ0Ic7SpnJX3sC8g==
+css-loader@6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/css-loader/-/css-loader-6.3.0.tgz#334d3500ff0a0c14cfbd4b0670088dbb5b5c1530"
+  integrity sha512-9NGvHOR+L6ps13Ilw/b216++Q8q+5RpJcVufCdW9S/9iCzs4KBDNa8qnA/n3FK/sSfWmH35PAIK/cfPi7LOSUg==
   dependencies:
     icss-utils "^5.1.0"
     postcss "^8.2.15"


### PR DESCRIPTION
Update postcss per https://bugzilla.redhat.com/show_bug.cgi?id=1984014

The postcss v8.3.8 package is actually a dependency of css-loader, which is only a development dependency required to run the UI locally.

This is not delivered in production, but we can update css-loader from version 6.2.0 to version 6.3.0.

https://issues.redhat.com/browse/COST-1925