### PR TITLE
update select menu appends

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -10015,6 +10015,12 @@
         "value": "Create a price list"
       }
     ],
+    "CostModelsWizardCurrencyToggleLabel": [
+      {
+        "type": 0,
+        "value": "Select currency"
+      }
+    ],
     "CostModelsWizardEmptySourceTypeLabel": [
       {
         "type": 0,

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -134,6 +134,7 @@
   "CostModelsUUIDEmptyStateDesc": "Cost model with uuid: {uuid} does not exist.",
   "CostModelsWizardCreateCostModel": "Create cost model",
   "CostModelsWizardCreatePriceList": "Create a price list",
+  "CostModelsWizardCurrencyToggleLabel": "Select currency",
   "CostModelsWizardEmptySourceTypeLabel": "Select source type",
   "CostModelsWizardEmptyStateCreate": "To create a price list, begin by clicking the {value} button.",
   "CostModelsWizardEmptyStateOtherTime": "You can create a price list or modify one at a later time.",

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -1026,6 +1026,11 @@ export default defineMessages({
     description: 'Create a price list',
     id: 'CostModelsWizardCreatePriceList',
   },
+  CostModelsWizardCurrencyToggleLabel: {
+    defaultMessage: 'Select currency',
+    description: 'Select currency',
+    id: 'CostModelsWizardCurrencyToggleLabel',
+  },
   CostModelsWizardEmptySourceTypeLabel: {
     defaultMessage: 'Select source type',
     description: 'Select source type',

--- a/src/pages/costModels/components/inputs/selector.tsx
+++ b/src/pages/costModels/components/inputs/selector.tsx
@@ -19,6 +19,7 @@ interface SelectorFormGroupOwnProps {
   label?: MessageDescriptor | string;
   appendMenuTo?: HTMLElement | 'parent' | 'inline' | (() => HTMLElement);
   toggleAriaLabel?: string;
+  maxHeight?: string | number;
   placeholderText?: string;
   direction?: SelectDirection.up | SelectDirection.down;
   options: {
@@ -51,6 +52,7 @@ const SelectorBase: React.FunctionComponent<SelectorProps> = ({
   id,
   intl = defaultIntl, // Default required for testing
   toggleAriaLabel,
+  maxHeight,
   placeholderText,
   direction = SelectDirection.down,
   isInvalid = false,
@@ -94,7 +96,8 @@ const SelectorBase: React.FunctionComponent<SelectorProps> = ({
     >
       <Select
         id={id}
-        maxHeight={350}
+        ouiaId={id}
+        maxHeight={maxHeight}
         toggleAriaLabel={toggleAriaLabel}
         variant={SelectVariant.single}
         placeholderText={placeholderText}

--- a/src/pages/costModels/components/inputs/selector.tsx
+++ b/src/pages/costModels/components/inputs/selector.tsx
@@ -94,6 +94,7 @@ const SelectorBase: React.FunctionComponent<SelectorProps> = ({
     >
       <Select
         id={id}
+        maxHeight={350}
         toggleAriaLabel={toggleAriaLabel}
         variant={SelectVariant.single}
         placeholderText={placeholderText}

--- a/src/pages/costModels/components/rateForm/rateForm.tsx
+++ b/src/pages/costModels/components/rateForm/rateForm.tsx
@@ -148,7 +148,7 @@ const RateFormBase: React.FunctionComponent<RateFormProps> = ({
                   : getMeasurementLabel(measurement, metricsHash[metric][measurement].label_measurement_unit)
               }
               onChange={setMeasurement}
-              placeholderText="Select..."
+              placeholderText="Select......"
               options={[
                 ...measurementOptions.map(opt => {
                   const unit = metricsHash[metric][opt].label_measurement_unit;

--- a/src/pages/costModels/components/rateForm/rateForm.tsx
+++ b/src/pages/costModels/components/rateForm/rateForm.tsx
@@ -148,7 +148,7 @@ const RateFormBase: React.FunctionComponent<RateFormProps> = ({
                   : getMeasurementLabel(measurement, metricsHash[metric][measurement].label_measurement_unit)
               }
               onChange={setMeasurement}
-              placeholderText="Select......"
+              placeholderText="Select..."
               options={[
                 ...measurementOptions.map(opt => {
                   const unit = metricsHash[metric][opt].label_measurement_unit;

--- a/src/pages/costModels/createCostModelWizard/generalInformation.tsx
+++ b/src/pages/costModels/createCostModelWizard/generalInformation.tsx
@@ -127,7 +127,8 @@ class GeneralInformation extends React.Component<GeneralInformationProps> {
                 <Selector
                   isRequired
                   id="source-type-selector"
-                  appendMenuTo={() => document.body}
+                  direction={SelectDirection.up}
+                  appendMenuTo="inline"
                   label={messages.CostModelsSourceType}
                   placeholderText={intl.formatMessage(messages.CostModelsWizardEmptySourceTypeLabel)}
                   value={getValueLabel(type, sourceTypeOptions)}
@@ -140,7 +141,7 @@ class GeneralInformation extends React.Component<GeneralInformationProps> {
                     <Selector
                       label={messages.Currency}
                       direction={SelectDirection.up}
-                      appendMenuTo={() => document.body}
+                      appendMenuTo="inline"
                       value={getValueLabel(currencyUnits, currencyOptions)}
                       onChange={onCurrencyChange}
                       id="currency-units-selector"

--- a/src/pages/costModels/createCostModelWizard/generalInformation.tsx
+++ b/src/pages/costModels/createCostModelWizard/generalInformation.tsx
@@ -129,7 +129,9 @@ class GeneralInformation extends React.Component<GeneralInformationProps> {
                   id="source-type-selector"
                   direction={SelectDirection.up}
                   appendMenuTo="inline"
+                  maxHeight={styles.selector.maxHeight}
                   label={messages.CostModelsSourceType}
+                  toggleAriaLabel={intl.formatMessage(messages.CostModelsWizardEmptySourceTypeLabel)}
                   placeholderText={intl.formatMessage(messages.CostModelsWizardEmptySourceTypeLabel)}
                   value={getValueLabel(type, sourceTypeOptions)}
                   onChange={onTypeChange}
@@ -142,6 +144,8 @@ class GeneralInformation extends React.Component<GeneralInformationProps> {
                       label={messages.Currency}
                       direction={SelectDirection.up}
                       appendMenuTo="inline"
+                      maxHeight={styles.selector.maxHeight}
+                      toggleAriaLabel={intl.formatMessage(messages.CostModelsWizardCurrencyToggleLabel)}
                       value={getValueLabel(currencyUnits, currencyOptions)}
                       onChange={onCurrencyChange}
                       id="currency-units-selector"

--- a/src/pages/costModels/createCostModelWizard/wizard.styles.ts
+++ b/src/pages/costModels/createCostModelWizard/wizard.styles.ts
@@ -8,4 +8,7 @@ export const styles = {
     minHeight: '75px',
     maxHeight: '150px',
   },
+  selector: {
+    maxHeight: '350px',
+  },
 } as { [className: string]: React.CSSProperties };


### PR DESCRIPTION
https://issues.redhat.com/browse/COST-2617

ended up using inline in cases where the menu for sure fits between edges of modal and doesn't go over header/footer of wizard with the new height restriction (scrollable), and parent for cases where it goes off the edge of the modal. both ways work with keyboard and a11y (being close in dom).

the 350 max height currently only affects the currency select, and gives it most of the usable space between wizard header/footer while cutting off at half an item so it's more obvious that scrolling is possible.