### PR TITLE
Updated tab key navigation for type-ahead

### DIFF
--- a/src/pages/views/components/resourceTypeahead/resourceInput.tsx
+++ b/src/pages/views/components/resourceTypeahead/resourceInput.tsx
@@ -201,12 +201,10 @@ class ResourceInputBase extends React.Component<ResourceInputProps> {
 
   // Enable keyboard only usage while focused on the menu
   private handleMenuKeyDown = event => {
-    if (event.key === 'Escape') {
+    if (event.key === 'Escape' || event.key === 'Tab') {
+      event.preventDefault();
       this.focusTextInput();
       this.setState({ menuIsOpen: false });
-    }
-    if (event.key === 'Tab') {
-      this.handleClearSearch();
     }
   };
 
@@ -234,6 +232,7 @@ class ResourceInputBase extends React.Component<ResourceInputProps> {
         this.handleMenuSelect(event);
         break;
       case 'Escape':
+      case 'Tab':
         this.focusTextInput();
         this.setState({ menuIsOpen: false });
         break;
@@ -244,9 +243,6 @@ class ResourceInputBase extends React.Component<ResourceInputProps> {
           const firstElement = this.menuRef.current.querySelector('li > button:not(:disabled)');
           firstElement && (firstElement as any).focus();
         }
-        break;
-      case 'Tab':
-        this.handleClearSearch();
         break;
       default:
         // Open menu upon any un-designated keys


### PR DESCRIPTION
The PatternFly Text Input Group component, used for type-ahead has issues regarding keyboard navigation. 

When navigating items with the tab key, focus should move back to the input, before moving to another element in the page. This will allow the user to edit the text input and / or tab to the clear button.

https://issues.redhat.com/browse/COST-2203