### PR TITLE
Add limit param to the sources API request

### DIFF
--- a/src/api/providers.test.ts
+++ b/src/api/providers.test.ts
@@ -10,5 +10,5 @@ import { fetchProviders } from './providers';
 test('api get provider calls axios.get', () => {
   const query = getProvidersQuery(awsProvidersQuery);
   fetchProviders(query);
-  expect(axios.get).toBeCalledWith('sources/?type=AWS');
+  expect(axios.get).toBeCalledWith('sources/?limit=100&type=AWS');
 });

--- a/src/api/queries/providersQuery.ts
+++ b/src/api/queries/providersQuery.ts
@@ -1,6 +1,7 @@
 import { parse, stringify } from 'qs';
 
 export interface ProvidersQuery {
+  limit?: number;
   page_size?: number;
   type?: 'AWS' | 'Azure' | 'GCP' | 'IBM' | 'OCP';
 }

--- a/src/pages/costModels/createCostModelWizard/review.tsx
+++ b/src/pages/costModels/createCostModelWizard/review.tsx
@@ -51,18 +51,7 @@ const ReviewSuccess = injectIntl(ReviewSuccessBase);
 
 const ReviewDetailsBase: React.SFC<WrappedComponentProps> = ({ intl }) => (
   <CostModelContext.Consumer>
-    {({
-      checked,
-      createError,
-      currencyUnits,
-      description,
-      distribution,
-      isDiscount,
-      markup,
-      name,
-      tiers,
-      type,
-    }) => {
+    {({ checked, createError, currencyUnits, description, distribution, isDiscount, markup, name, tiers, type }) => {
       const selectedSources = Object.keys(checked)
         .filter(key => checked[key].selected)
         .map(key => checked[key].meta);

--- a/src/pages/costModels/createCostModelWizard/review.tsx
+++ b/src/pages/costModels/createCostModelWizard/review.tsx
@@ -60,7 +60,6 @@ const ReviewDetailsBase: React.SFC<WrappedComponentProps> = ({ intl }) => (
       isDiscount,
       markup,
       name,
-      sources,
       tiers,
       type,
     }) => {

--- a/src/store/providers/providersCommon.ts
+++ b/src/store/providers/providersCommon.ts
@@ -5,22 +5,27 @@ export const stateKey = 'providers';
 export const addProviderKey = 'add-provider';
 
 export const awsProvidersQuery: ProvidersQuery = {
+  limit: 100,
   type: 'AWS',
 };
 
 export const azureProvidersQuery: ProvidersQuery = {
+  limit: 100,
   type: 'Azure',
 };
 
 export const gcpProvidersQuery: ProvidersQuery = {
+  limit: 100,
   type: 'GCP',
 };
 
 export const ibmProvidersQuery: ProvidersQuery = {
+  limit: 100,
   type: 'IBM',
 };
 
 export const ocpProvidersQuery: ProvidersQuery = {
+  limit: 100,
   type: 'OCP',
 };
 


### PR DESCRIPTION
Noticed an issue with the overview and details pages, using the insights-qa user. We recently added 15 sources to test a bug, but now those pages display an empty state indicating we're processing data.

For the overview and details pages, the UI looks at the current_month_data property returned by the sources API. By default, the API only returns 10 items, and none of those sources have data. We need to look at all the sources.

To resolve this issue, we should add the `limit=100` param to the sources API request. For example:

api/cost-management/v1/sources/?type=OCP&limit=100

https://issues.redhat.com/browse/COST-2164