### PR TITLE
Dependabot vulnerability alert

### DIFF
--- a/koku-ui-manifest
+++ b/koku-ui-manifest
@@ -337,7 +337,6 @@ mgmt_services/cost-mgmt:koku-ui/array.prototype.flat:1.2.5.yarnlock
 mgmt_services/cost-mgmt:koku-ui/array.prototype.flatmap:1.2.5.yarnlock
 mgmt_services/cost-mgmt:koku-ui/asap:2.0.6.yarnlock
 mgmt_services/cost-mgmt:koku-ui/ast-types-flow:0.0.7.yarnlock
-mgmt_services/cost-mgmt:koku-ui/async:2.6.3.yarnlock
 mgmt_services/cost-mgmt:koku-ui/asynckit:0.4.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/at-least-node:1.0.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/attr-accept:1.1.3.yarnlock
@@ -482,7 +481,6 @@ mgmt_services/cost-mgmt:koku-ui/debug:4.3.4.yarnlock
 mgmt_services/cost-mgmt:koku-ui/debug:4.3.4.yarnlock
 mgmt_services/cost-mgmt:koku-ui/debug:4.3.4.yarnlock
 mgmt_services/cost-mgmt:koku-ui/debug:4.3.4.yarnlock
-mgmt_services/cost-mgmt:koku-ui/debug:3.2.7.yarnlock
 mgmt_services/cost-mgmt:koku-ui/debug:3.2.7.yarnlock
 mgmt_services/cost-mgmt:koku-ui/decimal.js:10.3.1.yarnlock
 mgmt_services/cost-mgmt:koku-ui/dedent:0.7.0.yarnlock
@@ -900,7 +898,6 @@ mgmt_services/cost-mgmt:koku-ui/lodash:4.17.21.yarnlock
 mgmt_services/cost-mgmt:koku-ui/lodash:4.17.21.yarnlock
 mgmt_services/cost-mgmt:koku-ui/lodash:4.17.21.yarnlock
 mgmt_services/cost-mgmt:koku-ui/lodash:4.17.21.yarnlock
-mgmt_services/cost-mgmt:koku-ui/lodash:4.17.21.yarnlock
 mgmt_services/cost-mgmt:koku-ui/log-symbols:4.1.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/loose-envify:1.4.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/loose-envify:1.4.0.yarnlock
@@ -945,7 +942,6 @@ mgmt_services/cost-mgmt:koku-ui/minimatch:3.1.2.yarnlock
 mgmt_services/cost-mgmt:koku-ui/minimatch:3.1.2.yarnlock
 mgmt_services/cost-mgmt:koku-ui/minimist:1.2.6.yarnlock
 mgmt_services/cost-mgmt:koku-ui/minimist:1.2.6.yarnlock
-mgmt_services/cost-mgmt:koku-ui/mkdirp:0.5.6.yarnlock
 mgmt_services/cost-mgmt:koku-ui/mkdirp:1.0.4.yarnlock
 mgmt_services/cost-mgmt:koku-ui/moo:0.5.1.yarnlock
 mgmt_services/cost-mgmt:koku-ui/ms:2.0.0.yarnlock
@@ -1039,7 +1035,6 @@ mgmt_services/cost-mgmt:koku-ui/picomatch:2.3.1.yarnlock
 mgmt_services/cost-mgmt:koku-ui/pirates:4.0.5.yarnlock
 mgmt_services/cost-mgmt:koku-ui/pkg-dir:4.2.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/popper.js:1.16.1.yarnlock
-mgmt_services/cost-mgmt:koku-ui/portfinder:1.0.28.yarnlock
 mgmt_services/cost-mgmt:koku-ui/postcss-modules-extract-imports:3.0.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/postcss-modules-local-by-default:4.0.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/postcss-modules-scope:3.0.0.yarnlock
@@ -1350,7 +1345,7 @@ mgmt_services/cost-mgmt:koku-ui/webidl-conversions:5.0.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/webidl-conversions:6.1.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/webpack-cli:4.9.2.yarnlock
 mgmt_services/cost-mgmt:koku-ui/webpack-dev-middleware:5.3.1.yarnlock
-mgmt_services/cost-mgmt:koku-ui/webpack-dev-server:4.8.1.yarnlock
+mgmt_services/cost-mgmt:koku-ui/webpack-dev-server:4.9.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/webpack-merge:5.8.0.yarnlock
 mgmt_services/cost-mgmt:koku-ui/webpack-sources:3.2.3.yarnlock
 mgmt_services/cost-mgmt:koku-ui/webpack:5.71.0.yarnlock

--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "user-event": "^4.0.0",
     "webpack": "^5.69.0",
     "webpack-cli": "^4.9.2",
-    "webpack-dev-server": "^4.7.4"
+    "webpack-dev-server": "^4.9.0"
   },
   "insights": {
     "appname": "cost-management"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2103,13 +2103,6 @@ ast-types-flow@^0.0.7:
   resolved "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz"
   integrity sha1-9wtzXGvKGlycItmCw+Oef+ujva0=
 
-async@^2.6.2:
-  version "2.6.3"
-  resolved "https://registry.npmjs.org/async/-/async-2.6.3.tgz"
-  integrity sha512-zflvls11DCy+dQWzTW2dzuilv8Z5X/pjfmZOWba6TNIVDm+2UDaJmXSOXlasHKfNBs8oo3M0aT50fDEWfKZjXg==
-  dependencies:
-    lodash "^4.17.14"
-
 asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
@@ -2932,7 +2925,7 @@ debug@4, debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.2, debug@^4.3.3:
   dependencies:
     ms "2.1.2"
 
-debug@^3.1.1, debug@^3.2.7:
+debug@^3.2.7:
   version "3.2.7"
   resolved "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz"
   integrity sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
@@ -5514,7 +5507,7 @@ lodash.merge@^4.6.2:
   resolved "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash@^4.17.0, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
+lodash@^4.17.0, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.7.0:
   version "4.17.21"
   resolved "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -5704,13 +5697,6 @@ minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
-
-mkdirp@^0.5.5:
-  version "0.5.6"
-  resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz"
-  integrity sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==
-  dependencies:
-    minimist "^1.2.6"
 
 mkdirp@^1.0.4:
   version "1.0.4"
@@ -6180,15 +6166,6 @@ popper.js@^1.16.0:
   version "1.16.1"
   resolved "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz"
   integrity sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==
-
-portfinder@^1.0.28:
-  version "1.0.28"
-  resolved "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz"
-  integrity sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==
-  dependencies:
-    async "^2.6.2"
-    debug "^3.1.1"
-    mkdirp "^0.5.5"
 
 postcss-modules-extract-imports@^3.0.0:
   version "3.0.0"
@@ -7893,10 +7870,10 @@ webpack-dev-middleware@^5.3.1:
     range-parser "^1.2.1"
     schema-utils "^4.0.0"
 
-webpack-dev-server@^4.7.4:
-  version "4.8.1"
-  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.8.1.tgz#58f9d797710d6e25fa17d6afab8708f958c11a29"
-  integrity sha512-dwld70gkgNJa33czmcj/PlKY/nOy/BimbrgZRaR9vDATBQAYgLzggR0nxDtPLJiLrMgZwbE6RRfJ5vnBBasTyg==
+webpack-dev-server@^4.9.0:
+  version "4.9.0"
+  resolved "https://registry.yarnpkg.com/webpack-dev-server/-/webpack-dev-server-4.9.0.tgz#737dbf44335bb8bde68f8f39127fc401c97a1557"
+  integrity sha512-+Nlb39iQSOSsFv0lWUuUTim3jDQO8nhK3E68f//J2r5rIcp4lULHXz2oZ0UVdEeWXEh5lSzYUlzarZhDAeAVQw==
   dependencies:
     "@types/bonjour" "^3.5.9"
     "@types/connect-history-api-fallback" "^1.3.5"
@@ -7918,7 +7895,6 @@ webpack-dev-server@^4.7.4:
     ipaddr.js "^2.0.1"
     open "^8.0.9"
     p-retry "^4.5.0"
-    portfinder "^1.0.28"
     rimraf "^3.0.2"
     schema-utils "^4.0.0"
     selfsigned "^2.0.1"


### PR DESCRIPTION
GitHub's dependabot shows a "Prototype Pollution in async" alert. This dependency is inherited from webpack-dev-server.

https://issues.redhat.com/browse/COST-2644