### PR TITLE
Add cost type to forecast

### DIFF
--- a/src/pages/views/overview/components/dashboardWidgetBase.tsx
+++ b/src/pages/views/overview/components/dashboardWidgetBase.tsx
@@ -91,10 +91,13 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   }
 
   public componentDidUpdate(prevProps: DashboardWidgetProps) {
-    const { costType, fetchReports, widgetId } = this.props;
+    const { costType, fetchReports, fetchForecasts, trend, widgetId } = this.props;
 
     if (prevProps.costType !== costType) {
       fetchReports(widgetId);
+      if (trend.computedForecastItem !== undefined) {
+        fetchForecasts(widgetId);
+      }
     }
   }
 

--- a/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
@@ -34,7 +34,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       time_scope_value: -2,
     }),
     current: getQueryForWidget(widget, filter),
-    forecast: getQueryForWidget(widget, {}, { limit: 31, cost_type: undefined }), // Todo: forecast should support cost_type
+    forecast: getQueryForWidget(widget, {}),
     tabs: getQueryForWidgetTabs(widget, {
       ...tabsFilter,
       resolution: 'monthly',


### PR DESCRIPTION
Update forecast API requests to use the new `cost_type` param.

https://issues.redhat.com/browse/COST-2163

https://user-images.githubusercontent.com/17481322/146040585-06edff7f-9f4d-471f-8e7b-ddb56c0cde2e.mov


