### PR TITLE
Modified the "add sources" dialog to retain the applied sources

### DIFF
--- a/src/pages/costModels/costModel/addSourceStep.tsx
+++ b/src/pages/costModels/costModel/addSourceStep.tsx
@@ -49,7 +49,8 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
       if (rowId === -1) {
         const pageSelections = this.props.providers.reduce((acc, cur) => {
           const selected = this.props.checked[cur.uuid] ? this.props.checked[cur.uuid].selected : false;
-          const disabled = cur.cost_models.length > 0;
+          const disabled =
+            cur.cost_models.length && cur.cost_models.find(cm => cm.name === costModel.name) === undefined;
           return {
             ...acc,
             [cur.uuid]: { selected: disabled ? selected : isSelected, meta: cur, disabled },
@@ -97,7 +98,7 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
       return {
         cells: [cellName, provCostModels || ''],
         selected: isSelected,
-        disableSelection: providerData.cost_models.length > 0,
+        disableSelection: providerData.cost_models.length > 0 && warningIcon !== null,
       };
     });
 

--- a/src/pages/costModels/costModel/addSourceStep.tsx
+++ b/src/pages/costModels/costModel/addSourceStep.tsx
@@ -48,12 +48,13 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
     const onSelect = (_evt, isSelected, rowId) => {
       if (rowId === -1) {
         const pageSelections = this.props.providers.reduce((acc, cur) => {
-          const selected = this.props.checked[cur.uuid] ? this.props.checked[cur.uuid].selected : false;
-          const disabled =
+          // If assigned, maintain original selection
+          const isAssigned =
             cur.cost_models.length && cur.cost_models.find(cm => cm.name === costModel.name) === undefined;
+          const selected = this.props.checked[cur.uuid] ? this.props.checked[cur.uuid].selected : false;
           return {
             ...acc,
-            [cur.uuid]: { selected: disabled ? selected : isSelected, meta: cur, disabled },
+            [cur.uuid]: { selected: isAssigned ? selected : isSelected, meta: cur, isAssigned },
           };
         }, {});
         const newState = {
@@ -82,14 +83,15 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
         providerData.cost_models === undefined
           ? intl.formatMessage(messages.CostModelsWizardSourceTableDefaultCostModel)
           : providerData.cost_models.map(cm => cm.name).join(',');
-      const warningIcon =
+      const isAssigned =
         providerData.cost_models.length &&
-        providerData.cost_models.find(cm => cm.name === costModel.name) === undefined ? (
-          <WarningIcon
-            key={providerData.uuid}
-            text={intl.formatMessage(messages.CostModelsWizardSourceWarning, { costModel: provCostModels })}
-          />
-        ) : null;
+        providerData.cost_models.find(cm => cm.name === costModel.name) === undefined;
+      const warningIcon = isAssigned ? (
+        <WarningIcon
+          key={providerData.uuid}
+          text={intl.formatMessage(messages.CostModelsWizardSourceWarning, { costModel: provCostModels })}
+        />
+      ) : null;
       const cellName = (
         <div key={providerData.uuid}>
           {providerData.name} {warningIcon}
@@ -98,7 +100,7 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
       return {
         cells: [cellName, provCostModels || ''],
         selected: isSelected,
-        disableSelection: providerData.cost_models.length > 0 && warningIcon !== null,
+        disableSelection: isAssigned,
       };
     });
 

--- a/src/pages/costModels/costModel/addSourceStep.tsx
+++ b/src/pages/costModels/costModel/addSourceStep.tsx
@@ -48,7 +48,7 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
     const onSelect = (_evt, isSelected, rowId) => {
       if (rowId === -1) {
         const pageSelections = this.props.providers.reduce((acc, cur) => {
-          // If assigned, maintain original selection
+          // If assigned to another cost model, maintain original selection
           const isAssigned =
             cur.cost_models.length && cur.cost_models.find(cm => cm.name === costModel.name) === undefined;
           const selected = this.props.checked[cur.uuid] ? this.props.checked[cur.uuid].selected : false;
@@ -86,6 +86,7 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
       const isAssigned =
         providerData.cost_models.length &&
         providerData.cost_models.find(cm => cm.name === costModel.name) === undefined;
+      // If assigned to another cost model, show warning
       const warningIcon = isAssigned ? (
         <WarningIcon
           key={providerData.uuid}

--- a/src/pages/costModels/costModel/addSourceWizard.tsx
+++ b/src/pages/costModels/costModel/addSourceWizard.tsx
@@ -29,6 +29,7 @@ interface AddSourcesStepState {
 }
 
 interface Props extends WrappedComponentProps {
+  assigned?: Provider[];
   onClose: () => void;
   onSave: (sources_uuid: string[]) => void;
   isOpen: boolean;
@@ -53,12 +54,20 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
   public state = { checked: {} };
 
   public componentDidMount() {
+    const { assigned } = this.props;
+
     const {
       costModel: { source_type },
       fetch,
     } = this.props;
     const sourceType = sourceTypeMap[source_type];
     fetch(`type=${sourceType}&limit=10&offset=0`);
+
+    const checked = {};
+    for (const cur of assigned) {
+      checked[cur.uuid] = { selected: true, meta: cur, disabled: false };
+    }
+    this.setState({ checked });
   }
 
   private hasSelections = () => {

--- a/src/pages/costModels/costModel/sourceTable.tsx
+++ b/src/pages/costModels/costModel/sourceTable.tsx
@@ -32,6 +32,7 @@ class SourceTableBase extends React.Component<Props, State> {
       <>
         {isDialogOpen.addSource && (
           <AddSourceWizard
+            assigned={sources}
             costModel={costModel}
             isOpen
             onClose={() => setDialogOpen({ name: 'addSource', isOpen: false })}

--- a/src/pages/costModels/costModel/sourcesToolbar.tsx
+++ b/src/pages/costModels/costModel/sourcesToolbar.tsx
@@ -49,7 +49,7 @@ const FilterInput: React.SFC<FilterInputProps> = ({ id, placeholder = '', value,
 
 interface SourcesToolbarProps {
   actionButtonProps: ButtonProps;
-  paginationProps: PaginationProps;
+  paginationProps?: PaginationProps;
   filterInputProps: FilterInputProps;
   filter: {
     onRemove: (category: string, chip: string) => void;
@@ -84,16 +84,18 @@ export const SourcesToolbar: React.SFC<SourcesToolbarProps> = ({
             <Button {...actionButtonProps} />
           </ReadOnlyTooltip>
         </ToolbarItem>
-        <ToolbarItem variant="pagination">
-          <Pagination
-            isCompact={paginationProps.isCompact}
-            itemCount={paginationProps.itemCount}
-            page={paginationProps.page}
-            perPage={paginationProps.perPage}
-            onSetPage={paginationProps.onSetPage}
-            onPerPageSelect={paginationProps.onPerPageSelect}
-          />
-        </ToolbarItem>
+        {paginationProps && (
+          <ToolbarItem variant="pagination">
+            <Pagination
+              isCompact={paginationProps.isCompact}
+              itemCount={paginationProps.itemCount}
+              page={paginationProps.page}
+              perPage={paginationProps.perPage}
+              onSetPage={paginationProps.onSetPage}
+              onPerPageSelect={paginationProps.onPerPageSelect}
+            />
+          </ToolbarItem>
+        )}
       </ToolbarContent>
     </Toolbar>
   );

--- a/src/pages/costModels/costModel/table.tsx
+++ b/src/pages/costModels/costModel/table.tsx
@@ -4,7 +4,6 @@ import { CostModel } from 'api/costModels';
 import { EmptyFilterState } from 'components/state/emptyFilterState/emptyFilterState';
 import messages from 'locales/messages';
 import { addMultiValueQuery, removeMultiValueQuery } from 'pages/costModels/components/filterLogic';
-import { PaginationToolbarTemplate } from 'pages/costModels/components/paginationToolbarTemplate';
 import SourcesTable from 'pages/costModels/costModel/sourcesTable';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
@@ -60,6 +59,8 @@ class TableBase extends React.Component<Props, State> {
       .map(uuid => [uuid]);
     const res = filteredRows.slice((page - 1) * perPage, page * perPage);
 
+    // Note: Removed pagination props because the /cost-models/{cost_model_uuid}/ API does not support pagination
+    // See https://issues.redhat.com/browse/COST-2097
     return (
       <>
         <Title headingLevel="h2" size={TitleSizes.md} style={styles.sourceTypeTitle}>
@@ -85,23 +86,6 @@ class TableBase extends React.Component<Props, State> {
             },
             query: this.state.query,
             categoryNames: { name: intl.formatMessage(messages.Names, { count: 1 }) },
-          }}
-          paginationProps={{
-            isCompact: true,
-            itemCount: filteredRows.length,
-            perPage,
-            page,
-            onSetPage: (_evt, newPage) =>
-              this.setState({
-                pagination: {
-                  ...this.state.pagination,
-                  page: newPage,
-                },
-              }),
-            onPerPageSelect: (_evt, newPerPage) =>
-              this.setState({
-                pagination: { page: 1, perPage: newPerPage },
-              }),
           }}
           filterInputProps={{
             id: 'sources-tab-toolbar',
@@ -142,27 +126,6 @@ class TableBase extends React.Component<Props, State> {
         {filteredRows.length === 0 && rows.length > 0 && (
           <EmptyFilterState filter={this.state.filter} subTitle={messages.EmptyFilterSourceStateSubtitle} />
         )}
-        <PaginationToolbarTemplate
-          id="costmodels_details_filter_datatoolbar"
-          aria-label={intl.formatMessage(messages.CostModelsSourceTablePaginationAriaLabel)}
-          variant="bottom"
-          itemCount={filteredRows.length}
-          perPage={perPage}
-          page={page}
-          onSetPage={(_evt, newPage) =>
-            this.setState({
-              pagination: {
-                ...this.state.pagination,
-                page: newPage,
-              },
-            })
-          }
-          onPerPageSelect={(_evt, newPerPage) =>
-            this.setState({
-              pagination: { page: 1, perPage: newPerPage },
-            })
-          }
-        />
       </>
     );
   }


### PR DESCRIPTION
Modified the "add sources" dialog to retain the applied sources. Currently, anything previously assigned is replaced, unless everything is deselected first.

https://issues.redhat.com/browse/COST-2097

![chrome-capture](https://user-images.githubusercontent.com/17481322/145942472-a1f17c04-ce3d-4066-b623-1efeb95a6288.gif)

