### PR TITLE
Fix remote container initialization.

### DIFF
--- a/koku-ui-manifest
+++ b/koku-ui-manifest
@@ -121,7 +121,7 @@ mgmt_services/cost-mgmt:koku-ui/@patternfly/react-table:4.67.5.yarnlock
 mgmt_services/cost-mgmt:koku-ui/@patternfly/react-tokens:4.50.5.yarnlock
 mgmt_services/cost-mgmt:koku-ui/@popperjs/core:2.11.2.yarnlock
 mgmt_services/cost-mgmt:koku-ui/@react-aria/ssr:3.1.0.yarnlock
-mgmt_services/cost-mgmt:koku-ui/@redhat-cloud-services/frontend-components-config-utilities:1.5.11.yarnlock
+mgmt_services/cost-mgmt:koku-ui/@redhat-cloud-services/frontend-components-config-utilities:1.5.15.yarnlock
 mgmt_services/cost-mgmt:koku-ui/@redhat-cloud-services/frontend-components-notifications:3.2.5.yarnlock
 mgmt_services/cost-mgmt:koku-ui/@redhat-cloud-services/frontend-components-translations:3.2.4.yarnlock
 mgmt_services/cost-mgmt:koku-ui/@redhat-cloud-services/frontend-components-utilities:3.2.8.yarnlock

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "devDependencies": {
     "@formatjs/cli": "4.2.12",
-    "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.11",
+    "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.15",
     "@testing-library/react": "^12.1.2",
     "@types/enzyme": "^3.10.11",
     "@types/jest": "^27.4.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -216,17 +216,6 @@ module.exports = (_env, argv) => {
       // !isProduction && new webpack.HotModuleReplacementPlugin(),
       // production plugins
     ].filter(Boolean),
-    optimization: {
-      splitChunks: {
-        cacheGroups: {
-          commons: {
-            test: /[\\/]node_modules[\\/](react|react-dom|redux|@patternfly*)[\\/]/,
-            name: 'vendor',
-            chunks: 'all',
-          },
-        },
-      },
-    },
     performance: {
       assetFilter: assetFilename => !(fileRegEx.test(assetFilename) || /\.map$/.test(assetFilename)),
     },

--- a/yarn.lock
+++ b/yarn.lock
@@ -773,10 +773,10 @@
   dependencies:
     "@babel/runtime" "^7.6.2"
 
-"@redhat-cloud-services/frontend-components-config-utilities@^1.5.11":
-  version "1.5.11"
-  resolved "https://registry.yarnpkg.com/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.5.11.tgz#342b17e8a8fd0b3bd49087053e7f747c1eef6383"
-  integrity sha512-8fjp5l0/RiPWwHLldZnHM8ARrVYP/iYk8XscmE6YhNgDFG9C+Up0pJWXGsV3YeWwppwqR/NtGvdMufoEhy7e7Q==
+"@redhat-cloud-services/frontend-components-config-utilities@^1.5.15":
+  version "1.5.15"
+  resolved "https://registry.yarnpkg.com/@redhat-cloud-services/frontend-components-config-utilities/-/frontend-components-config-utilities-1.5.15.tgz#6d8d6cc903f65fed38a114d477cdac54c3902345"
+  integrity sha512-Sbfn2eIK51BdMef+2njasQRvvMZIZLbiiSgUnlEF0asuc3zh1DRHL6tRDKF5b0MqnlBA1Egc4RF+WRalDCkR0Q==
 
 "@redhat-cloud-services/frontend-components-notifications@^3.2.5":
   version "3.2.5"


### PR DESCRIPTION
Recent versions of webpack-dev-server are unable to run remote containers locally without injecting the container entry into HTML if a custom `splitChunks` configuration is defined.

The custom splint chunks config is ignored by webpack if a module is a part of a remote container but the dev server is still picking it up. Dropping it fixes the remote container initialization which is required 