### PR TITLE
Update Travis to use node 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 sudo: false
 node_js:
-  - "14"
+  - "16"
 cache: yarn
 before_script: yarn global add codecov @yarnpkg/lockfile
 script:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ User interface is based on Patternfly [![Patternfly][pf-logo]][patternfly]
 To submit an issue, please visit https://issues.redhat.com/projects/COST/
 
 ## Requirements
-* [NodeJS v14+][nodejs]
+* [NodeJS v16+][nodejs]
 * [yarn 1.22+][yarn]
 
 ## Setup /etc/hosts entries (do this once)


### PR DESCRIPTION
It appears that the user-event package requires a newer version of node. 
We should bump the Travis build to use node 16.

https://issues.redhat.com/browse/COST-2526