### PR TITLE
Enable "All cloud filtered by OpenShift" perspective

### DIFF
--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -134,11 +134,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
     const options = [];
     if (ocp) {
       options.push(...ocpOptions);
-
-      // Todo: Show new features in beta environment only
-      if (insights.chrome.isBeta()) {
-        options.push(...infrastructureOcpCloudOptions);
-      }
+      options.push(...infrastructureOcpCloudOptions);
     }
     if (aws) {
       options.push(...infrastructureAwsOptions);

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -266,10 +266,7 @@ class OverviewBase extends React.Component<OverviewProps> {
 
   private getDefaultInfrastructurePerspective = () => {
     if (this.isOcpAvailable()) {
-      // Todo: Show new features in beta environment only
-      if (insights.chrome.isBeta()) {
-        return InfrastructurePerspective.ocpCloud;
-      }
+      return InfrastructurePerspective.ocpCloud;
     }
     if (this.isAwsAvailable()) {
       return InfrastructurePerspective.aws;
@@ -312,10 +309,7 @@ class OverviewBase extends React.Component<OverviewProps> {
     const options = [];
     if (this.getCurrentTab() === OverviewTab.infrastructure) {
       if (ocp) {
-        // Todo: Show new features in beta environment only
-        if (insights.chrome.isBeta()) {
-          options.push(...infrastructureOcpCloudOptions);
-        }
+        options.push(...infrastructureOcpCloudOptions);
       }
       if (aws) {
         options.push(...infrastructureAwsOptions);


### PR DESCRIPTION
The "All cloud filtered by OpenShift" perspective is only visible in the overview and cost explorer for beta environments.

Now that we have re-summarized data, we would like to make this visible in all environments.

https://issues.redhat.com/browse/COST-1961

**Overview**
<img width="519" alt="Screen Shot 2021-10-14 at 3 28 34 PM" src="https://user-images.githubusercontent.com/17481322/137383047-31b517ac-5373-4629-98e8-6670c8947ba5.png">


**Cost explorer**
<img width="649" alt="Screen Shot 2021-10-14 at 3 28 46 PM" src="https://user-images.githubusercontent.com/17481322/137383076-a0794813-3608-4383-8bf0-213a03262016.png">

