### PR TITLE
Sync "All filtered by Openshift" network filters

### DIFF
--- a/src/store/dashboard/awsDashboard/index.ts
+++ b/src/store/dashboard/awsDashboard/index.ts
@@ -2,12 +2,14 @@ import * as awsDashboardActions from './awsDashboardActions';
 import { awsDashboardStateKey, AwsDashboardTab, AwsDashboardWidget } from './awsDashboardCommon';
 import { awsDashboardReducer } from './awsDashboardReducer';
 import * as awsDashboardSelectors from './awsDashboardSelectors';
+import * as awsDashboardWidgets from './awsDashboardWidgets';
 
 export {
   awsDashboardStateKey,
   awsDashboardReducer,
   awsDashboardActions,
   awsDashboardSelectors,
+  awsDashboardWidgets,
   AwsDashboardTab,
   AwsDashboardWidget,
 };

--- a/src/store/dashboard/awsOcpDashboard/awsOcpDashboardWidgets.ts
+++ b/src/store/dashboard/awsOcpDashboard/awsOcpDashboardWidgets.ts
@@ -7,6 +7,7 @@ import {
   ComputedReportItemType,
   ComputedReportItemValueType,
 } from 'pages/views/components/charts/common/chartDatumUtils';
+import { awsDashboardWidgets } from 'store/dashboard/awsDashboard';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { formatCurrency, formatUnits } from 'utils/format';
 
@@ -81,10 +82,10 @@ export const databaseWidget: AwsOcpDashboardWidget = {
     showUnits: true,
   },
   filter: {
-    service: 'AmazonRDS,AmazonDynamoDB,AmazonElastiCache,AmazonNeptune,AmazonRedshift,AmazonDocumentDB',
+    service: awsDashboardWidgets.databaseWidget.filter.service,
   },
   tabsFilter: {
-    service: 'AmazonRDS,AmazonDynamoDB,AmazonElastiCache,AmazonNeptune,AmazonRedshift,AmazonDocumentDB',
+    service: awsDashboardWidgets.databaseWidget.tabsFilter.service,
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
@@ -106,10 +107,10 @@ export const networkWidget: AwsOcpDashboardWidget = {
     showUnits: true,
   },
   filter: {
-    service: 'AmazonVPC,AmazonOcpFront,AmazonRoute53,AmazonAPIGateway',
+    service: awsDashboardWidgets.networkWidget.filter.service,
   },
   tabsFilter: {
-    service: 'AmazonVPC,AmazonOcpFront,AmazonRoute53,AmazonAPIGateway',
+    service: awsDashboardWidgets.networkWidget.tabsFilter.service,
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,

--- a/src/store/dashboard/azureDashboard/index.ts
+++ b/src/store/dashboard/azureDashboard/index.ts
@@ -2,12 +2,14 @@ import * as azureDashboardActions from './azureDashboardActions';
 import { azureDashboardStateKey, AzureDashboardTab, AzureDashboardWidget } from './azureDashboardCommon';
 import { azureDashboardReducer } from './azureDashboardReducer';
 import * as azureDashboardSelectors from './azureDashboardSelectors';
+import * as azureDashboardWidgets from './azureDashboardWidgets';
 
 export {
   azureDashboardStateKey,
   azureDashboardReducer,
   azureDashboardActions,
   azureDashboardSelectors,
+  azureDashboardWidgets,
   AzureDashboardTab,
   AzureDashboardWidget,
 };

--- a/src/store/dashboard/azureOcpDashboard/azureOcpDashboardWidgets.ts
+++ b/src/store/dashboard/azureOcpDashboard/azureOcpDashboardWidgets.ts
@@ -7,6 +7,7 @@ import {
   ComputedReportItemType,
   ComputedReportItemValueType,
 } from 'pages/views/components/charts/common/chartDatumUtils';
+import { azureDashboardWidgets } from 'store/dashboard/azureDashboard';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { formatUnits } from 'utils/format';
 
@@ -56,10 +57,10 @@ export const databaseWidget: AzureOcpDashboardWidget = {
     showUnits: true,
   },
   filter: {
-    service_name: 'Database,Cosmos DB,Cache for Redis',
+    service_name: azureDashboardWidgets.databaseWidget.filter.service_name,
   },
   tabsFilter: {
-    service_name: 'Database,Cosmos DB,Cache for Redis',
+    service_name: azureDashboardWidgets.databaseWidget.tabsFilter.service_name,
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
@@ -80,10 +81,10 @@ export const networkWidget: AzureOcpDashboardWidget = {
     showUnits: true,
   },
   filter: {
-    service_name: 'Virtual Network,VPN,DNS,Traffic Manager,ExpressRoute,Load Balancer,Application Gateway',
+    service_name: azureDashboardWidgets.networkWidget.filter.service_name,
   },
   tabsFilter: {
-    service_name: 'Virtual Network,VPN,DNS,Traffic Manager,ExpressRoute,Load Balancer,Application Gateway',
+    service_name: azureDashboardWidgets.networkWidget.tabsFilter.service_name,
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
@@ -7,7 +7,10 @@ import {
   ComputedReportItemType,
   ComputedReportItemValueType,
 } from 'pages/views/components/charts/common/chartDatumUtils';
+import { awsDashboardWidgets } from 'store/dashboard/awsDashboard';
+import { azureDashboardWidgets } from 'store/dashboard/azureDashboard';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
+import { gcpDashboardWidgets } from 'store/dashboard/gcpDashboard';
 import { formatCurrency, formatUnits } from 'utils/format';
 
 import { OcpCloudDashboardTab, OcpCloudDashboardWidget } from './ocpCloudDashboardCommon';
@@ -81,8 +84,11 @@ export const databaseWidget: OcpCloudDashboardWidget = {
   },
   filter: {
     service:
-      'AmazonRDS,AmazonDynamoDB,AmazonElastiCache,AmazonNeptune,AmazonRedshift,AmazonDocumentDB' +
-      'Database,Cosmos DB,Cache for Redis',
+      awsDashboardWidgets.databaseWidget.filter.service +
+      ',' +
+      azureDashboardWidgets.databaseWidget.filter.service_name +
+      ',' +
+      gcpDashboardWidgets.databaseWidget.filter.service,
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,
@@ -105,7 +111,11 @@ export const networkWidget: OcpCloudDashboardWidget = {
   },
   filter: {
     service:
-      'AmazonVPC,AmazonCloudFront,AmazonRoute53,AmazonAPIGateway,Virtual Network,VPN,DNS,Traffic Manager,ExpressRoute,Load Balancer,Application Gateway',
+      awsDashboardWidgets.networkWidget.filter.service +
+      ',' +
+      azureDashboardWidgets.networkWidget.filter.service_name +
+      ',' +
+      gcpDashboardWidgets.networkWidget.filter.service,
   },
   trend: {
     computedReportItem: ComputedReportItemType.cost,


### PR DESCRIPTION
The "All filtered by Openshift" view should include "GCP" network filters. We currently only include AWS and Azure.

https://issues.redhat.com/browse/COST-2691