### PR TITLE
Update how "Show cost as" value is cached

### DIFF
--- a/src/api/queries/query.ts
+++ b/src/api/queries/query.ts
@@ -23,6 +23,7 @@ export interface Filters {
 
 export interface Query {
   cost_type?: any;
+  currency?: any;
   dateRange?: any;
   end_date?: any;
   filter?: any;

--- a/src/pages/components/currency/currency.tsx
+++ b/src/pages/components/currency/currency.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
-import { getCurrency, invalidateCurrency, setCurrency } from 'utils/localStorage';
+import { getCurrency, invalidateSession, restoreCurrency, setCurrency } from 'utils/localStorage';
 
 import { styles } from './currency.styles';
 
@@ -65,6 +65,9 @@ class CurrencyBase extends React.Component<CurrencyProps> {
   private getSelect = () => {
     const { isDisabled } = this.props;
     const { isSelectOpen } = this.state;
+
+    // Restore from query param if available
+    restoreCurrency();
 
     const currency = getCurrency(); // Get currency from local storage
     const selectOptions = this.getSelectOptions();
@@ -127,7 +130,7 @@ class CurrencyBase extends React.Component<CurrencyProps> {
     const { intl } = this.props;
 
     // Clear local storage value if current session is not valid
-    invalidateCurrency();
+    invalidateSession();
 
     return (
       <div style={styles.currencySelector}>

--- a/src/pages/views/components/costType/costType.tsx
+++ b/src/pages/views/components/costType/costType.tsx
@@ -7,7 +7,7 @@ import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
-import { CostTypes, getCostType, invalidateCostType, setCostType } from 'utils/localStorage';
+import { CostTypes, getCostType, invalidateSession, restoreCostType, setCostType } from 'utils/localStorage';
 
 import { styles } from './costType.styles';
 
@@ -55,6 +55,9 @@ class CostTypeBase extends React.Component<CostTypeProps> {
   private getSelect = () => {
     const { isDisabled } = this.props;
     const { isSelectOpen } = this.state;
+
+    // Restore from query param if available
+    restoreCostType();
 
     const costType = getCostType(); // Get cost type from local storage
     const selectOptions = this.getSelectOptions();
@@ -118,7 +121,7 @@ class CostTypeBase extends React.Component<CostTypeProps> {
     const { intl } = this.props;
 
     // Clear local storage value if current session is not valid
-    invalidateCostType();
+    invalidateSession();
 
     return (
       <div style={styles.costSelector}>

--- a/src/pages/views/details/awsDetails/awsDetails.tsx
+++ b/src/pages/views/details/awsDetails/awsDetails.tsx
@@ -24,7 +24,6 @@ import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedAwsReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
-import { getCostType } from 'utils/localStorage';
 
 import { styles } from './awsDetails.styles';
 import { DetailsHeader } from './detailsHeader';
@@ -387,7 +386,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
           filter_by: query ? query.filter_by : undefined,
           group_by: query ? query.group_by : undefined,
           order_by: { cost: 'desc' },
-          cost_type: query ? query.cost_type : getCostType(),
+          cost_type: query ? query.cost_type : undefined,
         })
       );
     } else {
@@ -457,7 +456,7 @@ const mapStateToProps = createMapStateToProps<AwsDetailsOwnProps, AwsDetailsStat
     filter_by: queryFromRoute.filter_by || baseQuery.filter_by,
     group_by: queryFromRoute.group_by || baseQuery.group_by,
     order_by: queryFromRoute.order_by || baseQuery.order_by,
-    cost_type: queryFromRoute.cost_type || getCostType(),
+    cost_type: queryFromRoute.cost_type,
   };
   const queryString = getQuery(query);
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);

--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -22,7 +22,6 @@ import { userAccessQuery, userAccessSelectors } from 'store/userAccess';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
 import { getLast60DaysDate } from 'utils/dateRange';
 import { FeatureType, isFeatureVisible } from 'utils/feature';
-import { getCostType } from 'utils/localStorage';
 import {
   hasAwsAccess,
   hasAzureAccess,
@@ -185,7 +184,6 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
       group_by: { [getGroupByDefault(value)]: '*' },
       order_by: undefined, // Clear sort
       perspective: value,
-      ...(value === PerspectiveType.aws && { cost_type: getCostType() }),
     };
     this.setState({ currentPerspective: value }, () => {
       if (onPerspectiveClicked) {

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -52,7 +52,6 @@ import { providersQuery, providersSelectors } from 'store/providers';
 import { userAccessQuery, userAccessSelectors } from 'store/userAccess';
 import { getSinceDateRangeString } from 'utils/dateRange';
 import { FeatureType, isFeatureVisible } from 'utils/feature';
-import { getCostType } from 'utils/localStorage';
 import {
   hasAwsAccess,
   hasAzureAccess,
@@ -513,7 +512,6 @@ class OverviewBase extends React.Component<OverviewProps> {
         const newQuery = {
           ...JSON.parse(JSON.stringify(query)),
           perspective: value,
-          ...(value === InfrastructurePerspective.aws && { cost_type: getCostType() }),
         };
         history.replace(this.getRouteForQuery(newQuery));
       }

--- a/src/store/accountSettings/accountSettingsReducer.ts
+++ b/src/store/accountSettings/accountSettingsReducer.ts
@@ -4,8 +4,7 @@ import { FetchStatus } from 'store/common';
 import { resetState } from 'store/ui/uiActions';
 import { ActionType, getType } from 'typesafe-actions';
 import {
-  invalidateCostType,
-  invalidateCurrency,
+  invalidateSession,
   isCostTypeAvailable,
   isCurrencyAvailable,
   setAccountCurrency,
@@ -75,7 +74,7 @@ export function accountSettingsReducer(state = defaultState, action: AccountSett
 // Initialize cost type in local storage
 function initCostType(value: string) {
   // Clear local storage value if current session is not valid
-  invalidateCostType();
+  invalidateSession();
 
   if (!isCostTypeAvailable()) {
     setCostType(value);
@@ -85,7 +84,7 @@ function initCostType(value: string) {
 // Initialize currency in local storage
 function initCurrency(value: string) {
   // Clear local storage value if current session is not valid
-  invalidateCurrency();
+  invalidateSession();
 
   if (!isCurrencyAvailable()) {
     setCurrency(value);

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -27,6 +27,20 @@ export const getSessionToken = () => {
   return localStorage.getItem(sessionTokenID);
 };
 
+// Invalidates session if not valid and restores query param values
+export const invalidateSession = () => {
+  if (!isSessionValid()) {
+    deleteSessionToken();
+
+    // Delete cost type
+    deleteCostType();
+
+    // Delete currency
+    deleteAccountCurrency();
+    deleteCurrency();
+  }
+};
+
 // Returns true if session is valid
 export const isSessionValid = () => {
   return getSessionToken() === getPartialTokenCookie();
@@ -59,27 +73,17 @@ export const getCostType = () => {
   return costType && costType !== null ? costType : CostTypes.unblended;
 };
 
-// Invalidates cost type if current session is not valid
-export const invalidateCostType = () => {
-  if (!isSessionValid()) {
-    deleteSessionToken();
-    deleteCostType();
-    restoreCostType(); // Restore from query param
-  }
-};
-
 // Returns true if cost type is available
 export const isCostTypeAvailable = () => {
   const costType = localStorage.getItem(costTypeID);
   return costType && costType !== null;
 };
 
-// Restore cost type upon page refresh if query param is available
+// Restore cost type from query param if available
 export const restoreCostType = () => {
-  const costType = localStorage.getItem(costTypeID);
   const queryFromRoute = parseQuery<Query>(location.search);
 
-  if (queryFromRoute.cost_type && costType === null) {
+  if (queryFromRoute.cost_type) {
     setCostType(queryFromRoute.cost_type);
   }
 };
@@ -116,19 +120,19 @@ export const getCurrency = () => {
   return units ? units : 'USD';
 };
 
-// Invalidates currency if current session is not valid
-export const invalidateCurrency = () => {
-  if (!isSessionValid()) {
-    deleteAccountCurrency();
-    deleteSessionToken();
-    deleteCurrency();
-  }
-};
-
 // Returns true if currency is available
 export const isCurrencyAvailable = () => {
   const currency = localStorage.getItem(currencyID);
   return currency && currency !== null;
+};
+
+// Restore currency from query param if available
+export const restoreCurrency = () => {
+  const queryFromRoute = parseQuery<Query>(location.search);
+
+  if (queryFromRoute.currency) {
+    setCurrency(queryFromRoute.currency);
+  }
 };
 
 // Set account currency


### PR DESCRIPTION
Update how "Show cost as" value is cached

Testing:

1. Login via incognito window - to start with a clean slate
2. Navigate to account settings
3. Update the default "Show cost as" value
4. Navigate to AWS details and see the default value
5. Select a new "Show cost as" value (same page)
6. Refresh the page and confirm the new value has been applied
7. There should now be a cost_type query param in the page URL
8. Navigate to the Overview page and AWS perspective
9. Confirm the new value has been applied
10. Navigate to the Cost Explorer page and AWS perspective
11. Confirm the new value has been applied
12. Refresh the page
13. Confirm the default value is shown

https://issues.redhat.com/browse/COST-2451