### PR TITLE
Effective-usage metric should include units

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -16329,6 +16329,42 @@
               }
             ]
           },
+          "effective_usage": {
+            "value": [
+              {
+                "offset": 0,
+                "options": {
+                  "one": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "Request"
+                      }
+                    ]
+                  },
+                  "other": {
+                    "value": [
+                      {
+                        "type": 0,
+                        "value": "Effective-usage ("
+                      },
+                      {
+                        "type": 1,
+                        "value": "units"
+                      },
+                      {
+                        "type": 0,
+                        "value": ")"
+                      }
+                    ]
+                  }
+                },
+                "pluralType": "cardinal",
+                "type": 6,
+                "value": "count"
+              }
+            ]
+          },
           "other": {
             "value": []
           },

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -303,7 +303,7 @@
   "MarkupTitle": "Markup",
   "Measurement": "Measurement",
   "MeasurementPlaceholder": "Filter by measurements",
-  "MeasurementValues": "{value, select, count {{count, plural, one {Count} other {Count ({units})}}} request {{count, plural, one {Request} other {Request ({units})}}} usage {{count, plural, one {Usage} other {Usage ({units})}}} other {}}",
+  "MeasurementValues": "{value, select, count {{count, plural, one {Count} other {Count ({units})}}} effective_usage {{count, plural, one {Request} other {Effective-usage ({units})}}} request {{count, plural, one {Request} other {Request ({units})}}} usage {{count, plural, one {Usage} other {Usage ({units})}}} other {}}",
   "MemoryTitle": "Memory",
   "Metric": "Metric",
   "MetricPlaceholder": "Filter by metrics",

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -2256,6 +2256,7 @@ export default defineMessages({
     defaultMessage:
       '{value, select, ' +
       'count {{count, plural, one {Count} other {Count ({units})}}} ' +
+      'effective_usage {{count, plural, one {Request} other {Effective-usage ({units})}}} ' +
       'request {{count, plural, one {Request} other {Request ({units})}}} ' +
       'usage {{count, plural, one {Usage} other {Usage ({units})}}} ' +
       'other {}}',

--- a/src/pages/costModels/components/rateForm/rateForm.tsx
+++ b/src/pages/costModels/components/rateForm/rateForm.tsx
@@ -67,7 +67,7 @@ const RateFormBase: React.FunctionComponent<RateFormProps> = ({
     const _units = u.replace(/-/g, '_').toLowerCase();
     const units = intl.formatMessage(messages.Units, { units: unitsLookupKey(_units) });
     const label = intl.formatMessage(messages.MeasurementValues, {
-      value: m.toLowerCase(),
+      value: m.toLowerCase().replace('-', '_'),
       units: units ? units : u,
       count: 2,
     });

--- a/src/pages/costModels/costModel/priceListTable.tsx
+++ b/src/pages/costModels/costModel/priceListTable.tsx
@@ -85,7 +85,10 @@ class PriceListTable extends React.Component<Props, State> {
     };
     const getMeasurementLabel = m => {
       // Match message descriptor or default to API string
-      const label = intl.formatMessage(messages.MeasurementValues, { value: m.toLowerCase(), count: 1 });
+      const label = intl.formatMessage(messages.MeasurementValues, {
+        value: m.toLowerCase().replace('-', '_'),
+        count: 1,
+      });
       return label ? label : m;
     };
     const metricOpts = Object.keys(metricsHash).map(m => ({

--- a/src/pages/costModels/createCostModelWizard/priceListTable.tsx
+++ b/src/pages/costModels/createCostModelWizard/priceListTable.tsx
@@ -56,7 +56,10 @@ class PriceListTable extends React.Component<Props, State> {
     };
     const getMeasurementLabel = m => {
       // Match message descriptor or default to API string
-      const label = intl.formatMessage(messages.MeasurementValues, { value: m.toLowerCase(), count: 1 });
+      const label = intl.formatMessage(messages.MeasurementValues, {
+        value: m.toLowerCase().replace('-', '_'),
+        count: 1,
+      });
       return label ? label : m;
     };
     const metricOpts = Object.keys(metricsHash).map(m => ({


### PR DESCRIPTION
When creating rates, "Effective-usage" is presented as an option, but it should include units, similar to other localized options.

https://issues.redhat.com/browse/COST-2277