### PR TITLE
Can't assign multiple sources to a cost model across paginated pages

### DIFF
--- a/src/pages/costModels/costModel/addSourceStep.tsx
+++ b/src/pages/costModels/costModel/addSourceStep.tsx
@@ -47,7 +47,7 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
 
     const onSelect = (_evt, isSelected, rowId) => {
       if (rowId === -1) {
-        const newState = this.props.providers.reduce((acc, cur) => {
+        const pageSelections = this.props.providers.reduce((acc, cur) => {
           const selected = this.props.checked[cur.uuid] ? this.props.checked[cur.uuid].selected : false;
           const disabled = cur.cost_models.length > 0;
           return {
@@ -55,6 +55,10 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
             [cur.uuid]: { selected: disabled ? selected : isSelected, meta: cur, disabled },
           };
         }, {});
+        const newState = {
+          ...this.props.checked,
+          ...pageSelections,
+        };
         this.props.setState(
           newState as {
             [uuid: string]: { selected: boolean; meta: Provider };

--- a/src/pages/costModels/costModel/addSourceWizard.tsx
+++ b/src/pages/costModels/costModel/addSourceWizard.tsx
@@ -61,23 +61,6 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
     fetch(`type=${sourceType}&limit=10&offset=0`);
   }
 
-  public componentDidUpdate(prevProps: Props) {
-    if (prevProps.isLoadingSources === true && this.props.isLoadingSources === false) {
-      const initChecked = this.props.providers.reduce((acc, curr) => {
-        const selected = this.props.costModel.sources.some(p => p.uuid === curr.uuid);
-        return {
-          ...acc,
-          [curr.uuid]: {
-            disabled: selected,
-            selected,
-            meta: curr,
-          },
-        };
-      }, {}) as { [uuid: string]: { selected: boolean; meta: Provider } };
-      this.setState({ checked: initChecked });
-    }
-  }
-
   private hasSelections = () => {
     const { checked } = this.state;
     let result = false;


### PR DESCRIPTION
The addSourceWizard.tsx component resets the selected list of items whenever new sources are loaded; for example, when paginating between table items. If we omit that, selections will be saved across pages.

https://issues.redhat.com/browse/COST-2097

![chrome-capture](https://user-images.githubusercontent.com/17481322/145256223-03bd60ce-7642-49a9-a97f-92109b605b7e.gif)

