### PR TITLE
OCP managed columns shows 'infrastructure' label instead of 'supplementary'

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -16780,7 +16780,7 @@
     "OCPDetailsSupplementaryCost": [
       {
         "type": 0,
-        "value": "Infrastructure cost"
+        "value": "Supplementary cost"
       }
     ],
     "OCPDetailsSupplementaryCostDesc": [

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -348,7 +348,7 @@
   "OCPDashboardMemoryUsageAndRequests": "OpenShift Memory usage and requests",
   "OCPDetailsInfrastructureCost": "Infrastructure cost",
   "OCPDetailsInfrastructureCostDesc": "The cost based on raw usage data from the underlying infrastructure.",
-  "OCPDetailsSupplementaryCost": "Infrastructure cost",
+  "OCPDetailsSupplementaryCost": "Supplementary cost",
   "OCPDetailsSupplementaryCostDesc": "All costs not directly attributed to the infrastructure. These costs are determined by applying a price list within a cost model to OpenShift cluster metrics.",
   "OCPDetailsTable": "OpenShift details table",
   "OCPDetailsTitle": "OpenShift details",

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -2498,8 +2498,8 @@ export default defineMessages({
     id: 'OCPDetailsInfrastructureCostDesc',
   },
   OCPDetailsSupplementaryCost: {
-    defaultMessage: 'Infrastructure cost',
-    description: 'Infrastructure cost',
+    defaultMessage: 'Supplementary cost',
+    description: 'Supplementary cost',
     id: 'OCPDetailsSupplementaryCost',
   },
   OCPDetailsSupplementaryCostDesc: {

--- a/src/pages/views/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/views/details/ocpDetails/ocpDetails.tsx
@@ -93,7 +93,7 @@ const defaultColumnOptions: ColumnManagementModalOption[] = [
     hidden: true,
   },
   {
-    description: messages.OCPDetailsInfrastructureCostDesc,
+    description: messages.OCPDetailsSupplementaryCostDesc,
     label: messages.OCPDetailsSupplementaryCost,
     value: DetailsTableColumnIds.supplementary,
     hidden: true,


### PR DESCRIPTION
Fixed a bad translation.

OCP data was not available for a very long time in stage-beta, so we couldn't test this properly. Good news is that it's a simple fix.

https://issues.redhat.com/browse/COST-1940

**OCP details page**
<img width="1431" alt="Screen Shot 2021-10-10 at 2 55 09 PM" src="https://user-images.githubusercontent.com/17481322/136709524-d997fcd0-7371-4f93-831b-60206711da78.png">


**Managed columns dialog**
<img width="856" alt="Screen Shot 2021-10-10 at 3 03 12 PM" src="https://user-images.githubusercontent.com/17481322/136709738-215563a7-d35b-4872-857b-9e2d66dd99e3.png">

