### PR TITLE
Bullet chart requests shown as range for no capacity

### DIFF
--- a/src/pages/views/details/components/usageChart/usageChart.tsx
+++ b/src/pages/views/details/components/usageChart/usageChart.tsx
@@ -113,25 +113,11 @@ class UsageChartBase extends React.Component<UsageChartProps> {
     };
 
     const hasRequest = hasTotal && report.meta.total.request && report.meta.total.request !== null;
+    const hasUsage = hasTotal && report.meta.total.usage && report.meta.total.usage !== null;
     const request = Math.trunc(hasRequest ? report.meta.total.request.value : 0);
     const requestUnits = intl.formatMessage(messages.Units, {
       units: unitsLookupKey(hasRequest ? report.meta.total.request.units : undefined),
     });
-    datum.ranges = [
-      {
-        legend: intl.formatMessage(messages.DetailsUsageRequests, {
-          value: request,
-          units: requestUnits,
-        }),
-        tooltip: intl.formatMessage(messages.DetailsUsageRequests, {
-          value: request,
-          units: requestUnits,
-        }),
-        value: Math.trunc(request),
-      },
-    ];
-
-    const hasUsage = hasTotal && report.meta.total.usage && report.meta.total.usage !== null;
     const usage = Math.trunc(hasUsage ? report.meta.total.usage.value : 0);
     const usageUnits = intl.formatMessage(messages.Units, {
       units: unitsLookupKey(hasUsage ? report.meta.total.usage.units : undefined),
@@ -147,6 +133,17 @@ class UsageChartBase extends React.Component<UsageChartProps> {
           units: usageUnits,
         }),
         value: Math.trunc(usage),
+      },
+      {
+        legend: intl.formatMessage(messages.DetailsUsageRequests, {
+          value: request,
+          units: requestUnits,
+        }),
+        tooltip: intl.formatMessage(messages.DetailsUsageRequests, {
+          value: request,
+          units: requestUnits,
+        }),
+        value: Math.trunc(request),
       },
     ];
     return datum;

--- a/src/pages/views/details/components/usageChart/usageChart.tsx
+++ b/src/pages/views/details/components/usageChart/usageChart.tsx
@@ -85,7 +85,7 @@ class UsageChartBase extends React.Component<UsageChartProps> {
   };
 
   private getChartDatum(): ChartDatum {
-    const { report, intl } = this.props;
+    const { groupBy, report, intl } = this.props;
     const datum: ChartDatum = {
       limit: {},
       ranges: [],
@@ -112,89 +112,27 @@ class UsageChartBase extends React.Component<UsageChartProps> {
       value: Math.trunc(limit),
     };
 
-    const hasRequest = hasTotal && report.meta.total.request && report.meta.total.request !== null;
-    const hasUsage = hasTotal && report.meta.total.usage && report.meta.total.usage !== null;
-    const request = Math.trunc(hasRequest ? report.meta.total.request.value : 0);
-    const requestUnits = intl.formatMessage(messages.Units, {
-      units: unitsLookupKey(hasRequest ? report.meta.total.request.units : undefined),
-    });
-    const usage = Math.trunc(hasUsage ? report.meta.total.usage.value : 0);
-    const usageUnits = intl.formatMessage(messages.Units, {
-      units: unitsLookupKey(hasUsage ? report.meta.total.usage.units : undefined),
-    });
-    datum.usage = [
-      {
-        legend: intl.formatMessage(messages.DetailsUsageUsage, {
-          value: usage,
-          units: usageUnits,
-        }),
-        tooltip: intl.formatMessage(messages.DetailsUsageUsage, {
-          value: usage,
-          units: usageUnits,
-        }),
-        value: Math.trunc(usage),
-      },
-      {
-        legend: intl.formatMessage(messages.DetailsUsageRequests, {
-          value: request,
-          units: requestUnits,
-        }),
-        tooltip: intl.formatMessage(messages.DetailsUsageRequests, {
-          value: request,
-          units: requestUnits,
-        }),
-        value: Math.trunc(request),
-      },
-    ];
-    return datum;
-  }
-
-  private getChartDatumWithCapacity(): ChartDatum {
-    const { report, intl } = this.props;
-    const datum: ChartDatum = {
-      limit: {},
-      ranges: [],
-      usage: [],
-    };
-
-    // Always show bullet chart legends https://github.com/project-koku/koku-ui/issues/963
-    const hasTotal = report && report.meta && report.meta.total;
-
-    const hasLimit = hasTotal && report.meta.total.limit && report.meta.total.limit !== null;
-    const limit = Math.trunc(hasLimit ? report.meta.total.limit.value : 0);
-    const limitUnits = intl.formatMessage(messages.Units, {
-      units: unitsLookupKey(hasLimit ? report.meta.total.limit.units : undefined),
-    });
-    datum.limit = {
-      legend: intl.formatMessage(messages.DetailsUsageLimit, {
-        value: limit,
-        units: limitUnits,
-      }),
-      tooltip: intl.formatMessage(messages.DetailsUsageLimit, {
-        value: limit,
-        units: limitUnits,
-      }),
-      value: Math.trunc(limit),
-    };
-
-    const hasCapacity = hasTotal && report.meta.total.request && report.meta.total.request !== null;
-    const capacity = Math.trunc(hasCapacity ? report.meta.total.capacity.value : 0);
-    const capacityUnits = intl.formatMessage(messages.Units, {
-      units: unitsLookupKey(hasCapacity ? report.meta.total.capacity.units : undefined),
-    });
-    datum.ranges = [
-      {
-        legend: intl.formatMessage(messages.DetailsUsageCapacity, {
-          value: capacity,
-          units: capacityUnits,
-        }),
-        tooltip: intl.formatMessage(messages.DetailsUsageCapacity, {
-          value: capacity,
-          units: capacityUnits,
-        }),
-        value: Math.trunc(capacity),
-      },
-    ];
+    // Qualitative range included only when grouped by cluster
+    if (groupBy === 'cluster') {
+      const hasCapacity = hasTotal && report.meta.total.request && report.meta.total.request !== null;
+      const capacity = Math.trunc(hasCapacity ? report.meta.total.capacity.value : 0);
+      const capacityUnits = intl.formatMessage(messages.Units, {
+        units: unitsLookupKey(hasCapacity ? report.meta.total.capacity.units : undefined),
+      });
+      datum.ranges = [
+        {
+          legend: intl.formatMessage(messages.DetailsUsageCapacity, {
+            value: capacity,
+            units: capacityUnits,
+          }),
+          tooltip: intl.formatMessage(messages.DetailsUsageCapacity, {
+            value: capacity,
+            units: capacityUnits,
+          }),
+          value: Math.trunc(capacity),
+        },
+      ];
+    }
 
     const hasRequest = hasTotal && report.meta.total.request && report.meta.total.request !== null;
     const hasUsage = hasTotal && report.meta.total.usage && report.meta.total.usage !== null;
@@ -237,7 +175,7 @@ class UsageChartBase extends React.Component<UsageChartProps> {
     const { groupBy, reportFetchStatus, report } = this.props;
     const { width } = this.state;
 
-    const chartDatum = groupBy === 'cluster' ? this.getChartDatumWithCapacity() : this.getChartDatum();
+    const chartDatum = this.getChartDatum();
 
     if (!report || chartDatum.usage.length === 0) {
       return null;

--- a/src/utils/feature.ts
+++ b/src/utils/feature.ts
@@ -18,6 +18,8 @@ export const isStageBeta = () => {
 export const isFeatureVisible = (feature: FeatureType) => {
   // Show in-progress features for stage-beta only
   switch (feature) {
+    case FeatureType.ninetyDays:
+      return true; // Todo: Example of how to enable a feature for all envs
     case FeatureType.currency:
     case FeatureType.exports:
     case FeatureType.ibm:


### PR DESCRIPTION
When showing bullet charts without capacity, the requests are shown in grey instead of blue. For example, when OCP is grouped by project instead of cluster.

In this case, requests are shown as the bullet chart's "qualitative range". To be consistent, requests and usage should be shown together as the "primary segmented measure".

https://issues.redhat.com/browse/COST-2363

**Before (grouped by project)**
<img width="794" alt="no capacity" src="https://user-images.githubusercontent.com/17481322/155534782-e5a62a7a-95ac-4d05-842b-6e41a38661a5.png">

**After (grouped by project)**
<img width="681" alt="Screen Shot 2022-02-24 at 8 30 08 AM" src="https://user-images.githubusercontent.com/17481322/155534807-6d18b4ae-c730-4590-b5a8-ccf55d641263.png">
