### PR TITLE
2094 pf toolbar

### DIFF
--- a/src/pages/views/components/dataToolbar/dataToolbar.tsx
+++ b/src/pages/views/components/dataToolbar/dataToolbar.tsx
@@ -27,7 +27,7 @@ import { FilterIcon } from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import { SearchIcon } from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import { Org } from 'api/orgs/org';
 import { orgUnitIdKey, orgUnitNameKey, Query, tagKey, tagPrefix } from 'api/queries/query';
-import { ResourcePathsType } from 'api/resources/resource';
+import { ResourcePathsType, ResourceType } from 'api/resources/resource';
 import { isResourceTypeValid } from 'api/resources/resourceUtils';
 import { Tag, TagPathsType } from 'api/tags/tag';
 import messages from 'locales/messages';
@@ -367,25 +367,25 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
   };
 
   // Category input
-  public getCategoryInput = categoryOption => {
+  public getCategoryInput = (categoryOption: ToolbarChipGroup) => {
     const { intl, isDisabled, resourcePathsType } = this.props;
     const { currentCategory, filters, categoryInput } = this.state;
 
     return (
       <ToolbarFilter
-        categoryName={categoryOption}
-        chips={filters[categoryOption.key] as any}
+        categoryName={categoryOption.name}
+        chips={filters[categoryOption.key] as string[]}
         deleteChip={this.onDelete}
         key={categoryOption.key}
         showToolbarItem={currentCategory === categoryOption.key}
       >
         <InputGroup>
-          {isResourceTypeValid(resourcePathsType, categoryOption.key) ? (
+          {isResourceTypeValid(resourcePathsType, categoryOption.key as ResourceType) ? (
             <ResourceTypeahead
               isDisabled={isDisabled}
               onSelect={value => this.onCategoryInputSelect(value, categoryOption.key)}
               resourcePathsType={resourcePathsType}
-              resourceType={categoryOption.key}
+              resourceType={categoryOption.key as ResourceType}
             />
           ) : (
             <>
@@ -707,13 +707,13 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
 
   // Tag value select
 
-  public getTagValueSelect = tagKeyOption => {
+  public getTagValueSelect = (tagKeyOption: ToolbarChipGroup) => {
     const { tagReportPathsType } = this.props;
     const { currentCategory, currentTagKey, filters, tagKeyValueInput } = this.state;
 
     return (
       <ToolbarFilter
-        categoryName={tagKeyOption}
+        categoryName={tagKeyOption.name}
         chips={filters.tag[tagKeyOption.key]}
         deleteChip={this.onDelete}
         key={tagKeyOption.key}
@@ -862,8 +862,8 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
                   {this.getOrgUnitSelect()}
                   {options &&
                     options
-                      .filter(option => option.key !== tagKey && option.key !== orgUnitIdKey)
-                      .map(option => this.getCategoryInput(option))}
+                      .filter(val => val.key !== tagKey && val.key !== orgUnitIdKey)
+                      .map(val => this.getCategoryInput(val))}
                 </ToolbarGroup>
               </ToolbarToggleGroup>
             )}

--- a/src/pages/views/components/dataToolbar/dataToolbar.tsx
+++ b/src/pages/views/components/dataToolbar/dataToolbar.tsx
@@ -371,6 +371,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
     const { intl, isDisabled, resourcePathsType } = this.props;
     const { currentCategory, filters, categoryInput } = this.state;
 
+    // Todo: categoryName workaround for https://issues.redhat.com/browse/COST-2094
     return (
       <ToolbarFilter
         categoryName={categoryOption.name}

--- a/src/pages/views/components/dataToolbar/tagValue.tsx
+++ b/src/pages/views/components/dataToolbar/tagValue.tsx
@@ -10,7 +10,7 @@ import {
   ToolbarChipGroup,
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons/dist/esm/icons/search-icon';
-import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, Query, tagPrefix } from 'api/queries/query';
+import { getQuery, orgUnitIdKey, parseQuery, Query } from 'api/queries/query';
 import { Tag, TagPathsType, TagType } from 'api/tags/tag';
 import { intl } from 'components/i18n';
 import messages from 'locales/messages';
@@ -178,21 +178,13 @@ const mapStateToProps = createMapStateToProps<TagValueOwnProps, TagValueStatePro
     const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
     const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
 
-    // Prune unsupported tag params from filter_by
-    const filterByParams = query && query.filter_by ? query.filter_by : {};
-    for (const key of Object.keys(filterByParams)) {
-      if (key.indexOf(tagPrefix) !== -1) {
-        filterByParams[key] = undefined;
-      }
-    }
-
     const tagKeyFilter = tagKey
       ? {
           key: tagKey,
         }
       : {};
 
-    const tagQueryParams =
+    const tagQuery =
       endDate && startDate
         ? {
             start_date: startDate,
@@ -209,16 +201,6 @@ const mapStateToProps = createMapStateToProps<TagValueOwnProps, TagValueStatePro
               ...tagKeyFilter,
             },
           };
-
-    const tagQuery = {
-      ...tagQueryParams,
-      filter_by: {
-        // Add filters here to apply logical OR/AND
-        ...filterByParams,
-        ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
-        ...(groupBy && groupBy.indexOf(tagPrefix) === -1 && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
-      },
-    };
 
     // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
     const tagQueryString = getQuery({

--- a/src/pages/views/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/awsDetails/detailsToolbar.tsx
@@ -93,13 +93,13 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       { name: intl.formatMessage(messages.FilterByValues, { value: 'service' }), key: 'service' },
       { name: intl.formatMessage(messages.FilterByValues, { value: 'region' }), key: 'region' },
     ];
-    if (orgReport && orgReport.data && orgReport.data.length > 0) {
+    if (orgReport && orgReport.data && orgReport.data.length) {
       options.push({
         name: intl.formatMessage(messages.FilterByValues, { value: 'org_unit_id' }),
         key: orgUnitIdKey,
       });
     }
-    if (tagReport && tagReport.data && tagReport.data.length > 0) {
+    if (tagReport && tagReport.data && tagReport.data.length) {
       options.push({ name: intl.formatMessage(messages.FilterByValues, { value: 'tag' }), key: tagKey });
     }
     return options;

--- a/src/pages/views/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/azureDetails/detailsToolbar.tsx
@@ -89,12 +89,12 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         name: intl.formatMessage(messages.FilterByValues, { value: 'resource_location' }),
         key: 'resource_location',
       },
-      { name: intl.formatMessage(messages.FilterByValues, { value: 'tag' }), key: tagKey },
     ];
 
-    return tagReport && tagReport.data && tagReport.data.length
-      ? options
-      : options.filter(option => option.key !== tagKey);
+    if (tagReport && tagReport.data && tagReport.data.length) {
+      options.push({ name: intl.formatMessage(messages.FilterByValues, { value: tagKey }), key: tagKey });
+    }
+    return options;
   };
 
   public render() {

--- a/src/pages/views/details/gcpDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/gcpDetails/detailsToolbar.tsx
@@ -86,8 +86,8 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       { name: intl.formatMessage(messages.FilterByValues, { value: 'region' }), key: 'region' },
     ];
 
-    if (tagReport && tagReport.data && tagReport.data.length > 0) {
-      options.push({ name: intl.formatMessage(messages.FilterByValues, { value: 'tag' }), key: tagKey });
+    if (tagReport && tagReport.data && tagReport.data.length) {
+      options.push({ name: intl.formatMessage(messages.FilterByValues, { value: tagKey }), key: tagKey });
     }
     return options;
   };

--- a/src/pages/views/details/ibmDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ibmDetails/detailsToolbar.tsx
@@ -86,8 +86,8 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       { name: intl.formatMessage(messages.FilterByValues, { value: 'region' }), key: 'region' },
     ];
 
-    if (tagReport && tagReport.data && tagReport.data.length > 0) {
-      options.push({ name: intl.formatMessage(messages.FilterByValues, { value: 'tag' }), key: tagKey });
+    if (tagReport && tagReport.data && tagReport.data.length) {
+      options.push({ name: intl.formatMessage(messages.FilterByValues, { value: tagKey }), key: tagKey });
     }
     return options;
   };

--- a/src/pages/views/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ocpDetails/detailsToolbar.tsx
@@ -98,12 +98,12 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       { name: intl.formatMessage(messages.FilterByValues, { value: 'cluster' }), key: 'cluster' },
       { name: intl.formatMessage(messages.FilterByValues, { value: 'node' }), key: 'node' },
       { name: intl.formatMessage(messages.FilterByValues, { value: 'project' }), key: 'project' },
-      { name: intl.formatMessage(messages.FilterByValues, { value: 'tag' }), key: tagKey },
     ];
 
-    return tagReport && tagReport.data && tagReport.data.length
-      ? options
-      : options.filter(option => option.key !== tagKey);
+    if (tagReport && tagReport.data && tagReport.data.length) {
+      options.push({ name: intl.formatMessage(messages.FilterByValues, { value: tagKey }), key: tagKey });
+    }
+    return options;
   };
 
   public render() {


### PR DESCRIPTION
The PatternFly ToolbarFilter fails to save state when a "node" label is added to the user's settings list of available tags.

The debugger shows the issue may have something to do with how PatternFly tests `ToolbarChipGroup.hasOwnProperty`.

As a workaround, I'm able to provide a string to `ToolbarFilter.categoryName` instead of a `ToolbarChipGroup` object.

https://issues.redhat.com/browse/COST-2094


<img width="1547" alt="Screen Shot 2021-11-19 at 12 25 57 PM" src="https://user-images.githubusercontent.com/17481322/142665231-769d50d5-ff82-47cd-bb37-328281a5343a.png">


