### PR TITLE
Missing comma for "All cloud filtered by OpenShift" network filters

### DIFF
--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
@@ -105,8 +105,7 @@ export const networkWidget: OcpCloudDashboardWidget = {
   },
   filter: {
     service:
-      'AmazonVPC,AmazonCloudFront,AmazonRoute53,AmazonAPIGateway' +
-      'Virtual Network,VPN,DNS,Traffic Manager,ExpressRoute,Load Balancer,Application Gateway',
+      'AmazonVPC,AmazonCloudFront,AmazonRoute53,AmazonAPIGateway,Virtual Network,VPN,DNS,Traffic Manager,ExpressRoute,Load Balancer,Application Gateway',
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,


### PR DESCRIPTION
Missing comma for "All cloud filtered by OpenShift" network filters

https://issues.redhat.com/browse/COST-2649