### PR TITLE
Sync "GCP filtered by Openshift" network filters

### DIFF
--- a/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
@@ -111,11 +111,11 @@ export const networkWidget: GcpDashboardWidget = {
   },
   filter: {
     service:
-      'Network, VPC, Firewall, Route, IP, DNS, CDN, NAT, Traffic Director, Service Discovery, Cloud Domains, Private Service Connect, Cloud Armor',
+      'Network,VPC,Firewall,Route,IP,DNS,CDN,NAT,Traffic Director,Service Discovery,Cloud Domains,Private Service Connect,Cloud Armor',
   },
   tabsFilter: {
     service:
-      'Network, VPC, Firewall, Route, IP, DNS, CDN, NAT, Traffic Director, Service Discovery, Cloud Domains, Private Service Connect, Cloud Armor',
+      'Network,VPC,Firewall,Route,IP,DNS,CDN,NAT,Traffic Director,Service Discovery,Cloud Domains,Private Service Connect,Cloud Armor',
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,

--- a/src/store/dashboard/gcpDashboard/index.ts
+++ b/src/store/dashboard/gcpDashboard/index.ts
@@ -2,12 +2,14 @@ import * as gcpDashboardActions from './gcpDashboardActions';
 import { gcpDashboardStateKey, GcpDashboardTab, GcpDashboardWidget } from './gcpDashboardCommon';
 import { gcpDashboardReducer } from './gcpDashboardReducer';
 import * as gcpDashboardSelectors from './gcpDashboardSelectors';
+import * as gcpDashboardWidgets from './gcpDashboardWidgets';
 
 export {
   gcpDashboardStateKey,
   gcpDashboardReducer,
   gcpDashboardActions,
   gcpDashboardSelectors,
+  gcpDashboardWidgets,
   GcpDashboardTab,
   GcpDashboardWidget,
 };

--- a/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardWidgets.ts
@@ -8,6 +8,7 @@ import {
   ComputedReportItemValueType,
 } from 'pages/views/components/charts/common/chartDatumUtils';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
+import { gcpDashboardWidgets } from 'store/dashboard/gcpDashboard';
 import { formatCurrency, formatUnits } from 'utils/format';
 
 import { GcpOcpDashboardTab, GcpOcpDashboardWidget } from './gcpOcpDashboardCommon';
@@ -83,10 +84,10 @@ export const databaseWidget: GcpOcpDashboardWidget = {
     showUnits: true,
   },
   filter: {
-    service: 'Bigtable,Datastore,Database Migrations,Firestore,MemoryStore,Spanner,SQL',
+    service: gcpDashboardWidgets.databaseWidget.filter.service,
   },
   tabsFilter: {
-    service: 'Bigtable,Datastore,Database Migrations,Firestore,MemoryStore,Spanner,SQL',
+    service: gcpDashboardWidgets.databaseWidget.tabsFilter.service,
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
@@ -108,10 +109,10 @@ export const networkWidget: GcpOcpDashboardWidget = {
     showUnits: true,
   },
   filter: {
-    service: 'Cloud DNS',
+    service: gcpDashboardWidgets.networkWidget.filter.service,
   },
   tabsFilter: {
-    service: 'Cloud DNS',
+    service: gcpDashboardWidgets.networkWidget.tabsFilter.service,
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,


### PR DESCRIPTION
"GCP filtered by Openshift" view should use the same network filters as "GCP". Currently, we are only using the "Cloud DNS" filter.

https://issues.redhat.com/browse/COST-2690