### PR TITLE
Increase number of group_by options shown

### DIFF
--- a/src/api/queries/query.ts
+++ b/src/api/queries/query.ts
@@ -30,6 +30,7 @@ export interface Query {
   filter_by?: any;
   group_by?: any;
   key_only?: boolean;
+  limit?: number;
   order_by?: any;
   perspective?: any;
   search?: any;

--- a/src/pages/views/components/dataToolbar/tagValue.tsx
+++ b/src/pages/views/components/dataToolbar/tagValue.tsx
@@ -34,10 +34,8 @@ interface TagValueOwnProps extends WrappedComponentProps {
 }
 
 interface TagValueStateProps {
-  endDate?: string;
   groupBy: string;
   groupByValue: string | number;
-  startDate?: string;
   tagReport?: Tag;
   tagReportFetchStatus?: FetchStatus;
 }
@@ -178,39 +176,15 @@ const mapStateToProps = createMapStateToProps<TagValueOwnProps, TagValueStatePro
   (state, { tagKey, tagReportPathsType }) => {
     const query = parseQuery<Query>(location.search);
 
-    const endDate = query.end_date;
-    const startDate = query.start_date;
     const groupByOrgValue = getGroupByOrgValue(query);
     const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
     const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
 
-    const tagKeyFilter = tagKey
-      ? {
-          key: tagKey,
-        }
-      : {};
-
-    const tagQuery =
-      endDate && startDate
-        ? {
-            start_date: startDate,
-            end_date: endDate,
-            filter: {
-              ...tagKeyFilter,
-            },
-          }
-        : {
-            filter: {
-              resolution: 'monthly',
-              time_scope_units: 'month',
-              time_scope_value: -1,
-              ...tagKeyFilter,
-            },
-          };
-
     // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
     const tagQueryString = getQuery({
-      ...tagQuery,
+      filter: {
+        key: tagKey,
+      },
     });
     const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, tagQueryString);
     const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(
@@ -221,10 +195,8 @@ const mapStateToProps = createMapStateToProps<TagValueOwnProps, TagValueStatePro
     );
 
     return {
-      endDate,
       groupBy,
       groupByValue,
-      startDate,
       tagQueryString,
       tagReport,
       tagReportFetchStatus,
@@ -240,6 +212,3 @@ const TagValueConnect = connect(mapStateToProps, mapDispatchToProps)(TagValueBas
 const TagValue = injectIntl(TagValueConnect);
 
 export { TagValue, TagValueProps };
-
-// https://stage.foo.redhat.com:1337/api/cost-management/v1/tags/openshift/?start_date=2021-11-01&end_date=2021-11-08&key=environment&filter[tag:environment]=Development&filter[project]=*
-// https://stage.foo.redhat.com:1337/api/cost-management/v1/reports/openshift/costs/?filter[limit]=10&filter[offset]=0&filter[tag:environment]=Development&group_by[project]=*&end_date=2021-11-08&start_date=2021-11-01

--- a/src/pages/views/components/groupBy/groupBy.tsx
+++ b/src/pages/views/components/groupBy/groupBy.tsx
@@ -16,7 +16,6 @@ import { GroupByOrg } from './groupByOrg';
 import { GroupByTag } from './groupByTag';
 
 interface GroupByOwnProps extends WrappedComponentProps {
-  endDate?: string;
   getIdKeyForGroupBy: (groupBy: Query['group_by']) => string;
   groupBy?: string;
   isDisabled?: boolean;
@@ -30,7 +29,6 @@ interface GroupByOwnProps extends WrappedComponentProps {
   perspective?: PerspectiveType;
   showOrgs?: boolean;
   showTags?: boolean;
-  startDate?: string;
   tagQueryString?: string;
   tagReportPathsType: TagPathsType;
 }
@@ -293,25 +291,11 @@ class GroupByBase extends React.Component<GroupByProps> {
 }
 
 const mapStateToProps = createMapStateToProps<GroupByOwnProps, GroupByStateProps>(
-  (state, { endDate, startDate, orgReportPathsType, tagReportPathsType }) => {
-    const tagQuery =
-      endDate && startDate
-        ? {
-            start_date: startDate,
-            end_date: endDate,
-          }
-        : {
-            filter: {
-              resolution: 'monthly',
-              time_scope_units: 'month',
-              time_scope_value: -1,
-            },
-          };
-
+  (state, { orgReportPathsType, tagReportPathsType }) => {
     // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
     const tagQueryString = getQuery({
-      ...tagQuery,
       key_only: true,
+      limit: 1000,
     });
     const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, tagQueryString);
     const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(
@@ -322,7 +306,8 @@ const mapStateToProps = createMapStateToProps<GroupByOwnProps, GroupByStateProps
     );
 
     const orgQueryString = getQuery({
-      // TBD...
+      key_only: true,
+      limit: 1000,
     });
     const orgReport = orgSelectors.selectOrg(state, orgReportPathsType, orgReportType, orgQueryString);
     const orgReportFetchStatus = orgSelectors.selectOrgFetchStatus(

--- a/src/pages/views/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/awsDetails/detailsToolbar.tsx
@@ -181,12 +181,8 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
   // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
   const queryString = getQuery({
-    filter: {
-      resolution: 'monthly',
-      time_scope_units: 'month',
-      time_scope_value: -1,
-    },
     key_only: true,
+    limit: 1000,
   });
   const orgReport = orgSelectors.selectOrg(state, orgReportPathsType, orgReportType, queryString);
   const orgReportFetchStatus = orgSelectors.selectOrgFetchStatus(state, orgReportPathsType, orgReportType, queryString);

--- a/src/pages/views/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/azureDetails/detailsToolbar.tsx
@@ -161,12 +161,8 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
   // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
   const queryString = getQuery({
-    filter: {
-      resolution: 'monthly',
-      time_scope_units: 'month',
-      time_scope_value: -1,
-    },
     key_only: true,
+    limit: 1000,
   });
   const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
   const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);

--- a/src/pages/views/details/gcpDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/gcpDetails/detailsToolbar.tsx
@@ -158,12 +158,8 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
   // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
   const queryString = getQuery({
-    filter: {
-      resolution: 'monthly',
-      time_scope_units: 'month',
-      time_scope_value: -1,
-    },
     key_only: true,
+    limit: 1000,
   });
 
   const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);

--- a/src/pages/views/details/ibmDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ibmDetails/detailsToolbar.tsx
@@ -156,12 +156,8 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
   // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
   const queryString = getQuery({
-    filter: {
-      resolution: 'monthly',
-      time_scope_units: 'month',
-      time_scope_value: -1,
-    },
     key_only: true,
+    limit: 1000,
   });
 
   const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);

--- a/src/pages/views/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ocpDetails/detailsToolbar.tsx
@@ -158,12 +158,8 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
   // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
   const queryString = getQuery({
-    filter: {
-      resolution: 'monthly',
-      time_scope_units: 'month',
-      time_scope_value: -1,
-    },
     key_only: true,
+    limit: 1000,
   });
   const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
   const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);

--- a/src/pages/views/explorer/explorerFilter.tsx
+++ b/src/pages/views/explorer/explorerFilter.tsx
@@ -12,7 +12,6 @@ import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { orgActions, orgSelectors } from 'store/orgs';
 import { tagActions, tagSelectors } from 'store/tags';
-import { getLast60DaysDate } from 'utils/dateRange';
 import { isEqual } from 'utils/equal';
 
 import { DateRange } from './dateRange';
@@ -219,7 +218,7 @@ const mapStateToProps = createMapStateToProps<ExplorerFilterOwnProps, ExplorerFi
 
     // Omitting key_only to share a single request -- the toolbar needs key values
     const orgQueryString = getQuery({
-      // TBD...
+      limit: 1000,
     });
 
     let orgReport;
@@ -235,14 +234,10 @@ const mapStateToProps = createMapStateToProps<ExplorerFilterOwnProps, ExplorerFi
       );
     }
 
-    // Fetch tags with largest date range available
-    const { start_date, end_date } = getLast60DaysDate();
-
     // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
     const tagQueryString = getQuery({
-      start_date,
-      end_date,
       key_only: true,
+      limit: 1000,
     });
     let tagReport;
     let tagReportFetchStatus;

--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -20,7 +20,6 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { userAccessQuery, userAccessSelectors } from 'store/userAccess';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
-import { getLast60DaysDate } from 'utils/dateRange';
 import { FeatureType, isFeatureVisible } from 'utils/feature';
 import {
   hasAwsAccess,
@@ -283,9 +282,6 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
     const resourcePathsType = getResourcePathsType(perspective);
     const tagReportPathsType = getTagReportPathsType(perspective);
 
-    // Fetch tags with largest date range available
-    const { start_date, end_date } = getLast60DaysDate();
-
     return (
       <header style={styles.header}>
         <div style={styles.headerContent}>
@@ -302,7 +298,6 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
           {this.getPerspective(noProviders)}
           <div style={styles.groupBy}>
             <GroupBy
-              endDate={end_date}
               getIdKeyForGroupBy={getIdKeyForGroupBy}
               groupBy={groupBy}
               isDisabled={noProviders}
@@ -312,7 +307,6 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
               perspective={perspective}
               showOrgs={orgReportPathsType}
               showTags={tagReportPathsType}
-              startDate={start_date}
               tagReportPathsType={tagReportPathsType}
             />
           </div>


### PR DESCRIPTION
Increase number of group_by options shown for org units and tag keys. Also cleaned up some unused filters.

https://issues.redhat.com/browse/COST-2536

<img width="571" alt="Screen Shot 2022-04-06 at 7 52 47 PM" src="https://user-images.githubusercontent.com/17481322/162092960-3c532ce3-620e-41bc-9e05-6c0af14ea1ff.png">


