### PR TITLE
Remove Azure's unused storage filter

### DIFF
--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -109,12 +109,6 @@ export const storageWidget: AzureDashboardWidget = {
     showUsageLegendLabel: true,
     usageKey: messages.Usage,
   },
-  filter: {
-    service_name: 'Storage',
-  },
-  tabsFilter: {
-    service_name: 'Storage',
-  },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,


### PR DESCRIPTION
Removed Azure's unused storage filter. This is redundant since we're already making a request to the storage API.

https://issues.redhat.com/browse/COST-2731