### PR TITLE
fix issue with sorting on measurement in rate table

### DIFF
--- a/src/pages/costModels/components/rateTable.tsx
+++ b/src/pages/costModels/components/rateTable.tsx
@@ -39,7 +39,7 @@ const RateTableBase: React.SFC<RateTableProps> = ({ actions, intl = defaultIntl,
         sortBy.index === 1
           ? (r: Rate) => r.metric.label_metric
           : sortBy.index === 2
-          ? (r: Rate) => r.metric.label_measurement
+          ? (r: Rate) => r.metric.label_measurement + r.metric.label_measurement_unit
           : () => '';
       return compareBy(r1, r2, sortBy.direction, projection);
     })


### PR DESCRIPTION
https://issues.redhat.com/browse/COST-2702

when creating the data for the cells, this column includes the measurement_unit, however it is not included currently in the filter.. added that with this PR