### PR TITLE
Fix API requests for CSV files

### DIFF
--- a/src/pages/views/components/export/exportSubmit.tsx
+++ b/src/pages/views/components/export/exportSubmit.tsx
@@ -150,13 +150,14 @@ const mapStateToProps = createMapStateToProps<ExportSubmitOwnProps, ExportSubmit
         limit: undefined,
         offset: undefined,
         resolution: resolution ? resolution : undefined,
-        time_scope_value: timeScope === 'previous' ? -2 : -1,
+        ...(!query.dateRange && { time_scope_value: timeScope === 'previous' ? -2 : -1 }),
       },
       filter_by: {},
       limit: 0,
       order_by: undefined,
       perspective: undefined,
       dateRange: undefined,
+      delta: undefined,
     };
 
     // Store filter_by as an array so we can add to it below


### PR DESCRIPTION
The API requests for CSV files are currently broken. Not certain when the APIs changed, but query params such as `delta` and `time_scope_value` are now generating 500 errors.

https://issues.redhat.com/browse/COST-2000