### PR TITLE
AWS cost type dropdown state not updating

### DIFF
--- a/src/pages/views/components/costType/costType.tsx
+++ b/src/pages/views/components/costType/costType.tsx
@@ -7,11 +7,13 @@ import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
-import { CostTypes, getCostType, invalidateSession, restoreCostType, setCostType } from 'utils/localStorage';
+import { CostTypes } from 'utils/costType';
+import { invalidateSession, restoreCostType, setCostType } from 'utils/localStorage';
 
 import { styles } from './costType.styles';
 
 interface CostTypeOwnProps {
+  costType: CostTypes;
   isDisabled?: boolean;
   onSelect?: (value: string) => void;
 }
@@ -53,13 +55,12 @@ class CostTypeBase extends React.Component<CostTypeProps> {
   public state: CostTypeState = { ...this.defaultState };
 
   private getSelect = () => {
-    const { isDisabled } = this.props;
+    const { costType, isDisabled } = this.props;
     const { isSelectOpen } = this.state;
 
     // Restore from query param if available
     restoreCostType();
 
-    const costType = getCostType(); // Get cost type from local storage
     const selectOptions = this.getSelectOptions();
     const selection = selectOptions.find((option: CostTypeOption) => option.value === costType);
 

--- a/src/pages/views/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/pages/views/details/awsBreakdown/awsBreakdown.tsx
@@ -16,7 +16,7 @@ import { paths } from 'routes';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
-import { getCostType } from 'utils/localStorage';
+import { getCostType } from 'utils/costType';
 
 import { CostOverview } from './costOverview';
 import { HistoricalData } from './historicalData';
@@ -53,6 +53,7 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
   const groupByOrgValue = getGroupByOrgValue(query);
   const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
   const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
+  const costType = getCostType();
 
   const newQuery: Query = {
     filter: {
@@ -69,7 +70,7 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
-    cost_type: query.cost_type || getCostType(),
+    cost_type: costType,
   };
   const queryString = getQuery(newQuery);
 
@@ -86,15 +87,15 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
     providersQueryString
   );
 
-  const cost_type = getCostType();
   return {
-    costOverviewComponent: <CostOverview costType={cost_type} groupBy={groupBy} query={query} report={report} />,
+    costOverviewComponent: <CostOverview costType={costType} groupBy={groupBy} query={query} report={report} />,
+    costType,
     description: query[breakdownDescKey],
     detailsURL,
     emptyStateTitle: props.intl.formatMessage(messages.AWSDetailsTitle),
     groupBy,
     groupByValue,
-    historicalDataComponent: <HistoricalData costType={cost_type} />,
+    historicalDataComponent: <HistoricalData costType={costType} />,
     providers: filterProviders(providers, ProviderType.aws),
     providersError,
     providersFetchStatus,

--- a/src/pages/views/details/awsDetails/awsDetails.tsx
+++ b/src/pages/views/details/awsDetails/awsDetails.tsx
@@ -381,14 +381,14 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
   };
 
   private updateReport = () => {
-    const { query, location, fetchReport, history, queryString } = this.props;
+    const { costType, query, location, fetchReport, history, queryString } = this.props;
     if (!location.search) {
       history.replace(
         this.getRouteForQuery({
           filter_by: query ? query.filter_by : undefined,
           group_by: query ? query.group_by : undefined,
           order_by: { cost: 'desc' },
-          cost_type: getCostType(),
+          cost_type: costType,
         })
       );
     } else {

--- a/src/pages/views/details/awsDetails/awsDetails.tsx
+++ b/src/pages/views/details/awsDetails/awsDetails.tsx
@@ -24,6 +24,7 @@ import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedAwsReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
+import { CostTypes, getCostType } from 'utils/costType';
 
 import { styles } from './awsDetails.styles';
 import { DetailsHeader } from './detailsHeader';
@@ -31,6 +32,7 @@ import { DetailsTable } from './detailsTable';
 import { DetailsToolbar } from './detailsToolbar';
 
 interface AwsDetailsStateProps {
+  costType: CostTypes;
   providers: Providers;
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
@@ -386,7 +388,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
           filter_by: query ? query.filter_by : undefined,
           group_by: query ? query.group_by : undefined,
           order_by: { cost: 'desc' },
-          cost_type: query ? query.cost_type : undefined,
+          cost_type: getCostType(),
         })
       );
     } else {
@@ -395,7 +397,8 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
   };
 
   public render() {
-    const { providers, providersFetchStatus, query, report, reportError, reportFetchStatus, intl } = this.props;
+    const { costType, providers, providersFetchStatus, query, report, reportError, reportFetchStatus, intl } =
+      this.props;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
@@ -420,6 +423,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     return (
       <div style={styles.awsDetails}>
         <DetailsHeader
+          costType={costType}
           groupBy={groupById}
           onCostTypeSelected={this.handleCostTypeSelected}
           onGroupBySelected={this.handleGroupBySelected}
@@ -447,6 +451,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<AwsDetailsOwnProps, AwsDetailsStateProps>((state, props) => {
   const queryFromRoute = parseQuery<AwsQuery>(location.search);
+  const costType = getCostType();
   const query = {
     delta: 'cost',
     filter: {
@@ -456,7 +461,7 @@ const mapStateToProps = createMapStateToProps<AwsDetailsOwnProps, AwsDetailsStat
     filter_by: queryFromRoute.filter_by || baseQuery.filter_by,
     group_by: queryFromRoute.group_by || baseQuery.group_by,
     order_by: queryFromRoute.order_by || baseQuery.order_by,
-    cost_type: queryFromRoute.cost_type,
+    cost_type: costType,
   };
   const queryString = getQuery(query);
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
@@ -473,6 +478,7 @@ const mapStateToProps = createMapStateToProps<AwsDetailsOwnProps, AwsDetailsStat
   );
 
   return {
+    costType,
     providers: filterProviders(providers, ProviderType.aws),
     providersError,
     providersFetchStatus,

--- a/src/pages/views/details/awsDetails/detailsHeader.tsx
+++ b/src/pages/views/details/awsDetails/detailsHeader.tsx
@@ -18,6 +18,7 @@ import { connect } from 'react-redux';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { ComputedAwsReportItemsParams, getIdKeyForGroupBy } from 'utils/computedReport/getComputedAwsReportItems';
+import { CostTypes } from 'utils/costType';
 import { getSinceDateRangeString } from 'utils/dateRange';
 import { FeatureType, isFeatureVisible } from 'utils/feature';
 import { formatCurrency } from 'utils/format';
@@ -25,6 +26,7 @@ import { formatCurrency } from 'utils/format';
 import { styles } from './detailsHeader.styles';
 
 interface DetailsHeaderOwnProps {
+  costType?: CostTypes;
   groupBy?: string;
   onCostTypeSelected(value: string);
   onGroupBySelected(value: string);
@@ -71,7 +73,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
   };
 
   public render() {
-    const { groupBy, onGroupBySelected, providers, providersError, report, intl } = this.props;
+    const { costType, groupBy, onGroupBySelected, providers, providersError, report, intl } = this.props;
     const showContent = report && !providersError && providers && providers.meta && providers.meta.count > 0;
 
     const hasCost =
@@ -103,7 +105,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
               tagReportPathsType={tagReportPathsType}
             />
             <div style={styles.costType}>
-              <CostType onSelect={this.handleCostTypeSelected} />
+              <CostType onSelect={this.handleCostTypeSelected} costType={costType} />
             </div>
           </div>
           {Boolean(showContent) && (

--- a/src/pages/views/details/components/breakdown/breakdownBase.tsx
+++ b/src/pages/views/details/components/breakdown/breakdownBase.tsx
@@ -15,6 +15,7 @@ import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { RouteComponentProps } from 'react-router-dom';
 import { FetchStatus } from 'store/common';
 import { reportActions } from 'store/reports';
+import { CostTypes } from 'utils/costType';
 
 import { styles } from './breakdown.styles';
 import { BreakdownHeader } from './breakdownHeader';
@@ -36,6 +37,7 @@ export const getIdKeyForTab = (tab: BreakdownTab) => {
 
 interface BreakdownStateProps {
   costOverviewComponent?: React.ReactNode;
+  costType?: CostTypes;
   description?: string;
   detailsURL: string;
   emptyStateTitle?: string;
@@ -210,6 +212,7 @@ class BreakdownBase extends React.Component<BreakdownProps> {
 
   public render() {
     const {
+      costType,
       description,
       detailsURL,
       emptyStateTitle,
@@ -247,6 +250,7 @@ class BreakdownBase extends React.Component<BreakdownProps> {
     return (
       <>
         <BreakdownHeader
+          costType={costType}
           description={description}
           detailsURL={detailsURL}
           groupBy={groupBy}

--- a/src/pages/views/details/components/breakdown/breakdownHeader.tsx
+++ b/src/pages/views/details/components/breakdown/breakdownHeader.tsx
@@ -13,6 +13,7 @@ import { getGroupByOrgValue, getGroupByTagKey } from 'pages/views/utils/groupBy'
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { Link } from 'react-router-dom';
+import { CostTypes } from 'utils/costType';
 import { getForDateRangeString } from 'utils/dateRange';
 import { FeatureType, isFeatureVisible } from 'utils/feature';
 import { formatCurrency } from 'utils/format';
@@ -20,6 +21,7 @@ import { formatCurrency } from 'utils/format';
 import { styles } from './breakdownHeader.styles';
 
 interface BreakdownHeaderOwnProps {
+  costType?: CostTypes;
   detailsURL?: string;
   description?: string;
   groupBy?: string;
@@ -85,7 +87,17 @@ class BreakdownHeaderBase extends React.Component<BreakdownHeaderProps> {
   };
 
   public render() {
-    const { description, groupBy, query, intl, showCostType = false, tabs, tagReportPathsType, title } = this.props;
+    const {
+      costType,
+      description,
+      groupBy,
+      query,
+      intl,
+      showCostType = false,
+      tabs,
+      tagReportPathsType,
+      title,
+    } = this.props;
 
     const filterByAccount = query && query.filter ? query.filter.account : undefined;
     const groupByOrg = getGroupByOrgValue(query);
@@ -131,7 +143,7 @@ class BreakdownHeaderBase extends React.Component<BreakdownHeaderProps> {
             </Title>
             {showCostType && (
               <div style={styles.costType}>
-                <CostType onSelect={this.handleCostTypeSelected} />
+                <CostType onSelect={this.handleCostTypeSelected} costType={costType} />
               </div>
             )}
           </div>

--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -26,6 +26,7 @@ import { reportActions, reportSelectors } from 'store/reports';
 import { userAccessQuery, userAccessSelectors } from 'store/userAccess';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
+import { CostTypes, getCostType } from 'utils/costType';
 import { isAwsAvailable, isAzureAvailable, isGcpAvailable, isIbmAvailable, isOcpAvailable } from 'utils/userAccess';
 
 import { styles } from './explorer.styles';
@@ -51,6 +52,7 @@ import {
 interface ExplorerStateProps {
   awsProviders: Providers;
   azureProviders: Providers;
+  costType?: CostTypes;
   dateRange: DateRangeType;
   gcpProviders: Providers;
   ibmProviders: Providers;
@@ -419,6 +421,7 @@ class Explorer extends React.Component<ExplorerProps> {
     const {
       awsProviders,
       azureProviders,
+      costType,
       gcpProviders,
       ibmProviders,
       intl,
@@ -471,6 +474,7 @@ class Explorer extends React.Component<ExplorerProps> {
     return (
       <div style={styles.explorer}>
         <ExplorerHeader
+          costType={costType}
           groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
           onFilterAdded={this.handleFilterAdded}
           onFilterRemoved={this.handleFilterRemoved}
@@ -555,6 +559,7 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
     groupBy = { [getGroupByDefault(perspective)]: '*' };
   }
 
+  const costType = getCostType();
   const query = {
     filter: {
       ...baseQuery.filter,
@@ -567,7 +572,7 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
     dateRange,
     start_date,
     end_date,
-    ...(perspective === PerspectiveType.aws && { cost_type: queryFromRoute.cost_type }),
+    ...(perspective === PerspectiveType.aws && { cost_type: costType }),
   };
   const queryString = getQuery({
     ...query,
@@ -585,6 +590,7 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
   return {
     awsProviders,
     azureProviders,
+    costType,
     dateRange,
     gcpProviders,
     ibmProviders,

--- a/src/pages/views/explorer/explorerChart.tsx
+++ b/src/pages/views/explorer/explorerChart.tsx
@@ -21,6 +21,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
+import { getCostType } from 'utils/costType';
 import { formatUnits } from 'utils/format';
 import { skeletonWidth } from 'utils/skeleton';
 
@@ -275,7 +276,7 @@ const mapStateToProps = createMapStateToProps<ExplorerChartOwnProps, ExplorerCha
       dateRange,
       start_date,
       end_date,
-      ...(perspective === PerspectiveType.aws && { cost_type: queryFromRoute.cost_type }),
+      ...(perspective === PerspectiveType.aws && { cost_type: getCostType() }),
     };
     const queryString = getQuery({
       ...query,

--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -20,6 +20,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { userAccessQuery, userAccessSelectors } from 'store/userAccess';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
+import { CostTypes } from 'utils/costType';
 import { FeatureType, isFeatureVisible } from 'utils/feature';
 import {
   hasAwsAccess,
@@ -59,6 +60,7 @@ import {
 } from './explorerUtils';
 
 interface ExplorerHeaderOwnProps {
+  costType?: CostTypes;
   groupBy?: string;
   onFilterAdded(filterType: string, filterValue: string);
   onFilterRemoved(filterType: string, filterValue?: string);
@@ -259,6 +261,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
 
   public render() {
     const {
+      costType,
       groupBy,
       intl,
       onFilterAdded,
@@ -312,7 +315,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
           </div>
           {perspective === PerspectiveType.aws && (
             <div style={styles.costType}>
-              <CostType onSelect={this.handleCostTypeSelected} />
+              <CostType onSelect={this.handleCostTypeSelected} costType={costType} />
             </div>
           )}
         </div>
@@ -332,7 +335,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHeaderStateProps>(
-  (state, { perspective }) => {
+  (state, { costType, perspective }) => {
     const queryFromRoute = parseQuery<Query>(location.search);
     const dateRange = getDateRangeDefault(queryFromRoute);
     const { end_date, start_date } = getDateRange(getDateRangeDefault(queryFromRoute));
@@ -373,7 +376,7 @@ const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHe
       dateRange,
       start_date,
       end_date,
-      ...(perspective === PerspectiveType.aws && { cost_type: queryFromRoute.cost_type }),
+      ...(perspective === PerspectiveType.aws && { cost_type: costType }),
     };
     const queryString = getQuery({
       ...query,

--- a/src/pages/views/overview/awsDashboard/awsDashboardWidget.tsx
+++ b/src/pages/views/overview/awsDashboard/awsDashboardWidget.tsx
@@ -10,6 +10,7 @@ import { awsDashboardActions, awsDashboardSelectors, AwsDashboardTab } from 'sto
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import { ComputedAwsReportItemsParams } from 'utils/computedReport/getComputedAwsReportItems';
+import { getCostType } from 'utils/costType';
 
 interface AwsDashboardWidgetDispatchProps {
   fetchForecasts: typeof awsDashboardActions.fetchWidgetForecasts;
@@ -34,6 +35,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = awsDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
+      costType: getCostType(),
       getIdKeyForTab,
       currentQuery: queries.current,
       forecastQuery: queries.forecast,

--- a/src/store/dashboard/awsDashboard/awsDashboardCommon.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardCommon.ts
@@ -1,6 +1,6 @@
 import { AwsFilters, AwsQuery, getQuery } from 'api/queries/awsQuery';
 import { DashboardWidget } from 'store/dashboard/common/dashboardCommon';
-import { getCostType } from 'utils/localStorage';
+import { getCostType } from 'utils/costType';
 
 export const awsDashboardStateKey = 'awsDashboard';
 export const awsDashboardDefaultFilters: AwsFilters = {

--- a/src/utils/costType.ts
+++ b/src/utils/costType.ts
@@ -1,0 +1,27 @@
+import { parseQuery, Query } from 'api/queries/query';
+import { getCostType as getCostTypeFromLocaleStorage } from 'utils/localStorage';
+
+// eslint-disable-next-line no-shadow
+export const enum CostTypes {
+  amortized = 'savingsplan_effective_cost',
+  blended = 'blended_cost',
+  unblended = 'unblended_cost',
+}
+
+// Returns cost type
+export const getCostType = () => {
+  const query = parseQuery<Query>(location.search);
+
+  if (query.cost_type) {
+    return query.cost_type;
+  }
+  switch (getCostTypeFromLocaleStorage()) {
+    case 'blended_cost':
+      return CostTypes.blended;
+    case 'savingsplan_effective_cost':
+      return CostTypes.amortized;
+    case 'unblended_cost':
+    default:
+      return CostTypes.unblended;
+  }
+};

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -55,13 +55,6 @@ export const saveSessionToken = () => {
  * Cost type
  */
 
-// eslint-disable-next-line no-shadow
-export const enum CostTypes {
-  amortized = 'savingsplan_effective_cost',
-  blended = 'blended_cost',
-  unblended = 'unblended_cost',
-}
-
 // Delete cost type
 export const deleteCostType = () => {
   localStorage.removeItem(costTypeID);
@@ -70,7 +63,7 @@ export const deleteCostType = () => {
 // Returns cost type
 export const getCostType = () => {
   const costType = localStorage.getItem(costTypeID);
-  return costType && costType !== null ? costType : CostTypes.unblended;
+  return costType && costType !== null ? costType : undefined;
 };
 
 // Returns true if cost type is available


### PR DESCRIPTION
The AWS cost type dropdown state is not updating. This change ensures the dropdown state is updated as expected.

https://issues.redhat.com/browse/COST-2672

![chrome-capture-2022-5-6](https://user-images.githubusercontent.com/17481322/172218255-5964696b-36ea-4896-8633-62f941acb9a4.gif)

