### PR TITLE
Add limit param to metrics API request

### DIFF
--- a/src/api/metrics.test.ts
+++ b/src/api/metrics.test.ts
@@ -6,10 +6,10 @@ import { fetchRateMetrics } from './metrics';
 
 test('api get OpenShift metrics', () => {
   fetchRateMetrics('OCP');
-  expect(axios.get).toBeCalledWith('metrics/?source_type=OCP');
+  expect(axios.get).toBeCalledWith('metrics/?limit=20&source_type=OCP');
 });
 
 test('api get all metrics', () => {
   fetchRateMetrics();
-  expect(axios.get).toBeCalledWith('metrics/');
+  expect(axios.get).toBeCalledWith('metrics/?limit=20');
 });

--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -19,6 +19,6 @@ export interface MetricHash {
 export type Metrics = PagedResponse<Metric>;
 
 export function fetchRateMetrics(source_type = '') {
-  const query = source_type ? `?source_type=${source_type}` : '';
-  return axios.get<Metrics>(`metrics/${query}`);
+  const query = source_type ? `&source_type=${source_type}` : '';
+  return axios.get<Metrics>(`metrics/?limit=20${query}`);
 }


### PR DESCRIPTION
The metrics API request is not picking up newly added units. There are now 11 metrics, but the API returns 10 by default.

We need to add a `limit` parameter to metrics API request, so we can display all units.

https://issues.redhat.com/browse/COST-2262