### PR TITLE
Some chart tooltips are not formatted properly

### DIFF
--- a/src/pages/views/overview/components/dashboardWidgetBase.tsx
+++ b/src/pages/views/overview/components/dashboardWidgetBase.tsx
@@ -164,7 +164,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
 
   // This chart displays cumulative and daily cost compared to infrastructure cost
   private getDailyCostChart = (containerHeight: number, height: number, adjustContainerHeight: boolean = false) => {
-    const { currentReport, previousReport, trend } = this.props;
+    const { chartFormatter, currentReport, previousReport, trend } = this.props;
     const { currentComparison } = this.state;
 
     const computedReportItem = trend.computedReportItem; // cost, supplementary cost, etc.
@@ -213,7 +213,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
           forecastInfrastructureConeData={forecastInfrastructureData.forecastConeData}
           forecastInfrastructureData={forecastInfrastructureData.forecastData}
           formatOptions={trend.formatOptions}
-          formatter={formatCurrency}
+          formatter={chartFormatter || formatCurrency}
           height={height}
           previousCostData={previousCostData}
           previousInfrastructureCostData={previousInfrastructureData}
@@ -231,7 +231,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     showInfrastructureLabel: boolean = false,
     showSupplementaryLabel: boolean = false
   ) => {
-    const { currentReport, details, previousReport, trend } = this.props;
+    const { chartFormatter, currentReport, details, previousReport, trend } = this.props;
     const { currentComparison } = this.state;
 
     const computedReportItem = trend.computedReportItem; // cost, supplementary cost, etc.
@@ -260,7 +260,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
           forecastData={forecastData}
           forecastConeData={forecastConeData}
           formatOptions={trend.formatOptions}
-          formatter={formatCurrency}
+          formatter={chartFormatter || formatCurrency}
           height={height}
           previousData={previousData}
           showForecast={trend.computedForecastItem !== undefined}
@@ -405,7 +405,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     showInfrastructureLabel: boolean = false,
     showSupplementaryLabel: boolean = false
   ) => {
-    const { currentReport, details, intl, previousReport, trend } = this.props;
+    const { chartFormatter, currentReport, details, intl, previousReport, trend } = this.props;
 
     const computedReportItem = trend.computedReportItem || 'cost'; // cost, supplementary cost, etc.
     const computedReportItemValue = trend.computedReportItemValue; // infrastructure usage cost
@@ -432,7 +432,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         forecastData={forecastData}
         forecastConeData={forecastConeData}
         formatOptions={trend.formatOptions}
-        formatter={formatCurrency}
+        formatter={chartFormatter || formatCurrency}
         height={height}
         previousData={previousData}
         showForecast={trend.computedForecastItem !== undefined}
@@ -447,7 +447,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
 
   // This chart displays usage and requests
   private getUsageChart = (height: number, adjustContainerHeight: boolean = false) => {
-    const { currentReport, intl, previousReport, trend } = this.props;
+    const { chartFormatter, currentReport, intl, previousReport, trend } = this.props;
 
     const title = intl.formatMessage(trend.titleKey, {
       units: this.getFormattedUnits(),
@@ -468,7 +468,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         currentRequestData={currentRequestData}
         currentUsageData={currentUsageData}
         formatOptions={trend.formatOptions}
-        formatter={formatUnits}
+        formatter={chartFormatter || formatUnits}
         height={height}
         previousRequestData={previousRequestData}
         previousUsageData={previousUsageData}

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -9,6 +9,7 @@ import {
 } from 'pages/views/components/charts/common/chartDatumUtils';
 import { paths } from 'routes';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
+import { formatUnits } from 'utils/format';
 
 import { AwsDashboardTab, AwsDashboardWidget } from './awsDashboardCommon';
 
@@ -39,6 +40,7 @@ export const computeWidget: AwsDashboardWidget = {
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
   },
+  chartFormatter: formatUnits,
   chartType: DashboardChartType.trend,
 };
 

--- a/src/store/dashboard/awsOcpDashboard/awsOcpDashboardWidgets.ts
+++ b/src/store/dashboard/awsOcpDashboard/awsOcpDashboardWidgets.ts
@@ -8,6 +8,7 @@ import {
   ComputedReportItemValueType,
 } from 'pages/views/components/charts/common/chartDatumUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
+import { formatUnits } from 'utils/format';
 
 import { AwsOcpDashboardTab, AwsOcpDashboardWidget } from './awsOcpDashboardCommon';
 
@@ -38,6 +39,7 @@ export const computeWidget: AwsOcpDashboardWidget = {
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
   },
+  chartFormatter: formatUnits,
   chartType: DashboardChartType.trend,
 };
 

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -9,6 +9,7 @@ import {
 } from 'pages/views/components/charts/common/chartDatumUtils';
 import { paths } from 'routes';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
+import { formatUnits } from 'utils/format';
 
 import { AzureDashboardTab, AzureDashboardWidget } from './azureDashboardCommon';
 
@@ -147,5 +148,6 @@ export const virtualMachineWidget: AzureDashboardWidget = {
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
   },
+  chartFormatter: formatUnits,
   chartType: DashboardChartType.trend,
 };

--- a/src/store/dashboard/azureOcpDashboard/azureOcpDashboardWidgets.ts
+++ b/src/store/dashboard/azureOcpDashboard/azureOcpDashboardWidgets.ts
@@ -8,6 +8,7 @@ import {
   ComputedReportItemValueType,
 } from 'pages/views/components/charts/common/chartDatumUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
+import { formatUnits } from 'utils/format';
 
 import { AzureOcpDashboardTab, AzureOcpDashboardWidget } from './azureOcpDashboardCommon';
 
@@ -144,5 +145,6 @@ export const virtualMachineWidget: AzureOcpDashboardWidget = {
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
   },
+  chartFormatter: formatUnits,
   chartType: DashboardChartType.trend,
 };

--- a/src/store/dashboard/common/dashboardCommon.ts
+++ b/src/store/dashboard/common/dashboardCommon.ts
@@ -1,7 +1,7 @@
 import { MessageDescriptor } from '@formatjs/intl/src/types';
 import { ForecastPathsType, ForecastType } from 'api/forecasts/forecast';
 import { ReportPathsType, ReportType } from 'api/reports/report';
-import { FormatOptions } from 'utils/format';
+import { FormatOptions, Formatter } from 'utils/format';
 
 // eslint-disable-next-line no-shadow
 export const enum DashboardChartType {
@@ -14,6 +14,7 @@ export const enum DashboardChartType {
 
 export interface DashboardWidget<T> {
   availableTabs?: T[];
+  chartFormatter?: Formatter;
   chartType?: DashboardChartType;
   currentTab?: T;
   details: {

--- a/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
@@ -9,9 +9,9 @@ import {
 } from 'pages/views/components/charts/common/chartDatumUtils';
 import { paths } from 'routes';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
+import { formatUnits } from 'utils/format';
 
 import { GcpDashboardTab, GcpDashboardWidget } from './gcpDashboardCommon';
-import { formatUnits } from 'utils/format';
 
 let currrentId = 0;
 const getId = () => currrentId++;

--- a/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
@@ -11,6 +11,7 @@ import { paths } from 'routes';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 
 import { GcpDashboardTab, GcpDashboardWidget } from './gcpDashboardCommon';
+import { formatUnits } from 'utils/format';
 
 let currrentId = 0;
 const getId = () => currrentId++;
@@ -40,6 +41,7 @@ export const computeWidget: GcpDashboardWidget = {
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
   },
+  chartFormatter: formatUnits,
   chartType: DashboardChartType.trend,
 };
 

--- a/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardWidgets.ts
@@ -8,6 +8,7 @@ import {
   ComputedReportItemValueType,
 } from 'pages/views/components/charts/common/chartDatumUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
+import { formatUnits } from 'utils/format';
 
 import { GcpOcpDashboardTab, GcpOcpDashboardWidget } from './gcpOcpDashboardCommon';
 
@@ -39,6 +40,7 @@ export const computeWidget: GcpOcpDashboardWidget = {
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
   },
+  chartFormatter: formatUnits,
   chartType: DashboardChartType.trend,
 };
 

--- a/src/store/dashboard/ibmDashboard/ibmDashboardWidgets.ts
+++ b/src/store/dashboard/ibmDashboard/ibmDashboardWidgets.ts
@@ -9,6 +9,7 @@ import {
 } from 'pages/views/components/charts/common/chartDatumUtils';
 import { paths } from 'routes';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
+import { formatUnits } from 'utils/format';
 
 import { IbmDashboardTab, IbmDashboardWidget } from './ibmDashboardCommon';
 
@@ -40,6 +41,7 @@ export const computeWidget: IbmDashboardWidget = {
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
   },
+  chartFormatter: formatUnits,
   chartType: DashboardChartType.trend,
 };
 

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
@@ -8,6 +8,7 @@ import {
   ComputedReportItemValueType,
 } from 'pages/views/components/charts/common/chartDatumUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
+import { formatUnits } from 'utils/format';
 
 import { OcpCloudDashboardTab, OcpCloudDashboardWidget } from './ocpCloudDashboardCommon';
 
@@ -64,6 +65,7 @@ export const computeWidget: OcpCloudDashboardWidget = {
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
   },
+  chartFormatter: formatUnits,
   chartType: DashboardChartType.trend,
 };
 


### PR DESCRIPTION
Some overview charts are not showing tooltips correctly. For example, the AWS "Compute (EC2) instances usage" card is showing "HRS 96.00 hours" in the chart tooltip.

https://issues.redhat.com/browse/COST-2364

**Before**
<img width="657" alt="Screen Shot 2022-02-24 at 11 19 49 AM" src="https://user-images.githubusercontent.com/17481322/155567683-9c2ebc92-64e4-4b83-a527-ea6b48fb4be3.png">


**After**
<img width="662" alt="Screen Shot 2022-02-24 at 11 38 45 AM" src="https://user-images.githubusercontent.com/17481322/155567758-788f15bd-fb07-420c-b62d-cecf15d6c467.png">

