### PR TITLE
Change AZURE to Azure

### DIFF
--- a/src/api/queries/providersQuery.ts
+++ b/src/api/queries/providersQuery.ts
@@ -2,7 +2,7 @@ import { parse, stringify } from 'qs';
 
 export interface ProvidersQuery {
   page_size?: number;
-  type?: 'AWS' | 'AZURE' | 'GCP' | 'IBM' | 'OCP';
+  type?: 'AWS' | 'Azure' | 'GCP' | 'IBM' | 'OCP';
 }
 
 export function getProvidersQuery(query: ProvidersQuery) {

--- a/src/api/queries/userAccessQuery.ts
+++ b/src/api/queries/userAccessQuery.ts
@@ -2,7 +2,7 @@ import { parse, stringify } from 'qs';
 
 export interface UserAccessQuery {
   page_size?: number;
-  type?: '' | 'AWS' | 'AZURE' | 'cost_model' | 'GCP' | 'IBM' | 'OCP';
+  type?: '' | 'AWS' | 'Azure' | 'cost_model' | 'GCP' | 'IBM' | 'OCP';
   beta?: true;
 }
 

--- a/src/pages/costModels/costModel/addSourceStep.tsx
+++ b/src/pages/costModels/costModel/addSourceStep.tsx
@@ -99,7 +99,7 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
 
     const sourceTypeMap = {
       'OpenShift Container Platform': 'OCP',
-      'Microsoft Azure': 'AZURE',
+      'Microsoft Azure': 'Azure',
       'Amazon Web Services': 'AWS',
     };
 

--- a/src/pages/costModels/costModel/addSourceWizard.tsx
+++ b/src/pages/costModels/costModel/addSourceWizard.tsx
@@ -45,7 +45,7 @@ interface Props extends WrappedComponentProps {
 
 const sourceTypeMap = {
   'OpenShift Container Platform': 'OCP',
-  'Microsoft Azure': 'AZURE',
+  'Microsoft Azure': 'Azure',
   'Amazon Web Services': 'AWS',
 };
 

--- a/src/pages/costModels/createCostModelWizard/generalInformation.tsx
+++ b/src/pages/costModels/createCostModelWizard/generalInformation.tsx
@@ -120,7 +120,7 @@ class GeneralInformation extends React.Component<GeneralInformationProps> {
                       label={intl.formatMessage(messages.CostModelsWizardEmptySourceTypeLabel)}
                     />
                     <FormSelectOption value="AWS" label={intl.formatMessage(messages.CostModelsWizardOnboardAWS)} />
-                    <FormSelectOption value="AZURE" label={intl.formatMessage(messages.Azure)} />
+                    <FormSelectOption value="Azure" label={intl.formatMessage(messages.Azure)} />
                     <FormSelectOption value="GCP" label={intl.formatMessage(messages.GCP)} />
                     <FormSelectOption value="OCP" label={intl.formatMessage(messages.CostModelsWizardOnboardOCP)} />
                   </FormSelect>

--- a/src/pages/costModels/createCostModelWizard/index.tsx
+++ b/src/pages/costModels/createCostModelWizard/index.tsx
@@ -227,7 +227,7 @@ class CostModelWizardBase extends React.Component<Props, State> {
           component: <GeneralInformation />,
         },
       ],
-      AZURE: [
+      Azure: [
         {
           id: 1,
           name: intl.formatMessage(messages.CostModelsWizardStepsGenInfo),

--- a/src/pages/costModels/createCostModelWizard/sources.tsx
+++ b/src/pages/costModels/createCostModelWizard/sources.tsx
@@ -11,7 +11,7 @@ class Sources extends React.Component {
     super(props);
     this.fetchData = () => {
       const { type, query, page, perPage, fetchSources } = this.context;
-      const sourceType = type === 'AZURE' ? 'Azure' : type;
+      const sourceType = type === 'Azure' ? 'Azure' : type;
       fetchSources(sourceType, query, page, perPage);
     };
   }

--- a/src/pages/costModels/createCostModelWizard/steps.tsx
+++ b/src/pages/costModels/createCostModelWizard/steps.tsx
@@ -42,7 +42,7 @@ export const validatorsHash = {
     () => true,
     () => true,
   ],
-  AZURE: [
+  Azure: [
     ctx => nameErrors(ctx.name) === null && descriptionErrors(ctx.description) === null && ctx.type !== '',
     ctx => isMarkupValid(ctx.markup),
     () => true,

--- a/src/pages/costModels/createCostModelWizard/table.tsx
+++ b/src/pages/costModels/createCostModelWizard/table.tsx
@@ -15,7 +15,7 @@ const SourcesTable: React.SFC<WrappedComponentProps> = ({ intl }) => {
   return (
     <CostModelContext.Consumer>
       {({ loading, onSourceSelect, sources, perPage, page, type, query, fetchSources, filterName, onFilterChange }) => {
-        const sourceType = type === 'AZURE' ? 'Azure' : type;
+        const sourceType = type === 'Azure' ? 'Azure' : type;
         return (
           <Stack hasGutter>
             <StackItem>

--- a/src/store/providers/providersCommon.ts
+++ b/src/store/providers/providersCommon.ts
@@ -9,7 +9,7 @@ export const awsProvidersQuery: ProvidersQuery = {
 };
 
 export const azureProvidersQuery: ProvidersQuery = {
-  type: 'AZURE',
+  type: 'Azure',
 };
 
 export const gcpProvidersQuery: ProvidersQuery = {

--- a/src/store/userAccess/userAccessCommon.ts
+++ b/src/store/userAccess/userAccessCommon.ts
@@ -13,7 +13,7 @@ export const awsUserAccessQuery: UserAccessQuery = {
 };
 
 export const azureUserAccessQuery: UserAccessQuery = {
-  type: 'AZURE',
+  type: 'Azure',
 };
 
 export const costModelUserAccessQuery: UserAccessQuery = {


### PR DESCRIPTION
Change references of AZURE to Azure, matching the backend. For example, we should call the sources API with type=Azure.

"It was AZURE when Azure was first added as a source, but it's a word, not an acronym so someone/we switched it all to Azure in the back end." – Andrew

https://issues.redhat.com/browse/COST-1987