### PR TITLE
Specify formatter used for dashboard charts

### DIFF
--- a/src/pages/views/overview/components/dashboardWidgetBase.tsx
+++ b/src/pages/views/overview/components/dashboardWidgetBase.tsx
@@ -260,7 +260,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
           forecastData={forecastData}
           forecastConeData={forecastConeData}
           formatOptions={trend.formatOptions}
-          formatter={chartFormatter || formatCurrency}
+          formatter={chartFormatter || formatUnits}
           height={height}
           previousData={previousData}
           showForecast={trend.computedForecastItem !== undefined}
@@ -432,7 +432,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
         forecastData={forecastData}
         forecastConeData={forecastConeData}
         formatOptions={trend.formatOptions}
-        formatter={chartFormatter || formatCurrency}
+        formatter={chartFormatter || formatUnits}
         height={height}
         previousData={previousData}
         showForecast={trend.computedForecastItem !== undefined}

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -9,7 +9,7 @@ import {
 } from 'pages/views/components/charts/common/chartDatumUtils';
 import { paths } from 'routes';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
-import { formatUnits } from 'utils/format';
+import { formatCurrency, formatUnits } from 'utils/format';
 
 import { AwsDashboardTab, AwsDashboardWidget } from './awsDashboardCommon';
 
@@ -69,6 +69,7 @@ export const costSummaryWidget: AwsDashboardWidget = {
     type: ChartType.rolling,
   },
   availableTabs: [AwsDashboardTab.services, AwsDashboardTab.accounts, AwsDashboardTab.regions],
+  chartFormatter: formatCurrency,
   chartType: DashboardChartType.dailyTrend,
   currentTab: AwsDashboardTab.services,
   savingsPlan: true,
@@ -95,6 +96,7 @@ export const databaseWidget: AwsDashboardWidget = {
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
+  chartFormatter: formatCurrency,
   chartType: DashboardChartType.trend,
   savingsPlan: true,
 };
@@ -120,6 +122,7 @@ export const networkWidget: AwsDashboardWidget = {
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
+  chartFormatter: formatCurrency,
   chartType: DashboardChartType.trend,
   savingsPlan: true,
 };
@@ -142,5 +145,6 @@ export const storageWidget: AwsDashboardWidget = {
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
   },
+  chartFormatter: formatUnits,
   chartType: DashboardChartType.trend,
 };

--- a/src/store/dashboard/awsOcpDashboard/awsOcpDashboardWidgets.ts
+++ b/src/store/dashboard/awsOcpDashboard/awsOcpDashboardWidgets.ts
@@ -8,7 +8,7 @@ import {
   ComputedReportItemValueType,
 } from 'pages/views/components/charts/common/chartDatumUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
-import { formatUnits } from 'utils/format';
+import { formatCurrency, formatUnits } from 'utils/format';
 
 import { AwsOcpDashboardTab, AwsOcpDashboardWidget } from './awsOcpDashboardCommon';
 
@@ -66,6 +66,7 @@ export const costSummaryWidget: AwsOcpDashboardWidget = {
     type: ChartType.rolling,
   },
   availableTabs: [AwsOcpDashboardTab.services, AwsOcpDashboardTab.accounts, AwsOcpDashboardTab.regions],
+  chartFormatter: formatCurrency,
   chartType: DashboardChartType.dailyTrend,
   currentTab: AwsOcpDashboardTab.services,
 };
@@ -91,6 +92,7 @@ export const databaseWidget: AwsOcpDashboardWidget = {
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
+  chartFormatter: formatCurrency,
   chartType: DashboardChartType.trend,
 };
 
@@ -115,6 +117,7 @@ export const networkWidget: AwsOcpDashboardWidget = {
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
+  chartFormatter: formatCurrency,
   chartType: DashboardChartType.trend,
 };
 
@@ -136,5 +139,6 @@ export const storageWidget: AwsOcpDashboardWidget = {
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
   },
+  chartFormatter: formatUnits,
   chartType: DashboardChartType.trend,
 };

--- a/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
@@ -9,7 +9,7 @@ import {
 } from 'pages/views/components/charts/common/chartDatumUtils';
 import { paths } from 'routes';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
-import { formatUnits } from 'utils/format';
+import { formatCurrency, formatUnits } from 'utils/format';
 
 import { GcpDashboardTab, GcpDashboardWidget } from './gcpDashboardCommon';
 
@@ -70,6 +70,7 @@ export const costSummaryWidget: GcpDashboardWidget = {
     type: ChartType.rolling,
   },
   availableTabs: [GcpDashboardTab.services, GcpDashboardTab.gcpProjects, GcpDashboardTab.regions],
+  chartFormatter: formatCurrency,
   chartType: DashboardChartType.dailyTrend,
   currentTab: GcpDashboardTab.services,
 };
@@ -95,6 +96,7 @@ export const databaseWidget: GcpDashboardWidget = {
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
+  chartFormatter: formatCurrency,
   chartType: DashboardChartType.trend,
 };
 
@@ -121,6 +123,7 @@ export const networkWidget: GcpDashboardWidget = {
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
+  chartFormatter: formatCurrency,
   chartType: DashboardChartType.trend,
 };
 
@@ -142,5 +145,6 @@ export const storageWidget: GcpDashboardWidget = {
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
   },
+  chartFormatter: formatUnits,
   chartType: DashboardChartType.trend,
 };

--- a/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardWidgets.ts
@@ -8,7 +8,7 @@ import {
   ComputedReportItemValueType,
 } from 'pages/views/components/charts/common/chartDatumUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
-import { formatUnits } from 'utils/format';
+import { formatCurrency, formatUnits } from 'utils/format';
 
 import { GcpOcpDashboardTab, GcpOcpDashboardWidget } from './gcpOcpDashboardCommon';
 
@@ -68,6 +68,7 @@ export const costSummaryWidget: GcpOcpDashboardWidget = {
     type: ChartType.rolling,
   },
   availableTabs: [GcpOcpDashboardTab.services, GcpOcpDashboardTab.gcpProjects, GcpOcpDashboardTab.regions],
+  chartFormatter: formatCurrency,
   chartType: DashboardChartType.dailyTrend,
   currentTab: GcpOcpDashboardTab.services,
 };
@@ -93,6 +94,7 @@ export const databaseWidget: GcpOcpDashboardWidget = {
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
+  chartFormatter: formatCurrency,
   chartType: DashboardChartType.trend,
 };
 
@@ -117,6 +119,7 @@ export const networkWidget: GcpOcpDashboardWidget = {
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
+  chartFormatter: formatCurrency,
   chartType: DashboardChartType.trend,
 };
 
@@ -138,5 +141,6 @@ export const storageWidget: GcpOcpDashboardWidget = {
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
   },
+  chartFormatter: formatUnits,
   chartType: DashboardChartType.trend,
 };

--- a/src/store/dashboard/ibmDashboard/ibmDashboardWidgets.ts
+++ b/src/store/dashboard/ibmDashboard/ibmDashboardWidgets.ts
@@ -9,7 +9,7 @@ import {
 } from 'pages/views/components/charts/common/chartDatumUtils';
 import { paths } from 'routes';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
-import { formatUnits } from 'utils/format';
+import { formatCurrency, formatUnits } from 'utils/format';
 
 import { IbmDashboardTab, IbmDashboardWidget } from './ibmDashboardCommon';
 
@@ -70,6 +70,7 @@ export const costSummaryWidget: IbmDashboardWidget = {
     type: ChartType.rolling,
   },
   availableTabs: [IbmDashboardTab.services, IbmDashboardTab.projects, IbmDashboardTab.regions],
+  chartFormatter: formatCurrency,
   chartType: DashboardChartType.dailyTrend,
   currentTab: IbmDashboardTab.services,
 };
@@ -95,6 +96,7 @@ export const databaseWidget: IbmDashboardWidget = {
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
+  chartFormatter: formatCurrency,
   chartType: DashboardChartType.trend,
 };
 
@@ -121,6 +123,7 @@ export const networkWidget: IbmDashboardWidget = {
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
+  chartFormatter: formatCurrency,
   chartType: DashboardChartType.trend,
 };
 
@@ -142,5 +145,6 @@ export const storageWidget: IbmDashboardWidget = {
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
   },
+  chartFormatter: formatUnits,
   chartType: DashboardChartType.trend,
 };

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
@@ -8,7 +8,7 @@ import {
   ComputedReportItemValueType,
 } from 'pages/views/components/charts/common/chartDatumUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
-import { formatUnits } from 'utils/format';
+import { formatCurrency, formatUnits } from 'utils/format';
 
 import { OcpCloudDashboardTab, OcpCloudDashboardWidget } from './ocpCloudDashboardCommon';
 
@@ -38,6 +38,7 @@ export const costSummaryWidget: OcpCloudDashboardWidget = {
     type: ChartType.rolling,
   },
   availableTabs: [OcpCloudDashboardTab.services, OcpCloudDashboardTab.accounts, OcpCloudDashboardTab.regions],
+  chartFormatter: formatCurrency,
   chartType: DashboardChartType.dailyTrend,
   currentTab: OcpCloudDashboardTab.services,
 };
@@ -89,6 +90,7 @@ export const databaseWidget: OcpCloudDashboardWidget = {
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
+  chartFormatter: formatUnits,
   chartType: DashboardChartType.trend,
 };
 
@@ -112,6 +114,7 @@ export const networkWidget: OcpCloudDashboardWidget = {
     titleKey: messages.DashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
+  chartFormatter: formatCurrency,
   chartType: DashboardChartType.trend,
 };
 
@@ -133,5 +136,6 @@ export const storageWidget: OcpCloudDashboardWidget = {
     titleKey: messages.DashboardDailyUsageComparison,
     type: ChartType.daily,
   },
+  chartFormatter: formatUnits,
   chartType: DashboardChartType.trend,
 };

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -10,6 +10,8 @@ import {
 import { paths } from 'routes';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 
+import { formatCurrency, formatUnits } from 'utils/format';
+
 import { OcpDashboardTab, OcpDashboardWidget } from './ocpDashboardCommon';
 
 let currrentId = 0;
@@ -42,6 +44,7 @@ export const costSummaryWidget: OcpDashboardWidget = {
     limit: 3,
   },
   availableTabs: [OcpDashboardTab.projects, OcpDashboardTab.clusters],
+  chartFormatter: formatCurrency,
   chartType: DashboardChartType.dailyTrend, // No longer showing infrastructure via DashboardChartType.dailyCost
   currentTab: OcpDashboardTab.projects,
 };
@@ -63,6 +66,7 @@ export const cpuWidget: OcpDashboardWidget = {
     titleKey: messages.OCPDailyUsageAndRequestComparison,
     type: ChartType.daily,
   },
+  chartFormatter: formatUnits,
   chartType: DashboardChartType.usage,
 };
 
@@ -83,6 +87,7 @@ export const memoryWidget: OcpDashboardWidget = {
     titleKey: messages.OCPDailyUsageAndRequestComparison,
     type: ChartType.daily,
   },
+  chartFormatter: formatUnits,
   chartType: DashboardChartType.usage,
 };
 
@@ -103,5 +108,6 @@ export const volumeWidget: OcpDashboardWidget = {
     titleKey: messages.OCPDailyUsageAndRequestComparison,
     type: ChartType.daily,
   },
+  chartFormatter: formatUnits,
   chartType: DashboardChartType.usage,
 };

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -9,7 +9,6 @@ import {
 } from 'pages/views/components/charts/common/chartDatumUtils';
 import { paths } from 'routes';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
-
 import { formatCurrency, formatUnits } from 'utils/format';
 
 import { OcpDashboardTab, OcpDashboardWidget } from './ocpDashboardCommon';


### PR DESCRIPTION
Some dashboard charts are defaulting to the wrong formatter. Although, the tooltip units look ok, there are errors in the console.

https://issues.redhat.com/browse/COST-2638