### PR TITLE
Omit in-progress features from prod-beta

### DIFF
--- a/src/api/reports/awsReports.ts
+++ b/src/api/reports/awsReports.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import { Omit } from 'react-redux';
+import { isBetaFeature } from 'utils/feature';
 import { getCostType } from 'utils/localStorage';
 
 import { Report, ReportData, ReportItem, ReportItemValue, ReportMeta, ReportType, ReportValue } from './report';
@@ -61,8 +62,8 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
 
-  // Todo: Show new features in beta environment only
-  if (insights.chrome.isBeta()) {
+  // Todo: Show in-progress features in beta environment only
+  if (isBetaFeature()) {
     switch (reportType) {
       case ReportType.cost:
       case ReportType.database:

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -5,6 +5,7 @@ interface Chrome {
   init: () => void;
   identifyApp: (appId: string) => void;
   isBeta: () => boolean;
+  isProd: boolean;
   navigation: (navFunc: any) => void;
   on: (event: string, eventFunc: any) => () => void;
   appAction: (pageName: string) => void;

--- a/src/pages/costModels/createCostModelWizard/generalInformation.tsx
+++ b/src/pages/costModels/createCostModelWizard/generalInformation.tsx
@@ -18,6 +18,7 @@ import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { currencyActions, currencySelectors } from 'store/currency';
+import { isBetaFeature } from 'utils/feature';
 
 import { CostModelContext } from './context';
 import { descriptionErrors, nameErrors } from './steps';
@@ -126,8 +127,8 @@ class GeneralInformation extends React.Component<GeneralInformationProps> {
                   </FormSelect>
                 </FormGroup>
                 {
-                  /* Todo: Show new features in beta environment only */
-                  insights.chrome.isBeta() && (
+                  /* Todo: Show in-progress features in beta environment only */
+                  isBetaFeature() && (
                     <FormGroup label={intl.formatMessage(messages.Currency)} fieldId="currency-units">
                       <FormSelect id="currency-units" value={currencyUnits} onChange={onCurrencyChange}>
                         {currency &&

--- a/src/pages/views/details/awsDetails/detailsHeader.tsx
+++ b/src/pages/views/details/awsDetails/detailsHeader.tsx
@@ -17,6 +17,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { awsProvidersQuery, providersSelectors } from 'store/providers';
 import { ComputedAwsReportItemsParams, getIdKeyForGroupBy } from 'utils/computedReport/getComputedAwsReportItems';
 import { getSinceDateRangeString } from 'utils/dateRange';
+import { isBetaFeature } from 'utils/feature';
 import { formatCurrency } from 'utils/format';
 
 import { styles } from './detailsHeader.styles';
@@ -80,8 +81,8 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
             {intl.formatMessage(messages.AWSDetailsTitle)}
           </Title>
-          {/* Todo: Show new features in beta environment only */}
-          {insights.chrome.isBeta() && <Currency />}
+          {/* Todo: Show in-progress features in beta environment only */}
+          {isBetaFeature() && <Currency />}
         </div>
         <div style={styles.headerContent}>
           <div style={styles.headerContentLeft}>
@@ -96,8 +97,8 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
               showTags
               tagReportPathsType={tagReportPathsType}
             />
-            {/* Todo: Show new features in beta environment only */}
-            {insights.chrome.isBeta() && (
+            {/* Todo: Show in-progress features in beta environment only */}
+            {isBetaFeature() && (
               <div style={styles.costType}>
                 <CostType onSelect={this.handleCostTypeSelected} />
               </div>

--- a/src/pages/views/details/azureDetails/detailsHeader.tsx
+++ b/src/pages/views/details/azureDetails/detailsHeader.tsx
@@ -15,6 +15,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { azureProvidersQuery, providersSelectors } from 'store/providers';
 import { ComputedAzureReportItemsParams, getIdKeyForGroupBy } from 'utils/computedReport/getComputedAzureReportItems';
 import { getSinceDateRangeString } from 'utils/dateRange';
+import { isBetaFeature } from 'utils/feature';
 import { formatCurrency } from 'utils/format';
 
 import { styles } from './detailsHeader.styles';
@@ -68,8 +69,8 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
             {intl.formatMessage(messages.AzureDetailsTitle)}
           </Title>
-          {/* Todo: Show new features in beta environment only */}
-          {insights.chrome.isBeta() && <Currency />}
+          {/* Todo: Show in-progress features in beta environment only */}
+          {isBetaFeature() && <Currency />}
         </div>
         <div style={styles.headerContent}>
           <div style={styles.headerContentLeft}>

--- a/src/pages/views/details/components/breakdown/breakdownHeader.tsx
+++ b/src/pages/views/details/components/breakdown/breakdownHeader.tsx
@@ -14,6 +14,7 @@ import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { Link } from 'react-router-dom';
 import { getForDateRangeString } from 'utils/dateRange';
+import { isBetaFeature } from 'utils/feature';
 import { formatCurrency } from 'utils/format';
 
 import { styles } from './breakdownHeader.styles';
@@ -112,15 +113,15 @@ class BreakdownHeaderBase extends React.Component<BreakdownHeaderProps> {
               </li>
             </ol>
           </nav>
-          {/* Todo: Show new features in beta environment only */}
-          {insights.chrome.isBeta() && <Currency />}
+          {/* Todo: Show in-progress features in beta environment only */}
+          {isBetaFeature() && <Currency />}
         </div>
         <div style={styles.headerContent}>
           <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
             {intl.formatMessage(messages.BreakdownTitle, { value: title })}
             {description && <div style={styles.infoDescription}>{description}</div>}
-            {/* Todo: Show new features in beta environment only */}
-            {insights.chrome.isBeta() && showCostType && (
+            {/* Todo: Show in-progress features in beta environment only */}
+            {isBetaFeature() && showCostType && (
               <div style={styles.costType}>
                 <CostType onSelect={this.handleCostTypeSelected} />
               </div>

--- a/src/pages/views/details/gcpDetails/detailsHeader.tsx
+++ b/src/pages/views/details/gcpDetails/detailsHeader.tsx
@@ -15,6 +15,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { gcpProvidersQuery, providersSelectors } from 'store/providers';
 import { ComputedGcpReportItemsParams, getIdKeyForGroupBy } from 'utils/computedReport/getComputedGcpReportItems';
 import { getSinceDateRangeString } from 'utils/dateRange';
+import { isBetaFeature } from 'utils/feature';
 import { formatCurrency } from 'utils/format';
 
 import { styles } from './detailsHeader.styles';
@@ -69,8 +70,8 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
             {intl.formatMessage(messages.GCPDetailsTitle)}
           </Title>
-          {/* Todo: Show new features in beta environment only */}
-          {insights.chrome.isBeta() && <Currency />}
+          {/* Todo: Show in-progress features in beta environment only */}
+          {isBetaFeature() && <Currency />}
         </div>
         <div style={styles.headerContent}>
           <div style={styles.headerContentLeft}>

--- a/src/pages/views/details/ibmDetails/detailsHeader.tsx
+++ b/src/pages/views/details/ibmDetails/detailsHeader.tsx
@@ -15,6 +15,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { ibmProvidersQuery, providersSelectors } from 'store/providers';
 import { ComputedIbmReportItemsParams, getIdKeyForGroupBy } from 'utils/computedReport/getComputedIbmReportItems';
 import { getSinceDateRangeString } from 'utils/dateRange';
+import { isBetaFeature } from 'utils/feature';
 import { formatCurrency } from 'utils/format';
 
 import { styles } from './detailsHeader.styles';
@@ -69,8 +70,8 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
             {intl.formatMessage(messages.IBMDetailsTitle)}
           </Title>
-          {/* Todo: Show new features in beta environment only */}
-          {insights.chrome.isBeta() && <Currency />}
+          {/* Todo: Show in-progress features in beta environment only */}
+          {isBetaFeature() && <Currency />}
         </div>
         <div style={styles.headerContent}>
           <div style={styles.headerContentLeft}>

--- a/src/pages/views/details/ocpDetails/detailsHeader.tsx
+++ b/src/pages/views/details/ocpDetails/detailsHeader.tsx
@@ -16,6 +16,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { ocpProvidersQuery, providersSelectors } from 'store/providers';
 import { ComputedOcpReportItemsParams, getIdKeyForGroupBy } from 'utils/computedReport/getComputedOcpReportItems';
 import { getSinceDateRangeString } from 'utils/dateRange';
+import { isBetaFeature } from 'utils/feature';
 import { formatCurrency } from 'utils/format';
 
 import { styles } from './detailsHeader.styles';
@@ -93,8 +94,8 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
             {intl.formatMessage(messages.OCPDetailsTitle)}
           </Title>
-          {/* Todo: Show new features in beta environment only */}
-          {insights.chrome.isBeta() && <Currency />}
+          {/* Todo: Show in-progress features in beta environment only */}
+          {isBetaFeature() && <Currency />}
         </div>
         <div style={styles.headerContent}>
           <div style={styles.headerContentLeft}>

--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -27,6 +27,7 @@ import {
 import { allUserAccessQuery, ibmUserAccessQuery, userAccessSelectors } from 'store/userAccess';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
 import { getLast60DaysDate } from 'utils/dateRange';
+import { isBetaFeature } from 'utils/feature';
 import { isAwsAvailable, isAzureAvailable, isGcpAvailable, isIbmAvailable, isOcpAvailable } from 'utils/userAccess';
 
 import { ExplorerFilter } from './explorerFilter';
@@ -279,8 +280,8 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
           <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
             {intl.formatMessage(messages.ExplorerTitle)}
           </Title>
-          {/* Todo: Show new features in beta environment only */}
-          {insights.chrome.isBeta() && <Currency />}
+          {/* Todo: Show in-progress features in beta environment only */}
+          {isBetaFeature() && <Currency />}
         </div>
         <div style={styles.perspectiveContainer}>
           {this.getPerspective(noProviders)}
@@ -300,8 +301,8 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
               tagReportPathsType={tagReportPathsType}
             />
           </div>
-          {/* Todo: Show new features in beta environment only */}
-          {insights.chrome.isBeta() && perspective === PerspectiveType.aws && (
+          {/* Todo: Show in-progress features in beta environment only */}
+          {isBetaFeature() && perspective === PerspectiveType.aws && (
             <div style={styles.costType}>
               <CostType onSelect={this.handleCostTypeSelected} />
             </div>

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -16,8 +16,8 @@ import { ComputedGcpReportItemsParams } from 'utils/computedReport/getComputedGc
 import { ComputedIbmReportItemsParams } from 'utils/computedReport/getComputedIbmReportItems';
 import { ComputedOcpReportItemsParams } from 'utils/computedReport/getComputedOcpReportItems';
 import { getCurrentMonthDate, getLast30DaysDate, getLast60DaysDate, getLast90DaysDate } from 'utils/dateRange';
+import { isBetaFeature } from 'utils/feature';
 import { isAwsAvailable, isAzureAvailable, isGcpAvailable, isIbmAvailable, isOcpAvailable } from 'utils/userAccess';
-
 // The date range drop down has the options below (if today is Jan 18th…)
 // eslint-disable-next-line no-shadow
 export const enum DateRangeType {
@@ -62,8 +62,8 @@ export const dateRangeOptions: {
   { label: messages.ExplorerDateRange, value: 'last_sixty_days' },
 ];
 
-// Todo: Show new features in beta environment only
-if (insights.chrome.isBeta()) {
+// Todo: Show in-progress features in beta environment only
+if (isBetaFeature()) {
   dateRangeOptions.push({ label: messages.ExplorerDateRange, value: 'last_ninety_days' });
 }
 

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -58,6 +58,7 @@ import {
 import { uiActions } from 'store/ui';
 import { allUserAccessQuery, ibmUserAccessQuery, userAccessSelectors } from 'store/userAccess';
 import { getSinceDateRangeString } from 'utils/dateRange';
+import { isBetaFeature } from 'utils/feature';
 import { isAwsAvailable, isAzureAvailable, isGcpAvailable, isIbmAvailable, isOcpAvailable } from 'utils/userAccess';
 
 import { styles } from './overview.styles';
@@ -636,8 +637,8 @@ class OverviewBase extends React.Component<OverviewProps> {
                       <br />
                       <p style={styles.infoTitle}>{intl.formatMessage(messages.GCP)}</p>
                       <p>{intl.formatMessage(messages.GCPDesc)}</p>
-                      {/* Todo: Show new features in beta environment only */}
-                      {insights.chrome.isBeta() && (
+                      {/* Todo: Show in-progress features in beta environment only */}
+                      {isBetaFeature() && (
                         <>
                           <br />
                           <p style={styles.infoTitle}>{intl.formatMessage(messages.IBM)}</p>
@@ -659,15 +660,15 @@ class OverviewBase extends React.Component<OverviewProps> {
                 </Popover>
               </span>
             </Title>
-            {/* Todo: Show new features in beta environment only */}
-            {insights.chrome.isBeta() && <Currency />}
+            {/* Todo: Show in-progress features in beta environment only */}
+            {isBetaFeature() && <Currency />}
           </div>
           <div style={styles.tabs}>{this.getTabs(availableTabs)}</div>
           <div style={styles.headerContent}>
             <div style={styles.headerContentLeft}>
               {this.getPerspective()}
-              {/* Todo: Show new features in beta environment only */}
-              {insights.chrome.isBeta() && this.getCostType()}
+              {/* Todo: Show in-progress features in beta environment only */}
+              {isBetaFeature() && this.getCostType()}
             </div>
             <div style={styles.date}>{getSinceDateRangeString()}</div>
           </div>

--- a/src/store/reports/reportCommon.ts
+++ b/src/store/reports/reportCommon.ts
@@ -1,11 +1,11 @@
 import { ReportPathsType, ReportType } from 'api/reports/report';
+import { isBetaFeature } from 'utils/feature';
 import { getCostType } from 'utils/localStorage';
-
 export const reportStateKey = 'report';
 
 export function getReportId(reportPathsType: ReportPathsType, reportType: ReportType, query: string) {
-  // Todo: Show new features in beta environment only
-  if (insights.chrome.isBeta()) {
+  // Todo: Show in-progress features in beta environment only
+  if (isBetaFeature()) {
     switch (reportType) {
       case ReportType.cost:
       case ReportType.database:

--- a/src/utils/feature.ts
+++ b/src/utils/feature.ts
@@ -1,0 +1,5 @@
+// Show in-progress features in beta environment only
+export const isBetaFeature = () => {
+  const insights = (window as any).insights;
+  return insights && insights.chrome.isBeta() && !insights.chrome.isProd;
+};


### PR DESCRIPTION
The platform now has an isProd flag. We can use the isProd and isBeta flag to keep new features out of prod and prod-beta. This means, users will only see our "in progress" features in stage-beta.

https://issues.redhat.com/browse/COST-2028