### PR TITLE
Add content to "All exports" drawer

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -14327,6 +14327,12 @@
         "value": "All exports"
       }
     ],
+    "ExportsUnavailable": [
+      {
+        "type": 0,
+        "value": "Export cannot be generated"
+      }
+    ],
     "FilterByButtonAriaLabel": [
       {
         "options": {

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -253,6 +253,7 @@
   "ExportsSuccessDesc": "The export is preparing for download. It will be accessible from {value} view. {link}",
   "ExportsTableAriaLabel": "Available exports table",
   "ExportsTitle": "All exports",
+  "ExportsUnavailable": "Export cannot be generated",
   "FilterByButtonAriaLabel": "{value, select, account {Filter button for account name} cluster {Filter button for cluster name} gcp_project {Filter button for GCP project name} name {Filter button for name name} node {Filter button for node name} org_unit_id {Filter button for organizational unit name} project {Filter button for project name} region {Filter button for region name} resource_location {Filter button for region name} service {Filter button for service name} service_name {Filter button for service_name name} subscription_guid {Filter button for account name} tag {Filter button for tag name} other {}}",
   "FilterByInputAriaLabel": "{value, select, account {Input for account name} cluster {Input for cluster name} gcp_project {Input for GCP project name} name {Input for name name} node {Input for node name} org_unit_id {Input for organizational unit name} project {Input for project name} region {Input for region name} resource_location {Input for region name} service {Input for service name} service_name {Input for service_name name} subscription_guid {Input for account name} tag {Input for tag name} other {}}",
   "FilterByOrgUnitAriaLabel": "Organizational units",

--- a/src/components/exports/exportsTable.tsx
+++ b/src/components/exports/exportsTable.tsx
@@ -119,7 +119,7 @@ class ExportsTableBase extends React.Component<ExportsTableProps> {
             { title: <div>{item.created}</div>, id: ExportsTableColumnIds.created },
             { title: <div>{item.expires}</div>, id: ExportsTableColumnIds.expires },
             { title: this.getStatus(item.status), id: ExportsTableColumnIds.status },
-            { title: this.getActions(item.status), id: ExportsTableColumnIds.actions },
+            { title: <ExportsActions onDelete={this.handleOnDelete} />, id: ExportsTableColumnIds.actions },
           ],
           item,
         });
@@ -150,15 +150,6 @@ class ExportsTableBase extends React.Component<ExportsTableProps> {
       rows,
       sortBy: {},
     });
-  };
-
-  private getActions = (status: string) => {
-    switch (status) {
-      case 'failed':
-        return null;
-      default:
-        return <ExportsActions onDelete={this.handleOnDelete} />;
-    }
   };
 
   private getEmptyState = () => {

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -1850,6 +1850,11 @@ export default defineMessages({
     description: 'All exports',
     id: 'ExportsTitle',
   },
+  ExportsUnavailable: {
+    defaultMessage: 'Export cannot be generated',
+    description: 'Export cannot be generated',
+    id: 'ExportsUnavailable',
+  },
   FilterByButtonAriaLabel: {
     defaultMessage:
       '{value, select, ' +

--- a/src/pages/costModels/costModel/costModelsDetails.styles.ts
+++ b/src/pages/costModels/costModel/costModelsDetails.styles.ts
@@ -54,9 +54,6 @@ export const styles = {
     display: 'flex',
     justifyContent: 'space-between',
   },
-  headerContentRight: {
-    display: 'flex',
-  },
   headerCostModel: {
     padding: global_spacer_lg.value,
     paddingBottom: 0,

--- a/src/pages/costModels/costModel/header.tsx
+++ b/src/pages/costModels/costModel/header.tsx
@@ -20,7 +20,6 @@ import {
   TitleSizes,
 } from '@patternfly/react-core';
 import { CostModel } from 'api/costModels';
-import { ExportsLink } from 'components/exports';
 import * as H from 'history';
 import messages from 'locales/messages';
 import { ReadOnlyTooltip } from 'pages/costModels/components/readOnlyTooltip';
@@ -34,7 +33,6 @@ import { paths } from 'routes';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
 import { rbacSelectors } from 'store/rbac';
-import { FeatureType, isFeatureVisible } from 'utils/feature';
 import { getBaseName } from 'utils/paths';
 
 interface Props extends WrappedComponentProps {
@@ -113,10 +111,6 @@ const Header: React.FunctionComponent<Props> = ({
             </BreadcrumbItem>
             <BreadcrumbItem isActive>{current.name}</BreadcrumbItem>
           </Breadcrumb>
-          <div style={styles.headerContentRight}>
-            {/* Todo: Show in-progress features in beta environment only */}
-            {isFeatureVisible(FeatureType.exports) && <ExportsLink />}
-          </div>
         </div>
         <Split>
           <SplitItem style={styles.headerDescription}>

--- a/src/pages/costModels/costModelsDetails/header.styles.ts
+++ b/src/pages/costModels/costModelsDetails/header.styles.ts
@@ -5,7 +5,4 @@ export const styles = {
     display: 'flex',
     justifyContent: 'space-between',
   },
-  headerContentRight: {
-    display: 'flex',
-  },
 } as { [className: string]: React.CSSProperties };

--- a/src/pages/costModels/costModelsDetails/header.tsx
+++ b/src/pages/costModels/costModelsDetails/header.tsx
@@ -1,12 +1,10 @@
 import { Button, ButtonVariant, Popover, TextContent, Title, TitleSizes } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
-import { ExportsLink } from 'components/exports';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { RootState } from 'store';
-import { FeatureType, isFeatureVisible } from 'utils/feature';
 
 import { styles } from './header.styles';
 
@@ -22,10 +20,6 @@ function HeaderBase({ children }: HeaderProps): JSX.Element {
           {children}
         </Title>
       </TextContent>
-      <div style={styles.headerContentRight}>
-        {/* Todo: Show in-progress features in beta environment only */}
-        {isFeatureVisible(FeatureType.exports) && <ExportsLink />}
-      </div>
     </div>
   );
 }

--- a/src/pages/views/details/components/breakdown/breakdownHeader.tsx
+++ b/src/pages/views/details/components/breakdown/breakdownHeader.tsx
@@ -5,7 +5,6 @@ import { AngleLeftIcon } from '@patternfly/react-icons/dist/esm/icons/angle-left
 import { breakdownDescKey, breakdownTitleKey, getQueryRoute, orgUnitIdKey, Query } from 'api/queries/query';
 import { Report } from 'api/reports/report';
 import { TagPathsType } from 'api/tags/tag';
-import { ExportsLink } from 'components/exports';
 import messages from 'locales/messages';
 import { Currency } from 'pages/components/currency';
 import { CostType } from 'pages/views/components/costType';
@@ -122,7 +121,6 @@ class BreakdownHeaderBase extends React.Component<BreakdownHeaderProps> {
           <div style={styles.headerContentRight}>
             {/* Todo: Show in-progress features in beta environment only */}
             {isFeatureVisible(FeatureType.currency) && <Currency />}
-            {isFeatureVisible(FeatureType.exports) && <ExportsLink />}
           </div>
         </div>
         <div style={styles.headerContent}>

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -18,7 +18,6 @@ import { getProvidersQuery } from 'api/queries/providersQuery';
 import { getUserAccessQuery } from 'api/queries/userAccessQuery';
 import { UserAccess, UserAccessType } from 'api/userAccess';
 import { AxiosError } from 'axios';
-import { ExportsLink } from 'components/exports';
 import messages from 'locales/messages';
 import { Currency } from 'pages/components/currency';
 import Loading from 'pages/state/loading';
@@ -663,7 +662,6 @@ class OverviewBase extends React.Component<OverviewProps> {
             <div style={styles.headerContentRight}>
               {/* Todo: Show in-progress features in beta environment only */}
               {isFeatureVisible(FeatureType.currency) && <Currency />}
-              {isFeatureVisible(FeatureType.exports) && <ExportsLink />}
             </div>
           </div>
           <div style={styles.tabs}>{this.getTabs(availableTabs)}</div>

--- a/src/store/export/exportActions.tsx
+++ b/src/store/export/exportActions.tsx
@@ -73,7 +73,7 @@ export function exportReport(
             addNotification({
               description: intl.formatMessage(messages.ExportsFailedDesc),
               dismissable: true,
-              title: intl.formatMessage(messages.ExportsFailed),
+              title: intl.formatMessage(messages.ExportsUnavailable),
               variant: 'danger',
             })
           );

--- a/src/store/export/exportActions.tsx
+++ b/src/store/export/exportActions.tsx
@@ -1,4 +1,4 @@
-import { addNotification, clearNotifications } from '@redhat-cloud-services/frontend-components-notifications';
+import { addNotification, removeNotification } from '@redhat-cloud-services/frontend-components-notifications';
 import { Export } from 'api/export/export';
 import { runExport } from 'api/export/exportUtils';
 import { ReportPathsType, ReportType } from 'api/reports/report';
@@ -25,6 +25,8 @@ export const fetchExportRequest = createAction('report/request')<ExportActionMet
 export const fetchExportSuccess = createAction('report/success')<Export, ExportActionMeta>();
 export const fetchExportFailure = createAction('report/failure')<AxiosError, ExportActionMeta>();
 
+const exportSuccessID = 'cost_management_export_success';
+
 export function exportReport(
   reportPathsType: ReportPathsType,
   reportType: ReportType,
@@ -47,7 +49,7 @@ export function exportReport(
         /* Todo: Show in-progress features in beta environment only */
         if (isFeatureVisible(FeatureType.exports)) {
           const description = intl.formatMessage(messages.ExportsSuccessDesc, {
-            link: <ExportsLink isActionLink onClick={() => dispatch(clearNotifications())} />,
+            link: <ExportsLink isActionLink onClick={() => dispatch(removeNotification(exportSuccessID))} />,
             value: <b>{intl.formatMessage(messages.ExportsTitle)}</b>,
           });
 
@@ -55,6 +57,7 @@ export function exportReport(
             addNotification({
               description,
               dismissable: true,
+              id: exportSuccessID,
               title: intl.formatMessage(messages.ExportsSuccess),
               variant: 'success',
             })

--- a/src/utils/feature.ts
+++ b/src/utils/feature.ts
@@ -22,6 +22,7 @@ export const isFeatureVisible = (feature: FeatureType) => {
       return true; // Todo: Example of how to enable a feature for all envs
     case FeatureType.currency:
     case FeatureType.exports:
+    case FeatureType.gcpOcp:
     case FeatureType.ibm:
     case FeatureType.oci:
       return isStageBeta();


### PR DESCRIPTION
Add content to "All exports" drawer

- Remove only our own success notification when clicking "all exports" link
- Table's delete action should be visible for failed exports
- Omit "All exports" link from overview, cost models, and breakdown pages.
- Update failed export alert message

https://issues.redhat.com/browse/COST-2339

**Failed alert message**
<img width="710" alt="Screen Shot 2022-02-24 at 2 11 48 PM" src="https://user-images.githubusercontent.com/17481322/155591722-c0b94daa-e472-4e46-853b-d80fe79f5310.png">

