### PR TITLE
Wrap toolbar filters with PF ToolbarToggleGroup

### DIFF
--- a/src/pages/costModels/components/priceListToolbar.tsx
+++ b/src/pages/costModels/components/priceListToolbar.tsx
@@ -5,7 +5,9 @@ import {
   ToolbarGroup,
   ToolbarItem,
   ToolbarItemVariant,
+  ToolbarToggleGroup,
 } from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import React from 'react';
 
 import { styles } from './priceListToolbar.styles';
@@ -35,18 +37,24 @@ export const PriceListToolbar: React.SFC<PriceListToolbarProps> = ({
   return (
     <Toolbar style={styles.toolbar} clearAllFilters={onClear} id="price-list-toolbar">
       <ToolbarContent>
-        <ToolbarGroup variant="filter-group">
-          <ToolbarItem>{primary}</ToolbarItem>
-          {secondaries.map(secondary => {
-            return (
-              <ToolbarItem key={secondary.name}>
-                <ToolbarFilter deleteChip={secondary.onRemove} chips={secondary.filters} categoryName={secondary.name}>
-                  {selected === secondary.name ? secondary.component : ''}
-                </ToolbarFilter>
-              </ToolbarItem>
-            );
-          })}
-        </ToolbarGroup>
+        <ToolbarToggleGroup breakpoint="xl" toggleIcon={<FilterIcon />}>
+          <ToolbarGroup variant="filter-group">
+            <ToolbarItem>{primary}</ToolbarItem>
+            {secondaries.map(secondary => {
+              return (
+                <ToolbarItem key={secondary.name}>
+                  <ToolbarFilter
+                    deleteChip={secondary.onRemove}
+                    chips={secondary.filters}
+                    categoryName={secondary.name}
+                  >
+                    {selected === secondary.name ? secondary.component : ''}
+                  </ToolbarFilter>
+                </ToolbarItem>
+              );
+            })}
+          </ToolbarGroup>
+        </ToolbarToggleGroup>
         <ToolbarItem>{button}</ToolbarItem>
         <ToolbarItem variant={ToolbarItemVariant.pagination}>{pagination}</ToolbarItem>
       </ToolbarContent>

--- a/src/pages/costModels/costModel/assignSourcesModalToolbar.tsx
+++ b/src/pages/costModels/costModel/assignSourcesModalToolbar.tsx
@@ -8,7 +8,9 @@ import {
   ToolbarContent,
   ToolbarFilter,
   ToolbarItem,
+  ToolbarToggleGroup,
 } from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import { SearchIcon } from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import messages from 'locales/messages';
 import React from 'react';
@@ -64,11 +66,16 @@ export const AssignSourcesToolbarBase: React.SFC<AssignSourcesToolbarBaseProps> 
   return (
     <Toolbar id="assign-sources-toolbar" clearAllFilters={filter.onClearAll}>
       <ToolbarContent>
-        <ToolbarItem variant="search-filter">
-          <ToolbarFilter deleteChip={filter.onRemove} chips={filter.query.name} categoryName="name">
-            <FilterInput placeholder={intl.formatMessage(messages.CostModelsFilterPlaceholder)} {...filterInputProps} />
-          </ToolbarFilter>
-        </ToolbarItem>
+        <ToolbarToggleGroup breakpoint="xl" toggleIcon={<FilterIcon />}>
+          <ToolbarItem variant="search-filter">
+            <ToolbarFilter deleteChip={filter.onRemove} chips={filter.query.name} categoryName="name">
+              <FilterInput
+                placeholder={intl.formatMessage(messages.CostModelsFilterPlaceholder)}
+                {...filterInputProps}
+              />
+            </ToolbarFilter>
+          </ToolbarItem>
+        </ToolbarToggleGroup>
         <ToolbarItem variant="pagination">
           <Pagination
             isCompact={paginationProps.isCompact}

--- a/src/pages/costModels/costModel/sourcesToolbar.tsx
+++ b/src/pages/costModels/costModel/sourcesToolbar.tsx
@@ -10,7 +10,9 @@ import {
   ToolbarContent,
   ToolbarFilter,
   ToolbarItem,
+  ToolbarToggleGroup,
 } from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import { SearchIcon } from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import { ReadOnlyTooltip } from 'pages/costModels/components/readOnlyTooltip';
 import React from 'react';
@@ -66,15 +68,17 @@ export const SourcesToolbar: React.SFC<SourcesToolbarProps> = ({
   return (
     <Toolbar id="assign-sources-toolbar" clearAllFilters={filter.onClearAll}>
       <ToolbarContent>
-        <ToolbarItem variant="search-filter">
-          <ToolbarFilter
-            deleteChip={filter.onRemove}
-            chips={filter.query.name}
-            categoryName={filter.categoryNames.name}
-          >
-            <FilterInput {...filterInputProps} />
-          </ToolbarFilter>
-        </ToolbarItem>
+        <ToolbarToggleGroup breakpoint="xl" toggleIcon={<FilterIcon />}>
+          <ToolbarItem variant="search-filter">
+            <ToolbarFilter
+              deleteChip={filter.onRemove}
+              chips={filter.query.name}
+              categoryName={filter.categoryNames.name}
+            >
+              <FilterInput {...filterInputProps} />
+            </ToolbarFilter>
+          </ToolbarItem>
+        </ToolbarToggleGroup>
         <ToolbarItem>
           <ReadOnlyTooltip isDisabled={actionButtonProps.isDisabled}>
             <Button {...actionButtonProps} />

--- a/src/pages/costModels/costModelsDetails/toolbar.tsx
+++ b/src/pages/costModels/costModelsDetails/toolbar.tsx
@@ -1,4 +1,11 @@
-import { ToolbarContent, ToolbarGroup, ToolbarItem, ToolbarItemVariant } from '@patternfly/react-core';
+import {
+  ToolbarContent,
+  ToolbarGroup,
+  ToolbarItem,
+  ToolbarItemVariant,
+  ToolbarToggleGroup,
+} from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import React from 'react';
 
 import { CreateCostModelButton } from './createCostModelButton';
@@ -10,14 +17,16 @@ const CostModelsToolbar = () => {
     <ClearableToolbar>
       <ToolbarContent>
         <ToolbarGroup variant="filter-group">
-          <ToolbarItem>
-            <CostModelsFilterSelector />
-          </ToolbarItem>
-          <ToolbarItem>
-            <NameFilter />
-            <DescriptionFilter />
-            <SourceTypeFilter />
-          </ToolbarItem>
+          <ToolbarToggleGroup breakpoint="xl" toggleIcon={<FilterIcon />}>
+            <ToolbarItem>
+              <CostModelsFilterSelector />
+            </ToolbarItem>
+            <ToolbarItem>
+              <NameFilter />
+              <DescriptionFilter />
+              <SourceTypeFilter />
+            </ToolbarItem>
+          </ToolbarToggleGroup>
           <ToolbarItem>
             <CreateCostModelButton />
           </ToolbarItem>

--- a/src/pages/costModels/createCostModelWizard/assignSourcesToolbar.tsx
+++ b/src/pages/costModels/createCostModelWizard/assignSourcesToolbar.tsx
@@ -8,7 +8,9 @@ import {
   ToolbarContent,
   ToolbarFilter,
   ToolbarItem,
+  ToolbarToggleGroup,
 } from '@patternfly/react-core';
+import { FilterIcon } from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import { SearchIcon } from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import messages from 'locales/messages';
 import React from 'react';
@@ -64,11 +66,16 @@ export const AssignSourcesToolbarBase: React.SFC<AssignSourcesToolbarBaseProps> 
   return (
     <Toolbar id="assign-sources-toolbar" clearAllFilters={filter.onClearAll}>
       <ToolbarContent>
-        <ToolbarItem variant="search-filter">
-          <ToolbarFilter deleteChip={filter.onRemove} chips={filter.query.name} categoryName="name">
-            <FilterInput placeholder={intl.formatMessage(messages.CostModelsFilterPlaceholder)} {...filterInputProps} />
-          </ToolbarFilter>
-        </ToolbarItem>
+        <ToolbarToggleGroup breakpoint="xl" toggleIcon={<FilterIcon />}>
+          <ToolbarItem variant="search-filter">
+            <ToolbarFilter deleteChip={filter.onRemove} chips={filter.query.name} categoryName="name">
+              <FilterInput
+                placeholder={intl.formatMessage(messages.CostModelsFilterPlaceholder)}
+                {...filterInputProps}
+              />
+            </ToolbarFilter>
+          </ToolbarItem>
+        </ToolbarToggleGroup>
         <ToolbarItem variant="pagination">
           <Pagination
             isCompact={paginationProps.isCompact}

--- a/src/pages/views/components/dataToolbar/dataToolbar.tsx
+++ b/src/pages/views/components/dataToolbar/dataToolbar.tsx
@@ -852,9 +852,9 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
       <div style={style ? style : styles.toolbarContainer}>
         <Toolbar id="details-toolbar" clearAllFilters={this.onDelete as any} collapseListedFiltersBreakpoint="xl">
           <ToolbarContent>
-            <ToolbarToggleGroup breakpoint="xl" toggleIcon={<FilterIcon />}>
-              {showBulkSelect && <ToolbarItem variant="bulk-select">{this.getBulkSelect()}</ToolbarItem>}
-              {showFilter && (
+            {showBulkSelect && <ToolbarItem variant="bulk-select">{this.getBulkSelect()}</ToolbarItem>}
+            {showFilter && (
+              <ToolbarToggleGroup breakpoint="xl" toggleIcon={<FilterIcon />}>
                 <ToolbarGroup variant="filter-group">
                   {this.getCategorySelect()}
                   {this.getTagKeySelect()}
@@ -865,15 +865,16 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
                       .filter(option => option.key !== tagKey && option.key !== orgUnitIdKey)
                       .map(option => this.getCategoryInput(option))}
                 </ToolbarGroup>
-              )}
-              {(Boolean(showExport) || Boolean(showColumnManagement)) && (
-                <ToolbarGroup>
-                  {Boolean(showExport) && this.getExportButton()}
-                  {Boolean(showColumnManagement) && this.getColumnManagement()}
-                </ToolbarGroup>
-              )}
-              {dateRange && <ToolbarGroup>{dateRange}</ToolbarGroup>}
-            </ToolbarToggleGroup>
+              </ToolbarToggleGroup>
+            )}
+            {(Boolean(showExport) || Boolean(showColumnManagement)) && (
+              <ToolbarGroup>
+                {Boolean(showExport) && this.getExportButton()}
+                {Boolean(showColumnManagement) && this.getColumnManagement()}
+              </ToolbarGroup>
+            )}
+            {dateRange && <ToolbarGroup>{dateRange}</ToolbarGroup>}
+
             <ToolbarItem alignment={{ default: 'alignRight' }} variant="pagination">
               {pagination}
             </ToolbarItem>


### PR DESCRIPTION
The toolbar isn't broken per se. The toolbar items are wrapping as expected. However, the details page toolbar wraps the filter with a PatternFly `ToolbarToggleGroup` component. 

For small windows, the PatternFly `ToolbarToggleGroup` component replaces the filter with a simple icon. When the icon is clicked, the filter is expanded onto its own line.

https://issues.redhat.com/browse/COST-2065

**Device toolbar**
<img width="1075" alt="after" src="https://user-images.githubusercontent.com/17481322/141837502-b9e6d870-eb93-4f35-8422-c34105c66e75.png">


