### PR TITLE
Overview page doesn't show "Top GCP projects"

### DIFF
--- a/src/store/dashboard/gcpDashboard/gcpDashboardCommon.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardCommon.ts
@@ -34,7 +34,7 @@ export function getGroupByForTab(widget: GcpDashboardWidget): GcpQuery['group_by
     case GcpDashboardTab.accounts:
       return { account: '*' };
     case GcpDashboardTab.gcpProjects:
-      return { project: '*' };
+      return { gcp_project: '*' };
     case GcpDashboardTab.projects:
       return { project: '*' };
     case GcpDashboardTab.regions:


### PR DESCRIPTION
https://issues.redhat.com/browse/COST-2054

<img width="1452" alt="Screen Shot 2021-11-10 at 9 26 25 AM" src="https://user-images.githubusercontent.com/17481322/141131391-2eb9a271-a8ce-4a0a-8d90-30062846394d.png">


