### PR TITLE
Simplify API requests for AWS cost savings plan

### DIFF
--- a/src/api/reports/awsReports.ts
+++ b/src/api/reports/awsReports.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { Omit } from 'react-redux';
+import { getCostType } from 'utils/localStorage';
 
 import { Report, ReportData, ReportItem, ReportItemValue, ReportMeta, ReportType, ReportValue } from './report';
 
@@ -59,5 +60,15 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
+
+  // Todo: Show new features in beta environment only
+  if (insights.chrome.isBeta()) {
+    switch (reportType) {
+      case ReportType.cost:
+      case ReportType.database:
+      case ReportType.network:
+        return axios.get<AwsReport>(`${path}?cost_type=${getCostType()}&${query}`);
+    }
+  }
   return axios.get<AwsReport>(`${path}?${query}`);
 }

--- a/src/pages/views/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/pages/views/details/awsBreakdown/awsBreakdown.tsx
@@ -50,10 +50,7 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
   const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
   const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
 
-  const cost_type = getCostType();
   const newQuery: Query = {
-    // Todo: Show new features in beta environment only
-    ...(insights.chrome.isBeta() && { cost_type }),
     filter: {
       resolution: 'monthly',
       time_scope_units: 'month',
@@ -83,6 +80,7 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
     providersQueryString
   );
 
+  const cost_type = getCostType();
   return {
     costOverviewComponent: <CostOverview costType={cost_type} groupBy={groupBy} query={query} report={report} />,
     description: query[breakdownDescKey],

--- a/src/pages/views/details/awsDetails/awsDetails.tsx
+++ b/src/pages/views/details/awsDetails/awsDetails.tsx
@@ -25,7 +25,6 @@ import { reportActions, reportSelectors } from 'store/reports';
 import { uiActions } from 'store/ui';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedAwsReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
-import { getCostType } from 'utils/localStorage';
 
 import { styles } from './awsDetails.styles';
 import { DetailsHeader } from './detailsHeader';
@@ -451,8 +450,6 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 const mapStateToProps = createMapStateToProps<AwsDetailsOwnProps, AwsDetailsStateProps>((state, props) => {
   const queryFromRoute = parseQuery<AwsQuery>(location.search);
   const query = {
-    // Todo: Show new features in beta environment only
-    ...(insights.chrome.isBeta() && { cost_type: getCostType() }),
     delta: 'cost',
     filter: {
       ...baseQuery.filter,

--- a/src/pages/views/details/components/historicalData/historicalDataCostChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataCostChart.tsx
@@ -11,7 +11,6 @@ import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
 import { formatUnits } from 'utils/format';
-import { getCostType } from 'utils/localStorage';
 import { skeletonWidth } from 'utils/skeleton';
 
 import { chartStyles, styles } from './historicalChart.styles';
@@ -124,8 +123,6 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
     const groupByValue = getGroupByValue(query);
 
     const baseQuery: Query = {
-      // Todo: Show new features in beta environment only
-      ...(insights.chrome.isBeta() && reportPathsType === ReportPathsType.aws && { cost_type: getCostType() }),
       filter_by: {
         // Add filters here to apply logical OR/AND
         ...(query && query.filter_by && query.filter_by),

--- a/src/pages/views/details/components/historicalData/historicalDataTrendChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataTrendChart.tsx
@@ -11,7 +11,6 @@ import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
 import { formatUnits, unitsLookupKey } from 'utils/format';
-import { getCostType } from 'utils/localStorage';
 import { skeletonWidth } from 'utils/skeleton';
 
 import { chartStyles, styles } from './historicalChart.styles';
@@ -144,8 +143,6 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
     const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
 
     const baseQuery: Query = {
-      // Todo: Show new features in beta environment only
-      ...(insights.chrome.isBeta() && reportPathsType === ReportPathsType.aws && { cost_type: getCostType() }),
       filter_by: {
         // Add filters here to apply logical OR/AND
         ...(query && query.filter_by && query.filter_by),

--- a/src/pages/views/details/components/summary/summaryCard.tsx
+++ b/src/pages/views/details/components/summary/summaryCard.tsx
@@ -24,7 +24,6 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getTestProps, testIds } from 'testIds';
 import { getComputedReportItems } from 'utils/computedReport/getComputedReportItems';
-import { getCostType } from 'utils/localStorage';
 import { skeletonWidth } from 'utils/skeleton';
 
 import { styles } from './summaryCard.styles';
@@ -189,8 +188,6 @@ const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps
     const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
 
     const newQuery: Query = {
-      // Todo: Show new features in beta environment only
-      ...(insights.chrome.isBeta() && reportPathsType === ReportPathsType.aws && { cost_type: getCostType() }),
       filter: {
         limit: 3,
         resolution: 'monthly',

--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -34,7 +34,6 @@ import { uiActions } from 'store/ui';
 import { allUserAccessQuery, ibmUserAccessQuery, userAccessSelectors } from 'store/userAccess';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
-import { getCostType } from 'utils/localStorage';
 import { isAwsAvailable, isAzureAvailable, isGcpAvailable, isIbmAvailable, isOcpAvailable } from 'utils/userAccess';
 
 import { styles } from './explorer.styles';
@@ -610,8 +609,6 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
   }
 
   const query = {
-    // Todo: Show new features in beta environment only
-    ...(insights.chrome.isBeta() && perspective === PerspectiveType.aws && { cost_type: getCostType() }),
     filter: {
       ...baseQuery.filter,
       ...queryFromRoute.filter,

--- a/src/pages/views/explorer/explorerChart.tsx
+++ b/src/pages/views/explorer/explorerChart.tsx
@@ -22,7 +22,6 @@ import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { formatUnits } from 'utils/format';
-import { getCostType } from 'utils/localStorage';
 import { skeletonWidth } from 'utils/skeleton';
 
 import { chartStyles, styles } from './explorerChart.styles';
@@ -264,8 +263,6 @@ const mapStateToProps = createMapStateToProps<ExplorerChartOwnProps, ExplorerCha
     }
 
     const query = {
-      // Todo: Show new features in beta environment only
-      ...(insights.chrome.isBeta() && perspective === PerspectiveType.aws && { cost_type: getCostType() }),
       filter: {
         ...baseQuery.filter,
         ...queryFromRoute.filter,

--- a/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
@@ -1,6 +1,4 @@
-import { ReportType } from 'api/reports/report';
 import { RootState } from 'store/rootReducer';
-import { getCostType } from 'utils/localStorage';
 
 import {
   awsDashboardDefaultFilters,
@@ -21,14 +19,6 @@ export const selectCurrentWidgets = (state: RootState) => selectAwsDashboardStat
 export const selectWidgetQueries = (state: RootState, id: number) => {
   const widget = selectWidget(state, id);
 
-  const isCostType =
-    widget.reportType === ReportType.cost ||
-    widget.reportType === ReportType.database ||
-    widget.reportType === ReportType.network;
-
-  // Todo: Show new features in beta environment only
-  const cost_type = insights.chrome.isBeta() && isCostType ? { cost_type: getCostType() } : undefined;
-
   const filter = {
     ...awsDashboardDefaultFilters,
     ...(widget.filter ? widget.filter : {}),
@@ -39,22 +29,15 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
   };
 
   return {
-    previous: getQueryForWidget(
-      {
-        ...filter,
-        time_scope_value: -2,
-      },
-      cost_type
-    ),
-    current: getQueryForWidget(filter, cost_type),
+    previous: getQueryForWidget({
+      ...filter,
+      time_scope_value: -2,
+    }),
+    current: getQueryForWidget(filter),
     forecast: getQueryForWidget({}, { limit: 31 }),
-    tabs: getQueryForWidgetTabs(
-      widget,
-      {
-        ...tabsFilter,
-        resolution: 'monthly',
-      },
-      cost_type
-    ),
+    tabs: getQueryForWidgetTabs(widget, {
+      ...tabsFilter,
+      resolution: 'monthly',
+    }),
   };
 };

--- a/src/store/reports/reportCommon.ts
+++ b/src/store/reports/reportCommon.ts
@@ -1,7 +1,17 @@
 import { ReportPathsType, ReportType } from 'api/reports/report';
+import { getCostType } from 'utils/localStorage';
 
 export const reportStateKey = 'report';
 
 export function getReportId(reportPathsType: ReportPathsType, reportType: ReportType, query: string) {
+  // Todo: Show new features in beta environment only
+  if (insights.chrome.isBeta()) {
+    switch (reportType) {
+      case ReportType.cost:
+      case ReportType.database:
+      case ReportType.network:
+        return `${reportPathsType}--${reportType}--${getCostType()}--${query}`;
+    }
+  }
   return `${reportPathsType}--${reportType}--${query}`;
 }


### PR DESCRIPTION
We can simplify by adding the `cost_type` param in two places. Just needed to account for the report ID used to cache requests.

https://issues.redhat.com/browse/COST-1905