### PR TITLE
Show IBM description in overview popover for beta only

### DIFF
--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -553,9 +553,14 @@ class OverviewBase extends React.Component<OverviewProps> {
                       <br />
                       <p style={styles.infoTitle}>{intl.formatMessage(messages.GCP)}</p>
                       <p>{intl.formatMessage(messages.GCPDesc)}</p>
-                      <br />
-                      <p style={styles.infoTitle}>{intl.formatMessage(messages.IBM)}</p>
-                      <p>{intl.formatMessage(messages.IBMDesc)}</p>
+                      {/* Todo: Show new features in beta environment only */}
+                      {insights.chrome.isBeta() && (
+                        <>
+                          <br />
+                          <p style={styles.infoTitle}>{intl.formatMessage(messages.IBM)}</p>
+                          <p>{intl.formatMessage(messages.IBMDesc)}</p>
+                        </>
+                      )}
                       <br />
                       <p style={styles.infoTitle}>{intl.formatMessage(messages.AWS)}</p>
                       <p>{intl.formatMessage(messages.AWSDesc)}</p>


### PR DESCRIPTION
Show IBM description in overview popover for beta only

https://issues.redhat.com/browse/COST-1952

<img width="916" alt="Screen Shot 2021-10-18 at 9 15 15 AM" src="https://user-images.githubusercontent.com/17481322/137738443-9713f1b5-495a-45d8-861a-c83ab8e0077c.png">

