### PR TITLE
Pagination in cost model creation wizard shows only one page with sources

### DIFF
--- a/src/pages/costModels/createCostModelWizard/api.ts
+++ b/src/pages/costModels/createCostModelWizard/api.ts
@@ -7,14 +7,15 @@ export const fetchSources = ({ type, page, perPage, query }) => {
     (acc, cur) => (acc ? `${acc}&${cur}=${query[cur]}` : `${cur}=${query[cur]}`),
     ''
   );
-  return fetchProviders(`type=${type}&limit=${limit}&offset=${offset}&${queryParam}`)
-    .then(sources => sources.data.data)
-    .then(sources => {
-      return sources.map(src => ({
-        name: src.name,
-        uuid: src.uuid,
-        costmodel: src.cost_models.map(cm => cm.name).join(','),
-        selected: false,
-      }));
-    });
+  return fetchProviders(`type=${type}&limit=${limit}&offset=${offset}&${queryParam}`).then(sources => {
+    const payload = sources.data;
+    return payload.data.map(src => ({
+      name: src.name,
+      uuid: src.uuid,
+      costmodel: src.cost_models.map(cm => cm.name).join(','),
+      meta: payload.meta,
+    }));
+  });
 };
+
+// .then(sources => sources.data.data)

--- a/src/pages/costModels/createCostModelWizard/context.ts
+++ b/src/pages/costModels/createCostModelWizard/context.ts
@@ -4,6 +4,7 @@ import React from 'react';
 
 export const defaultCostModelContext = {
   apiError: null,
+  checked: {},
   clearQuery: () => null,
   createError: null,
   createProcess: false,

--- a/src/pages/costModels/createCostModelWizard/index.tsx
+++ b/src/pages/costModels/createCostModelWizard/index.tsx
@@ -407,11 +407,9 @@ class CostModelWizardBase extends React.Component<Props, State> {
           onPerPageChange: (_evt, perPage) => this.setState({ page: 1, perPage }),
           onSourceSelect: (rowId, isSelected) => {
             if (rowId === -1) {
-              const pageSelections = this.state.sources.map(s => {
-                return {
-                  [s.uuid]: { selected: isSelected, meta: s },
-                };
-              });
+              const pageSelections = this.state.sources.map(s => ({
+                [s.uuid]: { selected: isSelected, meta: s },
+              }));
               const newState = {
                 ...this.state.checked,
                 ...pageSelections,
@@ -494,9 +492,7 @@ class CostModelWizardBase extends React.Component<Props, State> {
             markup: `${this.state.isDiscount ? '-' : ''}${this.state.markup}`,
             tiers: this.state.tiers,
             priceListCurrent: this.state.priceListCurrent,
-            sources: Object.keys(this.state.checked).map(key => {
-              return this.state.checked[key].meta;
-            }),
+            sources: Object.keys(this.state.checked).map(key => this.state.checked[key].meta),
           }}
         />
         <Modal

--- a/src/pages/costModels/createCostModelWizard/review.tsx
+++ b/src/pages/costModels/createCostModelWizard/review.tsx
@@ -51,7 +51,22 @@ const ReviewSuccess = injectIntl(ReviewSuccessBase);
 
 const ReviewDetailsBase: React.SFC<WrappedComponentProps> = ({ intl }) => (
   <CostModelContext.Consumer>
-    {({ createError, currencyUnits, description, distribution, isDiscount, markup, name, sources, tiers, type }) => {
+    {({
+      checked,
+      createError,
+      currencyUnits,
+      description,
+      distribution,
+      isDiscount,
+      markup,
+      name,
+      sources,
+      tiers,
+      type,
+    }) => {
+      const selectedSources = Object.keys(checked)
+        .filter(key => checked[key].selected)
+        .map(key => checked[key].meta);
       return (
         <>
           {createError && <Alert variant="danger" title={`${createError}`} />}
@@ -118,15 +133,12 @@ const ReviewDetailsBase: React.SFC<WrappedComponentProps> = ({ intl }) => (
                   )}
                   <TextListItem component={TextListItemVariants.dt}>
                     {intl.formatMessage(messages.CostModelsAssignSources, { count: 2 })}{' '}
-                    {sources.find(src => src.selected && Boolean(src.costmodel)) && (
+                    {selectedSources.find(src => Boolean(src.costmodel)) && (
                       <WarningIcon text={intl.formatMessage(messages.CostModelsWizardWarningSources)} />
                     )}
                   </TextListItem>
                   <TextListItem component={TextListItemVariants.dd}>
-                    {sources
-                      .filter(r => r.selected)
-                      .map(r => r.name)
-                      .join(', ')}
+                    {selectedSources.map(r => r.name).join(', ')}
                   </TextListItem>
                 </TextList>
               </TextContent>

--- a/src/pages/costModels/createCostModelWizard/table.tsx
+++ b/src/pages/costModels/createCostModelWizard/table.tsx
@@ -14,8 +14,21 @@ import { CostModelContext } from './context';
 const SourcesTable: React.SFC<WrappedComponentProps> = ({ intl }) => {
   return (
     <CostModelContext.Consumer>
-      {({ loading, onSourceSelect, sources, perPage, page, type, query, fetchSources, filterName, onFilterChange }) => {
+      {({
+        checked,
+        loading,
+        onSourceSelect,
+        sources,
+        perPage,
+        page,
+        type,
+        query,
+        fetchSources,
+        filterName,
+        onFilterChange,
+      }) => {
         const sourceType = type === 'Azure' ? 'Azure' : type;
+        const itemCount = sources.length > 0 ? sources[0].meta.count : 0;
         return (
           <Stack hasGutter>
             <StackItem>
@@ -55,7 +68,7 @@ const SourcesTable: React.SFC<WrappedComponentProps> = ({ intl }) => {
                 }}
                 paginationProps={{
                   isCompact: true,
-                  itemCount: sources.length,
+                  itemCount,
                   perPage,
                   page,
                   onSetPage: (_evt, newPage) => {
@@ -84,7 +97,7 @@ const SourcesTable: React.SFC<WrappedComponentProps> = ({ intl }) => {
                             }}
                             id={r.name}
                             key={r.name}
-                            isChecked={r.selected}
+                            isChecked={checked[r.uuid] && checked[r.uuid].selected}
                             isDisabled={Boolean(r.costmodel)}
                           />
                         </>,
@@ -101,7 +114,7 @@ const SourcesTable: React.SFC<WrappedComponentProps> = ({ intl }) => {
                         </>,
                         r.costmodel ? r.costmodel : '',
                       ],
-                      selected: r.selected,
+                      selected: checked[r.uuid] && checked[r.uuid].selected,
                     };
                   })}
                 >
@@ -110,7 +123,7 @@ const SourcesTable: React.SFC<WrappedComponentProps> = ({ intl }) => {
                 </Table>
               )}
               <PaginationToolbarTemplate
-                itemCount={sources.length}
+                itemCount={itemCount}
                 perPage={perPage}
                 page={page}
                 onSetPage={(_evt, newPage) => {


### PR DESCRIPTION
The sources pagination did not function because it only counted items in the current page, not the API's meta count.
In addition, the cost models wizard only retains selections for the current page.

https://issues.redhat.com/browse/COST-2160

![chrome-capture (1)](https://user-images.githubusercontent.com/17481322/146033157-da60c620-3f22-43e5-a962-6a0e867386aa.gif)

