### PR TITLE
Connect currency selection to cost model API

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,4 +17,5 @@ module.exports = {
   roots: ['<rootDir>/src'],
   snapshotSerializers: ['enzyme-to-json/serializer'],
   testURL: 'http://localhost/',
+  testTimeout: 30000,
 };

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "verify": "tsc --noEmit"
   },
   "dependencies": {
-    "@formatjs/cli": "^4.8.2",
     "@fortawesome/free-solid-svg-icons": "^6.0.0",
     "@patternfly/patternfly": "^4.183.1",
     "@patternfly/react-charts": "^6.51.19",
@@ -77,7 +76,7 @@
     "xstate": "^4.30.0"
   },
   "devDependencies": {
-    "@formatjs/cli": "4.2.12",
+    "@formatjs/cli": "^4.8.3",
     "@redhat-cloud-services/frontend-components-config-utilities": "^1.5.15",
     "@testing-library/react": "^12.1.2",
     "@testing-library/user-event": "^13.5.0",

--- a/src/pages/costModels/components/rateForm/hasDiff.ts
+++ b/src/pages/costModels/components/rateForm/hasDiff.ts
@@ -40,7 +40,7 @@ export function hasDiff(rate: Rate, rateFormData: RateFormData): boolean {
       const isCurDefault = rateFormData.taggingRates.defaultTag === ix;
       return (
         tvalue.tag_value !== cur.tagValue ||
-        Number(tvalue.value) !== Number(cur.value) ||
+        Number(tvalue.value) !== Number(cur.inputValue) ||
         tvalue.description !== cur.description ||
         tvalue.default !== isCurDefault
       );

--- a/src/pages/costModels/components/rateForm/rateForm.tsx
+++ b/src/pages/costModels/components/rateForm/rateForm.tsx
@@ -50,7 +50,7 @@ const RateFormBase: React.FunctionComponent<RateFormProps> = ({
       tagValues,
     },
     tieredRates: {
-      0: { value: regular, isDirty: regularDirty },
+      0: { inputValue, isDirty: regularDirty },
     },
     toggleTaggingRate,
     updateDefaultTag,
@@ -199,7 +199,7 @@ const RateFormBase: React.FunctionComponent<RateFormProps> = ({
               onChange={setRegular}
               style={style}
               validated={errors.tieredRates && regularDirty ? 'error' : 'default'}
-              value={regular}
+              value={inputValue}
             />
           ) : (
             <>

--- a/src/pages/costModels/components/rateForm/taggingRatesForm.tsx
+++ b/src/pages/costModels/components/rateForm/taggingRatesForm.tsx
@@ -65,7 +65,7 @@ const TaggingRatesFormBase: React.FunctionComponent<TaggingRatesFormProps> = ({
                 onChange={value => updateTag({ value }, ix)}
                 style={style}
                 validated={tagValues[ix].isDirty && errors.tagValues[ix] ? 'error' : 'default'}
-                value={tag.value}
+                value={tag.inputValue}
               />
             </SplitItem>
             <SplitItem>

--- a/src/pages/costModels/components/rateForm/useRateForm.tsx
+++ b/src/pages/costModels/components/rateForm/useRateForm.tsx
@@ -202,12 +202,12 @@ export function rateFormReducer(state = initialRateFormData, action: Actions) {
               ...action.payload,
               isDirty,
               isTagValueDirty,
-
-              // Original user input
-              inputValue: action.payload.value,
-
-              // Normalize for API requests where USD decimal formatting is expected
-              value: unFormat(action.payload.value),
+              ...(action.payload.value && {
+                // Original user input
+                inputValue: action.payload.value,
+                // Normalize for API requests where USD decimal formatting is expected
+                value: unFormat(action.payload.value),
+              }),
             },
             ...state.taggingRates.tagValues.slice(action.index + 1),
           ],

--- a/src/pages/costModels/components/rateForm/useRateForm.tsx
+++ b/src/pages/costModels/components/rateForm/useRateForm.tsx
@@ -203,12 +203,12 @@ export function rateFormReducer(state = initialRateFormData, action: Actions) {
             {
               ...state.taggingRates.tagValues[action.index],
               ...action.payload,
-              isDirty,
-              isTagValueDirty,
               ...(action.payload.value && {
                 inputValue: action.payload.value, // Original user input
                 value: unFormat(action.payload.value), // Normalize for API requests where USD decimal format is expected
               }),
+              isDirty,
+              isTagValueDirty,
             },
             ...state.taggingRates.tagValues.slice(action.index + 1),
           ],

--- a/src/pages/costModels/components/rateForm/useRateForm.tsx
+++ b/src/pages/costModels/components/rateForm/useRateForm.tsx
@@ -123,12 +123,15 @@ export function rateFormReducer(state = initialRateFormData, action: Actions) {
       };
     }
     case 'UPDATE_REGULAR': {
-      // Normalize for API requests where USD decimal formatting is expected
-      const value = unFormat(action.value);
-
       return {
         ...state,
-        tieredRates: [{ inputValue: action.value, value, isDirty: true }],
+        tieredRates: [
+          {
+            isDirty: true,
+            inputValue: action.value,
+            value: unFormat(action.value), // Normalize for API requests where USD decimal format is expected
+          },
+        ],
         errors: {
           ...state.errors,
           tieredRates: checkRateOnChange(action.value),
@@ -203,10 +206,8 @@ export function rateFormReducer(state = initialRateFormData, action: Actions) {
               isDirty,
               isTagValueDirty,
               ...(action.payload.value && {
-                // Original user input
-                inputValue: action.payload.value,
-                // Normalize for API requests where USD decimal formatting is expected
-                value: unFormat(action.payload.value),
+                inputValue: action.payload.value, // Original user input
+                value: unFormat(action.payload.value), // Normalize for API requests where USD decimal format is expected
               }),
             },
             ...state.taggingRates.tagValues.slice(action.index + 1),

--- a/src/pages/costModels/components/rateForm/useRateForm.tsx
+++ b/src/pages/costModels/components/rateForm/useRateForm.tsx
@@ -1,6 +1,7 @@
 import { MetricHash } from 'api/metrics';
 import { Rate } from 'api/rates';
 import React from 'react';
+import { unFormat } from 'utils/format';
 
 import { textHelpers } from './constants';
 import {
@@ -122,9 +123,12 @@ export function rateFormReducer(state = initialRateFormData, action: Actions) {
       };
     }
     case 'UPDATE_REGULAR': {
+      // Normalize for API requests where USD decimal formatting is expected
+      const value = unFormat(action.value);
+
       return {
         ...state,
-        tieredRates: [{ value: action.value, isDirty: true }],
+        tieredRates: [{ inputValue: action.value, value, isDirty: true }],
         errors: {
           ...state.errors,
           tieredRates: checkRateOnChange(action.value),
@@ -174,6 +178,7 @@ export function rateFormReducer(state = initialRateFormData, action: Actions) {
       let descriptionError = state.errors.tagDescription[action.index];
       let isDirty = state.taggingRates.tagValues[action.index].isDirty;
       let isTagValueDirty = state.taggingRates.tagValues[action.index].isTagValueDirty;
+
       if (action.payload.value !== undefined) {
         const { value: rate } = action.payload;
         error = checkRateOnChange(rate);
@@ -197,6 +202,12 @@ export function rateFormReducer(state = initialRateFormData, action: Actions) {
               ...action.payload,
               isDirty,
               isTagValueDirty,
+
+              // Original user input
+              inputValue: action.payload.value,
+
+              // Normalize for API requests where USD decimal formatting is expected
+              value: unFormat(action.payload.value),
             },
             ...state.taggingRates.tagValues.slice(action.index + 1),
           ],

--- a/src/pages/costModels/components/rateForm/utils.tsx
+++ b/src/pages/costModels/components/rateForm/utils.tsx
@@ -95,7 +95,7 @@ export function genFormDataFromRate(rate: Rate, defaultValue = initialRateFormDa
     return { ...defaultValue, otherTiers };
   }
   const rateKind = rate.tiered_rates ? 'regular' : 'tagging';
-  let tieredRates = [{ value: '', isDirty: true }] as any;
+  let tieredRates = [{ inputValue: '', value: '', isDirty: true }];
   const tagRates = { ...initialtaggingRates };
   const errors = {
     description: null,
@@ -121,7 +121,7 @@ export function genFormDataFromRate(rate: Rate, defaultValue = initialRateFormDa
         tagValue: tvalue.tag_value,
         value,
       };
-    }) as any;
+    });
     errors.tieredRates = textHelpers.required;
     errors.tagValueValues = new Array(item.tag_values.length).fill(null);
     errors.tagValues = new Array(item.tag_values.length).fill(null);

--- a/src/pages/costModels/components/rateTable.tsx
+++ b/src/pages/costModels/components/rateTable.tsx
@@ -14,7 +14,7 @@ import { intl as defaultIntl } from 'components/i18n';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
-import { formatCurrencyRate, unFormat } from 'utils/format';
+import { formatCurrencyRate } from 'utils/format';
 
 import { compareBy } from './rateForm/utils';
 import TagRateTable from './tagRateTable';
@@ -22,18 +22,11 @@ import TagRateTable from './tagRateTable';
 interface RateTableProps extends WrappedComponentProps {
   actions?: IActions;
   isCompact?: boolean;
-  isNormalized?: boolean; // Normalize rates to format currency in current locale
   tiers: Rate[];
 }
 
 // defaultIntl required for testing
-const RateTableBase: React.SFC<RateTableProps> = ({
-  actions,
-  intl = defaultIntl,
-  isCompact,
-  isNormalized = false,
-  tiers,
-}) => {
+const RateTableBase: React.SFC<RateTableProps> = ({ actions, intl = defaultIntl, isCompact, tiers }) => {
   const [expanded, setExpanded] = React.useState({});
   const [sortBy, setSortBy] = React.useState<ISortBy>({});
   const onSort = (_event, index: number, direction: SortByDirection) => {
@@ -60,7 +53,7 @@ const RateTableBase: React.SFC<RateTableProps> = ({
             parent: ix + counter,
             cells: [
               {
-                title: <TagRateTable isNormalized={isNormalized} tagRates={tier.tag_rates} />,
+                title: <TagRateTable tagRates={tier.tag_rates} />,
                 props: { colSpan: 6, className: 'pf-m-no-padding' },
               },
             ],
@@ -70,7 +63,6 @@ const RateTableBase: React.SFC<RateTableProps> = ({
       }
       const isOpen = rateKind === 'tagging' ? expanded[ix + counter - 1] || false : undefined;
       const tierRate = tier.tiered_rates ? tier.tiered_rates[0].value : 0;
-      const tierRateValue = Number(isNormalized ? unFormat(tierRate.toString()) : tierRate);
 
       return [
         ...acc,
@@ -84,7 +76,7 @@ const RateTableBase: React.SFC<RateTableProps> = ({
             {
               title:
                 rateKind === 'regular'
-                  ? formatCurrencyRate(tierRateValue, tier.tiered_rates[0].unit)
+                  ? formatCurrencyRate(tierRate, tier.tiered_rates[0].unit)
                   : intl.formatMessage(messages.Various),
               props: { isOpen, style: { padding: rateKind === 'tagging' ? '' : '1.5rem 1rem' } },
             },

--- a/src/pages/costModels/components/tagRateTable.tsx
+++ b/src/pages/costModels/components/tagRateTable.tsx
@@ -4,19 +4,14 @@ import { intl as defaultIntl } from 'components/i18n';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
-import { formatCurrencyRate, unFormat } from 'utils/format';
+import { formatCurrencyRate } from 'utils/format';
 
 interface TagRateTableProps extends WrappedComponentProps {
   tagRates: TagRates;
-  isNormalized?: boolean; // Normalize rates to format currency in current locale
 }
 
 // defaultIntl required for testing
-const TagRateTable: React.FunctionComponent<TagRateTableProps> = ({
-  isNormalized = false,
-  intl = defaultIntl,
-  tagRates,
-}) => {
+const TagRateTable: React.FunctionComponent<TagRateTableProps> = ({ intl = defaultIntl, tagRates }) => {
   const cells = [
     intl.formatMessage(messages.CostModelsTagRateTableKey),
     intl.formatMessage(messages.CostModelsTagRateTableValue),
@@ -28,13 +23,11 @@ const TagRateTable: React.FunctionComponent<TagRateTableProps> = ({
   const rows =
     tagRates &&
     tagRates.tag_values.map((tagValue, ix) => {
-      const _tagValue = Number(isNormalized ? unFormat(tagValue.value.toString()) : tagValue.value);
-
       return {
         cells: [
           ix === 0 ? tagRates.tag_key : '',
           tagValue.tag_value,
-          formatCurrencyRate(_tagValue, tagValue.unit),
+          formatCurrencyRate(tagValue.value, tagValue.unit),
           tagValue.description,
           tagValue.default ? intl.formatMessage(messages.Yes) : intl.formatMessage(messages.No),
         ],

--- a/src/pages/costModels/costModel/addRateModal.tsx
+++ b/src/pages/costModels/costModel/addRateModal.tsx
@@ -74,7 +74,7 @@ export const AddRateModalBase: React.FunctionComponent<AddRateModalBaseProps> = 
     >
       <Form>
         {updateError && <Alert variant="danger" title={`${updateError}`} />}
-        <RateForm metricsHash={metricsHash} rateFormData={rateFormData} />
+        <RateForm currencyUnits={costModel.currency} metricsHash={metricsHash} rateFormData={rateFormData} />
       </Form>
     </Modal>
   );

--- a/src/pages/costModels/costModel/updateRateModel.test.tsx
+++ b/src/pages/costModels/costModel/updateRateModel.test.tsx
@@ -335,6 +335,7 @@ describe('update-rate', () => {
     fireEvent.change(getByDisplayValue(/any container/i), { target: { value: 'any container1' } });
     expect(getByText(regExp(messages.Save)).closest('button').disabled).toBeFalsy();
     fireEvent.change(getByDisplayValue(/any container1/i), { target: { value: 'any container' } });
+    expect(getByText(regExp(messages.Save)).closest('button').disabled).toBeTruthy();
 
     fireEvent.change(getByDisplayValue(/0.4/i), { target: { value: '1.23' } });
     expect(getByText(regExp(messages.Save)).closest('button').disabled).toBeFalsy();

--- a/src/pages/costModels/createCostModelWizard/priceListTable.tsx
+++ b/src/pages/costModels/createCostModelWizard/priceListTable.tsx
@@ -212,7 +212,6 @@ class PriceListTable extends React.Component<Props, State> {
                               },
                             ]}
                             isCompact
-                            isNormalized
                             tiers={res}
                           />
                         )}

--- a/src/pages/costModels/createCostModelWizard/review.tsx
+++ b/src/pages/costModels/createCostModelWizard/review.tsx
@@ -98,7 +98,7 @@ const ReviewDetailsBase: React.SFC<WrappedComponentProps> = ({ intl }) => (
                       </TextListItem>
                       <TextListItem component={TextListItemVariants.dd}>
                         {tiers.length > 0 ? (
-                          <RateTable isNormalized tiers={tiers} />
+                          <RateTable tiers={tiers} />
                         ) : (
                           intl.formatMessage(messages.CostModelsWizardNoRatesAdded)
                         )}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -206,7 +206,7 @@ export const isPercentageFormatValid = (value: string) => {
 };
 
 // Some locales have a comma decimal separator (e.g., "1.234,56" in German is "1,234.56" in USD).
-// This function normalizes a given currency or percentage for APIs.
+// This function normalizes a given currency or percentage for APIs where USD decimal formatting is expected.
 export const unFormat = (value: string) => {
   if (!value) {
     return value;

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -206,7 +206,7 @@ export const isPercentageFormatValid = (value: string) => {
 };
 
 // Some locales have a comma decimal separator (e.g., "1.234,56" in German is "1,234.56" in USD).
-// This function normalizes a given currency or percentage for APIs where USD decimal formatting is expected.
+// This function normalizes a given currency or percentage for APIs where USD decimal format is expected.
 export const unFormat = (value: string) => {
   if (!value) {
     return value;

--- a/yarn.lock
+++ b/yarn.lock
@@ -337,7 +337,7 @@
     minimatch "^3.0.4"
     strip-json-comments "^3.1.1"
 
-"@formatjs/cli@^4.8.2":
+"@formatjs/cli@^4.8.3":
   version "4.8.3"
   resolved "https://registry.yarnpkg.com/@formatjs/cli/-/cli-4.8.3.tgz#8984be6f1d333857d692f747cb8b16c663c1b354"
   integrity sha512-YmOTqKjmB4M/KJsE+e2k8IyViWwSrZwoW/lv2gLNGwucr+hc0+dWpP4oZzl07WSoVWW7NrbdvF8CEBopbfnmLQ==


### PR DESCRIPTION
The currency selector was already added via COST-1856 and available via the stage-beta env. However, we still need to provide the user's chosen currency to the cost-model API.

This change allows cost-models to be created in different currencies. In addition, rates can be edited and added in the cost model currency. Cost model currencies are always localized per the browser's locale.

https://issues.redhat.com/browse/COST-1907

**Cost model price list:**
<img width="1488" alt="Screen Shot 2022-04-01 at 2 44 56 PM" src="https://user-images.githubusercontent.com/17481322/161323726-cc926d82-7ada-4cf6-91eb-4b55d3eb8429.png">

