### PR TITLE
Export all "failed" button style

### DIFF
--- a/src/components/exports/exportsTable.styles.ts
+++ b/src/components/exports/exportsTable.styles.ts
@@ -18,7 +18,6 @@ export const styles = {
   },
   failedButton: {
     fontSize: global_FontSize_sm.value,
-    marginLeft: '-10px',
   },
   failedHeader: {
     marginLeft: global_spacer_md.value,


### PR DESCRIPTION
Remove the "failed" button style workaround, from the all export drawer, after changes to the latest PatternFly milestone update.

<img width="1391" alt="Screen Shot 2022-04-20 at 3 47 36 PM" src="https://user-images.githubusercontent.com/17481322/164313063-e6fae080-7eb9-45ae-a82e-3b5401275e1c.png">

https://issues.redhat.com/browse/COST-2571