### PR TITLE
GroupBy shifts while loading page

### DIFF
--- a/src/pages/views/details/awsDetails/detailsHeader.styles.ts
+++ b/src/pages/views/details/awsDetails/detailsHeader.styles.ts
@@ -32,6 +32,7 @@ export const styles = {
   },
   headerContentLeft: {
     display: 'flex',
+    minHeight: '90px',
   },
   title: {
     paddingBottom: global_spacer_sm.var,

--- a/src/pages/views/details/azureDetails/detailsHeader.styles.ts
+++ b/src/pages/views/details/azureDetails/detailsHeader.styles.ts
@@ -25,6 +25,10 @@ export const styles = {
     display: 'flex',
     justifyContent: 'space-between',
   },
+  headerContentLeft: {
+    display: 'flex',
+    minHeight: '90px',
+  },
   title: {
     paddingBottom: global_spacer_sm.var,
   },

--- a/src/pages/views/details/azureDetails/detailsHeader.tsx
+++ b/src/pages/views/details/azureDetails/detailsHeader.tsx
@@ -71,15 +71,17 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           <Currency />
         </div>
         <div style={styles.headerContent}>
-          <GroupBy
-            getIdKeyForGroupBy={getIdKeyForGroupBy}
-            groupBy={groupBy}
-            isDisabled={!showContent}
-            onSelected={onGroupBySelected}
-            options={groupByOptions}
-            showTags
-            tagReportPathsType={tagReportPathsType}
-          />
+          <div style={styles.headerContentLeft}>
+            <GroupBy
+              getIdKeyForGroupBy={getIdKeyForGroupBy}
+              groupBy={groupBy}
+              isDisabled={!showContent}
+              onSelected={onGroupBySelected}
+              options={groupByOptions}
+              showTags
+              tagReportPathsType={tagReportPathsType}
+            />
+          </div>
           {Boolean(showContent) && (
             <div>
               <Title headingLevel="h2" style={styles.costValue} size={TitleSizes['4xl']}>

--- a/src/pages/views/details/gcpDetails/detailsHeader.styles.ts
+++ b/src/pages/views/details/gcpDetails/detailsHeader.styles.ts
@@ -25,6 +25,10 @@ export const styles = {
     display: 'flex',
     justifyContent: 'space-between',
   },
+  headerContentLeft: {
+    display: 'flex',
+    minHeight: '90px',
+  },
   title: {
     paddingBottom: global_spacer_sm.var,
   },

--- a/src/pages/views/details/gcpDetails/detailsHeader.tsx
+++ b/src/pages/views/details/gcpDetails/detailsHeader.tsx
@@ -72,15 +72,17 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           <Currency />
         </div>
         <div style={styles.headerContent}>
-          <GroupBy
-            getIdKeyForGroupBy={getIdKeyForGroupBy}
-            groupBy={groupBy}
-            isDisabled={!showContent}
-            onSelected={onGroupBySelected}
-            options={groupByOptions}
-            showTags
-            tagReportPathsType={tagReportPathsType}
-          />
+          <div style={styles.headerContentLeft}>
+            <GroupBy
+              getIdKeyForGroupBy={getIdKeyForGroupBy}
+              groupBy={groupBy}
+              isDisabled={!showContent}
+              onSelected={onGroupBySelected}
+              options={groupByOptions}
+              showTags
+              tagReportPathsType={tagReportPathsType}
+            />
+          </div>
           {Boolean(showContent) && (
             <div>
               <Title headingLevel="h2" style={styles.costValue} size={TitleSizes['4xl']}>

--- a/src/pages/views/details/ibmDetails/detailsHeader.styles.ts
+++ b/src/pages/views/details/ibmDetails/detailsHeader.styles.ts
@@ -25,6 +25,10 @@ export const styles = {
     display: 'flex',
     justifyContent: 'space-between',
   },
+  headerContentLeft: {
+    display: 'flex',
+    minHeight: '90px',
+  },
   title: {
     paddingBottom: global_spacer_sm.var,
   },

--- a/src/pages/views/details/ibmDetails/detailsHeader.tsx
+++ b/src/pages/views/details/ibmDetails/detailsHeader.tsx
@@ -72,15 +72,17 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           <Currency />
         </div>
         <div style={styles.headerContent}>
-          <GroupBy
-            getIdKeyForGroupBy={getIdKeyForGroupBy}
-            groupBy={groupBy}
-            isDisabled={!showContent}
-            onSelected={onGroupBySelected}
-            options={groupByOptions}
-            showTags
-            tagReportPathsType={tagReportPathsType}
-          />
+          <div style={styles.headerContentLeft}>
+            <GroupBy
+              getIdKeyForGroupBy={getIdKeyForGroupBy}
+              groupBy={groupBy}
+              isDisabled={!showContent}
+              onSelected={onGroupBySelected}
+              options={groupByOptions}
+              showTags
+              tagReportPathsType={tagReportPathsType}
+            />
+          </div>
           {Boolean(showContent) && (
             <div>
               <Title headingLevel="h2" style={styles.costValue} size={TitleSizes['4xl']}>

--- a/src/pages/views/details/ocpDetails/detailsHeader.styles.ts
+++ b/src/pages/views/details/ocpDetails/detailsHeader.styles.ts
@@ -26,6 +26,10 @@ export const styles = {
     display: 'flex',
     justifyContent: 'space-between',
   },
+  headerContentLeft: {
+    display: 'flex',
+    minHeight: '90px',
+  },
   info: {
     verticalAlign: 'middle',
   },

--- a/src/pages/views/details/ocpDetails/detailsHeader.tsx
+++ b/src/pages/views/details/ocpDetails/detailsHeader.tsx
@@ -96,15 +96,17 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           <Currency />
         </div>
         <div style={styles.headerContent}>
-          <GroupBy
-            getIdKeyForGroupBy={getIdKeyForGroupBy}
-            groupBy={groupBy}
-            isDisabled={!showContent}
-            onSelected={onGroupBySelected}
-            options={groupByOptions}
-            showTags
-            tagReportPathsType={tagReportPathsType}
-          />
+          <div style={styles.headerContentLeft}>
+            <GroupBy
+              getIdKeyForGroupBy={getIdKeyForGroupBy}
+              groupBy={groupBy}
+              isDisabled={!showContent}
+              onSelected={onGroupBySelected}
+              options={groupByOptions}
+              showTags
+              tagReportPathsType={tagReportPathsType}
+            />
+          </div>
           {Boolean(showContent) && (
             <div>
               <Tooltip


### PR DESCRIPTION
The GroupBy shifts slightly while the page is loading, just before the total cost has been updated.

It's not very noticeable, but believe we can make it look a little cleaner.

https://issues.redhat.com/browse/COST-1941

![Screen Shot 2021-10-07 at 12 40 07 PM](https://user-images.githubusercontent.com/17481322/136427728-86dafc54-77eb-4e63-94e2-328c0405467a.png)

