### PR TITLE
GCP breakdown not showing all cards

### DIFF
--- a/src/store/breakdown/costOverview/gcpCostOverview/gcpCostOverviewWidgets.ts
+++ b/src/store/breakdown/costOverview/gcpCostOverview/gcpCostOverviewWidgets.ts
@@ -18,7 +18,7 @@ export const accountSummaryWidget: GcpCostOverviewWidget = {
   id: getId(),
   reportSummary: {
     reportGroupBy: 'account',
-    showWidgetOnGroupBy: ['project', 'region', 'service', tagPrefix],
+    showWidgetOnGroupBy: ['gcp_project', 'region', 'service', tagPrefix],
   },
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.cost,
@@ -28,7 +28,7 @@ export const accountSummaryWidget: GcpCostOverviewWidget = {
 export const projectSummaryWidget: GcpCostOverviewWidget = {
   id: getId(),
   reportSummary: {
-    reportGroupBy: 'project',
+    reportGroupBy: 'gcp_project',
     showWidgetOnGroupBy: ['account', 'region', 'service', tagPrefix],
   },
   reportPathsType: ReportPathsType.gcp,
@@ -40,7 +40,7 @@ export const regionSummaryWidget: GcpCostOverviewWidget = {
   id: getId(),
   reportSummary: {
     reportGroupBy: 'region',
-    showWidgetOnGroupBy: ['account', 'project', 'service', tagPrefix],
+    showWidgetOnGroupBy: ['account', 'gcp_project', 'service', tagPrefix],
   },
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.cost,
@@ -51,7 +51,7 @@ export const serviceSummaryWidget: GcpCostOverviewWidget = {
   id: getId(),
   reportSummary: {
     reportGroupBy: 'service',
-    showWidgetOnGroupBy: ['project', 'region', 'account', tagPrefix],
+    showWidgetOnGroupBy: ['gcp_project', 'region', 'account', tagPrefix],
   },
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.cost,


### PR DESCRIPTION
The GCP breakdown is missing a few cards when grouping by GCP Project; services, regions, etc. 

https://issues.redhat.com/browse/COST-2533

<img width="1796" alt="Screen Shot 2022-04-05 at 11 59 36 AM" src="https://user-images.githubusercontent.com/17481322/161796286-93c3ba26-92ab-4117-952b-b948859db91c.png">

