### PR TITLE
insights.chrome.isProd is broken

### DIFF
--- a/src/utils/feature.ts
+++ b/src/utils/feature.ts
@@ -11,7 +11,7 @@ export const enum FeatureType {
 // Show in-progress features for stage-beta environment only
 export const isStageBeta = () => {
   const insights = (window as any).insights;
-  return insights && insights.chrome.isBeta() && !insights.chrome.isProd;
+  return insights && insights.chrome.isBeta() && !insights.chrome.isProd();
 };
 
 // Helper function to track multiple code segments belonging to a specific feature


### PR DESCRIPTION
Insights recently broke insights.chrome.isProd, which is a public API. It now returns a function. As a result, none of the beta features are currently visible.

https://issues.redhat.com/browse/COST-2637