### PR TITLE
Lazy generate API requests for tags

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -348,7 +348,15 @@
             "value": [
               {
                 "type": 0,
-                "value": "Cost by tags"
+                "value": "Back to "
+              },
+              {
+                "type": 1,
+                "value": "value"
+              },
+              {
+                "type": 0,
+                "value": " tag details"
               }
             ]
           }

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -18,7 +18,7 @@
   "AzureDetailsTitle": "Microsoft Azure details",
   "AzureOcpDashboardCostTitle": "Microsoft Azure filtered by OpenShift cost",
   "Back": "Back",
-  "BreakdownBackToDetails": "{groupBy, select, account {Back to {value} account details} cluster {Back to {value} cluster details} gcp_project {Back to {value} GCP project details} instance_type {Back to {value} instance type details} node {Back to {value} node details} org_unit_id {Back to {value} organizational unit details} project {Back to {value} project details} region {Back to {value} region details} resource_location {Back to {value} region details} service {Back to {value} service details} service_name {Back to {value} service details} subscription_guid {Back to {value} account details} tag {Cost by tags} other {}}",
+  "BreakdownBackToDetails": "{groupBy, select, account {Back to {value} account details} cluster {Back to {value} cluster details} gcp_project {Back to {value} GCP project details} instance_type {Back to {value} instance type details} node {Back to {value} node details} org_unit_id {Back to {value} organizational unit details} project {Back to {value} project details} region {Back to {value} region details} resource_location {Back to {value} region details} service {Back to {value} service details} service_name {Back to {value} service details} subscription_guid {Back to {value} account details} tag {Back to {value} tag details} other {}}",
   "BreakdownBackToDetailsAriaLabel": "Back to details",
   "BreakdownCostBreakdownAriaLabel": "A description of markup, raw cost and usage cost",
   "BreakdownCostBreakdownTitle": "Cost breakdown",

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -112,7 +112,7 @@ export default defineMessages({
       'service {Back to {value} service details} ' +
       'service_name {Back to {value} service details} ' +
       'subscription_guid {Back to {value} account details} ' +
-      'tag {Cost by tags} ' +
+      'tag {Back to {value} tag details} ' +
       'other {}}',
     description: 'Back to {value} {groupBy} details',
     id: 'BreakdownBackToDetails',
@@ -121,6 +121,18 @@ export default defineMessages({
     defaultMessage: 'Back to details',
     description: 'Back to details',
     id: 'BreakdownBackToDetailsAriaLabel',
+  },
+  BreakdownBackToTitles: {
+    defaultMessage:
+      '{value, select, ' +
+      'aws {Amazon Web Services} ' +
+      'azure {Microsoft Azure} ' +
+      'gcp {Google Cloud Platform} ' +
+      'ibm {IBM Cloud - Top 5 Costliest} ' +
+      'ocp {OpenShift} ' +
+      'other {}}',
+    description: 'Breakdown back to page titles',
+    id: 'BreakdownBackToTitles',
   },
   BreakdownCostBreakdownAriaLabel: {
     defaultMessage: 'A description of markup, raw cost and usage cost',

--- a/src/pages/views/components/dataToolbar/tagValue.tsx
+++ b/src/pages/views/components/dataToolbar/tagValue.tsx
@@ -65,15 +65,20 @@ class TagValueBase extends React.Component<TagValueProps> {
   public state: TagValueState = { ...this.defaultState };
 
   public componentDidMount() {
-    const { fetchTag, tagQueryString, tagReportPathsType } = this.props;
+    const { fetchTag, tagQueryString, tagReportFetchStatus, tagReportPathsType } = this.props;
 
-    fetchTag(tagReportPathsType, tagReportType, tagQueryString);
+    if (tagReportFetchStatus !== FetchStatus.inProgress) {
+      fetchTag(tagReportPathsType, tagReportType, tagQueryString);
+    }
   }
 
   public componentDidUpdate(prevProps: TagValueProps) {
-    const { fetchTag, tagQueryString, tagReportPathsType } = this.props;
+    const { fetchTag, tagQueryString, tagReportFetchStatus, tagReportPathsType } = this.props;
 
-    if (prevProps.tagQueryString !== tagQueryString || prevProps.tagReportPathsType !== tagReportPathsType) {
+    if (
+      (prevProps.tagQueryString !== tagQueryString || prevProps.tagReportPathsType !== tagReportPathsType) &&
+      tagReportFetchStatus !== FetchStatus.inProgress
+    ) {
       fetchTag(tagReportPathsType, tagReportType, tagQueryString);
     }
   }

--- a/src/pages/views/components/dataToolbar/tagValue.tsx
+++ b/src/pages/views/components/dataToolbar/tagValue.tsx
@@ -1,0 +1,167 @@
+import { SelectOption, ToolbarChipGroup } from '@patternfly/react-core';
+import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
+import { Tag, TagPathsType, TagType } from 'api/tags/tag';
+import { PerspectiveType } from 'pages/views/explorer/explorerUtils';
+import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'pages/views/utils/groupBy';
+import React from 'react';
+import { injectIntl, WrappedComponentProps } from 'react-intl';
+import { connect } from 'react-redux';
+import { createMapStateToProps, FetchStatus } from 'store/common';
+import { tagActions, tagSelectors } from 'store/tags';
+
+interface TagValueOwnProps extends WrappedComponentProps {
+  endDate?: string;
+  isDisabled?: boolean;
+  onSelected(value: string);
+  perspective?: PerspectiveType;
+  startDate?: string;
+  tagKey: string;
+  tagQueryString?: string;
+  tagReportPathsType: TagPathsType;
+}
+
+interface TagValueStateProps {
+  groupBy: string;
+  groupByValue: string | number;
+  tagReport?: Tag;
+  tagReportFetchStatus?: FetchStatus;
+}
+
+interface TagValueDispatchProps {
+  fetchTag?: typeof tagActions.fetchTag;
+}
+
+interface TagValueState {
+  // TBD...
+}
+
+type TagValueProps = TagValueOwnProps & TagValueStateProps & TagValueDispatchProps;
+
+const tagReportType = TagType.tag;
+
+class TagValueBase extends React.Component<TagValueProps> {
+  protected defaultState: TagValueState = {
+    // TBD...
+  };
+  public state: TagValueState = { ...this.defaultState };
+
+  public componentDidMount() {
+    const { fetchTag, tagQueryString, tagReportPathsType } = this.props;
+
+    fetchTag(tagReportPathsType, tagReportType, tagQueryString);
+  }
+
+  public componentDidUpdate(prevProps: TagValueProps) {
+    const { fetchTag, groupBy, perspective, tagQueryString, tagReportPathsType } = this.props;
+
+    if (prevProps.groupBy !== groupBy || prevProps.perspective !== perspective) {
+      fetchTag(tagReportPathsType, tagReportType, tagQueryString);
+    }
+  }
+
+  private getTagValueOptions(): ToolbarChipGroup[] {
+    const { tagKey, tagReport } = this.props;
+
+    let data = [];
+    if (tagReport && tagReport.data) {
+      data = [...new Set([...tagReport.data])]; // prune duplicates
+    }
+
+    let options = [];
+    if (data.length > 0) {
+      for (const tag of data) {
+        if (tagKey === tag.key && tag.values) {
+          options = tag.values.map(val => {
+            return {
+              key: val,
+              name: val, // tag key values not localized
+            };
+          });
+          break;
+        }
+      }
+    }
+    return options;
+  }
+
+  public render() {
+    const selectOptions = this.getTagValueOptions().map(selectOption => {
+      return <SelectOption key={selectOption.key} value={selectOption.key} />;
+    });
+
+    if (selectOptions) {
+      return null;
+    }
+    return null;
+  }
+}
+
+const mapStateToProps = createMapStateToProps<TagValueOwnProps, TagValueStateProps>(
+  (state, { endDate, startDate, tagKey, tagReportPathsType }) => {
+    const query = parseQuery<Query>(location.search);
+    const groupByOrgValue = getGroupByOrgValue(query);
+    const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
+    const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
+
+    const tagKeyFilter = tagKey
+      ? {
+          key: tagKey,
+        }
+      : {};
+
+    const tagQueryParams =
+      endDate && startDate
+        ? {
+            start_date: startDate,
+            end_date: endDate,
+            ...tagKeyFilter,
+          }
+        : {
+            filter: {
+              resolution: 'monthly',
+              time_scope_units: 'month',
+              time_scope_value: -1,
+              ...tagKeyFilter,
+            },
+          };
+
+    const tagQuery = {
+      ...tagQueryParams,
+      filter_by: {
+        // Add filters here to apply logical OR/AND
+        ...(query && query.filter_by && query.filter_by),
+        ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
+        ...(groupBy && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
+      },
+    };
+
+    // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
+    const tagQueryString = getQuery({
+      ...tagQuery,
+    });
+    const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, tagQueryString);
+    const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(
+      state,
+      tagReportPathsType,
+      tagReportType,
+      tagQueryString
+    );
+
+    return {
+      groupBy,
+      groupByValue,
+      tagQueryString,
+      tagReport,
+      tagReportFetchStatus,
+    };
+  }
+);
+
+const mapDispatchToProps: TagValueDispatchProps = {
+  fetchTag: tagActions.fetchTag,
+};
+
+const TagValueConnect = connect(mapStateToProps, mapDispatchToProps)(TagValueBase);
+const TagValue = injectIntl(TagValueConnect);
+
+export { TagValue, TagValueProps };

--- a/src/pages/views/components/groupBy/groupBy.tsx
+++ b/src/pages/views/components/groupBy/groupBy.tsx
@@ -101,15 +101,19 @@ class GroupByBase extends React.Component<GroupByProps> {
       tagQueryString,
       tagReportPathsType,
     } = this.props;
-    if (showOrgs) {
-      fetchOrg(orgReportPathsType, orgReportType, orgQueryString);
-    }
-    if (showTags) {
-      fetchTag(tagReportPathsType, tagReportType, tagQueryString);
-    }
-    this.setState({
-      currentItem: this.getCurrentGroupBy(),
-    });
+    this.setState(
+      {
+        currentItem: this.getCurrentGroupBy(),
+      },
+      () => {
+        if (showOrgs) {
+          fetchOrg(orgReportPathsType, orgReportType, orgQueryString);
+        }
+        if (showTags) {
+          fetchTag(tagReportPathsType, tagReportType, tagQueryString);
+        }
+      }
+    );
   }
 
   public componentDidUpdate(prevProps: GroupByProps) {
@@ -126,13 +130,6 @@ class GroupByBase extends React.Component<GroupByProps> {
       tagReportPathsType,
     } = this.props;
     if (prevProps.groupBy !== groupBy || prevProps.perspective !== perspective) {
-      if (showOrgs) {
-        fetchOrg(orgReportPathsType, orgReportType, orgQueryString);
-      }
-      if (showTags) {
-        fetchTag(tagReportPathsType, tagReportType, tagQueryString);
-      }
-
       let options;
       if (prevProps.perspective !== perspective) {
         options = {
@@ -140,7 +137,14 @@ class GroupByBase extends React.Component<GroupByProps> {
           isGroupByTagVisible: false,
         };
       }
-      this.setState({ currentItem: this.getCurrentGroupBy(), ...(options ? options : {}) });
+      this.setState({ currentItem: this.getCurrentGroupBy(), ...(options ? options : {}) }, () => {
+        if (showOrgs) {
+          fetchOrg(orgReportPathsType, orgReportType, orgQueryString);
+        }
+        if (showTags) {
+          fetchTag(tagReportPathsType, tagReportType, tagQueryString);
+        }
+      });
     }
   }
 

--- a/src/pages/views/components/groupBy/groupBy.tsx
+++ b/src/pages/views/components/groupBy/groupBy.tsx
@@ -298,7 +298,7 @@ const mapStateToProps = createMapStateToProps<GroupByOwnProps, GroupByStateProps
     // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
     const tagQueryString = getQuery({
       ...tagQuery,
-      // key_only: true
+      key_only: true,
     });
     const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, tagQueryString);
     const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(

--- a/src/pages/views/components/groupBy/groupBy.tsx
+++ b/src/pages/views/components/groupBy/groupBy.tsx
@@ -223,19 +223,24 @@ class GroupByBase extends React.Component<GroupByProps> {
     if (selection.value === orgUnitIdKey || selection.value === tagKey) {
       this.setState({
         currentItem: selection.value,
+        isGroupByOpen: false,
         isGroupByOrgVisible: selection.value === orgUnitIdKey,
         isGroupByTagVisible: selection.value === tagKey,
       });
     } else {
-      this.setState({
-        currentItem: selection.value,
-        isGroupByOpen: false,
-        isGroupByOrgVisible: false,
-        isGroupByTagVisible: false,
-      });
-      if (onSelected) {
-        onSelected(selection.value);
-      }
+      this.setState(
+        {
+          currentItem: selection.value,
+          isGroupByOpen: false,
+          isGroupByOrgVisible: false,
+          isGroupByTagVisible: false,
+        },
+        () => {
+          if (onSelected) {
+            onSelected(selection.value);
+          }
+        }
+      );
     }
   };
 

--- a/src/pages/views/components/groupBy/groupBy.tsx
+++ b/src/pages/views/components/groupBy/groupBy.tsx
@@ -95,10 +95,12 @@ class GroupByBase extends React.Component<GroupByProps> {
       fetchOrg,
       fetchTag,
       orgQueryString,
+      orgReportFetchStatus,
       orgReportPathsType,
       showOrgs,
       showTags,
       tagQueryString,
+      tagReportFetchStatus,
       tagReportPathsType,
     } = this.props;
     this.setState(
@@ -106,10 +108,10 @@ class GroupByBase extends React.Component<GroupByProps> {
         currentItem: this.getCurrentGroupBy(),
       },
       () => {
-        if (showOrgs) {
+        if (showOrgs && orgReportFetchStatus !== FetchStatus.inProgress) {
           fetchOrg(orgReportPathsType, orgReportType, orgQueryString);
         }
-        if (showTags) {
+        if (showTags && tagReportFetchStatus !== FetchStatus.inProgress) {
           fetchTag(tagReportPathsType, tagReportType, tagQueryString);
         }
       }
@@ -122,11 +124,13 @@ class GroupByBase extends React.Component<GroupByProps> {
       fetchTag,
       groupBy,
       orgQueryString,
+      orgReportFetchStatus,
       orgReportPathsType,
       perspective,
       showOrgs,
       showTags,
       tagQueryString,
+      tagReportFetchStatus,
       tagReportPathsType,
     } = this.props;
     if (prevProps.groupBy !== groupBy || prevProps.perspective !== perspective) {
@@ -138,10 +142,10 @@ class GroupByBase extends React.Component<GroupByProps> {
         };
       }
       this.setState({ currentItem: this.getCurrentGroupBy(), ...(options ? options : {}) }, () => {
-        if (showOrgs) {
+        if (showOrgs && orgReportFetchStatus !== FetchStatus.inProgress) {
           fetchOrg(orgReportPathsType, orgReportType, orgQueryString);
         }
-        if (showTags) {
+        if (showTags && tagReportFetchStatus !== FetchStatus.inProgress) {
           fetchTag(tagReportPathsType, tagReportType, tagQueryString);
         }
       });

--- a/src/pages/views/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/awsDetails/detailsToolbar.tsx
@@ -147,6 +147,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         showExport
         showFilter
         tagReport={tagReport}
+        tagReportPathsType={tagReportPathsType}
       />
     );
   }

--- a/src/pages/views/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/awsDetails/detailsToolbar.tsx
@@ -161,7 +161,7 @@ const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToo
       time_scope_units: 'month',
       time_scope_value: -1,
     },
-    // key_only: true
+    key_only: true,
   });
   const orgReport = orgSelectors.selectOrg(state, orgReportPathsType, orgReportType, queryString);
   const orgReportFetchStatus = orgSelectors.selectOrgFetchStatus(state, orgReportPathsType, orgReportType, queryString);

--- a/src/pages/views/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/azureDetails/detailsToolbar.tsx
@@ -149,7 +149,7 @@ const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToo
       time_scope_units: 'month',
       time_scope_value: -1,
     },
-    // key_only: true
+    key_only: true,
   });
   const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
   const tagFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);

--- a/src/pages/views/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/azureDetails/detailsToolbar.tsx
@@ -135,6 +135,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         showExport
         showFilter
         tagReport={tagReport}
+        tagReportPathsType={tagReportPathsType}
       />
     );
   }

--- a/src/pages/views/details/components/breakdown/breakdownHeader.tsx
+++ b/src/pages/views/details/components/breakdown/breakdownHeader.tsx
@@ -9,7 +9,7 @@ import { CostType } from 'components/costType/costType';
 import { Currency } from 'components/currency/currency';
 import messages from 'locales/messages';
 import { TagLink } from 'pages/views/details/components/tag/tagLink';
-import { getGroupByOrgValue } from 'pages/views/utils/groupBy';
+import { getGroupByOrgValue, getGroupByTagKey } from 'pages/views/utils/groupBy';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { Link } from 'react-router-dom';
@@ -89,11 +89,16 @@ class BreakdownHeaderBase extends React.Component<BreakdownHeaderProps> {
 
     const filterByAccount = query && query.filter ? query.filter.account : undefined;
     const groupByOrg = getGroupByOrgValue(query);
+    const groupByTag = getGroupByTagKey(query);
     const showTags =
-      filterByAccount || groupBy === 'account' || groupBy === 'project' || groupBy === 'subscription_guid';
+      filterByAccount ||
+      groupBy === 'account' ||
+      groupBy === 'project' ||
+      groupBy === 'gcp_project' ||
+      groupBy === 'subscription_guid';
 
     // i18n groupBy key
-    const groupByKey = groupBy ? groupBy : filterByAccount ? 'account' : groupByOrg ? orgUnitIdKey : undefined;
+    const groupByKey = filterByAccount ? 'account' : groupByTag ? 'tag' : groupByOrg ? orgUnitIdKey : groupBy;
 
     return (
       <header style={styles.header}>
@@ -106,7 +111,7 @@ class BreakdownHeaderBase extends React.Component<BreakdownHeaderProps> {
                 </span>
                 <Link to={this.buildDetailsLink()}>
                   {intl.formatMessage(messages.BreakdownBackToDetails, {
-                    value: tagReportPathsType,
+                    value: intl.formatMessage(messages.BreakdownBackToTitles, { value: tagReportPathsType }),
                     groupBy: groupByKey,
                   })}
                 </Link>

--- a/src/pages/views/details/components/tag/tagModal.tsx
+++ b/src/pages/views/details/components/tag/tagModal.tsx
@@ -1,5 +1,5 @@
 import { Modal } from '@patternfly/react-core';
-import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
+import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query, tagPrefix } from 'api/queries/query';
 import { Tag, TagPathsType, TagType } from 'api/tags/tag';
 import messages from 'locales/messages';
 import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'pages/views/utils/groupBy';
@@ -100,6 +100,14 @@ const mapStateToProps = createMapStateToProps<TagModalOwnProps, TagModalStatePro
   const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
   const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
 
+  // Prune unsupported tag params from filter_by
+  const filterByParams = query && query.filter_by ? query.filter_by : {};
+  for (const key of Object.keys(filterByParams)) {
+    if (key.indexOf(tagPrefix) !== -1) {
+      filterByParams[key] = undefined;
+    }
+  }
+
   const newQuery: Query = {
     filter: {
       resolution: 'monthly',
@@ -108,11 +116,10 @@ const mapStateToProps = createMapStateToProps<TagModalOwnProps, TagModalStatePro
     },
     filter_by: {
       // Add filters here to apply logical OR/AND
-      ...(query && query.filter_by && query.filter_by),
+      ...filterByParams,
       ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
-      ...(groupBy && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
+      ...(groupBy && groupBy.indexOf(tagPrefix) === -1 && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
     },
-    // key_only: true
   };
   const queryString = getQuery(newQuery);
 

--- a/src/pages/views/details/gcpDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/gcpDetails/detailsToolbar.tsx
@@ -132,6 +132,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         showExport
         showFilter
         tagReport={tagReport}
+        tagReportPathsType={tagReportPathsType}
       />
     );
   }

--- a/src/pages/views/details/gcpDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/gcpDetails/detailsToolbar.tsx
@@ -146,7 +146,7 @@ const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToo
       time_scope_units: 'month',
       time_scope_value: -1,
     },
-    // key_only: true
+    key_only: true,
   });
 
   const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);

--- a/src/pages/views/details/ibmDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ibmDetails/detailsToolbar.tsx
@@ -132,6 +132,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         showExport
         showFilter
         tagReport={tagReport}
+        tagReportPathsType={tagReportPathsType}
       />
     );
   }

--- a/src/pages/views/details/ibmDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ibmDetails/detailsToolbar.tsx
@@ -146,7 +146,7 @@ const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToo
       time_scope_units: 'month',
       time_scope_value: -1,
     },
-    // key_only: true
+    key_only: true,
   });
 
   const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);

--- a/src/pages/views/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ocpDetails/detailsToolbar.tsx
@@ -57,22 +57,37 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   public state: DetailsToolbarState = { ...this.defaultState };
 
   public componentDidMount() {
-    const { fetchTag, queryString } = this.props;
-    fetchTag(tagReportPathsType, tagReportType, queryString);
-    this.setState({
-      categoryOptions: this.getCategoryOptions(),
-    });
+    const { fetchTag, queryString, tagReportFetchStatus } = this.props;
+
+    this.setState(
+      {
+        categoryOptions: this.getCategoryOptions(),
+      },
+      () => {
+        if (tagReportFetchStatus !== FetchStatus.inProgress) {
+          fetchTag(tagReportPathsType, tagReportType, queryString);
+        }
+      }
+    );
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps) {
-    const { fetchTag, query, queryString, tagReport } = this.props;
-    if (query && !isEqual(query, prevProps.query)) {
-      fetchTag(tagReportPathsType, tagReportType, queryString);
-    }
+    const { fetchTag, query, queryString, tagReport, tagReportFetchStatus } = this.props;
     if (!isEqual(tagReport, prevProps.tagReport)) {
-      this.setState({
-        categoryOptions: this.getCategoryOptions(),
-      });
+      this.setState(
+        {
+          categoryOptions: this.getCategoryOptions(),
+        },
+        () => {
+          if (tagReportFetchStatus !== FetchStatus.inProgress) {
+            fetchTag(tagReportPathsType, tagReportType, queryString);
+          }
+        }
+      );
+    } else {
+      if (query && !isEqual(query, prevProps.query) && tagReportFetchStatus !== FetchStatus.inProgress) {
+        fetchTag(tagReportPathsType, tagReportType, queryString);
+      }
     }
   }
 

--- a/src/pages/views/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ocpDetails/detailsToolbar.tsx
@@ -132,6 +132,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         showExport
         showFilter
         tagReport={tagReport}
+        tagReportPathsType={tagReportPathsType}
       />
     );
   }

--- a/src/pages/views/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ocpDetails/detailsToolbar.tsx
@@ -146,7 +146,7 @@ const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToo
       time_scope_units: 'month',
       time_scope_value: -1,
     },
-    // key_only: true
+    key_only: true,
   });
   const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
   const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);

--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -251,7 +251,7 @@ class Explorer extends React.Component<ExplorerProps> {
   };
 
   private getToolbar = (computedItems: ComputedReportItem[]) => {
-    const { report } = this.props;
+    const { perspective, report } = this.props;
     const { isAllSelected, selectedItems } = this.state;
 
     const itemsTotal = report && report.meta ? report.meta.count : 0;
@@ -265,6 +265,7 @@ class Explorer extends React.Component<ExplorerProps> {
         onBulkSelected={this.handleBulkSelected}
         onExportClicked={this.handleExportModalOpen}
         pagination={this.getPagination()}
+        perspective={perspective}
         selectedItems={selectedItems}
       />
     );

--- a/src/pages/views/explorer/explorerFilter.tsx
+++ b/src/pages/views/explorer/explorerFilter.tsx
@@ -178,8 +178,17 @@ export class ExplorerFilterBase extends React.Component<ExplorerFilterProps> {
   };
 
   public render() {
-    const { groupBy, isDisabled, onFilterAdded, onFilterRemoved, orgReport, query, resourcePathsType, tagReport } =
-      this.props;
+    const {
+      groupBy,
+      isDisabled,
+      onFilterAdded,
+      onFilterRemoved,
+      orgReport,
+      query,
+      resourcePathsType,
+      tagReport,
+      tagReportPathsType,
+    } = this.props;
     const { categoryOptions } = this.state;
 
     return (
@@ -196,6 +205,7 @@ export class ExplorerFilterBase extends React.Component<ExplorerFilterProps> {
         style={styles.toolbarContainer}
         showFilter
         tagReport={tagReport}
+        tagReportPathsType={tagReportPathsType}
       />
     );
   }

--- a/src/pages/views/explorer/explorerFilter.tsx
+++ b/src/pages/views/explorer/explorerFilter.tsx
@@ -232,7 +232,7 @@ const mapStateToProps = createMapStateToProps<ExplorerFilterOwnProps, ExplorerFi
     const tagQueryString = getQuery({
       start_date,
       end_date,
-      // key_only: true
+      key_only: true,
     });
     let tagReport;
     let tagReportFetchStatus;

--- a/src/pages/views/explorer/explorerToolbar.tsx
+++ b/src/pages/views/explorer/explorerToolbar.tsx
@@ -6,6 +6,8 @@ import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 
+import { getTagReportPathsType, PerspectiveType } from './explorerUtils';
+
 interface ExplorerToolbarOwnProps {
   isAllSelected?: boolean;
   isBulkSelectDisabled?: boolean;
@@ -15,6 +17,7 @@ interface ExplorerToolbarOwnProps {
   onBulkSelected(action: string);
   onExportClicked();
   pagination?: React.ReactNode;
+  perspective: PerspectiveType;
   selectedItems?: ComputedReportItem[];
 }
 
@@ -49,8 +52,11 @@ export class ExplorerToolbarBase extends React.Component<ExplorerToolbarProps> {
       onBulkSelected,
       onExportClicked,
       pagination,
+      perspective,
       selectedItems,
     } = this.props;
+
+    const tagReportPathsType = getTagReportPathsType(perspective);
 
     return (
       <DataToolbar
@@ -65,6 +71,7 @@ export class ExplorerToolbarBase extends React.Component<ExplorerToolbarProps> {
         selectedItems={selectedItems}
         showBulkSelect
         showExport
+        tagReportPathsType={tagReportPathsType}
       />
     );
   }


### PR DESCRIPTION
For better performance, we would like the UI to lazily generate API requests for tags.

In order to populate the "group by" dropdown, an initial API request will be made for just the tag keys. Then, we can lazily request tag key values after the user chooses to filter by a particular tag key.

https://issues.redhat.com/browse/COST-2053

https://user-images.githubusercontent.com/17481322/140975408-50186ebb-bc53-4a18-aee3-28e2258410cb.mov



