### PR TITLE
PatternFly ToolbarFilter error

### DIFF
--- a/src/pages/views/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ocpDetails/detailsToolbar.tsx
@@ -101,7 +101,10 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     ];
 
     if (tagReport && tagReport.data && tagReport.data.length) {
-      options.push({ name: intl.formatMessage(messages.FilterByValues, { value: tagKey }), key: tagKey });
+      options.push({
+        name: intl.formatMessage(messages.FilterByValues, { value: tagKey }),
+        key: tagKey,
+      });
     }
     return options;
   };


### PR DESCRIPTION
This adds a workaround to prevent category name collisions with the PatternFly ToolbarFilter

https://issues.redhat.com/browse/COST-2094

![chrome-capture](https://user-images.githubusercontent.com/17481322/142708333-75c2bc5d-3926-4050-999c-b5f5c2f83de4.gif)


