### PR TITLE
Cost type options appear bold in breakdown header

### DIFF
--- a/src/pages/views/details/components/breakdown/breakdownHeader.styles.ts
+++ b/src/pages/views/details/components/breakdown/breakdownHeader.styles.ts
@@ -47,6 +47,6 @@ export const styles = {
   },
   title: {
     paddingBottom: global_spacer_lg.var,
-    paddingTop: global_spacer_md.var,
+    paddingTop: global_spacer_xs.var,
   },
 } as { [className: string]: React.CSSProperties };

--- a/src/pages/views/details/components/breakdown/breakdownHeader.tsx
+++ b/src/pages/views/details/components/breakdown/breakdownHeader.tsx
@@ -122,15 +122,17 @@ class BreakdownHeaderBase extends React.Component<BreakdownHeaderProps> {
           {isBetaFeature() && <Currency />}
         </div>
         <div style={styles.headerContent}>
-          <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
-            {intl.formatMessage(messages.BreakdownTitle, { value: title })}
-            {description && <div style={styles.infoDescription}>{description}</div>}
+          <div style={styles.title}>
+            <Title headingLevel="h1" size={TitleSizes['2xl']}>
+              {intl.formatMessage(messages.BreakdownTitle, { value: title })}
+              {description && <div style={styles.infoDescription}>{description}</div>}
+            </Title>
             {showCostType && (
               <div style={styles.costType}>
                 <CostType onSelect={this.handleCostTypeSelected} />
               </div>
             )}
-          </Title>
+          </div>
           <div style={styles.cost}>
             <div style={styles.costLabel}>
               <Title headingLevel="h2" style={styles.costValue} size={TitleSizes['4xl']}>


### PR DESCRIPTION
Moved the cost type out of the PatternFly Title component's body.

**Before**
<img width="560" alt="Screen Shot 2021-12-03 at 9 12 06 AM" src="https://user-images.githubusercontent.com/17481322/144618659-ec827606-77c7-469e-aaf1-a6f996c36fae.png">

**After**
<img width="454" alt="Screen Shot 2021-12-03 at 9 26 54 AM" src="https://user-images.githubusercontent.com/17481322/144618812-2f8ed439-48b4-49c7-a52b-31e1f1980cdc.png">
