### PR TITLE
Use camel case for Messages

### DIFF
--- a/src/components/exports/exportActions.tsx
+++ b/src/components/exports/exportActions.tsx
@@ -52,7 +52,7 @@ class ExportsActionsBase extends React.Component<ExportsActionsProps> {
 
     const items = [
       <DropdownItem component="button" isDisabled={isDisabled} key="export-action" onClick={this.handleOnDelete}>
-        {intl.formatMessage(messages.Delete)}
+        {intl.formatMessage(messages.delete)}
       </DropdownItem>,
     ];
 

--- a/src/components/exports/exportsContent.tsx
+++ b/src/components/exports/exportsContent.tsx
@@ -168,7 +168,7 @@ class ExportsContentBase extends React.Component<ExportsContentProps> {
 
     return (
       <>
-        {intl.formatMessage(messages.ExportsDesc)}
+        {intl.formatMessage(messages.exportsDesc)}
         <div style={styles.content}>
           <ExportsToolbar
             onFilterAdded={this.handleFilterAdded}

--- a/src/components/exports/exportsDrawer.tsx
+++ b/src/components/exports/exportsDrawer.tsx
@@ -64,7 +64,7 @@ class ExportsDrawerBase extends React.Component<ExportsDrawerProps> {
           /* @ts-ignore */}
           <span tabIndex={isOpen ? 0 : -1} ref={this.drawerRef}>
             <Title headingLevel="h1" size={TitleSizes.xl}>
-              {intl.formatMessage(messages.ExportsTitle)}
+              {intl.formatMessage(messages.exportsTitle)}
             </Title>
           </span>
           <DrawerActions>

--- a/src/components/exports/exportsLink.tsx
+++ b/src/components/exports/exportsLink.tsx
@@ -50,7 +50,7 @@ class ExportsLinkBase extends React.Component<ExportsLinkProps> {
     if (isActionLink) {
       return (
         <div className="pf-c-alert__action-group">
-          <AlertActionLink onClick={this.handleToggle}>{intl.formatMessage(messages.ExportsTitle)}</AlertActionLink>
+          <AlertActionLink onClick={this.handleToggle}>{intl.formatMessage(messages.exportsTitle)}</AlertActionLink>
         </div>
       );
     }
@@ -60,7 +60,7 @@ class ExportsLinkBase extends React.Component<ExportsLinkProps> {
           <span style={styles.exportsIcon}>
             <AngleDoubleLeftIcon />
           </span>
-          {intl.formatMessage(messages.ExportsTitle)}
+          {intl.formatMessage(messages.exportsTitle)}
         </Button>
       </div>
     );

--- a/src/components/exports/exportsTable.tsx
+++ b/src/components/exports/exportsTable.tsx
@@ -88,24 +88,24 @@ class ExportsTableBase extends React.Component<ExportsTableProps> {
       {
         id: ExportsTableColumnIds.names,
         orderBy: 'name',
-        title: intl.formatMessage(messages.Names, { count: 1 }),
+        title: intl.formatMessage(messages.names, { count: 1 }),
         ...(isSortable && { transforms: [sortable] }),
       },
       {
         id: ExportsTableColumnIds.created,
         orderBy: 'created',
-        title: intl.formatMessage(messages.TimeOfExport),
+        title: intl.formatMessage(messages.timeOfExport),
         ...(isSortable && { transforms: [sortable] }),
       },
       {
         id: ExportsTableColumnIds.expires,
         orderBy: 'expires',
-        title: intl.formatMessage(messages.ExpiresOn),
+        title: intl.formatMessage(messages.expiresOn),
         ...(isSortable && { transforms: [sortable] }),
       },
       {
         id: ExportsTableColumnIds.status,
-        title: intl.formatMessage(messages.StatusActions),
+        title: intl.formatMessage(messages.statusActions),
       },
       {
         id: ExportsTableColumnIds.actions,
@@ -169,11 +169,11 @@ class ExportsTableBase extends React.Component<ExportsTableProps> {
       <EmptyState>
         <EmptyStateIcon icon={PlusCircleIcon} />
         <Title headingLevel="h5" size="lg">
-          {intl.formatMessage(messages.NoExportsStateTitle)}
+          {intl.formatMessage(messages.noExportsStateTitle)}
         </Title>
-        <EmptyStateBody>{intl.formatMessage(messages.ExportsEmptyState)}</EmptyStateBody>
+        <EmptyStateBody>{intl.formatMessage(messages.exportsEmptyState)}</EmptyStateBody>
         <Button variant="primary" onClick={onClose}>
-          {intl.formatMessage(messages.Close)}
+          {intl.formatMessage(messages.close)}
         </Button>
       </EmptyState>
     );
@@ -207,7 +207,7 @@ class ExportsTableBase extends React.Component<ExportsTableProps> {
       case 'completed':
         return (
           <Button icon={<DownloadIcon />} isInline onClick={this.handleOnDownload} variant={ButtonVariant.link}>
-            {intl.formatMessage(messages.Download)}
+            {intl.formatMessage(messages.download)}
           </Button>
         );
       case 'failed':
@@ -218,15 +218,15 @@ class ExportsTableBase extends React.Component<ExportsTableProps> {
             variant="outline"
             render={({ className, content, componentRef }) => (
               <Popover
-                aria-label={intl.formatMessage(messages.ExportsFailed)}
+                aria-label={intl.formatMessage(messages.exportsFailed)}
                 className={className}
                 headerContent={
                   <div style={styles.failed}>
                     <ExclamationCircleIcon />
-                    <span style={styles.failedHeader}>{intl.formatMessage(messages.ExportsFailed)}</span>
+                    <span style={styles.failedHeader}>{intl.formatMessage(messages.exportsFailed)}</span>
                   </div>
                 }
-                bodyContent={<div>{intl.formatMessage(messages.ExportsFailedDesc)}</div>}
+                bodyContent={<div>{intl.formatMessage(messages.exportsFailedDesc)}</div>}
               >
                 <Button
                   className={className}
@@ -239,21 +239,21 @@ class ExportsTableBase extends React.Component<ExportsTableProps> {
               </Popover>
             )}
           >
-            {intl.formatMessage(messages.Status, { value: status })}
+            {intl.formatMessage(messages.status, { value: status })}
           </Label>
         );
         break;
       case 'running':
         return (
           <Label color={'blue'} icon={<SyncIcon />} variant="outline">
-            {intl.formatMessage(messages.Status, { value: status })}
+            {intl.formatMessage(messages.status, { value: status })}
           </Label>
         );
       case 'pending':
       default:
         return (
           <Label color={'blue'} icon={<OutlinedClockIcon />} variant="outline">
-            {intl.formatMessage(messages.Status, { value: status })}
+            {intl.formatMessage(messages.status, { value: status })}
           </Label>
         );
     }
@@ -287,7 +287,7 @@ class ExportsTableBase extends React.Component<ExportsTableProps> {
     return (
       <>
         <Table
-          aria-label={intl.formatMessage(messages.ExportsTableAriaLabel)}
+          aria-label={intl.formatMessage(messages.exportsTableAriaLabel)}
           cells={columns}
           rows={isLoading ? loadingRows : rows}
           sortBy={this.getSortBy()}

--- a/src/components/exports/exportsToolbar.tsx
+++ b/src/components/exports/exportsToolbar.tsx
@@ -33,7 +33,7 @@ export class ExportsToolbarBase extends React.Component<ExportsToolbarProps> {
   private getCategoryOptions = (): ToolbarChipGroup[] => {
     const { intl } = this.props;
 
-    return [{ name: intl.formatMessage(messages.FilterByValues, { value: 'name' }), key: 'name' }];
+    return [{ name: intl.formatMessage(messages.filterByValues, { value: 'name' }), key: 'name' }];
   };
 
   public render() {

--- a/src/components/inactiveSources/inactiveSources.tsx
+++ b/src/components/inactiveSources/inactiveSources.tsx
@@ -80,8 +80,8 @@ class InactiveSourcesBase extends React.Component<InactiveSourcesProps> {
     const names = this.getInactiveSourceNames();
     const title =
       names.length === 1
-        ? intl.formatMessage(messages.InactiveSourcesTitle, { value: names[0] })
-        : intl.formatMessage(messages.InactiveSourcesTitleMultiplier);
+        ? intl.formatMessage(messages.inactiveSourcesTitle, { value: names[0] })
+        : intl.formatMessage(messages.inactiveSourcesTitleMultiplier);
 
     if (names.length === 0) {
       if (providers && providersFetchStatus === FetchStatus.complete && !providersError) {
@@ -105,7 +105,7 @@ class InactiveSourcesBase extends React.Component<InactiveSourcesProps> {
           actionClose={<AlertActionCloseButton onClose={this.handleOnClose} />}
           actionLinks={
             <React.Fragment>
-              <a href={`${release}/settings/sources`}>{intl.formatMessage(messages.InactiveSourcesGoTo)}</a>
+              <a href={`${release}/settings/sources`}>{intl.formatMessage(messages.inactiveSourcesGoTo)}</a>
             </React.Fragment>
           }
         >

--- a/src/components/pageTitle/pageTitle.tsx
+++ b/src/components/pageTitle/pageTitle.tsx
@@ -36,28 +36,28 @@ class PageTitleBase extends React.Component<PageTitleProps> {
 
     switch (path) {
       case paths.explorer:
-        return messages.PageTitleExplorer;
+        return messages.pageTitleExplorer;
       case paths.overview:
-        return messages.PageTitleOverview;
+        return messages.pageTitleOverview;
       case paths.awsDetails:
       case paths.awsDetailsBreakdown:
-        return messages.PageTitleAWS;
+        return messages.pageTitleAws;
       case paths.azureDetails:
       case paths.azureDetailsBreakdown:
-        return messages.PageTitleAzure;
+        return messages.pageTitleAzure;
       case paths.costModels:
-        return messages.PageTitleCostModels;
+        return messages.pageTitleCostModels;
       case paths.gcpDetails:
       case paths.gcpDetailsBreakdown:
-        return messages.PageTitleGCP;
+        return messages.pageTitleGcp;
       case paths.ibmDetails:
       case paths.ibmDetailsBreakdown:
-        return messages.PageTitleIBM;
+        return messages.pageTitleIbm;
       case paths.ocpDetails:
       case paths.ocpDetailsBreakdown:
-        return messages.PageTitleOCP;
+        return messages.pageTitleOcp;
       default:
-        return messages.PageTitleDefault;
+        return messages.pageTitleDefault;
     }
   }
 

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -2,102 +2,102 @@
 import { defineMessages } from 'react-intl';
 
 export default defineMessages({
-  AWS: {
+  aws: {
     defaultMessage: 'Amazon Web Services',
     description: 'Amazon Web Services',
-    id: 'AWS',
+    id: 'aws',
   },
-  AWSComputeTitle: {
+  awsComputeTitle: {
     defaultMessage: 'Compute (EC2) instances usage',
     description: 'Compute (EC2) instances usage',
-    id: 'AWSComputeTitle',
+    id: 'awsComputeTitle',
   },
-  AWSCostTrendTitle: {
+  awsCostTrendTitle: {
     defaultMessage: 'Amazon Web Services cumulative cost comparison ({units})',
     description: 'Amazon Web Services cumulative cost comparison ({units})',
-    id: 'AWSCostTrendTitle',
+    id: 'awsCostTrendTitle',
   },
-  AWSDailyCostTrendTitle: {
+  awsDailyCostTrendTitle: {
     defaultMessage: 'Amazon Web Services daily cost comparison ({units})',
     description: 'Amazon Web Services daily cost comparison ({units})',
-    id: 'AWSDailyCostTrendTitle',
+    id: 'awsDailyCostTrendTitle',
   },
-  AWSDashboardCostTitle: {
+  awsDashboardCostTitle: {
     defaultMessage: 'Amazon Web Services cost',
     description: 'Amazon Web Services cost',
-    id: 'AWSDashboardCostTitle',
+    id: 'awsDashboardCostTitle',
   },
-  AWSDesc: {
+  awsDesc: {
     defaultMessage: 'Raw cost from Amazon Web Services infrastructure.',
     description: 'Raw cost from Amazon Web Services infrastructure.',
-    id: 'AWSDesc',
+    id: 'awsDesc',
   },
-  AWSDetailsTableAriaLabel: {
+  awsDetailsTableAriaLabel: {
     defaultMessage: 'Amazon Web Services details table',
     description: 'Amazon Web Services details table',
-    id: 'AWSDetailsTable',
+    id: 'awsDetailsTable',
   },
-  AWSDetailsTitle: {
+  awsDetailsTitle: {
     defaultMessage: 'Amazon Web Services Details',
     description: 'Amazon Web Services Details',
-    id: 'AWSDetailsTitle',
+    id: 'awsDetailsTitle',
   },
-  AWSOcpDashboardCostTitle: {
+  awsOcpDashboardCostTitle: {
     defaultMessage: 'Amazon Web Services filtered by OpenShift cost',
     description: 'Amazon Web Services filtered by OpenShift cost',
-    id: 'AWSOcpDashboardCostTitle',
+    id: 'awsOcpDashboardCostTitle',
   },
-  Azure: {
+  azure: {
     defaultMessage: 'Microsoft Azure',
     description: 'Microsoft Azure',
-    id: 'Azure',
+    id: 'azure',
   },
-  AzureComputeTitle: {
+  azureComputeTitle: {
     defaultMessage: 'Virtual machines usage',
     description: 'Virtual machines usage',
-    id: 'AzureComputeTitle',
+    id: 'azureComputeTitle',
   },
-  AzureCostTrendTitle: {
+  azureCostTrendTitle: {
     defaultMessage: 'Microsoft Azure cumulative cost comparison ({units})',
     description: 'Microsoft Azure cumulative cost comparison ({units})',
-    id: 'AzureCostTrendTitle',
+    id: 'azureCostTrendTitle',
   },
-  AzureDailyCostTrendTitle: {
+  azureDailyCostTrendTitle: {
     defaultMessage: 'Microsoft Azure daily cost comparison ({units})',
     description: 'Microsoft Azure daily cost comparison ({units})',
-    id: 'AzureDailyCostTrendTitle',
+    id: 'azureDailyCostTrendTitle',
   },
-  AzureDashboardCostTitle: {
+  azureDashboardCostTitle: {
     defaultMessage: 'Microsoft Azure cost',
     description: 'Microsoft Azure cost',
-    id: 'AzureDashboardCostTitle',
+    id: 'azureDashboardCostTitle',
   },
-  AzureDesc: {
+  azureDesc: {
     defaultMessage: 'Raw cost from Azure infrastructure.',
     description: 'Raw cost from Azure infrastructure.',
-    id: 'AzureDesc',
+    id: 'azureDesc',
   },
-  AzureDetailsTableAriaLabel: {
+  azureDetailsTableAriaLabel: {
     defaultMessage: 'Microsoft Azure details table',
     description: 'Microsoft Azure details table',
-    id: 'AzureDetailsTable',
+    id: 'azureDetailsTable',
   },
-  AzureDetailsTitle: {
+  azureDetailsTitle: {
     defaultMessage: 'Microsoft Azure details',
     description: 'Microsoft Azure details',
-    id: 'AzureDetailsTitle',
+    id: 'azureDetailsTitle',
   },
-  AzureOcpDashboardCostTitle: {
+  azureOcpDashboardCostTitle: {
     defaultMessage: 'Microsoft Azure filtered by OpenShift cost',
     description: 'Microsoft Azure filtered by OpenShift cost',
-    id: 'AzureOcpDashboardCostTitle',
+    id: 'azureOcpDashboardCostTitle',
   },
-  Back: {
+  back: {
     defaultMessage: 'Back',
     description: 'Back',
-    id: 'Back',
+    id: 'back',
   },
-  BreakdownBackToDetails: {
+  breakdownBackToDetails: {
     defaultMessage:
       '{groupBy, select, ' +
       'account {Back to {value} account details} ' +
@@ -114,14 +114,14 @@ export default defineMessages({
       'tag {Back to {value} tag details} ' +
       'other {}}',
     description: 'Back to {value} {groupBy} details',
-    id: 'BreakdownBackToDetails',
+    id: 'breakdownBackToDetails',
   },
-  BreakdownBackToDetailsAriaLabel: {
+  breakdownBackToDetailsAriaLabel: {
     defaultMessage: 'Back to details',
     description: 'Back to details',
-    id: 'BreakdownBackToDetailsAriaLabel',
+    id: 'breakdownBackToDetailsAriaLabel',
   },
-  BreakdownBackToTitles: {
+  breakdownBackToTitles: {
     defaultMessage:
       '{value, select, ' +
       'aws {Amazon Web Services} ' +
@@ -131,39 +131,39 @@ export default defineMessages({
       'ocp {OpenShift} ' +
       'other {}}',
     description: 'Breakdown back to page titles',
-    id: 'BreakdownBackToTitles',
+    id: 'breakdownBackToTitles',
   },
-  BreakdownCostBreakdownAriaLabel: {
+  breakdownCostBreakdownAriaLabel: {
     defaultMessage: 'A description of markup, raw cost and usage cost',
     description: 'A description of markup, raw cost and usage cost',
-    id: 'BreakdownCostBreakdownAriaLabel',
+    id: 'breakdownCostBreakdownAriaLabel',
   },
-  BreakdownCostBreakdownTitle: {
+  breakdownCostBreakdownTitle: {
     defaultMessage: 'Cost breakdown',
     description: 'A description of markup, raw cost and usage cost',
-    id: 'BreakdownCostBreakdownTitle',
+    id: 'breakdownCostBreakdownTitle',
   },
-  BreakdownCostChartAriaDesc: {
+  breakdownCostChartAriaDesc: {
     defaultMessage: 'Breakdown of markup, raw, and usage costs',
     description: 'Breakdown of markup, raw, and usage costs',
-    id: 'BreakdownCostChartAriaDesc',
+    id: 'breakdownCostChartAriaDesc',
   },
-  BreakdownCostChartTooltip: {
+  breakdownCostChartTooltip: {
     defaultMessage: '{name}: {value}',
     description: '{name}: {value}',
-    id: 'BreakdownCostChartTooltip',
+    id: 'breakdownCostChartTooltip',
   },
-  BreakdownCostOverviewTitle: {
+  breakdownCostOverviewTitle: {
     defaultMessage: 'Cost overview',
     description: 'Cost overview',
-    id: 'BreakdownCostOverviewTitle',
+    id: 'breakdownCostOverviewTitle',
   },
-  BreakdownHistoricalDataTitle: {
+  breakdownHistoricalDataTitle: {
     defaultMessage: 'Historical data',
     description: 'Historical data',
-    id: 'BreakdownHistoricalDataTitle',
+    id: 'breakdownHistoricalDataTitle',
   },
-  BreakdownSummaryTitle: {
+  breakdownSummaryTitle: {
     defaultMessage:
       '{value, select, ' +
       'account {Cost by accounts} ' +
@@ -180,14 +180,14 @@ export default defineMessages({
       'tag {Cost by tags} ' +
       'other {}}',
     description: 'Cost by {value}',
-    id: 'BreakdownSummaryTitle',
+    id: 'breakdownSummaryTitle',
   },
-  BreakdownTitle: {
+  breakdownTitle: {
     defaultMessage: '{value}',
-    description: 'breakdown title',
-    id: 'BreakdownTitle',
+    description: 'Breakdown title',
+    id: 'breakdownTitle',
   },
-  BreakdownTotalCostDate: {
+  breakdownTotalCostDate: {
     defaultMessage:
       '{month, select, ' +
       '0 {{count, plural, one {{value} total cost (January {startDate})} other {{value} total cost (January {startDate}-{endDate})}}} ' +
@@ -204,19 +204,19 @@ export default defineMessages({
       '11 {{count, plural, one {{value} total cost (December {startDate})} other {{value} total cost (December {startDate}-{endDate})}}} ' +
       'other {}}',
     description: 'Break down total cost by date',
-    id: 'BreakdownTotalCostDate',
+    id: 'breakdownTotalCostDate',
   },
-  CalculationType: {
+  calculationType: {
     defaultMessage: 'Calculation type',
     description: 'Calculation type',
-    id: 'CalculationType',
+    id: 'calculationType',
   },
-  Cancel: {
+  cancel: {
     defaultMessage: 'Cancel',
     description: 'Cancel',
-    id: 'Cancel',
+    id: 'cancel',
   },
-  ChartCostForecastConeLegendLabel: {
+  chartCostForecastConeLegendLabel: {
     defaultMessage:
       '{month, select, ' +
       '0 {{count, plural, one {Cost confidence (Jan {startDate})} other {Cost confidence (Jan {startDate}-{endDate})}}} ' +
@@ -233,14 +233,14 @@ export default defineMessages({
       '11 {{count, plural, one {Cost confidence (Dec {startDate})} other {Cost confidence (Dec {startDate}-{endDate})}}} ' +
       'other {}}',
     description: 'Cost forecast cone date label',
-    id: 'ChartCostForecastConeLegendLabel',
+    id: 'chartCostForecastConeLegendLabel',
   },
-  ChartCostForecastConeLegendNoDataLabel: {
+  chartCostForecastConeLegendNoDataLabel: {
     defaultMessage: 'Cost confidence (no data)',
     description: 'Cost confidence (no data)',
-    id: 'ChartCostForecastConeLegendNoDataLabel',
+    id: 'chartCostForecastConeLegendNoDataLabel',
   },
-  ChartCostForecastConeLegendTooltip: {
+  chartCostForecastConeLegendTooltip: {
     defaultMessage:
       '{month, select, ' +
       '0 {Cost confidence (Jan)} ' +
@@ -256,15 +256,15 @@ export default defineMessages({
       '10 {Cost confidence (Nov)} ' +
       '11 {Cost confidence (Dec)} ' +
       'other {}}',
-    description: 'Cost confidence forecast date label tooltip',
-    id: 'ChartCostForecastConeLegendTooltip',
+    description: 'Cost forecast confidence date label tooltip',
+    id: 'chartCostForecastConeLegendTooltip',
   },
-  ChartCostForecastConeTooltip: {
+  chartCostForecastConeTooltip: {
     defaultMessage: '{value0} - {value1}',
-    description: '{value0} - {value1}',
-    id: 'ChartCostForecastConeTooltip',
+    description: 'Cost forecast confidence min/max tooltip',
+    id: 'chartCostForecastConeTooltip',
   },
-  ChartCostForecastLegendLabel: {
+  chartCostForecastLegendLabel: {
     defaultMessage:
       '{month, select, ' +
       '0 {{count, plural, one {Cost forecast (Jan {startDate})} other {Cost forecast (Jan {startDate}-{endDate})}}} ' +
@@ -281,14 +281,14 @@ export default defineMessages({
       '11 {{count, plural, one {Cost forecast (Dec {startDate})} other {Cost forecast (Dec {startDate}-{endDate})}}} ' +
       'other {}}',
     description: 'Cost forecast date label',
-    id: 'ChartCostForecastLegendLabel',
+    id: 'chartCostForecastLegendLabel',
   },
-  ChartCostForecastLegendNoDataLabel: {
+  chartCostForecastLegendNoDataLabel: {
     defaultMessage: 'Cost forecast (no data)',
     description: 'Cost forecast (no data)',
-    id: 'ChartCostForecastLegendNoDataLabel',
+    id: 'chartCostForecastLegendNoDataLabel',
   },
-  ChartCostForecastLegendTooltip: {
+  chartCostForecastLegendTooltip: {
     defaultMessage:
       '{month, select, ' +
       '0 {Cost forecast (Jan)} ' +
@@ -305,9 +305,9 @@ export default defineMessages({
       '11 {Cost forecast (Dec)} ' +
       'other {}}',
     description: 'Cost forecast date label tooltip',
-    id: 'ChartCostForecastLegendTooltip',
+    id: 'chartCostForecastLegendTooltip',
   },
-  ChartCostInfrastructureForecastConeLegendLabel: {
+  chartCostInfrastructureForecastConeLegendLabel: {
     defaultMessage:
       '{month, select, ' +
       '0 {{count, plural, one {Infrastructure confidence (Jan {startDate})} other {Infrastructure confidence (Jan {startDate}-{endDate})}}} ' +
@@ -324,14 +324,14 @@ export default defineMessages({
       '11 {{count, plural, one {Infrastructure confidence (Dec {startDate})} other {Infrastructure confidence (Dec {startDate}-{endDate})}}} ' +
       'other {}}',
     description: 'Infrastructure date label',
-    id: 'ChartCostInfrastructureForecastConeLegendLabel',
+    id: 'chartCostInfrastructureForecastConeLegendLabel',
   },
-  ChartCostInfrastructureForecastConeLegendNoDataLabel: {
+  chartCostInfrastructureForecastConeLegendNoDataLabel: {
     defaultMessage: 'Infrastructure confidence (no data)',
     description: 'Infrastructure confidence (no data)',
-    id: 'ChartCostInfrastructureForecastConeLegendNoDataLabel',
+    id: 'chartCostInfrastructureForecastConeLegendNoDataLabel',
   },
-  ChartCostInfrastructureForecastConeLegendTooltip: {
+  chartCostInfrastructureForecastConeLegendTooltip: {
     defaultMessage:
       '{month, select, ' +
       '0 {Infrastructure confidence (Jan)} ' +
@@ -348,9 +348,9 @@ export default defineMessages({
       '11 {Infrastructure confidence (Dec)} ' +
       'other {}}',
     description: 'Infrastructure date label tooltip',
-    id: 'ChartCostInfrastructureForecastConeLegendTooltip',
+    id: 'chartCostInfrastructureForecastConeLegendTooltip',
   },
-  ChartCostInfrastructureForecastLegendLabel: {
+  chartCostInfrastructureForecastLegendLabel: {
     defaultMessage:
       '{month, select, ' +
       '0 {{count, plural, one {Infrastructure forecast (Jan {startDate})} other {Infrastructure forecast (Jan {startDate}-{endDate})}}} ' +
@@ -367,14 +367,14 @@ export default defineMessages({
       '11 {{count, plural, one {Infrastructure forecast (Dec {startDate})} other {Infrastructure forecast (Dec {startDate}-{endDate})}}} ' +
       'other {}}',
     description: 'Infrastructure date label',
-    id: 'ChartCostInfrastructureForecastLegendLabel',
+    id: 'chartCostInfrastructureForecastLegendLabel',
   },
-  ChartCostInfrastructureForecastLegendNoDataLabel: {
+  chartCostInfrastructureForecastLegendNoDataLabel: {
     defaultMessage: 'Infrastructure forecast (no data)',
     description: 'Infrastructure forecast (no data)',
-    id: 'ChartCostInfrastructureForecastLegendNoDataLabel',
+    id: 'chartCostInfrastructureForecastLegendNoDataLabel',
   },
-  ChartCostInfrastructureForecastLegendTooltip: {
+  chartCostInfrastructureForecastLegendTooltip: {
     defaultMessage:
       '{month, select, ' +
       '0 {Infrastructure forecast (Jan)} ' +
@@ -391,9 +391,9 @@ export default defineMessages({
       '11 {Infrastructure forecast (Dec)} ' +
       'other {}}',
     description: 'Infrastructure date label tooltip',
-    id: 'ChartCostInfrastructureForecastLegendTooltip',
+    id: 'chartCostInfrastructureForecastLegendTooltip',
   },
-  ChartCostInfrastructureLegendLabel: {
+  chartCostInfrastructureLegendLabel: {
     defaultMessage:
       '{month, select, ' +
       '0 {{count, plural, one {Infrastructure cost (Jan {startDate})} other {Infrastructure cost (Jan {startDate}-{endDate})}}} ' +
@@ -410,14 +410,14 @@ export default defineMessages({
       '11 {{count, plural, one {Infrastructure cost (Dec {startDate})} other {Infrastructure cost (Dec {startDate}-{endDate})}}} ' +
       'other {}}',
     description: 'Infrastructure cost label',
-    id: 'ChartCostInfrastructureLegendLabel',
+    id: 'chartCostInfrastructureLegendLabel',
   },
-  ChartCostInfrastructureLegendNoDataLabel: {
+  chartCostInfrastructureLegendNoDataLabel: {
     defaultMessage: 'Infrastructure cost (no data)',
     description: 'Infrastructure cost (no data)',
-    id: 'ChartCostInfrastructureLegendNoDataLabel',
+    id: 'chartCostInfrastructureLegendNoDataLabel',
   },
-  ChartCostInfrastructureLegendTooltip: {
+  chartCostInfrastructureLegendTooltip: {
     defaultMessage:
       '{month, select, ' +
       '0 {Infrastructure cost (Jan)} ' +
@@ -434,9 +434,9 @@ export default defineMessages({
       '11 {Infrastructure cost (Dec)} ' +
       'other {}}',
     description: 'Infrastructure cost label tooltip',
-    id: 'ChartCostInfrastructureLegendTooltip',
+    id: 'chartCostInfrastructureLegendTooltip',
   },
-  ChartCostLegendLabel: {
+  chartCostLegendLabel: {
     defaultMessage:
       '{month, select, ' +
       '0 {{count, plural, one {Cost (Jan {startDate})} other {Cost (Jan {startDate}-{endDate})}}} ' +
@@ -453,14 +453,14 @@ export default defineMessages({
       '11 {{count, plural, one {Cost (Dec {startDate})} other {Cost (Dec {startDate}-{endDate})}}} ' +
       'other {}}',
     description: 'Cost date label',
-    id: 'ChartCostLegendLabel',
+    id: 'chartCostLegendLabel',
   },
-  ChartCostLegendNoDataLabel: {
+  chartCostLegendNoDataLabel: {
     defaultMessage: 'Cost (no data)',
     description: 'Cost (no data)',
-    id: 'ChartCostLegendNoDataLabel',
+    id: 'chartCostLegendNoDataLabel',
   },
-  ChartCostLegendTooltip: {
+  chartCostLegendTooltip: {
     defaultMessage:
       '{month, select, ' +
       '0 {Cost (Jan)} ' +
@@ -477,9 +477,9 @@ export default defineMessages({
       '11 {Cost (Dec)} ' +
       'other {}}',
     description: 'Cost (month)',
-    id: 'ChartCostLegendTooltip',
+    id: 'chartCostLegendTooltip',
   },
-  ChartCostSupplementaryLegendLabel: {
+  chartCostSupplementaryLegendLabel: {
     defaultMessage:
       '{month, select, ' +
       '0 {{count, plural, one {Supplementary cost (Jan {startDate})} other {Supplementary cost (Jan {startDate}-{endDate})}}} ' +
@@ -496,14 +496,14 @@ export default defineMessages({
       '11 {{count, plural, one {Supplementary cost (Dec {startDate})} other {Supplementary cost (Dec {startDate}-{endDate})}}} ' +
       'other {}}',
     description: 'Supplementary cost date label',
-    id: 'ChartCostSupplementaryLegendLabel',
+    id: 'chartCostSupplementaryLegendLabel',
   },
-  ChartCostSupplementaryLegendNoDataLabel: {
+  chartCostSupplementaryLegendNoDataLabel: {
     defaultMessage: 'Supplementary cost (no data)',
     description: 'Supplementary cost (no data)',
-    id: 'ChartCostSupplementaryLegendNoDataLabel',
+    id: 'chartCostSupplementaryLegendNoDataLabel',
   },
-  ChartCostSupplementaryLegendTooltip: {
+  chartCostSupplementaryLegendTooltip: {
     defaultMessage:
       '{month, select, ' +
       '0 {Supplementary cost (Jan)} ' +
@@ -520,9 +520,9 @@ export default defineMessages({
       '11 {Supplementary cost (Dec)} ' +
       'other {}}',
     description: 'Supplementary cost (month)',
-    id: 'ChartCostSupplementaryLegendTooltip',
+    id: 'chartCostSupplementaryLegendTooltip',
   },
-  ChartDateRange: {
+  chartDateRange: {
     defaultMessage:
       '{month, select, ' +
       '0 {{count, plural, one {Jan {startDate} {year}} other {{startDate}-{endDate} Jan {year}}}} ' +
@@ -539,14 +539,14 @@ export default defineMessages({
       '11 {{count, plural, one {Dec {startDate} {year}} other {{startDate}-{endDate} Dec {year}}}} ' +
       'other {}}',
     description: 'Date range that handles singular and plural',
-    id: 'ChartDateRange',
+    id: 'chartDateRange',
   },
-  ChartDayOfTheMonth: {
+  chartDayOfTheMonth: {
     defaultMessage: 'Day {day}',
     description: 'The day of the month',
-    id: 'ChartDayOfTheMonth',
+    id: 'chartDayOfTheMonth',
   },
-  ChartLimitLegendLabel: {
+  chartLimitLegendLabel: {
     defaultMessage:
       '{month, select, ' +
       '0 {{count, plural, one {Limit (Jan {startDate})} other {Limit (Jan {startDate}-{endDate})}}} ' +
@@ -563,14 +563,14 @@ export default defineMessages({
       '11 {{count, plural, one {Limit (Dec {startDate})} other {Limit (Dec {startDate}-{endDate})}}} ' +
       'other {}}',
     description: 'Limit date label',
-    id: 'ChartLimitLegendLabel',
+    id: 'chartLimitLegendLabel',
   },
-  ChartLimitLegendNoDataLabel: {
+  chartLimitLegendNoDataLabel: {
     defaultMessage: 'Limit (no data)',
     description: 'Limit (no data)',
-    id: 'ChartLimitLegendNoDataLabel',
+    id: 'chartLimitLegendNoDataLabel',
   },
-  ChartLimitLegendTooltip: {
+  chartLimitLegendTooltip: {
     defaultMessage:
       '{month, select, ' +
       '0 {Limit (Jan)} ' +
@@ -587,19 +587,19 @@ export default defineMessages({
       '11 {Limit (Dec)} ' +
       'other {}}',
     description: 'Limit (month)',
-    id: 'ChartLimitLegendTooltip',
+    id: 'chartLimitLegendTooltip',
   },
-  ChartNoData: {
+  chartNoData: {
     defaultMessage: 'no data',
     description: 'no data',
-    id: 'ChartNoData',
+    id: 'chartNoData',
   },
-  ChartOthers: {
+  chartOthers: {
     defaultMessage: '{count, plural, one {{count} Other} other {{count} Others}}',
-    description: 'Other || Others',
-    id: 'ChartOthers',
+    description: 'Others category for top costliest',
+    id: 'chartOthers',
   },
-  ChartRequestsLegendLabel: {
+  chartRequestsLegendLabel: {
     defaultMessage:
       '{month, select, ' +
       '0 {{count, plural, one {Requests (Jan {startDate})} other {Requests (Jan {startDate}-{endDate})}}} ' +
@@ -616,14 +616,14 @@ export default defineMessages({
       '11 {{count, plural, one {Requests (Dec {startDate})} other {Requests (Dec {startDate}-{endDate})}}} ' +
       'other {}}',
     description: 'Requests date label',
-    id: 'ChartRequestLegendLabel',
+    id: 'chartRequestLegendLabel',
   },
-  ChartRequestsLegendNoDataLabel: {
+  chartRequestsLegendNoDataLabel: {
     defaultMessage: 'Requests (no data)',
     description: 'Requests (no data)',
-    id: 'ChartRequestsLegendNoDataLabel',
+    id: 'chartRequestsLegendNoDataLabel',
   },
-  ChartRequestsLegendTooltip: {
+  chartRequestsLegendTooltip: {
     defaultMessage:
       '{month, select, ' +
       '0 {Requests (Jan)} ' +
@@ -640,9 +640,9 @@ export default defineMessages({
       '11 {Requests (Dec)} ' +
       'other {}}',
     description: 'Requests (month)',
-    id: 'ChartRequestLegendTooltip',
+    id: 'chartRequestLegendTooltip',
   },
-  ChartUsageLegendLabel: {
+  chartUsageLegendLabel: {
     defaultMessage:
       '{month, select, ' +
       '0 {{count, plural, one {Usage (Jan {startDate})} other {Usage (Jan {startDate}-{endDate})}}} ' +
@@ -659,14 +659,14 @@ export default defineMessages({
       '11 {{count, plural, one {Usage (Dec {startDate})} other {Usage (Dec {startDate}-{endDate})}}} ' +
       'other {}}',
     description: 'Usage (month {startDate})',
-    id: 'ChartUsageLegendLabel',
+    id: 'chartUsageLegendLabel',
   },
-  ChartUsageLegendNoDataLabel: {
+  chartUsageLegendNoDataLabel: {
     defaultMessage: 'Usage (no data)',
     description: 'Usage (no data)',
-    id: 'ChartUsageLegendNoDataLabel',
+    id: 'chartUsageLegendNoDataLabel',
   },
-  ChartUsageLegendTooltip: {
+  chartUsageLegendTooltip: {
     defaultMessage:
       '{month, select, ' +
       '0 {Usage (Jan)} ' +
@@ -683,436 +683,436 @@ export default defineMessages({
       '11 {Usage (Dec)} ' +
       'other {}}',
     description: 'Usage (month)',
-    id: 'ChartUsageLegendTooltip',
+    id: 'chartUsageLegendTooltip',
   },
-  Close: {
+  close: {
     defaultMessage: 'Close',
     description: 'Close',
-    id: 'Close',
+    id: 'close',
   },
-  Clusters: {
+  clusters: {
     defaultMessage: 'Clusters',
     description: 'Clusters',
-    id: 'Clusters',
+    id: 'clusters',
   },
-  Cost: {
+  cost: {
     defaultMessage: 'Cost',
     description: 'Cost',
-    id: 'Cost',
+    id: 'cost',
   },
-  CostCalculations: {
+  costCalculations: {
     defaultMessage: 'Cost calculations',
     description: 'Cost calculations',
-    id: 'CostCalculations',
+    id: 'costCalculations',
   },
-  CostManagement: {
+  costManagement: {
     defaultMessage: 'Cost Management',
     description: 'Cost Management',
-    id: 'CostManagement',
+    id: 'costManagement',
   },
-  CostModels: {
+  costModels: {
     defaultMessage: 'Cost Models',
     description: 'Cost Models',
-    id: 'CostModels',
+    id: 'costModels',
   },
-  CostModelsAddTagValues: {
+  costModelsAddTagValues: {
     defaultMessage: 'Add more tag values',
     description: 'Add more tag values',
-    id: 'CostModelsAddTagValues',
+    id: 'costModelsAddTagValues',
   },
-  CostModelsAssignSources: {
+  costModelsAssignSources: {
     defaultMessage: '{count, plural, one {Assign source} other {Assign sources}}',
     description: 'Assign sources -- plural or singular',
-    id: 'CostModelsAssignSources',
+    id: 'costModelsAssignSources',
   },
-  CostModelsAssignSourcesErrorDescription: {
+  costModelsAssignSourcesErrorDescription: {
     defaultMessage:
       'You cannot assign a source at this time. Try refreshing this page. If the problem persists, contact your organization administrator or visit our {url} for known outages.',
     description: 'You cannot assign a source at this time',
-    id: 'CostModelsAssignSourcesErrorDescription',
+    id: 'costModelsAssignSourcesErrorDescription',
   },
-  CostModelsAssignSourcesErrorTitle: {
+  costModelsAssignSourcesErrorTitle: {
     defaultMessage: 'This action is temporarily unavailable',
     description: 'This action is temporarily unavailable',
-    id: 'CostModelsAssignSourcesErrorTitle',
+    id: 'costModelsAssignSourcesErrorTitle',
   },
-  CostModelsAssignSourcesParen: {
+  costModelsAssignSourcesParen: {
     defaultMessage: 'Assign source(s)',
     description: 'Assign source(s)',
-    id: 'CostModelsAssignSourcesParen',
+    id: 'costModelsAssignSourcesParen',
   },
-  CostModelsAssignedSources: {
+  costModelsAssignedSources: {
     defaultMessage: 'Assigned sources',
     description: 'Assigned sourcess',
-    id: 'CostModelsAssignedSources',
+    id: 'costModelsAssignedSources',
   },
-  CostModelsAvailableSources: {
+  costModelsAvailableSources: {
     defaultMessage: 'The following sources are assigned to my production cost model:',
     description: 'The following sources are assigned to my production cost model:',
-    id: 'CostModelsAvailableSources',
+    id: 'costModelsAvailableSources',
   },
-  CostModelsCanDelete: {
+  costModelsCanDelete: {
     defaultMessage: 'This action will delete {name} cost model from the system. This action cannot be undone',
     description: 'This action will delete {name} cost model from the system. This action cannot be undone',
-    id: 'CostModelsCanDelete',
+    id: 'costModelsCanDelete',
   },
-  CostModelsCanNotDelete: {
+  costModelsCanNotDelete: {
     defaultMessage: 'The following sources are assigned to {name} cost model:',
     description: 'The following sources are assigned to {name} cost model:',
-    id: 'CostModelsCanNotDelete',
+    id: 'costModelsCanNotDelete',
   },
-  CostModelsDelete: {
+  costModelsDelete: {
     defaultMessage: 'Delete cost model',
     description: 'Delete cost model',
-    id: 'CostModelsDelete',
+    id: 'costModelsDelete',
   },
-  CostModelsDeleteDesc: {
+  costModelsDeleteDesc: {
     defaultMessage: 'This action will delete {costModel} cost model from the system. This action cannot be undone.',
     description: 'This action will delete {costModel} cost model from the system. This action cannot be undone.',
-    id: 'CostModelsDeleteDesc',
+    id: 'costModelsDeleteDesc',
   },
-  CostModelsDeleteSource: {
+  costModelsDeleteSource: {
     defaultMessage: 'You must unassign any sources before you can delete this cost model.',
     description: 'You must unassign any sources before you can delete this cost model.',
-    id: 'CostModelsDeleteSource',
+    id: 'costModelsDeleteSource',
   },
-  CostModelsDescTooLong: {
+  costModelsDescTooLong: {
     defaultMessage: 'Should not exceed 500 characters',
     description: 'Should not exceed 500 characters',
-    id: 'CostModelsDescTooLong',
+    id: 'costModelsDescTooLong',
   },
-  CostModelsDetailsAssignSourcesTitle: {
+  costModelsDetailsAssignSourcesTitle: {
     defaultMessage: 'Assign sources',
     description: 'Assign sources',
-    id: 'CostModelsDetailsAssignSourcesTitle',
+    id: 'costModelsDetailsAssignSourcesTitle',
   },
-  CostModelsDistributionDesc: {
+  costModelsDistributionDesc: {
     defaultMessage:
       'The following is the type of metric that is set to be used when distributing costs to the project level breakdowns.',
     description:
       'The following is the type of metric that is set to be used when distributing costs to the project level breakdowns.',
-    id: 'CostModelsDistributionDesc',
+    id: 'costModelsDistributionDesc',
   },
-  CostModelsDistributionEdit: {
+  costModelsDistributionEdit: {
     defaultMessage: 'Edit distribution',
     description: 'Edit distribution',
-    id: 'CostModelsDistributionEdit',
+    id: 'costModelsDistributionEdit',
   },
-  CostModelsEmptyState: {
+  costModelsEmptyState: {
     defaultMessage: 'What is your hybrid cloud costing you?',
     description: 'What is your hybrid cloud costing you?',
-    id: 'CostModelsEmptyState',
+    id: 'costModelsEmptyState',
   },
-  CostModelsEmptyStateDesc: {
+  costModelsEmptyStateDesc: {
     defaultMessage:
       'Create a cost model to start calculating your hybrid cloud costs using custom price lists, markups, or both. Click on the button below to begin the journey.',
     description:
       'Create a cost model to start calculating your hybrid cloud costs using custom price lists, markups, or both. Click on the button below to begin the journey.',
-    id: 'CostModelsEmptyStateDesc',
+    id: 'costModelsEmptyStateDesc',
   },
-  CostModelsEmptyStateLearnMore: {
+  costModelsEmptyStateLearnMore: {
     defaultMessage: 'Read about setting up a cost model',
     description: 'Read about setting up a cost model',
-    id: 'CostModelsEmptyStateLearnMore',
+    id: 'costModelsEmptyStateLearnMore',
   },
-  CostModelsEnterTagDescription: {
+  costModelsEnterTagDescription: {
     defaultMessage: 'Enter a tag description',
     description: 'Enter a tag description',
-    id: 'CostModelsEnterTagDescription',
+    id: 'costModelsEnterTagDescription',
   },
-  CostModelsEnterTagKey: {
+  costModelsEnterTagKey: {
     defaultMessage: 'Enter a tag key',
     description: 'Enter a tag key',
-    id: 'CostModelsEnterTagKey',
+    id: 'costModelsEnterTagKey',
   },
-  CostModelsEnterTagRate: {
+  costModelsEnterTagRate: {
     defaultMessage: 'Enter rate by tag',
     description: 'Enter rate by tag',
-    id: 'CostModelsEnterTagRate',
+    id: 'costModelsEnterTagRate',
   },
-  CostModelsEnterTagValue: {
+  costModelsEnterTagValue: {
     defaultMessage: 'Enter a tag value',
     description: 'Enter a tag value',
-    id: 'CostModelsEnterTagValue',
+    id: 'costModelsEnterTagValue',
   },
-  CostModelsExamplesDoubleMarkup: {
+  costModelsExamplesDoubleMarkup: {
     defaultMessage: 'A markup rate of (+) 100% doubles the base costs of your source(s).',
     description: 'A markup rate of (+) 100% doubles the base costs of your source(s).',
-    id: 'CostModelsExamplesDoubleMarkup',
+    id: 'costModelsExamplesDoubleMarkup',
   },
-  CostModelsExamplesNoAdjust: {
+  costModelsExamplesNoAdjust: {
     defaultMessage:
       'A markup or discount rate of (+/-) 0% (the default) makes no adjustments to the base costs of your source(s).',
     description:
       'A markup or discount rate of (+/-) 0% (the default) makes no adjustments to the base costs of your source(s).',
-    id: 'CostModelsExamplesNoAdjust',
+    id: 'costModelsExamplesNoAdjust',
   },
-  CostModelsExamplesReduceSeventyfive: {
+  costModelsExamplesReduceSeventyfive: {
     defaultMessage: 'A discount rate of (-) 25% reduces the base costs of your source(s) to 75% of the original value.',
     description: 'A discount rate of (-) 25% reduces the base costs of your source(s) to 75% of the original value.',
-    id: 'CostModelsExamplesReduceSeventyfive',
+    id: 'costModelsExamplesReduceSeventyfive',
   },
-  CostModelsExamplesReduceZero: {
+  costModelsExamplesReduceZero: {
     defaultMessage: 'A discount rate of (-) 100% reduces the base costs of your source(s) to 0.',
     description: 'A discount rate of (-) 100% reduces the base costs of your source(s) to 0.',
-    id: 'CostModelsExamplesReduceZero',
+    id: 'costModelsExamplesReduceZero',
   },
-  CostModelsFilterPlaceholder: {
+  costModelsFilterPlaceholder: {
     defaultMessage: 'Filter by name...',
     description: 'Filter by name',
-    id: 'CostModelsFilterPlaceholder',
+    id: 'costModelsFilterPlaceholder',
   },
-  CostModelsFilterTagKey: {
+  costModelsFilterTagKey: {
     defaultMessage: 'Filter by tag key',
     description: 'Filter by tag key',
-    id: 'CostModelsFilterTagKey',
+    id: 'costModelsFilterTagKey',
   },
-  CostModelsInfoTooLong: {
+  costModelsInfoTooLong: {
     defaultMessage: 'Should not exceed 100 characters',
     description: 'Should not exceed 100 characters',
-    id: 'CostModelsInfoTooLong',
+    id: 'costModelsInfoTooLong',
   },
-  CostModelsLastChange: {
+  costModelsLastChange: {
     defaultMessage: 'Last change',
     description: 'Last change',
-    id: 'CostModelsLastChange',
+    id: 'costModelsLastChange',
   },
-  CostModelsPopover: {
+  costModelsPopover: {
     defaultMessage:
       'A cost model allows you to associate a price to metrics provided by your sources to charge for utilization of resources. {learnMore}',
     description:
       'A cost model allows you to associate a price to metrics provided by your sources to charge for utilization of resources. {learnMore}',
-    id: 'CostModelsPopover',
+    id: 'costModelsPopover',
   },
-  CostModelsPopoverAriaLabel: {
+  costModelsPopoverAriaLabel: {
     defaultMessage: 'Cost model info popover',
     description: 'Cost model info popover',
-    id: 'CostModelsPopoverAriaLabel',
+    id: 'costModelsPopoverAriaLabel',
   },
-  CostModelsRateTooLong: {
+  costModelsRateTooLong: {
     defaultMessage: 'Should not exceed 10 decimals',
     description: 'Should not exceed 10 decimals',
-    id: 'CostModelsRateTooLong',
+    id: 'costModelsRateTooLong',
   },
-  CostModelsReadOnly: {
+  costModelsReadOnly: {
     defaultMessage: 'You have read only permissions',
     description: 'You have read only permissions',
-    id: 'CostModelsReadOnly',
+    id: 'costModelsReadOnly',
   },
-  CostModelsRefreshDialog: {
+  costModelsRefreshDialog: {
     defaultMessage: 'Refresh this dialog',
     description: 'Refresh this dialog',
-    id: 'CostModelsRefreshDialog',
+    id: 'costModelsRefreshDialog',
   },
-  CostModelsRemoveTagLabel: {
+  costModelsRemoveTagLabel: {
     defaultMessage: 'Remove tag value',
     description: 'Remove tag value',
-    id: 'CostModelsRemoveTagLabel',
+    id: 'costModelsRemoveTagLabel',
   },
-  CostModelsRequiredField: {
+  costModelsRequiredField: {
     defaultMessage: 'This field is required',
     description: 'This field is required',
-    id: 'CostModelsRequiredField',
+    id: 'costModelsRequiredField',
   },
-  CostModelsRouterErrorTitle: {
+  costModelsRouterErrorTitle: {
     defaultMessage: 'Fail routing to cost model',
-    description: 'cost models router error title',
-    id: 'CostModelsRouterErrorTitle',
+    description: 'Cost models router error title',
+    id: 'costModelsRouterErrorTitle',
   },
-  CostModelsRouterServerError: {
+  costModelsRouterServerError: {
     defaultMessage: 'Server error: could not get the cost model.',
     description: 'Server error: could not get the cost model.',
-    id: 'CostModelsRouterServerError',
+    id: 'costModelsRouterServerError',
   },
-  CostModelsSelectMeasurement: {
+  costModelsSelectMeasurement: {
     defaultMessage: 'Select Measurement',
     description: 'Select Measurement',
-    id: 'CostModelsSelectMeasurement',
+    id: 'costModelsSelectMeasurement',
   },
-  CostModelsSelectMetric: {
+  costModelsSelectMetric: {
     defaultMessage: 'Select Metric',
     description: 'Select Metric',
-    id: 'CostModelsSelectMetric',
+    id: 'costModelsSelectMetric',
   },
-  CostModelsSourceDelete: {
+  costModelsSourceDelete: {
     defaultMessage: 'Unassign',
     description: 'Unassign',
-    id: 'CostModelsSourceDelete',
+    id: 'costModelsSourceDelete',
   },
-  CostModelsSourceDeleteSource: {
+  costModelsSourceDeleteSource: {
     defaultMessage: 'Unassign source',
     description: 'Unassign source',
-    id: 'CostModelsSourceDeleteSource',
+    id: 'costModelsSourceDeleteSource',
   },
-  CostModelsSourceDeleteSourceDesc: {
+  costModelsSourceDeleteSourceDesc: {
     defaultMessage:
       'This will remove the assignment of {source} from the {costModel} cost model. You can then assign the cost model to a new source.',
     description:
       'This will remove the assignment of {source} from the {costModel} cost model. You can then assign the cost model to a new source.',
-    id: 'CostModelsSourceDeleteSourceDesc',
+    id: 'costModelsSourceDeleteSourceDesc',
   },
-  CostModelsSourceEmptyStateDesc: {
+  costModelsSourceEmptyStateDesc: {
     defaultMessage: 'Select the source(s) you want to apply this cost model to.',
     description: 'Select the source(s) you want to apply this cost model to.',
-    id: 'CostModelsSourceEmptyStateDesc',
+    id: 'costModelsSourceEmptyStateDesc',
   },
-  CostModelsSourceEmptyStateTitle: {
+  costModelsSourceEmptyStateTitle: {
     defaultMessage: 'No sources are assigned',
     description: 'No sources are assigned',
-    id: 'CostModelsSourceEmptyStateTitle',
+    id: 'costModelsSourceEmptyStateTitle',
   },
-  CostModelsSourceTableAriaLabel: {
+  costModelsSourceTableAriaLabel: {
     defaultMessage: 'Sources table',
     description: 'Sources table',
-    id: 'CostModelsSourcesTableAriaLabel',
+    id: 'costModelsSourcesTableAriaLabel',
   },
-  CostModelsSourceTablePaginationAriaLabel: {
+  costModelsSourceTablePaginationAriaLabel: {
     defaultMessage: 'Sources table pagination controls',
     description: 'Sources table pagination controls',
-    id: 'CostModelsSourceTablePaginationAriaLabel',
+    id: 'costModelsSourceTablePaginationAriaLabel',
   },
-  CostModelsSourceType: {
+  costModelsSourceType: {
     defaultMessage: 'Source type',
     description: 'Source type',
-    id: 'CostModelsSourceType',
+    id: 'costModelsSourceType',
   },
-  CostModelsTableAriaLabel: {
+  costModelsTableAriaLabel: {
     defaultMessage: 'Cost models table',
     description: 'Cost models table',
-    id: 'CostModelsTableAriaLabel',
+    id: 'costModelsTableAriaLabel',
   },
-  CostModelsTagRateTableAriaLabel: {
+  costModelsTagRateTableAriaLabel: {
     defaultMessage: 'Tag rates',
     description: 'Tag rates',
-    id: 'CostModelsTagRateTableAriaLabel',
+    id: 'costModelsTagRateTableAriaLabel',
   },
-  CostModelsTagRateTableDefault: {
+  costModelsTagRateTableDefault: {
     defaultMessage: 'Default',
     description: 'Default',
-    id: 'CostModelsTagRateTableDefault',
+    id: 'costModelsTagRateTableDefault',
   },
-  CostModelsTagRateTableKey: {
+  costModelsTagRateTableKey: {
     defaultMessage: 'Tag key',
     description: 'Tag key',
-    id: 'CostModelsTagRateTableKey',
+    id: 'costModelsTagRateTableKey',
   },
-  CostModelsTagRateTableRate: {
+  costModelsTagRateTableRate: {
     defaultMessage: 'Rate',
     description: 'Rate',
-    id: 'CostModelsTagRateTableRate',
+    id: 'costModelsTagRateTableRate',
   },
-  CostModelsTagRateTableValue: {
+  costModelsTagRateTableValue: {
     defaultMessage: 'Tag value',
     description: 'Tag value',
-    id: 'CostModelsTagRateTableValue',
+    id: 'costModelsTagRateTableValue',
   },
-  CostModelsUUIDEmptyState: {
+  costModelsUUIDEmptyState: {
     defaultMessage: 'Cost model can not be found',
     description: 'Cost model can not be found',
-    id: 'CostModelsUUIDEmptyState',
+    id: 'costModelsUUIDEmptyState',
   },
-  CostModelsUUIDEmptyStateDesc: {
+  costModelsUUIDEmptyStateDesc: {
     defaultMessage: 'Cost model with uuid: {uuid} does not exist.',
     description: 'Cost model with uuid: {uuid} does not exist.',
-    id: 'CostModelsUUIDEmptyStateDesc',
+    id: 'costModelsUUIDEmptyStateDesc',
   },
-  CostModelsWizardCreateCostModel: {
+  costModelsWizardCreateCostModel: {
     defaultMessage: 'Create cost model',
     description: 'Create cost model',
-    id: 'CostModelsWizardCreateCostModel',
+    id: 'costModelsWizardCreateCostModel',
   },
-  CostModelsWizardCreatePriceList: {
+  costModelsWizardCreatePriceList: {
     defaultMessage: 'Create a price list',
     description: 'Create a price list',
-    id: 'CostModelsWizardCreatePriceList',
+    id: 'costModelsWizardCreatePriceList',
   },
-  CostModelsWizardCurrencyToggleLabel: {
+  costModelsWizardCurrencyToggleLabel: {
     defaultMessage: 'Select currency',
     description: 'Select currency',
-    id: 'CostModelsWizardCurrencyToggleLabel',
+    id: 'costModelsWizardCurrencyToggleLabel',
   },
-  CostModelsWizardEmptySourceTypeLabel: {
+  costModelsWizardEmptySourceTypeLabel: {
     defaultMessage: 'Select source type',
     description: 'Select source type',
-    id: 'CostModelsWizardEmptySourceTypeLabel',
+    id: 'costModelsWizardEmptySourceTypeLabel',
   },
-  CostModelsWizardEmptyStateCreate: {
+  costModelsWizardEmptyStateCreate: {
     defaultMessage: 'To create a price list, begin by clicking the {value} button.',
     description: 'To create a price list, begin by clicking the {Create rate} button.',
-    id: 'CostModelsWizardEmptyStateCreate',
+    id: 'costModelsWizardEmptyStateCreate',
   },
-  CostModelsWizardEmptyStateOtherTime: {
+  costModelsWizardEmptyStateOtherTime: {
     defaultMessage: 'You can create a price list or modify one at a later time.',
     description: 'You can create a price list or modify one at a later time.',
-    id: 'CostModelsWizardEmptyStateOtherTime',
+    id: 'costModelsWizardEmptyStateOtherTime',
   },
-  CostModelsWizardEmptyStateSkipStep: {
+  costModelsWizardEmptyStateSkipStep: {
     defaultMessage: 'To skip this step, click the {value} button.',
     description: 'To skip this step, click the {next} button.',
-    id: 'CostModelsWizardEmptyStateSkipStep',
+    id: 'costModelsWizardEmptyStateSkipStep',
   },
-  CostModelsWizardEmptyStateTitle: {
+  costModelsWizardEmptyStateTitle: {
     defaultMessage: 'A price list has not been created.',
     description: 'A price list has not been created.',
-    id: 'CostModelsWizardEmptyStateTitle',
+    id: 'costModelsWizardEmptyStateTitle',
   },
-  CostModelsWizardGeneralInfoTitle: {
+  costModelsWizardGeneralInfoTitle: {
     defaultMessage: 'Enter general information',
     description: 'Enter general information',
-    id: 'CostModelsWizardGeneralInfoTitle',
+    id: 'costModelsWizardGeneralInfoTitle',
   },
-  CostModelsWizardNoRatesAdded: {
+  costModelsWizardNoRatesAdded: {
     defaultMessage: 'No rates were added to the price list',
     description: 'No rates were added to the price list',
-    id: 'CostModelsWizardNoRatesAdded',
+    id: 'costModelsWizardNoRatesAdded',
   },
-  CostModelsWizardOnboardAWS: {
+  costModelsWizardOnboardAws: {
     defaultMessage: 'Amazon Web Services (AWS)',
     description: 'Amazon Web Services (AWS)',
-    id: 'CostModelsWizardOnboardAWS',
+    id: 'costModelsWizardOnboardAws',
   },
-  CostModelsWizardOnboardOCP: {
+  costModelsWizardOnboardOcp: {
     defaultMessage: 'Red Hat OpenShift Container Platform',
     description: 'Red Hat OpenShift Container Platform',
-    id: 'CostModelsWizardOnboardOCP',
+    id: 'costModelsWizardOnboardOcp',
   },
-  CostModelsWizardPriceListMetric: {
+  costModelsWizardPriceListMetric: {
     defaultMessage:
       'Select the metric you want to assign a price to, and specify a measurement unit and rate. You can optionally set multiple rates for particular tags.',
     description:
       'Select the metric you want to assign a price to, and specify a measurement unit and rate. You can optionally set multiple rates for particular tags.',
-    id: 'CostModelsWizardPriceListMetric',
+    id: 'costModelsWizardPriceListMetric',
   },
-  CostModelsWizardRateAriaLabel: {
+  costModelsWizardRateAriaLabel: {
     defaultMessage: 'Assign rate',
     description: 'Assign rate',
-    id: 'CostModelsWizardRateAriaLabel',
+    id: 'costModelsWizardRateAriaLabel',
   },
-  CostModelsWizardReviewMarkDiscount: {
+  costModelsWizardReviewMarkDiscount: {
     defaultMessage: 'Markup/Discount',
     description: 'No Markup/Discount',
-    id: 'CostModelsWizardReviewMarkDiscount',
+    id: 'costModelsWizardReviewMarkDiscount',
   },
-  CostModelsWizardReviewStatusSubDetails: {
+  costModelsWizardReviewStatusSubDetails: {
     defaultMessage:
       'Review and confirm your cost model configuration and assignments. Click {create} to create the cost model, or {back} to revise.',
     description:
       'Review and confirm your cost model configuration and assignments. Click {Create} to create the cost model, or {Back} to revise.',
-    id: 'CostModelsWizardReviewStatusSubDetails',
+    id: 'costModelsWizardReviewStatusSubDetails',
   },
-  CostModelsWizardReviewStatusSubTitle: {
+  costModelsWizardReviewStatusSubTitle: {
     defaultMessage:
       'Costs for resources connected to the assigned sources will now be calculated using the newly created {value} cost model.',
     description:
       'Costs for resources connected to the assigned sources will now be calculated using the newly created {value} cost model.',
-    id: 'CostModelsWizardReviewStatusSubTitle',
+    id: 'costModelsWizardReviewStatusSubTitle',
   },
-  CostModelsWizardReviewStatusTitle: {
+  costModelsWizardReviewStatusTitle: {
     defaultMessage: 'Creation successful',
     description: 'Creation successful',
-    id: 'CostModelsWizardReviewStatusTitle',
+    id: 'costModelsWizardReviewStatusTitle',
   },
-  CostModelsWizardSourceCaption: {
+  costModelsWizardSourceCaption: {
     defaultMessage:
       '{value, select, ' +
       'aws {Select from the following Amazon Web Services sources:} ' +
@@ -1121,169 +1121,169 @@ export default defineMessages({
       'ocp {Select from the following Red Hat OpenShift sources:} ' +
       'other {}}',
     description: 'Select from the following {value} sources:',
-    id: 'CostModelsWizardSourceCaption',
+    id: 'costModelsWizardSourceCaption',
   },
-  CostModelsWizardSourceErrorDescription: {
+  costModelsWizardSourceErrorDescription: {
     defaultMessage:
       'Try refreshing this step or you can skip this step (as it is optional) and assign the source to the cost model at a later time. If the problem persists, contact your organization administrator or visit our {url} for known outages.',
     description: 'This step is temporarily unavailable',
-    id: 'CostModelsWizardSourceErrorDescription',
+    id: 'costModelsWizardSourceErrorDescription',
   },
-  CostModelsWizardSourceErrorTitle: {
+  costModelsWizardSourceErrorTitle: {
     defaultMessage: 'This step is temporarily unavailable',
     description: 'This step is temporarily unavailable',
-    id: 'CostModelsWizardSourceErrorTitle',
+    id: 'costModelsWizardSourceErrorTitle',
   },
-  CostModelsWizardSourceSubtitle: {
+  costModelsWizardSourceSubtitle: {
     defaultMessage:
       'Select one or more sources to this cost model. You can skip this step and assign the cost model to a source at a later time. A source will be unavailable for selection if a cost model is already assigned to it.',
     description:
       'Select one or more sources to this cost model. You can skip this step and assign the cost model to a source at a later time. A source will be unavailable for selection if a cost model is already assigned to it.',
-    id: 'CostModelsWizardSourceSubtitle',
+    id: 'costModelsWizardSourceSubtitle',
   },
-  CostModelsWizardSourceTableAriaLabel: {
+  costModelsWizardSourceTableAriaLabel: {
     defaultMessage: 'Assign sources to cost model table',
     description: 'Assign sources to cost model table',
-    id: 'CostModelsWizardSourceTableAriaLabel',
+    id: 'costModelsWizardSourceTableAriaLabel',
   },
-  CostModelsWizardSourceTableCostModel: {
+  costModelsWizardSourceTableCostModel: {
     defaultMessage: 'Cost model assigned',
     description: 'Cost model assigned',
-    id: 'CostModelsWizardSourceTableCostModel',
+    id: 'costModelsWizardSourceTableCostModel',
   },
-  CostModelsWizardSourceTableDefaultCostModel: {
+  costModelsWizardSourceTableDefaultCostModel: {
     defaultMessage: 'Default cost model',
     description: 'Default cost model',
-    id: 'CostModelsWizardSourceTableDefaultCostModel',
+    id: 'costModelsWizardSourceTableDefaultCostModel',
   },
-  CostModelsWizardSourceTitle: {
+  costModelsWizardSourceTitle: {
     defaultMessage: 'Assign sources to the cost model (optional)',
     description: 'Assign sources to the cost model (optional)',
-    id: 'CostModelsWizardSourceTitle',
+    id: 'costModelsWizardSourceTitle',
   },
-  CostModelsWizardSourceWarning: {
+  costModelsWizardSourceWarning: {
     defaultMessage: 'This source is assigned to {costModel} cost model. You will have to unassigned it first',
     description: 'This source is assigned to {costModel} cost model. You will have to unassigned it first',
-    id: 'CostModelsWizardSourceWarning',
+    id: 'costModelsWizardSourceWarning',
   },
-  CostModelsWizardStepsGenInfo: {
+  costModelsWizardStepsGenInfo: {
     defaultMessage: 'Enter information',
     description: 'Enter information',
-    id: 'CostModelsWizardStepsGenInfo',
+    id: 'costModelsWizardStepsGenInfo',
   },
-  CostModelsWizardStepsPriceList: {
+  costModelsWizardStepsPriceList: {
     defaultMessage: 'Price list',
     description: 'Price list',
-    id: 'CostModelsWizardStepsPriceList',
+    id: 'costModelsWizardStepsPriceList',
   },
-  CostModelsWizardStepsReview: {
+  costModelsWizardStepsReview: {
     defaultMessage: 'Review details',
     description: 'Review details',
-    id: 'CostModelsWizardStepsReview',
+    id: 'costModelsWizardStepsReview',
   },
-  CostModelsWizardStepsSources: {
+  costModelsWizardStepsSources: {
     defaultMessage: 'Assign a source to the cost model',
     description: 'Assign a source to the cost model',
-    id: 'CostModelsWizardStepsSources',
+    id: 'costModelsWizardStepsSources',
   },
-  CostModelsWizardSubTitleTable: {
+  costModelsWizardSubTitleTable: {
     defaultMessage: 'The following is a list of rates you have set so far for this price list.',
     description: 'The following is a list of rates you have set so far for this price list.',
-    id: 'CostModelsWizardSubTitleTable',
+    id: 'costModelsWizardSubTitleTable',
   },
-  CostModelsWizardWarningSources: {
+  costModelsWizardWarningSources: {
     defaultMessage: 'Cannot assign cost model to a source that is already assigned to another one',
     description: 'No Cannot assign cost model to a source that is already assigned to another one',
-    id: 'CostModelsWizardWarningSources',
+    id: 'costModelsWizardWarningSources',
   },
-  CostTypeAmortized: {
+  costTypeAmortized: {
     defaultMessage: 'Amortized',
     description: 'Amortized cost type',
-    id: 'CostTypeAmortized',
+    id: 'costTypeAmortized',
   },
-  CostTypeAmortizedDesc: {
+  costTypeAmortizedDesc: {
     defaultMessage: 'Recurring and/or upfront costs are distributed evenly across the month',
     description: 'Recurring and/or upfront costs are distributed evenly across the month',
-    id: 'CostTypeAmortizedDesc',
+    id: 'costTypeAmortizedDesc',
   },
-  CostTypeBlended: {
+  costTypeBlended: {
     defaultMessage: 'Blended',
     description: 'Blended cost type',
-    id: 'CostTypeBlended',
+    id: 'costTypeBlended',
   },
-  CostTypeBlendedDesc: {
+  costTypeBlendedDesc: {
     defaultMessage: 'Using a blended rate to calcuate cost usage',
     description: 'Using a blended rate to calcuate cost usage',
-    id: 'CostTypeBlendedDesc',
+    id: 'costTypeBlendedDesc',
   },
-  CostTypeLabel: {
+  costTypeLabel: {
     defaultMessage: 'Show cost as',
     description: 'Show cost as',
-    id: 'CostTypeLabel',
+    id: 'costTypeLabel',
   },
-  CostTypeUnblended: {
+  costTypeUnblended: {
     defaultMessage: 'Unblended',
     description: 'Unblended cost type',
-    id: 'CostTypeUnblended',
+    id: 'costTypeUnblended',
   },
-  CostTypeUnblendedDesc: {
+  costTypeUnblendedDesc: {
     defaultMessage: 'Usage cost on the day you are charged',
     description: 'Usage cost on the day you are charged',
-    id: 'CostTypeUnblendedDesc',
+    id: 'costTypeUnblendedDesc',
   },
-  CpuTitle: {
+  cpuTitle: {
     defaultMessage: 'CPU',
     description: 'CPU',
-    id: 'CPUTitle',
+    id: 'cpuTitle',
   },
-  Create: {
+  create: {
     defaultMessage: 'Create',
     description: 'Create',
-    id: 'Create',
+    id: 'create',
   },
-  CreateCostModelConfirmMsg: {
+  createCostModelConfirmMsg: {
     defaultMessage: 'Are you sure you want to stop creating a cost model? All settings will be discarded.',
     description: 'Are you sure you want to stop creating a cost model? All settings will be discarded.',
-    id: 'CreateCostModelConfirmMsg',
+    id: 'createCostModelConfirmMsg',
   },
-  CreateCostModelDesc: {
+  createCostModelDesc: {
     defaultMessage:
       'A cost model allows you to associate a price to metrics provided by your sources to charge for utilization of resources.',
     description:
       'A cost model allows you to associate a price to metrics provided by your sources to charge for utilization of resources.',
-    id: 'CreateCostModelDesc',
+    id: 'createCostModelDesc',
   },
-  CreateCostModelExit: {
+  createCostModelExit: {
     defaultMessage: 'Exit cost model creation',
     description: 'Exit cost model creation',
-    id: 'CreateCostModelExit',
+    id: 'createCostModelExit',
   },
-  CreateCostModelExitYes: {
+  createCostModelExitYes: {
     defaultMessage: 'Yes, I want to exit',
     description: 'Yes, I want to exit',
-    id: 'CreateCostModelExitYes',
+    id: 'createCostModelExitYes',
   },
-  CreateCostModelNoContinue: {
+  createCostModelNoContinue: {
     defaultMessage: 'No, I want to continue',
     description: 'No, I want to continue',
-    id: 'CreateCostModelNoContinue',
+    id: 'createCostModelNoContinue',
   },
-  CreateCostModelTitle: {
+  createCostModelTitle: {
     defaultMessage: 'Create a cost model',
     description: 'Create a cost model',
-    id: 'CreateCostModelTitle',
+    id: 'createCostModelTitle',
   },
-  CreateRate: {
+  createRate: {
     defaultMessage: 'Create rate',
     description: 'Create rate',
-    id: 'CreateRate',
+    id: 'createRate',
   },
-  Currency: {
+  currency: {
     defaultMessage: 'Currency',
     description: 'Currency',
-    id: 'Currency',
+    id: 'currency',
   },
-  CurrencyAbbreviations: {
+  currencyAbbreviations: {
     defaultMessage:
       '{symbol, select, ' +
       'billion {{value} B} ' +
@@ -1293,10 +1293,10 @@ export default defineMessages({
       'trillion {{value} t} ' +
       'other {}}',
     description: 'str.match(/([\\D]*)([\\d.,]+)([\\D]*)/)',
-    id: 'CurrencyAbbreviations',
+    id: 'currencyAbbreviations',
   },
   // See https://www.localeplanet.com/icu/currency.html
-  CurrencyOptions: {
+  currencyOptions: {
     defaultMessage:
       '{units, select, ' +
       'AUD {AUD (A$) - Australian Dollar}' +
@@ -1316,10 +1316,10 @@ export default defineMessages({
       'ZAR {ZAR (ZAR) - South African Rand}' +
       'other {}}',
     description: 'return the proper unit label based on key: "units"',
-    id: 'CurrencyOptions',
+    id: 'currencyOptions',
   },
   // See https://www.localeplanet.com/icu/currency.html
-  CurrencyUnits: {
+  currencyUnits: {
     defaultMessage:
       '{units, select, ' +
       'AUD {A$}' +
@@ -1339,60 +1339,60 @@ export default defineMessages({
       'ZAR {ZAR}' +
       'other {}}',
     description: 'return the proper unit label based on key: "units"',
-    id: 'CurrencyUnits',
+    id: 'currencyUnits',
   },
-  DashboardCumulativeCostComparison: {
+  dashboardCumulativeCostComparison: {
     defaultMessage: 'Cumulative cost comparison ({units})',
     description: 'Cumulative cost comparison ({units})',
-    id: 'DashboardCumulativeCostComparison',
+    id: 'dashboardCumulativeCostComparison',
   },
-  DashboardDailyUsageComparison: {
+  dashboardDailyUsageComparison: {
     defaultMessage: 'Daily usage comparison ({units})',
     description: 'Daily usage comparison ({units})',
-    id: 'DashboardDailyUsageComparison',
+    id: 'dashboardDailyUsageComparison',
   },
-  DashboardDatabaseTitle: {
+  dashboardDatabaseTitle: {
     defaultMessage: 'Database services cost',
     description: 'Database services cost',
-    id: 'DashboardDatabaseTitle',
+    id: 'dashboardDatabaseTitle',
   },
-  DashboardNetworkTitle: {
+  dashboardNetworkTitle: {
     defaultMessage: 'Network services cost',
     description: 'Network services cost',
-    id: 'DashboardNetworkTitle',
+    id: 'dashboardNetworkTitle',
   },
-  DashboardStorageTitle: {
+  dashboardStorageTitle: {
     defaultMessage: 'Storage services usage',
     description: 'Storage services usage',
-    id: 'DashboardStorageTitle',
+    id: 'dashboardStorageTitle',
   },
-  DashboardTotalCostTooltip: {
+  dashboardTotalCostTooltip: {
     defaultMessage:
       'This total cost is the sum of the infrastructure cost {infrastructureCost} and supplementary cost {supplementaryCost}',
     description: 'total cost is the sum of the infrastructure cost and supplementary cost',
-    id: 'DashboardTotalCostTooltip',
+    id: 'dashboardTotalCostTooltip',
   },
-  Delete: {
+  delete: {
     defaultMessage: 'Delete',
     description: 'Delete',
-    id: 'Delete',
+    id: 'delete',
   },
-  Description: {
+  description: {
     defaultMessage: 'Description',
     description: 'Description',
-    id: 'Description',
+    id: 'description',
   },
-  DetailsActionsExport: {
+  detailsActionsExport: {
     defaultMessage: 'Export data',
     description: 'Export data',
-    id: 'DetailsActionsExport',
+    id: 'detailsActionsExport',
   },
-  DetailsActionsPriceList: {
+  detailsActionsPriceList: {
     defaultMessage: 'View all price lists',
     description: 'View all price lists',
-    id: 'DetailsActionsPriceList',
+    id: 'detailsActionsPriceList',
   },
-  DetailsClustersModalTitle: {
+  detailsClustersModalTitle: {
     defaultMessage:
       '{groupBy, select, ' +
       'account {account {name} clusters} ' +
@@ -1409,29 +1409,29 @@ export default defineMessages({
       'tag {tags {name} clusters} ' +
       'other {}}',
     description: '{groupBy} {name} clusters',
-    id: 'DetailsClustersModalTitle',
+    id: 'detailsClustersModalTitle',
   },
-  DetailsColumnManagementTitle: {
+  detailsColumnManagementTitle: {
     defaultMessage: 'Manage columns',
     description: 'Manage columns',
-    id: 'DetailsColumnManagementTitle',
+    id: 'detailsColumnManagementTitle',
   },
-  DetailsCostValue: {
+  detailsCostValue: {
     defaultMessage: 'Cost: {value}',
     description: 'Cost value',
-    id: 'DetailsCostValue',
+    id: 'detailsCostValue',
   },
-  DetailsEmptyState: {
+  detailsEmptyState: {
     defaultMessage: 'Processing data to generate a list of all services that sums to a total cost...',
     description: 'Processing data to generate a list of all services that sums to a total cost...',
-    id: 'DetailsEmptyState',
+    id: 'detailsEmptyState',
   },
-  DetailsMoreClusters: {
+  detailsMoreClusters: {
     defaultMessage: ', {value} more...',
     description: ', {value} more...',
-    id: 'DetailsMoreClusters',
+    id: 'detailsMoreClusters',
   },
-  DetailsResourceNames: {
+  detailsResourceNames: {
     defaultMessage:
       '{value, select, ' +
       'account {Account names} ' +
@@ -1447,10 +1447,10 @@ export default defineMessages({
       'subscription_guid {Account names} ' +
       'tag {Tag names} ' +
       'other {}}',
-    description: 'details table resource names',
-    id: 'DetailsResourceNames',
+    description: 'Details table resource names',
+    id: 'detailsResourceNames',
   },
-  DetailsSummaryModalTitle: {
+  detailsSummaryModalTitle: {
     defaultMessage:
       '{groupBy, select, ' +
       'account {{name} accounts} ' +
@@ -1467,44 +1467,44 @@ export default defineMessages({
       'tag {{name} tags} ' +
       'other {}}',
     description: ', {value} more...',
-    id: 'DetailsSummaryModalTitle',
+    id: 'detailsSummaryModalTitle',
   },
-  DetailsUnusedRequestsLabel: {
+  detailsUnusedRequestsLabel: {
     defaultMessage: 'Unrequested capacity',
     description: 'Unrequested capacity',
-    id: 'DetailsUnusedRequestsLabel',
+    id: 'detailsUnusedRequestsLabel',
   },
-  DetailsUnusedUnits: {
+  detailsUnusedUnits: {
     defaultMessage: '{units} ({percentage}% of capacity)',
     description: '{units} ({percentage}% of capacity)',
-    id: 'DetailsUnusedUsageUnits',
+    id: 'detailsUnusedUsageUnits',
   },
-  DetailsUnusedUsageLabel: {
+  detailsUnusedUsageLabel: {
     defaultMessage: 'Unused capacity',
     description: 'Unused capacity',
-    id: 'DetailsUnusedUsageLabel',
+    id: 'detailsUnusedUsageLabel',
   },
-  DetailsUsageCapacity: {
+  detailsUsageCapacity: {
     defaultMessage: 'Capacity - {value} {units}',
     description: 'Capacity - {value} {units}',
-    id: 'DetailsUsageCapacity',
+    id: 'detailsUsageCapacity',
   },
-  DetailsUsageLimit: {
+  detailsUsageLimit: {
     defaultMessage: 'Limit - {value} {units}',
     description: 'Limit - {value} {units}',
-    id: 'DetailsUsageLimit',
+    id: 'detailsUsageLimit',
   },
-  DetailsUsageRequests: {
+  detailsUsageRequests: {
     defaultMessage: 'Requests - {value} {units}',
     description: 'Requests - {value} {units}',
-    id: 'DetailsUsageRequests',
+    id: 'detailsUsageRequests',
   },
-  DetailsUsageUsage: {
+  detailsUsageUsage: {
     defaultMessage: 'Usage - {value} {units}',
     description: 'Usage - {value} {units}',
-    id: 'DetailsUsageUsage',
+    id: 'detailsUsageUsage',
   },
-  DetailsViewAll: {
+  detailsViewAll: {
     defaultMessage:
       '{value, select, ' +
       'account {View all accounts} ' +
@@ -1521,129 +1521,129 @@ export default defineMessages({
       'tag {View all tags} ' +
       'other {}}',
     description: 'View all {value}',
-    id: 'DetailsViewAll',
+    id: 'detailsViewAll',
   },
-  DiscountMinus: {
+  discountMinus: {
     defaultMessage: 'Discount (-)',
     description: 'Discount (-)',
-    id: 'DiscountMinus',
+    id: 'discountMinus',
   },
-  DistributionModelDesc: {
+  distributionModelDesc: {
     defaultMessage:
       'This choice is for users to direct how their raw costs are distributed either by CPU or Memory on the project level breakdowns.',
     description:
       'This choice is for users to direct how their raw costs are distributed either by CPU or Memory on the project level breakdowns.',
-    id: 'DistributionModelDesc',
+    id: 'distributionModelDesc',
   },
-  DistributionType: {
+  distributionType: {
     defaultMessage: 'Distribution type',
     description: 'Distribution type',
-    id: 'DistributionType',
+    id: 'distributionType',
   },
-  DocsAddOcpSources: {
+  docsAddOcpSources: {
     defaultMessage:
       'https://access.redhat.com/documentation/en-us/cost_management_service/2021/html-single/adding_an_openshift_container_platform_source_to_cost_management',
     description:
       'https://access.redhat.com/documentation/en-us/cost_management_service/2021/html-single/adding_an_openshift_container_platform_source_to_cost_management',
-    id: 'DocsAddOcpSources',
+    id: 'docsAddOcpSources',
   },
-  DocsConfigCostModels: {
+  docsConfigCostModels: {
     defaultMessage:
       'https://access.redhat.com/documentation/en-us/cost_management_service/2021/html-single/using_cost_models/index#assembly-setting-up-cost-models',
     description:
       'https://access.redhat.com/documentation/en-us/cost_management_service/2021/html-single/using_cost_models/index#assembly-setting-up-cost-models',
-    id: 'DocsConfigCostModels',
+    id: 'docsConfigCostModels',
   },
-  DocsCostModelTerminology: {
+  docsCostModelTerminology: {
     defaultMessage:
       'https://access.redhat.com/documentation/en-us/cost_management_service/2021/html-single/using_cost_models/index#cost-model-terminology',
     description:
       'https://access.redhat.com/documentation/en-us/cost_management_service/2021/html-single/using_cost_models/index#cost-model-terminology',
-    id: 'DocsCostModelTerminology',
+    id: 'docsCostModelTerminology',
   },
-  DocsUsingCostModels: {
+  docsUsingCostModels: {
     defaultMessage:
       'https://access.redhat.com/documentation/en-us/cost_management_service/2021/html-single/using_cost_models',
     description:
       'https://access.redhat.com/documentation/en-us/cost_management_service/2021/html-single/using_cost_models',
-    id: 'DocsUsingCostModels',
+    id: 'docsUsingCostModels',
   },
-  Download: {
+  download: {
     defaultMessage: 'Download',
-    description: 'download',
-    id: 'Download',
+    description: 'Download',
+    id: 'download',
   },
-  Edit: {
+  edit: {
     defaultMessage: 'Edit',
     description: 'Edit',
-    id: 'Edit',
+    id: 'edit',
   },
-  EditCostModel: {
+  editCostModel: {
     defaultMessage: 'Edit cost model',
     description: 'Edit cost model',
-    id: 'EditCostModel',
+    id: 'editCostModel',
   },
-  EditMarkup: {
+  editMarkup: {
     defaultMessage: 'Edit markup',
     description: 'Edit markup',
-    id: 'EditMarkup',
+    id: 'editMarkup',
   },
-  EditMarkupOrDiscount: {
+  editMarkupOrDiscount: {
     defaultMessage: 'Edit markup or discount',
     description: 'Edit markup or discount',
-    id: 'EditMarkupOrDiscount',
+    id: 'editMarkupOrDiscount',
   },
-  EmptyFilterSourceStateSubtitle: {
+  emptyFilterSourceStateSubtitle: {
     defaultMessage: 'Sorry, no source with the given filter was found.',
     description: 'Sorry, no source with the given filter was found.',
-    id: 'EmptyFilterSourceStateSubtitle',
+    id: 'emptyFilterSourceStateSubtitle',
   },
-  EmptyFilterStateSubtitle: {
+  emptyFilterStateSubtitle: {
     defaultMessage: 'Sorry, no data with the given filter was found.',
     description: 'Sorry, no data with the given filter was found.',
-    id: 'EmptyFilterStateSubtitle',
+    id: 'emptyFilterStateSubtitle',
   },
-  EmptyFilterStateTitle: {
+  emptyFilterStateTitle: {
     defaultMessage: 'No match found',
     description: 'No match found',
-    id: 'EmptyFilterStateTitle',
+    id: 'emptyFilterStateTitle',
   },
-  EqualsSymbol: {
+  equalsSymbol: {
     defaultMessage: '=',
-    description: 'equals',
-    id: 'EqualsSymbol',
+    description: 'Equals symbol',
+    id: 'equalsSymbol',
   },
-  ErrorStateNotAuthorizedDesc: {
+  errorStateNotAuthorizedDesc: {
     defaultMessage: 'Contact the cost management administrator to provide access to this application',
     description: 'Contact the cost management administrator to provide access to this application',
-    id: 'ErrorStateNotAuthorizedDesc',
+    id: 'errorStateNotAuthorizedDesc',
   },
-  ErrorStateNotAuthorizedTitle: {
+  errorStateNotAuthorizedTitle: {
     defaultMessage: "You don't have access to the Cost management application",
     description: "You don't have access to the Cost management application",
-    id: 'ErrorStateNotAuthorizedTitle',
+    id: 'errorStateNotAuthorizedTitle',
   },
-  ErrorStateUnexpectedDesc: {
+  errorStateUnexpectedDesc: {
     defaultMessage: 'We encountered an unexpected error. Contact your administrator.',
     description: 'We encountered an unexpected error. Contact your administrator.',
-    id: 'ErrorStateUnexpectedDesc',
+    id: 'errorStateUnexpectedDesc',
   },
-  ErrorStateUnexpectedTitle: {
+  errorStateUnexpectedTitle: {
     defaultMessage: 'Oops!',
     description: 'Oops!',
-    id: 'ErrorStateUnexpectedTitle',
+    id: 'errorStateUnexpectedTitle',
   },
-  ExamplesTitle: {
+  examplesTitle: {
     defaultMessage: 'Examples',
     description: 'Examples',
     id: 'ExamplesTitle',
   },
-  ExpiresOn: {
+  expiresOn: {
     defaultMessage: 'Expires on',
     description: 'Expires on',
-    id: 'ExpiresOn',
+    id: 'expiresOn',
   },
-  ExplorerChartDate: {
+  explorerChartDate: {
     defaultMessage:
       '{month, select, ' +
       '0 {Jan {date}} ' +
@@ -1660,9 +1660,9 @@ export default defineMessages({
       '11 {Dec {date}} ' +
       'other {}}',
     description: 'Month {date}',
-    id: 'ExplorerDateColumn',
+    id: 'explorerDateColumn',
   },
-  ExplorerChartTitle: {
+  explorerChartTitle: {
     defaultMessage:
       '{value, select, ' +
       'aws {Amazon Web Services - Top 5 Costliest} ' +
@@ -1677,9 +1677,9 @@ export default defineMessages({
       'ocp_cloud {All cloud filtered by OpenShift - Top 5 Costliest} ' +
       'other {}}',
     description: 'Explorer chart title',
-    id: 'ExplorerChartTitle',
+    id: 'explorerChartTitle',
   },
-  ExplorerDateRange: {
+  explorerDateRange: {
     defaultMessage:
       '{value, select, ' +
       'current_month_to_date {Month to date} ' +
@@ -1688,46 +1688,46 @@ export default defineMessages({
       'last_thirty_days {Last 30 days} ' +
       'previous_month_to_date {Previous month and month to date} ' +
       'other {}}',
-    description: 'date range based on {value}',
-    id: 'ExplorerDateRange',
+    description: 'Date range based on {value}',
+    id: 'explorerDateRange',
   },
-  ExplorerMonthDate: {
+  explorerMonthDate: {
     defaultMessage: '{month} {date}',
     description: 'Cost {month} {date}',
-    id: 'ExplorerMonthDate',
+    id: 'explorerMonthDate',
   },
-  ExplorerTableAriaLabel: {
+  explorerTableAriaLabel: {
     defaultMessage: 'Cost Explorer table',
     description: 'Cost Explorer table',
-    id: 'ExplorerTableAriaLabel',
+    id: 'explorerTableAriaLabel',
   },
-  ExplorerTitle: {
+  explorerTitle: {
     defaultMessage: 'Cost Explorer',
     description: 'Cost Explorer title',
-    id: 'ExplorerTitle',
+    id: 'explorerTitle',
   },
-  ExportAggregateType: {
+  exportAggregateType: {
     defaultMessage: 'Aggregate type',
     description: 'Aggregate type',
-    id: 'ExportAggregateType',
+    id: 'exportAggregateType',
   },
-  ExportAll: {
+  exportAll: {
     defaultMessage: 'Export all',
     description: 'Export all',
-    id: 'ExportAll',
+    id: 'exportAll',
   },
-  ExportDesc: {
+  exportDesc: {
     defaultMessage:
       'The active selections from the table plus the values here will be used to generate an export file. When the file is available, download it from the {value} view.',
     description: 'Export description',
-    id: 'ExportAll',
+    id: 'exportAll',
   },
-  ExportError: {
+  exportError: {
     defaultMessage: 'Something went wrong, please try fewer selections',
     description: 'Export error',
-    id: 'ExportError',
+    id: 'exportError',
   },
-  ExportFileName: {
+  exportFileName: {
     defaultMessage:
       '{groupBy, select, ' +
       'account {{resolution, select, daily {{provider}_accounts_daily_{startDate}_{endDate}} monthly {{provider}_accounts_monthly_{startDate}_{endDate}} other {}}} ' +
@@ -1744,24 +1744,24 @@ export default defineMessages({
       'tag {{resolution, select, daily {{provider}_tags_daily_{startDate}_{endDate}} monthly {{provider}_tags_monthly_{startDate}_{endDate}} other {}}} ' +
       'other {}}',
     description: 'Export file name',
-    id: 'ExportFileName',
+    id: 'exportFileName',
   },
-  ExportFormatType: {
+  exportFormatType: {
     defaultMessage: '{value, select, csv {CSV} json {JSON} other {}}',
     description: 'Export format type',
-    id: 'ExportFormatType',
+    id: 'exportFormatType',
   },
-  ExportFormatTypeTitle: {
+  exportFormatTypeTitle: {
     defaultMessage: 'Format type',
     description: 'Format type',
-    id: 'ExportFormatTypeTitle',
+    id: 'exportFormatTypeTitle',
   },
-  ExportGenerate: {
+  exportGenerate: {
     defaultMessage: 'Generate export',
     description: 'Export export',
-    id: 'ExportGenerate',
+    id: 'exportGenerate',
   },
-  ExportHeading: {
+  exportHeading: {
     defaultMessage:
       '{groupBy, select, ' +
       'account {Aggregates of the following accounts will be exported to a .csv file.} ' +
@@ -1778,9 +1778,9 @@ export default defineMessages({
       'tag {Aggregates of the following tags will be exported to a .csv file.} ' +
       'other {}}',
     description: 'Export heading',
-    id: 'ExportHeading',
+    id: 'exportHeading',
   },
-  ExportName: {
+  exportName: {
     defaultMessage:
       '{groupBy, select, ' +
       'account {{provider, select, aws {Amazon Web Services grouped by Account} aws_ocp {Amazon Web Services filtered by OpenShift grouped by Account} azure {Microsoft Azure grouped by Account} azure_ocp {Microsoft Azure filtered by OpenShift grouped by Account} gcp {Google Cloud Platform grouped by Account} gcp_ocp {Google Cloud Platform filtered by OpenShift grouped by Account} ibm {IBM Cloud grouped by Account} ibm_ocp {IBM Cloud filtered by OpenShift grouped by Account} ocp {OpenShift grouped by Account} ocp_cloud {All cloud filtered by OpenShift grouped by Account} other {}}} ' +
@@ -1797,24 +1797,24 @@ export default defineMessages({
       'tag {{provider, select, aws {Amazon Web Services grouped by Tag} aws_ocp {Amazon Web Services filtered by OpenShift grouped by Tag} azure {Microsoft Azure grouped by Tag} azure_ocp {Microsoft Azure filtered by OpenShift grouped by Tag} gcp {Google Cloud Platform grouped by Tag} gcp_ocp {Google Cloud Platform filtered by OpenShift grouped by Tag} ibm {IBM Cloud grouped by Tag} ibm_ocp {IBM Cloud filtered by OpenShift grouped by Tag} ocp {OpenShift grouped by Tag} ocp_cloud {All cloud filtered by OpenShift grouped by Tag} other {}}} ' +
       'other {}}',
     description: 'Export name',
-    id: 'ExportName',
+    id: 'exportName',
   },
-  ExportNameRequired: {
+  exportNameRequired: {
     defaultMessage: 'Please enter a name for the export',
     description: 'Please enter a name for the export',
-    id: 'ExportNameRequired',
+    id: 'exportNameRequired',
   },
-  ExportNameTooLong: {
+  exportNameTooLong: {
     defaultMessage: 'Should not exceed 50 characters',
     description: 'Should not exceed 50 characters',
-    id: 'ExportNameTooLong',
+    id: 'exportNameTooLong',
   },
-  ExportResolution: {
+  exportResolution: {
     defaultMessage: '{value, select, daily {Daily} monthly {Monthly} other {}}',
     description: 'Export file name',
-    id: 'ExportResolution',
+    id: 'exportResolution',
   },
-  ExportSelected: {
+  exportSelected: {
     defaultMessage:
       '{groupBy, select, ' +
       'account {Selected accounts ({count})} ' +
@@ -1831,73 +1831,73 @@ export default defineMessages({
       'tag {Selected tags ({count})} ' +
       'other {}}',
     description: 'Selected items for export',
-    id: 'ExportSelected',
+    id: 'exportSelected',
   },
-  ExportTimeScope: {
+  exportTimeScope: {
     defaultMessage: '{value, select, current {Current ({date})} previous {Previous ({date})} other {}}',
     description: 'Export time scope',
-    id: 'ExportTimeScope',
+    id: 'exportTimeScope',
   },
-  ExportTimeScopeTitle: {
+  exportTimeScopeTitle: {
     defaultMessage: 'Month',
     description: 'Month',
-    id: 'ExportTimeScopeTitle',
+    id: 'exportTimeScopeTitle',
   },
-  ExportTitle: {
+  exportTitle: {
     defaultMessage: 'Export',
     description: 'Export title',
-    id: 'ExportTitle',
+    id: 'exportTitle',
   },
-  ExportsDesc: {
+  exportsDesc: {
     defaultMessage:
       'Exports are available for download from the time that they are generated up to 7 days later. After 7 days, the export file will be removed.',
     description:
       'Exports are available for download from the time that they are generated up to 7 days later. After 7 days, the export file will be removed.',
-    id: 'ExportsDesc',
+    id: 'exportsDesc',
   },
-  ExportsEmptyState: {
+  exportsEmptyState: {
     defaultMessage:
       'To get started, close this view and select rows in the table you want to export and click the export button to start the journey.',
     description:
       'To get started, close this view and select rows in the table you want to export and click the export button to start the journey.',
-    id: 'ExportsEmptyState',
+    id: 'exportsEmptyState',
   },
-  ExportsFailed: {
+  exportsFailed: {
     defaultMessage: 'Could not create export file',
     description: 'Export failed',
-    id: 'ExportsFailed',
+    id: 'exportsFailed',
   },
-  ExportsFailedDesc: {
+  exportsFailedDesc: {
     defaultMessage: 'Something went wrong with the generation of this export file. Try exporting again.',
     description: 'Export failed description',
-    id: 'ExportsFailedDesc',
+    id: 'exportsFailedDesc',
   },
-  ExportsSuccess: {
+  exportsSuccess: {
     defaultMessage: 'Export preparing for download',
     description: 'Export success',
-    id: 'ExportsSuccess',
+    id: 'exportsSuccess',
   },
-  ExportsSuccessDesc: {
+  exportsSuccessDesc: {
     defaultMessage: 'The export is preparing for download. It will be accessible from {value} view. {link}',
     description: 'Export success description',
-    id: 'ExportsSuccessDesc',
+    id: 'exportsSuccessDesc',
   },
-  ExportsTableAriaLabel: {
+  exportsTableAriaLabel: {
     defaultMessage: 'Available exports table',
     description: 'Available exports table',
-    id: 'ExportsTableAriaLabel',
+    id: 'exportsTableAriaLabel',
   },
-  ExportsTitle: {
+  exportsTitle: {
     defaultMessage: 'All exports',
     description: 'All exports',
-    id: 'ExportsTitle',
+    id: 'exportsTitle',
   },
-  ExportsUnavailable: {
+  exportsUnavailable: {
     defaultMessage: 'Export cannot be generated',
     description: 'Export cannot be generated',
-    id: 'ExportsUnavailable',
+    id: 'exportsUnavailable',
   },
-  FilterByButtonAriaLabel: {
+  filterByButtonAriaLabel: {
     defaultMessage:
       '{value, select, ' +
       'account {Filter button for account name} ' +
@@ -1915,9 +1915,9 @@ export default defineMessages({
       'tag {Filter button for tag name} ' +
       'other {}}',
     description: 'Filter button for "value" name',
-    id: 'FilterByButtonAriaLabel',
+    id: 'filterByButtonAriaLabel',
   },
-  FilterByInputAriaLabel: {
+  filterByInputAriaLabel: {
     defaultMessage:
       '{value, select, ' +
       'account {Input for account name} ' +
@@ -1935,19 +1935,19 @@ export default defineMessages({
       'tag {Input for tag name} ' +
       'other {}}',
     description: 'Input for {value} name',
-    id: 'FilterByInputAriaLabel',
+    id: 'filterByInputAriaLabel',
   },
-  FilterByOrgUnitAriaLabel: {
+  filterByOrgUnitAriaLabel: {
     defaultMessage: 'Organizational units',
     description: 'Organizational units',
-    id: 'FilterByOrgUnitAriaLabel',
+    id: 'filterByOrgUnitAriaLabel',
   },
-  FilterByOrgUnitPlaceholder: {
+  filterByOrgUnitPlaceholder: {
     defaultMessage: 'Choose unit',
     description: 'Choose unit',
-    id: 'FilterByOrgUnitPlaceholder',
+    id: 'filterByOrgUnitPlaceholder',
   },
-  FilterByPlaceholder: {
+  filterByPlaceholder: {
     defaultMessage:
       '{value, select, ' +
       'account {Filter by account} ' +
@@ -1967,39 +1967,39 @@ export default defineMessages({
       'tag {Filter by tag} ' +
       'other {}}',
     description: 'Filter by "value"',
-    id: 'FilterByPlaceholder',
+    id: 'filterByPlaceholder',
   },
-  FilterByTagKeyAriaLabel: {
+  filterByTagKeyAriaLabel: {
     defaultMessage: 'Tag keys',
     description: 'Tag keys',
-    id: 'FilterByTagKeyAriaLabel',
+    id: 'filterByTagKeyAriaLabel',
   },
-  FilterByTagKeyPlaceholder: {
+  filterByTagKeyPlaceholder: {
     defaultMessage: 'Choose key',
     description: 'Choose key',
-    id: 'FilterByTagKeyPlaceholder',
+    id: 'filterByTagKeyPlaceholder',
   },
-  FilterByTagValueAriaLabel: {
+  filterByTagValueAriaLabel: {
     defaultMessage: 'Tag values',
     description: 'Tag values',
-    id: 'FilterByTagValueAriaLabel',
+    id: 'filterByTagValueAriaLabel',
   },
-  FilterByTagValueButtonAriaLabel: {
+  filterByTagValueButtonAriaLabel: {
     defaultMessage: 'Filter button for tag value',
     description: 'Filter button for tag value',
-    id: 'FilterByTagValueButtonAriaLabel',
+    id: 'filterByTagValueButtonAriaLabel',
   },
-  FilterByTagValueInputPlaceholder: {
+  filterByTagValueInputPlaceholder: {
     defaultMessage: 'Filter by value',
     description: 'Filter by value',
-    id: 'FilterByTagValueInputPlaceholder',
+    id: 'filterByTagValueInputPlaceholder',
   },
-  FilterByTagValuePlaceholder: {
+  filterByTagValuePlaceholder: {
     defaultMessage: 'Choose value',
     description: 'Choose value',
-    id: 'FilterByTagValuePlaceholder',
+    id: 'filterByTagValuePlaceholder',
   },
-  FilterByValues: {
+  filterByValues: {
     defaultMessage:
       '{value, select, ' +
       'account {Account} ' +
@@ -2017,9 +2017,9 @@ export default defineMessages({
       'tag {Tag} ' +
       'other {}}',
     description: 'Filter by values',
-    id: 'FilterByValues',
+    id: 'filterByValues',
   },
-  ForDate: {
+  forDate: {
     defaultMessage:
       '{month, select, ' +
       '0 {{count, plural, one {{value} for January {startDate}} other {{value} for January {startDate}-{endDate}}}} ' +
@@ -2036,49 +2036,49 @@ export default defineMessages({
       '11 {{count, plural, one {{value} for December {startDate}} other {{value} for December {startDate}-{endDate}}}} ' +
       'other {}}',
     description: '{value} for date range',
-    id: 'ForDate',
+    id: 'forDate',
   },
-  GCP: {
+  gcp: {
     defaultMessage: 'Google Cloud Platform',
     description: 'Google Cloud Platform',
-    id: 'GCP',
+    id: 'gcp',
   },
-  GCPComputeTitle: {
+  gcpComputeTitle: {
     defaultMessage: 'Compute instances usage',
     description: 'Compute instances usage',
-    id: 'GCPComputeTitle',
+    id: 'gcpComputeTitle',
   },
-  GCPCostTitle: {
+  gcpCostTitle: {
     defaultMessage: 'Google Cloud Platform Services cost',
     description: 'Google Cloud Platform Services cost',
-    id: 'GCPCostTitle',
+    id: 'gcpCostTitle',
   },
-  GCPCostTrendTitle: {
+  gcpCostTrendTitle: {
     defaultMessage: 'Google Cloud Platform Services cumulative cost comparison ({units})',
     description: 'Google Cloud Platform Services cumulative cost comparison ({units})',
-    id: 'GCPCostTrendTitle',
+    id: 'gcpCostTrendTitle',
   },
-  GCPDailyCostTrendTitle: {
+  gcpDailyCostTrendTitle: {
     defaultMessage: 'Google Cloud Platform Services daily cost comparison ({units})',
     description: 'Google Cloud Platform Services daily cost comparison ({units})',
-    id: 'GCPDailyCostTrendTitle',
+    id: 'gcpDailyCostTrendTitle',
   },
-  GCPDesc: {
+  gcpDesc: {
     defaultMessage: 'Raw cost from Google Cloud Platform infrastructure.',
     description: 'Raw cost from Google Cloud Platform infrastructure.',
-    id: 'GCPDesc',
+    id: 'gcpDesc',
   },
-  GCPDetailsTableAriaLabel: {
+  gcpDetailsTableAriaLabel: {
     defaultMessage: 'Google Cloud Platform details table',
     description: 'Google Cloud Platform details table',
-    id: 'GCPDetailsTable',
+    id: 'gcpDetailsTable',
   },
-  GCPDetailsTitle: {
+  gcpDetailsTitle: {
     defaultMessage: 'Google Cloud Platform Details',
     description: 'Google Cloud Platform Details',
-    id: 'GCPDetailsTitle',
+    id: 'gcpDetailsTitle',
   },
-  GroupByAll: {
+  groupByAll: {
     defaultMessage:
       '{value, select, ' +
       'account {{count, plural, one {All account} other {All accounts}}} ' +
@@ -2095,14 +2095,14 @@ export default defineMessages({
       'tag {{count, plural, one {All tag} other {All tags}}} ' +
       'other {}}',
     description: 'All group by value',
-    id: 'GroupByAll',
+    id: 'groupByAll',
   },
-  GroupByLabel: {
+  groupByLabel: {
     defaultMessage: 'Group by',
     description: 'group by label',
-    id: 'GroupByLabel',
+    id: 'groupByLabel',
   },
-  GroupByTop: {
+  groupByTop: {
     defaultMessage:
       '{value, select, ' +
       'account {{count, plural, one {Top account} other {Top accounts}}} ' +
@@ -2119,9 +2119,9 @@ export default defineMessages({
       'tag {{count, plural, one {Top tag} other {Top tags}}} ' +
       'other {}}',
     description: 'Top group by value',
-    id: 'GroupByTop',
+    id: 'groupByTop',
   },
-  GroupByValueNames: {
+  groupByValueNames: {
     defaultMessage:
       '{groupBy, select, ' +
       'account {Account names} ' +
@@ -2138,9 +2138,9 @@ export default defineMessages({
       'tag {Tag names} ' +
       'other {}}',
     description: 'Selected items for export',
-    id: 'GroupByValueNames',
+    id: 'groupByValueNames',
   },
-  GroupByValues: {
+  groupByValues: {
     defaultMessage:
       '{value, select, ' +
       'account {{count, plural, one {account} other {accounts}}} ' +
@@ -2157,9 +2157,9 @@ export default defineMessages({
       'tag {{count, plural, one {tag} other {tags}}} ' +
       'other {}}',
     description: 'Group by values',
-    id: 'GroupByValues',
+    id: 'groupByValues',
   },
-  GroupByValuesTitleCase: {
+  groupByValuesTitleCase: {
     defaultMessage:
       '{value, select, ' +
       'account {{count, plural, one {Account} other {Accounts}}} ' +
@@ -2176,19 +2176,19 @@ export default defineMessages({
       'tag {{count, plural, one {Tag} other {Tags}}} ' +
       'other {}}',
     description: 'Group by values',
-    id: 'GroupByValuesTitleCase',
+    id: 'groupByValuesTitleCase',
   },
-  HistoricalChartCostLabel: {
+  historicalChartCostLabel: {
     defaultMessage: 'Cost ({units})',
     description: 'Cost ({units})',
-    id: 'HistoricalChartCostLabel',
+    id: 'historicalChartCostLabel',
   },
-  HistoricalChartDayOfMonthLabel: {
+  historicalChartDayOfMonthLabel: {
     defaultMessage: 'Day of Month',
     description: 'Day of Month',
-    id: 'HistoricalChartDayOfMonthLabel',
+    id: 'historicalChartDayOfMonthLabel',
   },
-  HistoricalChartTitle: {
+  historicalChartTitle: {
     defaultMessage:
       '{value, select, ' +
       'cost {Cost comparison} ' +
@@ -2197,177 +2197,177 @@ export default defineMessages({
       'modal {{name} daily usage comparison} ' +
       'storage {Storage usage comparison} ' +
       'other {}}',
-    description: 'historical chart titles',
-    id: 'HistoricalChartTitle',
+    description: 'Historical chart titles',
+    id: 'historicalChartTitle',
   },
-  HistoricalChartUsageLabel: {
+  historicalChartUsageLabel: {
     defaultMessage: '{value, select, instance_type {hrs} storage {gb-mo} other {}}',
-    description: 'historical chart usage labels',
-    id: 'HistoricalChartUsageLabel',
+    description: 'Historical chart usage labels',
+    id: 'historicalChartUsageLabel',
   },
-  IBM: {
+  ibm: {
     defaultMessage: 'IBM Cloud',
     description: 'IBM Cloud',
-    id: 'IBM',
+    id: 'ibm',
   },
-  IBMComputeTitle: {
+  ibmComputeTitle: {
     defaultMessage: 'Compute instances usage',
     description: 'Compute instances usage',
-    id: 'IBMComputeTitle',
+    id: 'ibmComputeTitle',
   },
-  IBMCostTitle: {
+  ibmCostTitle: {
     defaultMessage: 'IBM Cloud Services cost',
     description: 'IBM Cloud Services cost',
-    id: 'IBMCostTitle',
+    id: 'ibmCostTitle',
   },
-  IBMCostTrendTitle: {
+  ibmCostTrendTitle: {
     defaultMessage: 'IBM Cloud Services cumulative cost comparison ({units})',
     description: 'IBM Cloud Services cumulative cost comparison ({units})',
-    id: 'IBMCostTrendTitle',
+    id: 'ibmCostTrendTitle',
   },
-  IBMDailyCostTrendTitle: {
+  ibmDailyCostTrendTitle: {
     defaultMessage: 'IBM Cloud Services daily cost comparison ({units})',
     description: 'IBM Cloud Services daily cost comparison ({units})',
-    id: 'IBMDailyCostTrendTitle',
+    id: 'ibmDailyCostTrendTitle',
   },
-  IBMDesc: {
+  ibmDesc: {
     defaultMessage: 'Raw cost from IBM Cloud infrastructure.',
     description: 'Raw cost from IBM Cloud infrastructure.',
-    id: 'IBMDesc',
+    id: 'ibmDesc',
   },
-  IBMDetailsTableAriaLabel: {
+  ibmDetailsTableAriaLabel: {
     defaultMessage: 'IBM Cloud details table',
     description: 'IBM Cloud details table',
-    id: 'IBMDetailsTable',
+    id: 'ibmDetailsTable',
   },
-  IBMDetailsTitle: {
+  ibmDetailsTitle: {
     defaultMessage: 'IBM Cloud Details',
     description: 'IBM details title',
-    id: 'IBMDetailsTitle',
+    id: 'ibmDetailsTitle',
   },
-  InactiveSourcesGoTo: {
+  inactiveSourcesGoTo: {
     defaultMessage: 'Go to Sources for more information',
     description: 'Go to Sources for more information',
-    id: 'InactiveSourcesGoTo',
+    id: 'inactiveSourcesGoTo',
   },
-  InactiveSourcesTitle: {
+  inactiveSourcesTitle: {
     defaultMessage: 'A problem was detected with {value}',
     description: 'A problem was detected with {value}',
-    id: 'InactiveSourcesGoTitle',
+    id: 'inactiveSourcesGoTitle',
   },
-  InactiveSourcesTitleMultiplier: {
+  inactiveSourcesTitleMultiplier: {
     defaultMessage: 'A problem was detected with the following sources',
     description: 'A problem was detected with the following sources',
-    id: 'InactiveSourcesTitleMultiplier',
+    id: 'inactiveSourcesTitleMultiplier',
   },
-  Infrastructure: {
+  infrastructure: {
     defaultMessage: 'Infrastructure',
     description: 'Infrastructure',
-    id: 'Infrastructure',
+    id: 'infrastructure',
   },
-  LearnMore: {
+  learnMore: {
     defaultMessage: 'Learn more',
     description: 'Learn more',
-    id: 'LearnMore',
+    id: 'learnMore',
   },
-  LoadingStateDesc: {
+  loadingStateDesc: {
     defaultMessage: 'Searching for your sources. Do not refresh the browser',
     description: 'Searching for your sources. Do not refresh the browser',
-    id: 'LoadingStateDesc',
+    id: 'loadingStateDesc',
   },
-  LoadingStateTitle: {
+  loadingStateTitle: {
     defaultMessage: 'Looking for sources...',
     description: 'Looking for sources',
-    id: 'LoadingStateTitle',
+    id: 'loadingStateTitle',
   },
-  MaintenanceEmptyStateDesc: {
+  maintenanceEmptyStateDesc: {
     defaultMessage:
       'Cost Management is currently undergoing scheduled maintenance and will be unavailable from 13:00 - 19:00 UTC (09:00 AM - 03:00 PM EDT).',
     description: 'Cost Management is currently undergoing scheduled maintenance',
-    id: 'MaintenanceEmptyStateDesc',
+    id: 'maintenanceEmptyStateDesc',
   },
-  MaintenanceEmptyStateInfo: {
+  maintenanceEmptyStateInfo: {
     defaultMessage: 'For more information visit {url}',
     description: 'more information url',
-    id: 'MaintenanceEmptyStateInfo',
+    id: 'maintenanceEmptyStateInfo',
   },
-  MaintenanceEmptyStateThanks: {
+  maintenanceEmptyStateThanks: {
     defaultMessage: 'We will be back soon. Thank you for your patience!',
     description: 'thanks you for your patience',
-    id: 'MaintenanceEmptyStateThanks',
+    id: 'maintenanceEmptyStateThanks',
   },
-  ManageColumnsAriaLabel: {
+  manageColumnsAriaLabel: {
     defaultMessage: 'Table column management',
     description: 'Table column management',
-    id: 'ManageColumnsAriaLabel',
+    id: 'manageColumnsAriaLabel',
   },
-  ManageColumnsDesc: {
+  manageColumnsDesc: {
     defaultMessage: 'Selected categories will be displayed in the table',
     description: 'Selected categories will be displayed in the table',
-    id: 'ManageColumnsDesc',
+    id: 'manageColumnsDesc',
   },
-  ManageColumnsTitle: {
+  manageColumnsTitle: {
     defaultMessage: 'Manage columns',
     description: 'Manage columns',
-    id: 'ManageColumnsTitle',
+    id: 'manageColumnsTitle',
   },
-  MarkupDescription: {
+  markupDescription: {
     defaultMessage:
       'The portion of cost calculated by applying markup or discount to infrastructure raw cost in the cost management application',
     description:
       'The portion of cost calculated by applying markup or discount to infrastructure raw cost in the cost management application',
-    id: 'MarkupDescription',
+    id: 'markupDescription',
   },
-  MarkupOrDiscount: {
+  markupOrDiscount: {
     defaultMessage: 'Markup or Discount',
     description: 'Markup or Discount',
-    id: 'MarkupOrDiscount',
+    id: 'markupOrDiscount',
   },
-  MarkupOrDiscountDesc: {
+  markupOrDiscountDesc: {
     defaultMessage:
       'This Percentage is applied to raw cost calculations by multiplying the cost with this percentage. Costs calculated from price list rates will not be effected.',
     description:
       'This Percentage is applied to raw cost calculations by multiplying the cost with this percentage. Costs calculated from price list rates will not be effected.',
-    id: 'MarkupOrDiscountDesc',
+    id: 'markupOrDiscountDesc',
   },
-  MarkupOrDiscountModalDesc: {
+  markupOrDiscountModalDesc: {
     defaultMessage:
       'Use markup/discount to manipulate how the raw costs are being calculated for your sources. Note, costs calculated from price list rates will not be affected by this.',
     description:
       'Use markup/discount to manipulate how the raw costs are being calculated for your sources. Note, costs calculated from price list rates will not be affected by this.',
-    id: 'MarkupOrDiscountModalDesc',
+    id: 'markupOrDiscountModalDesc',
   },
-  MarkupOrDiscountNumber: {
+  markupOrDiscountNumber: {
     defaultMessage: 'Markup or discount must be a number',
     description: 'Markup or discount must be a number',
-    id: 'MarkupOrDiscountNumber',
+    id: 'markupOrDiscountNumber',
   },
-  MarkupOrDiscountTooLong: {
+  markupOrDiscountTooLong: {
     defaultMessage: 'Should not exceed 10 decimals',
     description: 'Should not exceed 10 decimals',
-    id: 'MarkupOrDiscountTooLong',
+    id: 'markupOrDiscountTooLong',
   },
-  MarkupPlus: {
+  markupPlus: {
     defaultMessage: 'Markup (+)',
     description: 'Markup (+)',
-    id: 'MarkupPlus',
+    id: 'markupPlus',
   },
-  MarkupTitle: {
+  markupTitle: {
     defaultMessage: 'Markup',
     description: 'Markup',
-    id: 'MarkupTitle',
+    id: 'markupTitle',
   },
-  Measurement: {
+  measurement: {
     defaultMessage: 'Measurement',
     description: 'Measurement',
-    id: 'Measurement',
+    id: 'measurement',
   },
-  MeasurementPlaceholder: {
+  measurementPlaceholder: {
     defaultMessage: 'Filter by measurements',
     description: 'Filter by measurements',
-    id: 'MeasurementPlaceholder',
+    id: 'measurementPlaceholder',
   },
-  MeasurementValues: {
+  measurementValues: {
     defaultMessage:
       '{value, select, ' +
       'count {{count, plural, one {Count} other {Count ({units})}}} ' +
@@ -2376,9 +2376,9 @@ export default defineMessages({
       'usage {{count, plural, one {Usage} other {Usage ({units})}}} ' +
       'other {}}',
     description: 'Measurement values',
-    id: 'MeasurementValues',
+    id: 'measurementValues',
   },
-  MeasurementValuesDesc: {
+  measurementValuesDesc: {
     defaultMessage:
       '{value, select, ' +
       'count {{units, select, ' +
@@ -2391,24 +2391,24 @@ export default defineMessages({
       'usage {The pod resources used, as reported by OpenShift} ' +
       'other {}}',
     description: 'Measurement descriptions',
-    id: 'MeasurementValuesDesc',
+    id: 'measurementValuesDesc',
   },
-  MemoryTitle: {
+  memoryTitle: {
     defaultMessage: 'Memory',
     description: 'Memory',
-    id: 'MemoryTitle',
+    id: 'memoryTitle',
   },
-  Metric: {
+  metric: {
     defaultMessage: 'Metric',
     description: 'Metric',
-    id: 'Metric',
+    id: 'metric',
   },
-  MetricPlaceholder: {
+  metricPlaceholder: {
     defaultMessage: 'Filter by metrics',
     description: 'Filter by metrics',
-    id: 'MetricPlaceholder',
+    id: 'metricPlaceholder',
   },
-  MetricValues: {
+  metricValues: {
     defaultMessage:
       '{value, select, ' +
       'cpu {CPU} ' +
@@ -2419,29 +2419,29 @@ export default defineMessages({
       'storage {Storage} ' +
       'other {}}',
     description: 'Metric values',
-    id: 'MetricValues',
+    id: 'metricValues',
   },
-  MonthOverMonthChange: {
+  monthOverMonthChange: {
     defaultMessage: 'Month over month change',
     description: 'Month over month change',
-    id: 'MonthOverMonthChange',
+    id: 'monthOverMonthChange',
   },
-  Names: {
+  names: {
     defaultMessage: '{count, plural, one {Name} other {Names}}',
     description: 'Name plural or singular',
-    id: 'Name',
+    id: 'names',
   },
-  Next: {
+  next: {
     defaultMessage: 'next',
     description: 'next',
-    id: 'Next',
+    id: 'next',
   },
-  No: {
-    defaultMessage: 'no',
-    description: 'no',
-    id: 'No',
+  no: {
+    defaultMessage: 'No',
+    description: 'No',
+    id: 'no',
   },
-  NoDataForDate: {
+  noDataForDate: {
     defaultMessage:
       '{month, select, ' +
       '0 {{count, plural, one {No data available for Jan {startDate}} other {No data available for Jan {startDate}-{endDate}}}} ' +
@@ -2458,398 +2458,398 @@ export default defineMessages({
       '11 {{count, plural, one {No data available for Dec {startDate}} other {No data available for Dec {startDate}-{endDate}}}} ' +
       'other {}}',
     description: 'No data available for date range',
-    id: 'NoDataForDate',
+    id: 'noDataForDate',
   },
-  NoDataStateDesc: {
+  noDataStateDesc: {
     defaultMessage:
       'We have detected a source, but we are not done processing the incoming data. The time to process could take up to 24 hours. Try refreshing the page at a later time.',
     description: 'still processing request, 24 hour message',
-    id: 'NoDataStateDesc',
+    id: 'noDataStateDesc',
   },
-  NoDataStateRefresh: {
+  noDataStateRefresh: {
     defaultMessage: 'Refresh this page',
     description: 'Refresh this page',
-    id: 'NoDataStateRefresh',
+    id: 'noDataStateRefresh',
   },
-  NoDataStateTitle: {
+  noDataStateTitle: {
     defaultMessage: 'Still processing the data',
     description: 'Still processing the data',
-    id: 'NoDataStateTitle',
+    id: 'noDataStateTitle',
   },
-  NoExportsStateTitle: {
+  noExportsStateTitle: {
     defaultMessage: 'There are no export files available',
     description: 'There are no export files available',
     id: 'NoExportsStateTitle',
   },
-  NoProvidersStateAwsDesc: {
+  noProvidersStateAwsDesc: {
     defaultMessage:
       'Add an Amazon Web Services account to see a total cost breakdown of your spend by accounts, organizational units, services, regions, or tags.',
     description:
       'Add an Amazon Web Services account to see a total cost breakdown of your spend by accounts, organizational units, services, regions, or tags.',
-    id: 'NoProvidersStateAwsDesc',
+    id: 'noProvidersStateAwsDesc',
   },
-  NoProvidersStateAwsTitle: {
+  noProvidersStateAwsTitle: {
     defaultMessage: 'Track your Amazon Web Services spending!',
     description: 'Track your Amazon Web Services spending!',
-    id: 'NoProvidersStateAwsTitle',
+    id: 'noProvidersStateAwsTitle',
   },
-  NoProvidersStateAzureDesc: {
+  noProvidersStateAzureDesc: {
     defaultMessage:
       'Add a Microsoft Azure account to see a total cost breakdown of your spend by accounts, services, regions, or tags.',
     description:
       'Add a Microsoft Azure account to see a total cost breakdown of your spend by accounts, services, regions, or tags.',
-    id: 'NoProvidersStateAzureDesc',
+    id: 'noProvidersStateAzureDesc',
   },
-  NoProvidersStateAzureTitle: {
+  noProvidersStateAzureTitle: {
     defaultMessage: 'Track your Microsoft Azure spending!',
     description: 'Track your Microsoft Azure spending!',
-    id: 'NoProvidersStateAzureTitle',
+    id: 'noProvidersStateAzureTitle',
   },
-  NoProvidersStateGcpDesc: {
+  noProvidersStateGcpDesc: {
     defaultMessage:
       'Add a Google Cloud Platform account to see a total cost breakdown of your spend by accounts, services, regions, or tags.',
     description:
       'Add a Google Cloud Platform account to see a total cost breakdown of your spend by accounts, services, regions, or tags.',
-    id: 'NoProvidersStateGcpDesc',
+    id: 'noProvidersStateGcpDesc',
   },
-  NoProvidersStateGcpTitle: {
+  noProvidersStateGcpTitle: {
     defaultMessage: 'Track your Google Cloud Platform spending!',
     description: 'Track your Google Cloud Platform spending!',
-    id: 'NoProvidersStateGcpTitle',
+    id: 'noProvidersStateGcpTitle',
   },
-  NoProvidersStateGetStarted: {
+  noProvidersStateGetStarted: {
     defaultMessage: 'Get started with Sources',
     description: 'Get started with Sources',
-    id: 'NoProvidersStateGetStarted',
+    id: 'noProvidersStateGetStarted',
   },
-  NoProvidersStateIbmDesc: {
+  noProvidersStateIbmDesc: {
     defaultMessage:
       'Add an IBM Cloud account to see a total cost breakdown of your spend by accounts, services, regions, or tags.',
     description:
       'Add an IBM Cloud account to see a total cost breakdown of your spend by accounts, services, regions, or tags.',
-    id: 'NoProvidersStateIbmDesc',
+    id: 'noProvidersStateIbmDesc',
   },
-  NoProvidersStateIbmTitle: {
+  noProvidersStateIbmTitle: {
     defaultMessage: 'Track your IBM Cloud spending!',
     description: 'Track your IBM Cloud spending!',
-    id: 'NoProvidersStateIbmTitle',
+    id: 'noProvidersStateIbmTitle',
   },
-  NoProvidersStateOcpAddSources: {
+  noProvidersStateOcpAddSources: {
     defaultMessage: 'Add an OpenShift cluster to Cost Management',
     description: 'Add an OpenShift cluster to Cost Management',
-    id: 'NoProvidersStateOcpAddSources',
+    id: 'noProvidersStateOcpAddSources',
   },
-  NoProvidersStateOcpDesc: {
+  noProvidersStateOcpDesc: {
     defaultMessage:
       'Add an OpenShift Container Platform cluster to see a total cost breakdown of your pods by cluster, node, project, or labels.',
     description:
       'Add an OpenShift Container Platform cluster to see a total cost breakdown of your pods by cluster, node, project, or labels.',
-    id: 'NoProvidersStateOcpDesc',
+    id: 'noProvidersStateOcpDesc',
   },
-  NoProvidersStateOcpTitle: {
+  noProvidersStateOcpTitle: {
     defaultMessage: 'Track your OpenShift spending!',
     description: 'Track your OpenShift spending!',
-    id: 'NoProvidersStateOcpTitle',
+    id: 'noProvidersStateOcpTitle',
   },
-  NoProvidersStateOverviewDesc: {
+  noProvidersStateOverviewDesc: {
     defaultMessage:
       'Add a source, like an OpenShift Container Platform cluster or a cloud services account, to see a total cost breakdown as well as usage information like instance counts and storage.',
     description:
       'Add a source, like an OpenShift Container Platform cluster or a cloud services account, to see a total cost breakdown as well as usage information like instance counts and storage.',
-    id: 'NoProvidersStateOverviewDesc',
+    id: 'noProvidersStateOverviewDesc',
   },
-  NoProvidersStateOverviewTitle: {
+  noProvidersStateOverviewTitle: {
     defaultMessage: 'Track your spending!',
     description: 'Track your spending!',
-    id: 'NoProvidersStateOverviewTitle',
+    id: 'noProvidersStateOverviewTitle',
   },
-  NoResultsFound: {
+  noResultsFound: {
     defaultMessage: 'No results found',
     description: 'No results found',
-    id: 'NoResultsFound',
+    id: 'noResultsFound',
   },
-  NotAuthorizedStateAws: {
+  notAuthorizedStateAws: {
     defaultMessage: 'Amazon Web Services in Cost Management',
     description: 'Amazon Web Services in Cost Management',
-    id: 'NoAuthorizedStateAws',
+    id: 'noAuthorizedStateAws',
   },
-  NotAuthorizedStateAzure: {
+  notAuthorizedStateAzure: {
     defaultMessage: 'Microsoft Azure in Cost Management',
     description: 'Microsoft Azure in Cost Management',
-    id: 'NotAuthorizedStateAzure',
+    id: 'notAuthorizedStateAzure',
   },
-  NotAuthorizedStateCostModels: {
+  notAuthorizedStateCostModels: {
     defaultMessage: 'Cost Models in Cost Management',
     description: 'Cost Models in Cost Management',
-    id: 'NotAuthorizedStateCostModels',
+    id: 'notAuthorizedStateCostModels',
   },
-  NotAuthorizedStateGcp: {
+  notAuthorizedStateGcp: {
     defaultMessage: 'Google Cloud Platform in Cost Management',
     description: 'Google Cloud Platform in Cost Management',
-    id: 'NotAuthorizedStateGcp',
+    id: 'notAuthorizedStateGcp',
   },
-  NotAuthorizedStateIbm: {
+  notAuthorizedStateIbm: {
     defaultMessage: 'IBM Cloud in Cost Management',
     description: 'IBM Cloud in Cost Management',
-    id: 'NotAuthorizedStateIbm',
+    id: 'notAuthorizedStateIbm',
   },
-  NotAuthorizedStateOcp: {
+  notAuthorizedStateOcp: {
     defaultMessage: 'OpenShift in Cost Management',
     description: 'OpenShift in Cost Management',
-    id: 'NotAuthorizedStateOcp',
+    id: 'notAuthorizedStateOcp',
   },
-  OCPCPUUsageAndRequests: {
-    defaultMessage: 'CPU usage and requests',
-    description: 'CPU usage and requests',
-    id: 'OCPCPUUsageAndRequests',
-  },
-  OCPCloudDashboardComputeTitle: {
+  ocpCloudDashboardComputeTitle: {
     defaultMessage: 'Compute services usage',
     description: 'Compute services usage',
-    id: 'OCPCloudDashboardComputeTitle',
+    id: 'ocpCloudDashboardComputeTitle',
   },
-  OCPCloudDashboardCostTitle: {
+  ocpCloudDashboardCostTitle: {
     defaultMessage: 'All cloud filtered by OpenShift cost',
     description: 'All cloud filtered by OpenShift cost',
-    id: 'OCPCloudDashboardCostTitle',
+    id: 'ocpCloudDashboardCostTitle',
   },
-  OCPCloudDashboardCostTrendTitle: {
+  ocpCloudDashboardCostTrendTitle: {
     defaultMessage: 'All cloud filtered by OpenShift cumulative cost comparison ({units})',
     description: 'All cloud filtered by OpenShift cumulative cost comparison ({units})',
-    id: 'OCPCloudDashboardCostTrendTitle',
+    id: 'ocpCloudDashboardCostTrendTitle',
   },
-  OCPCloudDashboardDailyCostTrendTitle: {
+  ocpCloudDashboardDailyCostTrendTitle: {
     defaultMessage: 'All cloud filtered by OpenShift daily cost comparison ({units})',
     description: 'All cloud filtered by OpenShift daily cost comparison ({units})',
-    id: 'OCPCloudDashboardDailyCostTrendTitle',
+    id: 'ocpCloudDashboardDailyCostTrendTitle',
   },
-  OCPDailyUsageAndRequestComparison: {
+  ocpCpuUsageAndRequests: {
+    defaultMessage: 'CPU usage and requests',
+    description: 'CPU usage and requests',
+    id: 'ocpCpuUsageAndRequests',
+  },
+  ocpDailyUsageAndRequestComparison: {
     defaultMessage: 'Daily usage and requests comparison ({units})',
     description: 'Daily usage and requests comparison',
-    id: 'OCPDailyUsageAndRequestComparison',
+    id: 'ocpDailyUsageAndRequestComparison',
   },
-  OCPDashboardCPUUsageAndRequests: {
+  ocpDashboardCPUUsageAndRequests: {
     defaultMessage: 'OpenShift CPU usage and requests',
     description: 'OpenShift CPU usage and requests',
-    id: 'OCPDashboardCPUUsageAndRequests',
+    id: 'ocpDashboardCPUUsageAndRequests',
   },
-  OCPDashboardCostTitle: {
+  ocpDashboardCostTitle: {
     defaultMessage: 'All OpenShift cost',
     description: 'All OpenShift cost',
-    id: 'OCPDashboardCostTitle',
+    id: 'ocpDashboardCostTitle',
   },
-  OCPDashboardCostTrendTitle: {
+  ocpDashboardCostTrendTitle: {
     defaultMessage: 'All OpenShift cumulative cost comparison ({units})',
     description: 'All OpenShift cumulative cost comparison in units',
-    id: 'OCPDashboardCostTrendTitle',
+    id: 'ocpDashboardCostTrendTitle',
   },
-  OCPDashboardDailyCostTitle: {
+  ocpDashboardDailyCostTitle: {
     defaultMessage: 'All OpenShift daily cost comparison ({units})',
     description: 'All OpenShift daily cost comparison in units',
-    id: 'OCPDashboardDailyCostTitle',
+    id: 'ocpDashboardDailyCostTitle',
   },
-  OCPDashboardMemoryUsageAndRequests: {
+  ocpDashboardMemoryUsageAndRequests: {
     defaultMessage: 'OpenShift Memory usage and requests',
     description: 'OpenShift Memory usage and requests',
-    id: 'OCPDashboardMemoryUsageAndRequests',
+    id: 'ocpDashboardMemoryUsageAndRequests',
   },
-  OCPDashboardVolumeUsageAndRequests: {
+  ocpDashboardVolumeUsageAndRequests: {
     defaultMessage: 'OpenShift Volume usage and requests',
     description: 'OpenShift Volume usage and requests',
-    id: 'OCPUsageAndRequests',
+    id: 'ocpUsageAndRequests',
   },
-  OCPDetailsInfrastructureCost: {
+  ocpDetailsInfrastructureCost: {
     defaultMessage: 'Infrastructure cost',
     description: 'Infrastructure cost',
-    id: 'OCPDetailsInfrastructureCost',
+    id: 'ocpDetailsInfrastructureCost',
   },
-  OCPDetailsInfrastructureCostDesc: {
+  ocpDetailsInfrastructureCostDesc: {
     defaultMessage: 'The cost based on raw usage data from the underlying infrastructure.',
     description: 'The cost based on raw usage data from the underlying infrastructure.',
-    id: 'OCPDetailsInfrastructureCostDesc',
+    id: 'ocpDetailsInfrastructureCostDesc',
   },
-  OCPDetailsSupplementaryCost: {
+  ocpDetailsSupplementaryCost: {
     defaultMessage: 'Supplementary cost',
     description: 'Supplementary cost',
-    id: 'OCPDetailsSupplementaryCost',
+    id: 'ocpDetailsSupplementaryCost',
   },
-  OCPDetailsSupplementaryCostDesc: {
+  ocpDetailsSupplementaryCostDesc: {
     defaultMessage:
       'All costs not directly attributed to the infrastructure. These costs are determined by applying a price list within a cost model to OpenShift cluster metrics.',
     description:
       'All costs not directly attributed to the infrastructure. These costs are determined by applying a price list within a cost model to OpenShift cluster metrics.',
-    id: 'OCPDetailsSupplementaryCostDesc',
+    id: 'ocpDetailsSupplementaryCostDesc',
   },
-  OCPDetailsTableAriaLabel: {
+  ocpDetailsTableAriaLabel: {
     defaultMessage: 'OpenShift details table',
     description: 'OpenShift details table',
-    id: 'OCPDetailsTable',
+    id: 'ocpDetailsTable',
   },
-  OCPDetailsTitle: {
+  ocpDetailsTitle: {
     defaultMessage: 'OpenShift details',
     description: 'OpenShift details title',
-    id: 'OCPDetailsTitle',
+    id: 'ocpDetailsTitle',
   },
-  OCPInfrastructureCostTitle: {
+  ocpInfrastructureCostTitle: {
     defaultMessage: 'OpenShift infrastructure cost',
     description: 'OpenShift infrastructure cost',
-    id: 'OCPInfrastructureCostTitle',
+    id: 'ocpInfrastructureCostTitle',
   },
-  OCPInfrastructureCostTrendTitle: {
+  ocpInfrastructureCostTrendTitle: {
     defaultMessage: 'OpenShift cumulative infrastructure cost comparison ({units})',
     description: 'OpenShift cumulative infrastructure cost comparison with units',
-    id: 'OCPInfrastructureCostTrendTitle',
+    id: 'ocpInfrastructureCostTrendTitle',
   },
-  OCPInfrastructureDailyCostTrendTitle: {
+  ocpInfrastructureDailyCostTrendTitle: {
     defaultMessage: 'OpenShift daily infrastructure cost comparison ({units})',
     description: 'OpenShift daily infrastructure cost comparison with units',
-    id: 'OCPInfrastructureDailyCostTrendTitle',
+    id: 'ocpInfrastructureDailyCostTrendTitle',
   },
-  OCPMemoryUsageAndRequests: {
+  ocpMemoryUsageAndRequests: {
     defaultMessage: 'Memory usage and requests',
     description: 'Memory usage and requests',
-    id: 'OCPMemoryUsageAndRequests',
+    id: 'ocpMemoryUsageAndRequests',
   },
-  OCPSupplementaryCostTitle: {
+  ocpSupplementaryCostTitle: {
     defaultMessage: 'OpenShift supplementary cost',
     description: 'OpenShift supplementary cost',
-    id: 'OCPSupplementaryCostTitle',
+    id: 'ocpSupplementaryCostTitle',
   },
-  OCPSupplementaryCostTrendTitle: {
+  ocpSupplementaryCostTrendTitle: {
     defaultMessage: 'OpenShift cumulative supplementary cost comparison ({units})',
     description: 'OpenShift cumulative supplementary cost comparison with units',
-    id: 'OCPSupplementaryCostTrendTitle',
+    id: 'ocpSupplementaryCostTrendTitle',
   },
-  OCPSupplementaryDailyCostTrendTitle: {
+  ocpSupplementaryDailyCostTrendTitle: {
     defaultMessage: 'OpenShift daily supplementary cost comparison ({units})',
     description: 'OpenShift daily supplementary cost comparison with units',
-    id: 'OCPSupplementaryDailyCostTrendTitle',
+    id: 'ocpSupplementaryDailyCostTrendTitle',
   },
-  OCPUsageCostTitle: {
+  ocpUsageCostTitle: {
     defaultMessage: 'OpenShift usage cost',
     description: 'OpenShift usage cost',
-    id: 'OCPUsageCostTitle',
+    id: 'ocpUsageCostTitle',
   },
-  OCPUsageDashboardCPUTitle: {
+  ocpUsageDashboardCPUTitle: {
     defaultMessage: 'OpenShift CPU usage and requests',
     description: 'OpenShift CPU usage and requests',
-    id: 'OCPUsageDashboardCPUTitle',
+    id: 'ocpUsageDashboardCPUTitle',
   },
-  OCPUsageDashboardCostTrendTitle: {
+  ocpUsageDashboardCostTrendTitle: {
     defaultMessage: 'Metering cumulative cost comparison ({units})',
     description: 'Metering cumulative cost comparison with units',
-    id: 'OCPUsageDashboardCostTrendTitle',
+    id: 'ocpUsageDashboardCostTrendTitle',
   },
-  OCPVolumeUsageAndRequests: {
+  ocpVolumeUsageAndRequests: {
     defaultMessage: 'Volume usage and requests',
     description: 'Volume usage and requests',
-    id: 'OCPVolumeUsageAndRequests',
+    id: 'ocpVolumeUsageAndRequests',
   },
-  OpenShift: {
+  openShift: {
     defaultMessage: 'OpenShift',
     description: 'OpenShift',
-    id: 'OpenShift',
+    id: 'openShift',
   },
-  OpenShiftCloudInfrastructure: {
+  openShiftCloudInfrastructure: {
     defaultMessage: 'OpenShift cloud infrastructure',
     description: 'OpenShift cloud infrastructure',
-    id: 'OpenShiftCloudInfrastructure',
+    id: 'openShiftCloudInfrastructure',
   },
-  OpenShiftCloudInfrastructureDesc: {
+  openShiftCloudInfrastructureDesc: {
     defaultMessage:
       'Infrastructure cost attributed to OpenShift Container Platform, based on a subset of cloud cost data.',
     description:
       'Infrastructure cost attributed to OpenShift Container Platform, based on a subset of cloud cost data.',
-    id: 'OpenShiftCloudInfrastructureDesc',
+    id: 'openShiftCloudInfrastructureDesc',
   },
-  OpenShiftDesc: {
+  openShiftDesc: {
     defaultMessage:
       'Total cost for OpenShift Container Platform, comprising the infrastructure cost and cost calculated from metrics.',
     description:
       'Total cost for OpenShift Container Platform, comprising the infrastructure cost and cost calculated from metrics.',
-    id: 'OpenShiftDesc',
+    id: 'openShiftDesc',
   },
-  OverviewInfoArialLabel: {
+  overviewInfoArialLabel: {
     defaultMessage: 'A description of perspectives',
     description: 'A description of perspectives',
-    id: 'OverviewInfoArialLabel',
+    id: 'overviewInfoArialLabel',
   },
-  OverviewTitle: {
+  overviewTitle: {
     defaultMessage: 'Cost Management Overview',
     description: 'Cost Management Overview',
-    id: 'OverviewTitle',
+    id: 'overviewTitle',
   },
-  PageTitleAWS: {
+  pageTitleAws: {
     defaultMessage: 'Amazon Web Services - Cost Management | Red Hat OpenShift Cluster Manager',
     description: 'Amazon Web Services - Cost Management | Red Hat OpenShift Cluster Manager',
-    id: 'PageTitleAWS',
+    id: 'pageTitleAws',
   },
-  PageTitleAzure: {
+  pageTitleAzure: {
     defaultMessage: 'Microsoft Azure - Cost Management | Red Hat OpenShift Cluster Manager',
     description: 'Microsoft Azure - Cost Management | Red Hat OpenShift Cluster Manager',
-    id: 'PageTitleAzure',
+    id: 'pageTitleAzure',
   },
-  PageTitleCostModels: {
+  pageTitleCostModels: {
     defaultMessage: 'Cost Models - Cost Management | Red Hat OpenShift Cluster Manager',
     description: 'Cost Models - Cost Management | Red Hat OpenShift Cluster Manager',
-    id: 'PageTitleCostModels',
+    id: 'pageTitleCostModels',
   },
-  PageTitleDefault: {
+  pageTitleDefault: {
     defaultMessage: 'Cost Management | Red Hat OpenShift Cluster Manager',
     description: 'Cost Management | Red Hat OpenShift Cluster Manager',
-    id: 'PageTitleDefault',
+    id: 'pageTitleDefault',
   },
-  PageTitleExplorer: {
+  pageTitleExplorer: {
     defaultMessage: 'Cost Explorer - Cost Management | Red Hat OpenShift Cluster Manager',
     description: 'Cost Explorer - Cost Management | Red Hat OpenShift Cluster Manager',
-    id: 'PageTitleExplorer',
+    id: 'pageTitleExplorer',
   },
-  PageTitleGCP: {
+  pageTitleGcp: {
     defaultMessage: 'Google Cloud Platform - Cost Management | Red Hat OpenShift Cluster Manager',
     description: 'Google Cloud Platform - Cost Management | Red Hat OpenShift Cluster Manager',
-    id: 'PageTitleGCP',
+    id: 'pageTitleGcp',
   },
-  PageTitleIBM: {
+  pageTitleIbm: {
     defaultMessage: 'IBM Cloud - Cost Management | Red Hat OpenShift Cluster Manager',
     description: 'IBM Cloud - Cost Management | Red Hat OpenShift Cluster Manager',
-    id: 'PageTitleIBM',
+    id: 'pageTitleIbm',
   },
-  PageTitleOCP: {
+  pageTitleOcp: {
     defaultMessage: 'OpenShift - Cost Management | Red Hat OpenShift Cluster Manager',
     description: 'OpenShift - Cost Management | Red Hat OpenShift Cluster Manager',
-    id: 'PageTitleOpenShift',
+    id: 'pageTitleOcp',
   },
-  PageTitleOverview: {
+  pageTitleOverview: {
     defaultMessage: 'Overview - Cost Management | Red Hat OpenShift Cluster Manager',
     description: 'Overview - Cost Management | Red Hat OpenShift Cluster Manager',
-    id: 'PageTitleOverview',
+    id: 'pageTitleOverview',
   },
-  Percent: {
+  percent: {
     defaultMessage: '{value} %',
-    description: 'percent value',
-    id: 'Percent',
+    description: 'Percent value',
+    id: 'percent',
   },
-  PercentOfCost: {
+  percentOfCost: {
     defaultMessage: '{value} % of cost',
     description: '{value} % of cost',
-    id: 'PercentOfCost',
+    id: 'percentOfCost',
   },
-  PercentSymbol: {
+  percentSymbol: {
     defaultMessage: '%',
-    description: 'percent symbol',
-    id: 'PercentSymbol',
+    description: 'Percent symbol',
+    id: 'percentSymbol',
   },
-  PercentTotalCost: {
+  percentTotalCost: {
     defaultMessage: '{value} {units} ({percent} %)',
     description: '{value} {units} ({percent} %)',
-    id: 'PercentTotalCost',
+    id: 'percentTotalCost',
   },
-  Perspective: {
+  perspective: {
     defaultMessage: 'Perspective',
     description: 'Perspective dropdown label',
-    id: 'Perspective',
+    id: 'perspective',
   },
-  PerspectiveValues: {
+  perspectiveValues: {
     defaultMessage:
       '{value, select, ' +
       'aws {Amazon Web Services} ' +
@@ -2864,116 +2864,116 @@ export default defineMessages({
       'ocp_cloud {All cloud filtered by OpenShift} ' +
       'other {}}',
     description: 'Perspective values',
-    id: 'PerspectiveValues',
+    id: 'perspectiveValues',
   },
-  PriceList: {
+  priceList: {
     defaultMessage: 'Price list',
     description: 'Price list',
-    id: 'PriceList',
+    id: 'priceList',
   },
-  PriceListAddRate: {
+  priceListAddRate: {
     defaultMessage: 'Add rate',
     description: 'Add rate',
-    id: 'PriceListAddRate',
+    id: 'priceListAddRate',
   },
-  PriceListDeleteRate: {
+  priceListDeleteRate: {
     defaultMessage: 'Delete rate',
     description: 'Delete rate',
-    id: 'PriceListDeleteRate',
+    id: 'priceListDeleteRate',
   },
-  PriceListDeleteRateDesc: {
+  priceListDeleteRateDesc: {
     defaultMessage:
       '{count, plural, one {This action will remove {metric} rate from {costModel}} other {This action will remove {metric} rate from {costModel}, which is assigned to the following sources:}}',
     description: 'This action will remove {metric} rate from {costModel}, which is assigned to the following sources:',
-    id: 'PriceListDesc',
+    id: 'priceListDesc',
   },
-  PriceListDuplicate: {
+  priceListDuplicate: {
     defaultMessage: 'This tag key is already in use',
     description: 'This tag key is already in use',
-    id: 'PriceListDuplicate',
+    id: 'priceListDuplicate',
   },
-  PriceListEditRate: {
+  priceListEditRate: {
     defaultMessage: 'Edit rate',
     description: 'Edit rate',
-    id: 'PriceListEditRate',
+    id: 'priceListEditRate',
   },
-  PriceListEmptyRate: {
+  priceListEmptyRate: {
     defaultMessage: 'No rates are set',
     description: 'No rates are set',
-    id: 'PriceListEmptyRate',
+    id: 'priceListEmptyRate',
   },
-  PriceListEmptyRateDesc: {
+  priceListEmptyRateDesc: {
     defaultMessage: 'To add rates to the price list, click on the "Add" rate button above.',
     description: 'To add rates to the price list, click on the "Add" rate button above.',
-    id: 'PriceListEmptyRateDesc',
+    id: 'priceListEmptyRateDesc',
   },
-  PriceListNumberRate: {
+  priceListNumberRate: {
     defaultMessage: 'Rate must be a number',
     description: 'Rate must be a number',
-    id: 'PriceListNumberRate',
+    id: 'priceListNumberRate',
   },
-  PriceListPosNumberRate: {
+  priceListPosNumberRate: {
     defaultMessage: 'Rate must be a positive number',
     description: 'Rate must be a positive number',
     id: 'PriceListPosNumberRate',
   },
-  Rate: {
+  rate: {
     defaultMessage: 'Rate',
     description: 'Rate',
-    id: 'Rate',
+    id: 'rate',
   },
-  RawCostDescription: {
+  rawCostDescription: {
     defaultMessage: 'The costs reported by a cloud provider without any cost model calculations applied.',
     description: 'The costs reported by a cloud provider without any cost model calculations applied.',
-    id: 'RawCostDescription',
+    id: 'rawCostDescription',
   },
-  RawCostTitle: {
+  rawCostTitle: {
     defaultMessage: 'Raw cost',
     description: 'Raw cost',
-    id: 'RawCostTitle',
+    id: 'rawCostTitle',
   },
-  RbacErrorDescription: {
+  rbacErrorDescription: {
     defaultMessage:
       'There was a problem receiving user permissions. Refreshing this page may fix it. If it does not, please contact your admin.',
     description: 'rbac error description',
-    id: 'RbacErrorDescription',
+    id: 'rbacErrorDescription',
   },
-  RbacErrorTitle: {
+  rbacErrorTitle: {
     defaultMessage: 'Failed to get RBAC information',
-    description: 'rbac error title',
-    id: 'RbacErrorTitle',
+    description: 'RBAC error title',
+    id: 'rbacErrorTitle',
   },
-  RedHatStatusUrl: {
+  redHatStatusUrl: {
     defaultMessage: 'https://status.redhat.com',
     description: 'Red Hat status url for cloud services',
-    id: 'RedHatStatusUrl',
+    id: 'redHatStatusUrl',
   },
-  Requests: {
+  requests: {
     defaultMessage: 'Requests',
     description: 'Requests',
-    id: 'Requests',
+    id: 'requests',
   },
-  Save: {
+  save: {
     defaultMessage: 'Save',
     description: 'Save',
-    id: 'Save',
+    id: 'save',
   },
-  Select: {
+  select: {
     defaultMessage: 'Select...',
     description: 'Select...',
-    id: 'Select',
+    id: 'select',
   },
-  SelectAll: {
+  selectAll: {
     defaultMessage: 'Select all',
     description: 'Select all',
-    id: 'SelectAll',
+    id: 'selectAll',
   },
-  Selected: {
+  selected: {
     defaultMessage: '{value} selected',
     description: '{value} selected',
-    id: 'Selected',
+    id: 'selected',
   },
-  SinceDate: {
+  sinceDate: {
     defaultMessage:
       '{month, select, ' +
       '0 {{count, plural, one {January {startDate}} other {January {startDate}-{endDate}}}} ' +
@@ -2989,95 +2989,95 @@ export default defineMessages({
       '10 {{count, plural, one {November {startDate}} other {November {startDate}-{endDate}}}} ' +
       '11 {{count, plural, one {December {startDate}} other {December {startDate}-{endDate}}}} ' +
       'other {}}',
-    description: 'SinceDate',
-    id: 'SinceDate',
+    description: 'Monthly date range',
+    id: 'sinceDate',
   },
-  Sources: {
+  sources: {
     defaultMessage: 'Sources',
     description: 'Sources',
-    id: 'Sources',
+    id: 'sources',
   },
-  Status: {
+  status: {
     defaultMessage: '{value, select, ' + 'pending {Pending} ' + 'running {Running} ' + 'failed {Failed} ' + 'other {}}',
     description: 'Status',
-    id: 'Status',
+    id: 'status',
   },
-  StatusActions: {
+  statusActions: {
     defaultMessage: 'Status/Actions',
     description: 'Status/Actions',
-    id: 'StatusActions',
+    id: 'statusActions',
   },
-  Suggestions: {
+  suggestions: {
     defaultMessage: 'Suggestions',
     description: 'Suggestions',
-    id: 'Suggestions',
+    id: 'suggestions',
   },
-  Supplementary: {
+  supplementary: {
     defaultMessage: 'Supplementary',
     description: 'Supplementary',
-    id: 'Supplementary',
+    id: 'supplementary',
   },
-  TagHeadingKey: {
+  tagHeadingKey: {
     defaultMessage: 'Key',
     description: 'Key',
-    id: 'TagHeadingKey',
+    id: 'tagHeadingKey',
   },
-  TagHeadingTitle: {
+  tagHeadingTitle: {
     defaultMessage: 'Tags ({value})',
     description: 'Tags ({value})',
-    id: 'TagHeadingTitle',
+    id: 'tagHeadingTitle',
   },
-  TagHeadingValue: {
+  tagHeadingValue: {
     defaultMessage: 'Value',
     description: 'Value',
-    id: 'TagHeadingValue',
+    id: 'tagHeadingValue',
   },
-  TagNames: {
+  tagNames: {
     defaultMessage: 'Tag names',
     description: 'Tag Names',
-    id: 'TagNames',
+    id: 'tagNames',
   },
-  TimeOfExport: {
+  timeOfExport: {
     defaultMessage: 'Time of export',
     description: 'Time of export',
-    id: 'TimeOfExport',
+    id: 'timeOfExport',
   },
-  ToolBarBulkSelectAll: {
+  toolBarBulkSelectAll: {
     defaultMessage: 'Select all ({value} items)',
     description: 'Select all ({value} items)',
-    id: 'ToolBarBulkSelectAll',
+    id: 'toolBarBulkSelectAll',
   },
-  ToolBarBulkSelectAriaDeselect: {
+  toolBarBulkSelectAriaDeselect: {
     defaultMessage: 'Deselect all items',
     description: 'Deselect all items',
-    id: 'ToolBarBulkSelectAriaDeselect',
+    id: 'toolBarBulkSelectAriaDeselect',
   },
-  ToolBarBulkSelectAriaSelect: {
+  toolBarBulkSelectAriaSelect: {
     defaultMessage: 'Select all items',
     description: 'Select all items',
-    id: 'ToolBarBulkSelectAriaSelect',
+    id: 'toolBarBulkSelectAriaSelect',
   },
-  ToolBarBulkSelectNone: {
+  toolBarBulkSelectNone: {
     defaultMessage: 'Select none (0 items)',
     description: 'Select none (0 items)',
-    id: 'ToolBarBulkSelectNone',
+    id: 'toolBarBulkSelectNone',
   },
-  ToolBarBulkSelectPage: {
+  toolBarBulkSelectPage: {
     defaultMessage: 'Select page ({value} items)',
     description: 'Select page ({value} items)',
-    id: 'ToolBarBulkSelectPage',
+    id: 'toolBarBulkSelectPage',
   },
-  ToolBarPriceListMeasurementPlaceHolder: {
+  toolBarPriceListMeasurementPlaceHolder: {
     defaultMessage: 'Filter by measurements',
     description: 'Filter by measurements',
-    id: 'ToolBarPriceListMeasurementPlaceHolder',
+    id: 'toolBarPriceListMeasurementPlaceHolder',
   },
-  ToolBarPriceListMetricPlaceHolder: {
+  toolBarPriceListMetricPlaceHolder: {
     defaultMessage: 'Filter by metrics',
     description: 'Filter by metrics',
-    id: 'ToolBarPriceListMetricPlaceHolder',
+    id: 'toolBarPriceListMetricPlaceHolder',
   },
-  UnitTooltips: {
+  unitTooltips: {
     defaultMessage:
       '{units, select, ' +
       'core_hours {{value} core-hours} ' +
@@ -3090,9 +3090,9 @@ export default defineMessages({
       'vm_hours {{value} VM-hours} ' +
       'other {{value}}}',
     description: 'return value and unit based on key: "units"',
-    id: 'UnitTooltips',
+    id: 'unitTooltips',
   },
-  Units: {
+  units: {
     defaultMessage:
       '{units, select, ' +
       'core_hours {core-hours} ' +
@@ -3105,31 +3105,31 @@ export default defineMessages({
       'vm_hours {VM-hours} ' +
       'other {}}',
     description: 'return the proper unit label based on key: "units"',
-    id: 'Units',
+    id: 'units',
   },
-  Usage: {
+  usage: {
     defaultMessage: 'Usage',
     description: 'Usage',
-    id: 'Usage',
+    id: 'usage',
   },
-  UsageCostDescription: {
+  usageCostDescription: {
     defaultMessage: 'The portion of cost calculated by applying hourly and/or monthly price list rates to metrics.',
     description: 'The portion of cost calculated by applying hourly and/or monthly price list rates to metrics.',
-    id: 'UsageCostDescription',
+    id: 'usageCostDescription',
   },
-  UsageCostTitle: {
+  usageCostTitle: {
     defaultMessage: 'Usage cost',
     description: 'Usage cost',
-    id: 'UsageCostTitle',
+    id: 'usageCostTitle',
   },
-  Various: {
+  various: {
     defaultMessage: 'Various',
     description: 'Various',
-    id: 'Various',
+    id: 'various',
   },
-  Yes: {
+  yes: {
     defaultMessage: 'Yes',
     description: 'Yes',
-    id: 'Yes',
+    id: 'yes',
   },
 });

--- a/src/pages/components/currency/currency.tsx
+++ b/src/pages/components/currency/currency.tsx
@@ -39,21 +39,21 @@ export const currencyOptions: {
   label: MessageDescriptor;
   value: string;
 }[] = [
-  { label: messages.CurrencyOptions, value: 'AUD' },
-  { label: messages.CurrencyOptions, value: 'CAD' },
-  { label: messages.CurrencyOptions, value: 'CHF' },
-  { label: messages.CurrencyOptions, value: 'CNY' },
-  { label: messages.CurrencyOptions, value: 'DKK' },
-  { label: messages.CurrencyOptions, value: 'EUR' },
-  { label: messages.CurrencyOptions, value: 'GBP' },
-  { label: messages.CurrencyOptions, value: 'HKD' },
-  { label: messages.CurrencyOptions, value: 'JPY' },
-  { label: messages.CurrencyOptions, value: 'NOK' },
-  { label: messages.CurrencyOptions, value: 'NZD' },
-  { label: messages.CurrencyOptions, value: 'SEK' },
-  { label: messages.CurrencyOptions, value: 'SGD' },
-  { label: messages.CurrencyOptions, value: 'USD' },
-  { label: messages.CurrencyOptions, value: 'ZAR' },
+  { label: messages.currencyOptions, value: 'AUD' },
+  { label: messages.currencyOptions, value: 'CAD' },
+  { label: messages.currencyOptions, value: 'CHF' },
+  { label: messages.currencyOptions, value: 'CNY' },
+  { label: messages.currencyOptions, value: 'DKK' },
+  { label: messages.currencyOptions, value: 'EUR' },
+  { label: messages.currencyOptions, value: 'GBP' },
+  { label: messages.currencyOptions, value: 'HKD' },
+  { label: messages.currencyOptions, value: 'JPY' },
+  { label: messages.currencyOptions, value: 'NOK' },
+  { label: messages.currencyOptions, value: 'NZD' },
+  { label: messages.currencyOptions, value: 'SEK' },
+  { label: messages.currencyOptions, value: 'SGD' },
+  { label: messages.currencyOptions, value: 'USD' },
+  { label: messages.currencyOptions, value: 'ZAR' },
 ];
 
 class CurrencyBase extends React.Component<CurrencyProps> {
@@ -135,7 +135,7 @@ class CurrencyBase extends React.Component<CurrencyProps> {
     return (
       <div style={styles.currencySelector}>
         <Title headingLevel="h2" size="md" style={styles.currencyLabel}>
-          {intl.formatMessage(messages.Currency)}
+          {intl.formatMessage(messages.currency)}
         </Title>
         {this.getSelect()}
       </div>

--- a/src/pages/components/icons/costIcon/costIcon.tsx
+++ b/src/pages/components/icons/costIcon/costIcon.tsx
@@ -15,7 +15,7 @@ const CostIcon: React.SFC<CostIconProps> = ({ className, intl }) => {
     <img
       className={`cost-icon ${className}`}
       src={icon}
-      alt={intl.formatMessage(messages.CostManagement)}
+      alt={intl.formatMessage(messages.costManagement)}
       aria-hidden="true"
     />
   );

--- a/src/pages/components/state/emptyFilterState/emptyFilterState.tsx
+++ b/src/pages/components/state/emptyFilterState/emptyFilterState.tsx
@@ -24,8 +24,8 @@ const EmptyFilterStateBase: React.SFC<EmptyFilterStateProps> = ({
   showMargin = true,
 
   // destructure last
-  subTitle = messages.EmptyFilterStateSubtitle,
-  title = messages.EmptyFilterStateTitle,
+  subTitle = messages.emptyFilterStateSubtitle,
+  title = messages.emptyFilterStateTitle,
 }) => {
   const getIcon = () => {
     const trim = (val: string) => val.replace(/\s+/g, '').toLowerCase();

--- a/src/pages/components/state/errorState/errorState.tsx
+++ b/src/pages/components/state/errorState/errorState.tsx
@@ -12,13 +12,13 @@ interface ErrorStateProps extends WrappedComponentProps {
 }
 
 const ErrorStateBase: React.SFC<ErrorStateProps> = ({ error, icon = ErrorCircleOIcon, intl }) => {
-  let title = intl.formatMessage(messages.ErrorStateUnexpectedTitle);
-  let subTitle = intl.formatMessage(messages.ErrorStateUnexpectedDesc);
+  let title = intl.formatMessage(messages.errorStateUnexpectedTitle);
+  let subTitle = intl.formatMessage(messages.errorStateUnexpectedDesc);
 
   if (error && error.response && (error.response.status === 401 || error.response.status === 403)) {
     icon = LockIcon;
-    title = intl.formatMessage(messages.ErrorStateNotAuthorizedTitle);
-    subTitle = intl.formatMessage(messages.ErrorStateNotAuthorizedDesc);
+    title = intl.formatMessage(messages.errorStateNotAuthorizedTitle);
+    subTitle = intl.formatMessage(messages.errorStateNotAuthorizedDesc);
   }
 
   return (

--- a/src/pages/components/state/loadingState/loadingState.tsx
+++ b/src/pages/components/state/loadingState/loadingState.tsx
@@ -10,8 +10,8 @@ interface LoadingStateProps extends WrappedComponentProps {
 
 // defaultIntl required for testing
 const LoadingStateBase: React.SFC<LoadingStateProps> = ({ intl = defaultIntl }) => {
-  const title = intl.formatMessage(messages.LoadingStateTitle);
-  const subTitle = intl.formatMessage(messages.LoadingStateDesc);
+  const title = intl.formatMessage(messages.loadingStateTitle);
+  const subTitle = intl.formatMessage(messages.loadingStateDesc);
 
   return (
     <EmptyState variant={EmptyStateVariant.large} className="pf-m-redhat-font">

--- a/src/pages/costModels/components/addPriceList.test.tsx
+++ b/src/pages/costModels/components/addPriceList.test.tsx
@@ -154,7 +154,7 @@ describe('add-a-new-rate', () => {
     options = await screen.findAllByRole('option');
     userEvent.click(options[1]);
 
-    expect(screen.getByText(regExp(messages.CostModelsRequiredField))).not.toBeNull();
+    expect(screen.getByText(regExp(messages.costModelsRequiredField))).not.toBeNull();
 
     userEvent.click(screen.getByLabelText('Select Measurement'));
     options = await screen.findAllByRole('option');
@@ -166,22 +166,22 @@ describe('add-a-new-rate', () => {
     const rateInput = screen.getByLabelText('Assign rate');
 
     // setting rate to anything but a number
-    expect(screen.queryByText(regExp(messages.PriceListNumberRate))).toBeNull();
+    expect(screen.queryByText(regExp(messages.priceListNumberRate))).toBeNull();
     userEvent.type(rateInput, 'A');
-    expect(screen.getByText(regExp(messages.PriceListNumberRate))).not.toBeNull();
+    expect(screen.getByText(regExp(messages.priceListNumberRate))).not.toBeNull();
 
     // setting rate to a negative number - validation is done on blur
     userEvent.clear(rateInput);
     userEvent.type(rateInput, '-12');
-    expect(screen.getByText(regExp(messages.PriceListPosNumberRate))).not.toBeNull();
+    expect(screen.getByText(regExp(messages.priceListPosNumberRate))).not.toBeNull();
 
     // setting rate to a valid number
     userEvent.clear(rateInput);
     userEvent.type(rateInput, '0.2');
-    expect(screen.queryByText(regExp(messages.PriceListNumberRate))).toBeNull();
+    expect(screen.queryByText(regExp(messages.priceListNumberRate))).toBeNull();
 
     // making sure button is enabled
-    const createButton = screen.getByText(regExp(messages.CreateRate));
+    const createButton = screen.getByText(regExp(messages.createRate));
     expect(createButton.getAttribute('aria-disabled')).toBe('false');
     userEvent.click(createButton);
     expect(submit).toHaveBeenCalled();
@@ -203,41 +203,41 @@ describe('add-a-new-rate', () => {
     options = await screen.findAllByRole('option');
     userEvent.click(options[0]);
 
-    userEvent.click(screen.getByLabelText(regExp(messages.CostModelsEnterTagRate)));
+    userEvent.click(screen.getByLabelText(regExp(messages.costModelsEnterTagRate)));
 
     // tag key is required validation
     const tagKeyInput = screen.getByPlaceholderText(qr.tagKeyPlaceHolder);
     userEvent.type(tagKeyInput, 'test');
-    expect(screen.queryByText(regExp(messages.CostModelsRequiredField))).toBeNull();
+    expect(screen.queryByText(regExp(messages.costModelsRequiredField))).toBeNull();
     userEvent.clear(tagKeyInput);
-    expect(screen.getByText(regExp(messages.CostModelsRequiredField))).not.toBeNull();
+    expect(screen.getByText(regExp(messages.costModelsRequiredField))).not.toBeNull();
     userEvent.type(tagKeyInput, 'openshift');
-    expect(screen.queryByText(regExp(messages.CostModelsRequiredField))).toBeNull();
+    expect(screen.queryByText(regExp(messages.costModelsRequiredField))).toBeNull();
 
     // tag value is required validation
     const tagValueInput = screen.getByPlaceholderText('Enter a tag value');
     userEvent.type(tagValueInput, 'test');
-    expect(screen.queryByText(regExp(messages.CostModelsRequiredField))).toBeNull();
+    expect(screen.queryByText(regExp(messages.costModelsRequiredField))).toBeNull();
     userEvent.clear(tagValueInput);
-    expect(screen.getByText(regExp(messages.CostModelsRequiredField))).not.toBeNull();
+    expect(screen.getByText(regExp(messages.costModelsRequiredField))).not.toBeNull();
     userEvent.type(tagValueInput, 'openshift');
-    expect(screen.queryByText(regExp(messages.CostModelsRequiredField))).toBeNull();
+    expect(screen.queryByText(regExp(messages.costModelsRequiredField))).toBeNull();
 
     // rate must be a number
     const tagRateInput = screen.getByLabelText('Assign rate');
     userEvent.type(tagRateInput, 'test');
-    expect(screen.getByText(regExp(messages.PriceListNumberRate))).not.toBeNull();
+    expect(screen.getByText(regExp(messages.priceListNumberRate))).not.toBeNull();
 
     // rate is required
     userEvent.clear(tagRateInput);
-    expect(screen.getByText(regExp(messages.CostModelsRequiredField))).not.toBeNull();
+    expect(screen.getByText(regExp(messages.costModelsRequiredField))).not.toBeNull();
 
     // rate must be positive
     userEvent.type(tagRateInput, '-0.23');
-    expect(screen.getByText(regExp(messages.PriceListPosNumberRate))).not.toBeNull();
+    expect(screen.getByText(regExp(messages.priceListPosNumberRate))).not.toBeNull();
 
     // setting a valid rate - now form is valid and can be submitted
-    const createButton = screen.getByText(regExp(messages.CreateRate));
+    const createButton = screen.getByText(regExp(messages.createRate));
     expect(createButton.getAttribute('aria-disabled')).toBe('true');
     userEvent.clear(tagRateInput);
 
@@ -273,31 +273,31 @@ describe('add-a-new-rate', () => {
     options = await screen.findAllByRole('option');
     userEvent.click(options[0]);
 
-    userEvent.click(screen.getByLabelText(regExp(messages.CostModelsEnterTagRate)));
+    userEvent.click(screen.getByLabelText(regExp(messages.costModelsEnterTagRate)));
 
     // tag key is duplicated
     const tagKeyInput = screen.getByPlaceholderText(qr.tagKeyPlaceHolder);
     userEvent.type(tagKeyInput, 'app');
-    expect(screen.getByText(regExp(messages.PriceListDuplicate))).not.toBeNull();
+    expect(screen.getByText(regExp(messages.priceListDuplicate))).not.toBeNull();
 
     userEvent.type(tagKeyInput, '1');
-    expect(screen.queryByText(regExp(messages.PriceListDuplicate))).toBeNull();
+    expect(screen.queryByText(regExp(messages.priceListDuplicate))).toBeNull();
 
     // change measurement will set tag key as not duplicate
     userEvent.type(tagKeyInput, '{backspace}');
-    expect(screen.getByText(regExp(messages.PriceListDuplicate))).not.toBeNull();
+    expect(screen.getByText(regExp(messages.priceListDuplicate))).not.toBeNull();
 
     userEvent.click(measurementSelect);
     options = await screen.findAllByRole('option');
     userEvent.click(options[1]);
 
-    expect(screen.queryByText(regExp(messages.PriceListDuplicate))).toBeNull();
+    expect(screen.queryByText(regExp(messages.priceListDuplicate))).toBeNull();
 
     userEvent.click(screen.getByLabelText('Select Measurement'));
     options = await screen.findAllByRole('option');
     userEvent.click(options[0]);
 
-    expect(screen.getByText(regExp(messages.PriceListDuplicate))).not.toBeNull();
+    expect(screen.getByText(regExp(messages.priceListDuplicate))).not.toBeNull();
   });
 
   test('hide "enter tag rates" switch on Cluster metric', async () => {
@@ -313,6 +313,6 @@ describe('add-a-new-rate', () => {
     userEvent.click(screen.getByLabelText('Select Measurement'));
     options = await screen.findAllByRole('option');
     userEvent.click(options[0]);
-    expect(screen.queryAllByLabelText(regExp(messages.CostModelsEnterTagRate))).toHaveLength(0);
+    expect(screen.queryAllByLabelText(regExp(messages.costModelsEnterTagRate))).toHaveLength(0);
   });
 });

--- a/src/pages/costModels/components/addPriceList.tsx
+++ b/src/pages/costModels/components/addPriceList.tsx
@@ -47,12 +47,12 @@ const AddPriceList: React.FunctionComponent<AddPriceListProps> = ({
     <Stack hasGutter>
       <StackItem>
         <Title headingLevel="h2" size={TitleSizes.xl}>
-          {intl.formatMessage(messages.CostModelsWizardCreatePriceList)}
+          {intl.formatMessage(messages.costModelsWizardCreatePriceList)}
         </Title>
       </StackItem>
       <StackItem>
         <TextContent>
-          <Text component={TextVariants.h6}>{intl.formatMessage(messages.CostModelsWizardPriceListMetric)}</Text>
+          <Text component={TextVariants.h6}>{intl.formatMessage(messages.costModelsWizardPriceListMetric)}</Text>
         </TextContent>
       </StackItem>
       <StackItem>
@@ -63,10 +63,10 @@ const AddPriceList: React.FunctionComponent<AddPriceListProps> = ({
       <StackItem>
         <ActionGroup>
           <Button variant={ButtonVariant.primary} isDisabled={!canSubmit} onClick={() => submitRate(rateFormData)}>
-            {intl.formatMessage(messages.CreateRate)}
+            {intl.formatMessage(messages.createRate)}
           </Button>
           <Button variant={ButtonVariant.link} onClick={cancel}>
-            {intl.formatMessage(messages.Cancel)}
+            {intl.formatMessage(messages.cancel)}
           </Button>
         </ActionGroup>
       </StackItem>

--- a/src/pages/costModels/components/errorState.tsx
+++ b/src/pages/costModels/components/errorState.tsx
@@ -49,20 +49,20 @@ interface SourcesErrorStateProps extends WrappedComponentProps {
 }
 
 export const SourceStepErrorStateBase: React.FunctionComponent<SourcesErrorStateProps> = ({ intl, onRefresh }) => {
-  const title = intl.formatMessage(messages.CostModelsWizardSourceErrorTitle);
-  const description = intl.formatMessage(messages.CostModelsWizardSourceErrorDescription, {
+  const title = intl.formatMessage(messages.costModelsWizardSourceErrorTitle);
+  const description = intl.formatMessage(messages.costModelsWizardSourceErrorDescription, {
     url: (
-      <a href={intl.formatMessage(messages.RedHatStatusUrl)} rel="noreferrer" target="_blank">
+      <a href={intl.formatMessage(messages.redHatStatusUrl)} rel="noreferrer" target="_blank">
         "Status Page"
       </a>
     ),
   });
-  const actionButton = <Button onClick={onRefresh}>{intl.formatMessage(messages.CostModelsRefreshDialog)}</Button>;
+  const actionButton = <Button onClick={onRefresh}>{intl.formatMessage(messages.costModelsRefreshDialog)}</Button>;
   return (
     <Stack hasGutter>
       <StackItem>
         <Title headingLevel="h2" size={TitleSizes.xl}>
-          {intl.formatMessage(messages.CostModelsWizardSourceTitle)}
+          {intl.formatMessage(messages.costModelsWizardSourceTitle)}
         </Title>
       </StackItem>
       <StackItem>
@@ -80,15 +80,15 @@ const SourceStepErrorState = injectIntl(SourceStepErrorStateBase);
 export { SourceStepErrorState };
 
 export const SourcesModalErrorStateBase: React.FunctionComponent<SourcesErrorStateProps> = ({ intl, onRefresh }) => {
-  const title = intl.formatMessage(messages.CostModelsAssignSourcesErrorTitle);
-  const description = intl.formatMessage(messages.CostModelsAssignSourcesErrorDescription, {
+  const title = intl.formatMessage(messages.costModelsAssignSourcesErrorTitle);
+  const description = intl.formatMessage(messages.costModelsAssignSourcesErrorDescription, {
     url: (
-      <a href={intl.formatMessage(messages.RedHatStatusUrl)} rel="noreferrer" target="_blank">
+      <a href={intl.formatMessage(messages.redHatStatusUrl)} rel="noreferrer" target="_blank">
         "Status Page"
       </a>
     ),
   });
-  const actionButton = <Button onClick={onRefresh}>{intl.formatMessage(messages.CostModelsRefreshDialog)}</Button>;
+  const actionButton = <Button onClick={onRefresh}>{intl.formatMessage(messages.costModelsRefreshDialog)}</Button>;
   return (
     <ErrorState variant={EmptyStateVariant.large} actionButton={actionButton} description={description} title={title} />
   );

--- a/src/pages/costModels/components/inputs/rateInput.tsx
+++ b/src/pages/costModels/components/inputs/rateInput.tsx
@@ -28,9 +28,9 @@ type RateInputBaseProps = RateFormGroup & RateTextInput & UniqueProps & WrappedC
 const RateInputBase: React.FunctionComponent<RateInputBaseProps> = ({
   currencyUnits = 'USD',
   fieldId,
-  helperTextInvalid: helpText = messages.PriceListPosNumberRate,
+  helperTextInvalid: helpText = messages.priceListPosNumberRate,
   intl = defaultIntl, // Default required for testing
-  label = messages.Rate,
+  label = messages.rate,
   onBlur,
   onChange,
   style,
@@ -54,13 +54,13 @@ const RateInputBase: React.FunctionComponent<RateInputBaseProps> = ({
     >
       <InputGroup>
         <InputGroupText style={styles.currency}>
-          {intl.formatMessage(messages.CurrencyUnits, { units: currencyUnits })}
+          {intl.formatMessage(messages.currencyUnits, { units: currencyUnits })}
         </InputGroupText>
         <TextInput
           onBlur={onBlur}
           isRequired
           type="text"
-          aria-label={intl.formatMessage(messages.CostModelsWizardRateAriaLabel)}
+          aria-label={intl.formatMessage(messages.costModelsWizardRateAriaLabel)}
           id={fieldId}
           placeholder={formatCurrencyRaw(0, currencyUnits, { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
           value={value}

--- a/src/pages/costModels/components/rateForm/constants.ts
+++ b/src/pages/costModels/components/rateForm/constants.ts
@@ -1,11 +1,11 @@
 import messages from 'locales/messages';
 
 export const textHelpers = {
-  description_too_long: messages.CostModelsDescTooLong,
-  duplicate: messages.PriceListDuplicate,
-  not_number: messages.PriceListNumberRate,
-  not_positive: messages.PriceListPosNumberRate,
-  rate_too_long: messages.CostModelsRateTooLong,
-  required: messages.CostModelsRequiredField,
-  tag_too_long: messages.CostModelsInfoTooLong,
+  description_too_long: messages.costModelsDescTooLong,
+  duplicate: messages.priceListDuplicate,
+  not_number: messages.priceListNumberRate,
+  not_positive: messages.priceListPosNumberRate,
+  rate_too_long: messages.costModelsRateTooLong,
+  required: messages.costModelsRequiredField,
+  tag_too_long: messages.costModelsInfoTooLong,
 };

--- a/src/pages/costModels/components/rateForm/rateForm.tsx
+++ b/src/pages/costModels/components/rateForm/rateForm.tsx
@@ -59,13 +59,13 @@ const RateFormBase: React.FunctionComponent<RateFormProps> = ({
   const getMetricLabel = m => {
     // Match message descriptor or default to API string
     const value = m.replace(/ /g, '_').toLowerCase();
-    return intl.formatMessage(messages.MetricValues, { value }) || m;
+    return intl.formatMessage(messages.metricValues, { value }) || m;
   };
   const getMeasurementLabel = (m, u) => {
     // Match message descriptor or default to API string
-    const units = intl.formatMessage(messages.Units, { units: unitsLookupKey(u) }) || u;
+    const units = intl.formatMessage(messages.units, { units: unitsLookupKey(u) }) || u;
     return (
-      intl.formatMessage(messages.MeasurementValues, {
+      intl.formatMessage(messages.measurementValues, {
         value: m.toLowerCase().replace('-', '_'),
         units,
         count: 2,
@@ -77,7 +77,7 @@ const RateFormBase: React.FunctionComponent<RateFormProps> = ({
     // units only works with Node, Cluster, and PVC. it does not need to be translated
     // if the metric is CPU, Memory, or Storage, units will be like `core_hours` or `gb_hours` and must be translated
     const units = u.toLowerCase().replace('-', '_');
-    const desc = intl.formatMessage(messages.MeasurementValuesDesc, {
+    const desc = intl.formatMessage(messages.measurementValuesDesc, {
       value: o.toLowerCase().replace('-', '_'),
       units: units ? units : u,
     });
@@ -103,7 +103,7 @@ const RateFormBase: React.FunctionComponent<RateFormProps> = ({
       <SimpleInput
         style={style}
         id="description"
-        label={messages.Description}
+        label={messages.description}
         value={description}
         validated={errors.description ? 'error' : 'default'}
         helperTextInvalid={errors.description}
@@ -115,9 +115,9 @@ const RateFormBase: React.FunctionComponent<RateFormProps> = ({
             isRequired
             style={style}
             id="metric-selector"
-            toggleAriaLabel={intl.formatMessage(messages.CostModelsSelectMetric)}
-            label={intl.formatMessage(messages.Metric)}
-            placeholderText={intl.formatMessage(messages.Select)}
+            toggleAriaLabel={intl.formatMessage(messages.costModelsSelectMetric)}
+            label={intl.formatMessage(messages.metric)}
+            placeholderText={intl.formatMessage(messages.select)}
             value={metric}
             onChange={setMetric}
             options={[
@@ -139,8 +139,8 @@ const RateFormBase: React.FunctionComponent<RateFormProps> = ({
               isInvalid={errors.measurement && measurementDirty}
               style={style}
               id="measurement-selector"
-              label={intl.formatMessage(messages.Measurement)}
-              toggleAriaLabel={intl.formatMessage(messages.CostModelsSelectMeasurement)}
+              label={intl.formatMessage(messages.measurement)}
+              toggleAriaLabel={intl.formatMessage(messages.costModelsSelectMeasurement)}
               value={
                 !metricsHash[metric][measurement]
                   ? measurement
@@ -170,27 +170,27 @@ const RateFormBase: React.FunctionComponent<RateFormProps> = ({
               isInline
               style={style}
               fieldId="calculation"
-              label={intl.formatMessage(messages.CalculationType)}
+              label={intl.formatMessage(messages.calculationType)}
             >
               <Radio
                 name="calculation"
                 id="calculation_infra"
-                label={intl.formatMessage(messages.Infrastructure)}
+                label={intl.formatMessage(messages.infrastructure)}
                 isChecked={calculation === 'Infrastructure'}
                 onChange={() => setCalculation('Infrastructure')}
               />
               <Radio
                 name="calculation"
                 id="calculation_suppl"
-                label={intl.formatMessage(messages.Supplementary)}
+                label={intl.formatMessage(messages.supplementary)}
                 isChecked={calculation === 'Supplementary'}
                 onChange={() => setCalculation('Supplementary')}
               />
             </FormGroup>
             {metric !== 'Cluster' ? (
               <Switch
-                aria-label={intl.formatMessage(messages.CostModelsEnterTagRate)}
-                label={intl.formatMessage(messages.CostModelsEnterTagRate)}
+                aria-label={intl.formatMessage(messages.costModelsEnterTagRate)}
+                label={intl.formatMessage(messages.costModelsEnterTagRate)}
                 isChecked={rateKind === 'tagging'}
                 onChange={toggleTaggingRate}
               />
@@ -214,8 +214,8 @@ const RateFormBase: React.FunctionComponent<RateFormProps> = ({
                 value={tagKey}
                 onChange={setTagKey}
                 id="tag-key"
-                label={messages.CostModelsFilterTagKey}
-                placeholder={intl.formatMessage(messages.CostModelsEnterTagKey)}
+                label={messages.costModelsFilterTagKey}
+                placeholder={intl.formatMessage(messages.costModelsEnterTagKey)}
                 validated={errors.tagKey && isTagKeyDirty ? 'error' : 'default'}
                 helperTextInvalid={errors.tagKey}
               />
@@ -233,7 +233,7 @@ const RateFormBase: React.FunctionComponent<RateFormProps> = ({
                 updateTag={updateTag}
               />
               <Button style={addStyle} variant={ButtonVariant.link} onClick={addTag}>
-                <PlusCircleIcon /> {intl.formatMessage(messages.CostModelsAddTagValues)}
+                <PlusCircleIcon /> {intl.formatMessage(messages.costModelsAddTagValues)}
               </Button>
             </>
           )}

--- a/src/pages/costModels/components/rateForm/taggingRatesForm.tsx
+++ b/src/pages/costModels/components/rateForm/taggingRatesForm.tsx
@@ -43,14 +43,14 @@ const TaggingRatesFormBase: React.FunctionComponent<TaggingRatesFormProps> = ({
       {tagValues.map((tag, ix: number) => {
         return (
           <Split hasGutter key={ix}>
-            <SplitItem style={elementStyle}>{intl.formatMessage(messages.EqualsSymbol)}</SplitItem>
+            <SplitItem style={elementStyle}>{intl.formatMessage(messages.equalsSymbol)}</SplitItem>
             <SplitItem>
               <SimpleInput
                 isRequired
                 style={style}
                 id={`tagValue_${ix}`}
-                label={messages.CostModelsTagRateTableValue}
-                placeholder={intl.formatMessage(messages.CostModelsEnterTagValue)}
+                label={messages.costModelsTagRateTableValue}
+                placeholder={intl.formatMessage(messages.costModelsEnterTagValue)}
                 value={tag.tagValue}
                 onChange={value => updateTag({ tagValue: value }, ix)}
                 validated={tagValues[ix].isTagValueDirty && errors.tagValueValues[ix] ? 'error' : 'default'}
@@ -72,23 +72,23 @@ const TaggingRatesFormBase: React.FunctionComponent<TaggingRatesFormProps> = ({
               <SimpleInput
                 style={style}
                 id={`desc_${ix}`}
-                label={messages.Description}
+                label={messages.description}
                 validated={errors.tagDescription[ix] ? 'error' : 'default'}
-                placeholder={intl.formatMessage(messages.CostModelsEnterTagDescription)}
+                placeholder={intl.formatMessage(messages.costModelsEnterTagDescription)}
                 value={tag.description}
                 onChange={value => updateTag({ description: value }, ix)}
                 helperTextInvalid={errors.tagDescription[ix]}
               />
             </SplitItem>
             <SplitItem>
-              <FormGroup fieldId={`isDefault_${ix}`} label={intl.formatMessage(messages.CostModelsTagRateTableDefault)}>
+              <FormGroup fieldId={`isDefault_${ix}`} label={intl.formatMessage(messages.costModelsTagRateTableDefault)}>
                 <Checkbox id={`isDefault_${ix}`} isChecked={defaultTag === ix} onChange={() => updateDefaultTag(ix)} />
               </FormGroup>
             </SplitItem>
             <SplitItem>
               <FormGroup fieldId="__irrelevant" label={<div>&nbsp;</div>}>
                 <Button
-                  aria-label={intl.formatMessage(messages.CostModelsRemoveTagLabel)}
+                  aria-label={intl.formatMessage(messages.costModelsRemoveTagLabel)}
                   variant={ButtonVariant.plain}
                   isDisabled={tagValues.length === 1}
                   onClick={() => removeTag(ix)}

--- a/src/pages/costModels/components/rateTable.tsx
+++ b/src/pages/costModels/components/rateTable.tsx
@@ -35,10 +35,10 @@ const RateTableBase: React.SFC<RateTableProps> = ({
 }) => {
   const [expanded, setExpanded] = React.useState({});
   const [sortBy, setSortBy] = React.useState<ISortBy>({});
-  const getMetric = value => intl.formatMessage(messages.MetricValues, { value }) || value;
+  const getMetric = value => intl.formatMessage(messages.metricValues, { value }) || value;
   const getMeasurement = (measurement, units) => {
-    units = intl.formatMessage(messages.Units, { units: unitsLookupKey(units) }) || units;
-    return intl.formatMessage(messages.MeasurementValues, {
+    units = intl.formatMessage(messages.units, { units: unitsLookupKey(units) }) || units;
+    return intl.formatMessage(messages.measurementValues, {
       value: measurement.toLowerCase().replace('-', '_'),
       units,
       count: 2,
@@ -82,7 +82,7 @@ const RateTableBase: React.SFC<RateTableProps> = ({
             title:
               rateKind === 'regular'
                 ? formatCurrencyRate(tierRate, tier.tiered_rates[0].unit)
-                : intl.formatMessage(messages.Various),
+                : intl.formatMessage(messages.various),
             props: { isOpen, style: { padding: rateKind === 'tagging' ? '' : '1.5rem 1rem' } },
           },
         ],
@@ -91,11 +91,11 @@ const RateTableBase: React.SFC<RateTableProps> = ({
     ];
   }, []);
   const cells = [
-    { title: intl.formatMessage(messages.Description) },
-    { title: intl.formatMessage(messages.Metric), ...(rows.length && { transforms: [sortable] }) },
-    { title: intl.formatMessage(messages.Measurement), ...(rows.length && { transforms: [sortable] }) },
-    { title: intl.formatMessage(messages.CalculationType) },
-    { title: intl.formatMessage(messages.Rate), cellTransforms: [compoundExpand] },
+    { title: intl.formatMessage(messages.description) },
+    { title: intl.formatMessage(messages.metric), ...(rows.length && { transforms: [sortable] }) },
+    { title: intl.formatMessage(messages.measurement), ...(rows.length && { transforms: [sortable] }) },
+    { title: intl.formatMessage(messages.calculationType) },
+    { title: intl.formatMessage(messages.rate), cellTransforms: [compoundExpand] },
   ];
   const onExpand = (_event: any, rowIndex: number, _colIndex: number, isOpen: boolean) => {
     setExpanded({ ...expanded, [rowIndex]: !isOpen });
@@ -110,7 +110,7 @@ const RateTableBase: React.SFC<RateTableProps> = ({
     <Table
       onSort={onSort}
       sortBy={sortBy}
-      aria-label={intl.formatMessage(messages.CostModelsWizardCreatePriceList)}
+      aria-label={intl.formatMessage(messages.costModelsWizardCreatePriceList)}
       variant={isCompact ? TableVariant.compact : undefined}
       rows={rows}
       cells={cells}

--- a/src/pages/costModels/components/tagRateTable.tsx
+++ b/src/pages/costModels/components/tagRateTable.tsx
@@ -13,11 +13,11 @@ interface TagRateTableProps extends WrappedComponentProps {
 // defaultIntl required for testing
 const TagRateTable: React.FunctionComponent<TagRateTableProps> = ({ intl = defaultIntl, tagRates }) => {
   const cells = [
-    intl.formatMessage(messages.CostModelsTagRateTableKey),
-    intl.formatMessage(messages.CostModelsTagRateTableValue),
-    intl.formatMessage(messages.Rate),
-    intl.formatMessage(messages.Description),
-    intl.formatMessage(messages.CostModelsTagRateTableDefault),
+    intl.formatMessage(messages.costModelsTagRateTableKey),
+    intl.formatMessage(messages.costModelsTagRateTableValue),
+    intl.formatMessage(messages.rate),
+    intl.formatMessage(messages.description),
+    intl.formatMessage(messages.costModelsTagRateTableDefault),
   ];
 
   const rows =
@@ -29,14 +29,14 @@ const TagRateTable: React.FunctionComponent<TagRateTableProps> = ({ intl = defau
           tagValue.tag_value,
           formatCurrencyRate(tagValue.value, tagValue.unit),
           tagValue.description,
-          tagValue.default ? intl.formatMessage(messages.Yes) : intl.formatMessage(messages.No),
+          tagValue.default ? intl.formatMessage(messages.yes) : intl.formatMessage(messages.no),
         ],
       };
     });
 
   return (
     <Table
-      aria-label={intl.formatMessage(messages.CostModelsTagRateTableAriaLabel)}
+      aria-label={intl.formatMessage(messages.costModelsTagRateTableAriaLabel)}
       borders={false}
       cells={cells}
       gridBreakPoint={TableGridBreakpoint.grid2xl}

--- a/src/pages/costModels/costModel/addRateModal.tsx
+++ b/src/pages/costModels/costModel/addRateModal.tsx
@@ -54,7 +54,7 @@ export const AddRateModalBase: React.FunctionComponent<AddRateModalBaseProps> = 
 
   return (
     <Modal
-      title={intl.formatMessage(messages.PriceListAddRate)}
+      title={intl.formatMessage(messages.priceListAddRate)}
       isOpen={isOpen}
       onClose={onClose}
       variant="large"
@@ -65,10 +65,10 @@ export const AddRateModalBase: React.FunctionComponent<AddRateModalBaseProps> = 
           isDisabled={!canSubmit || isProcessing}
           onClick={onProceed}
         >
-          {intl.formatMessage(messages.PriceListAddRate)}
+          {intl.formatMessage(messages.priceListAddRate)}
         </Button>,
         <Button key="cancel" variant={ButtonVariant.link} isDisabled={isProcessing} onClick={onClose}>
-          {intl.formatMessage(messages.Cancel)}
+          {intl.formatMessage(messages.cancel)}
         </Button>,
       ]}
     >

--- a/src/pages/costModels/costModel/addSourceStep.tsx
+++ b/src/pages/costModels/costModel/addSourceStep.tsx
@@ -81,7 +81,7 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
       const isSelected = this.props.checked[providerData.uuid] ? this.props.checked[providerData.uuid].selected : false;
       const provCostModels =
         providerData.cost_models === undefined
-          ? intl.formatMessage(messages.CostModelsWizardSourceTableDefaultCostModel)
+          ? intl.formatMessage(messages.costModelsWizardSourceTableDefaultCostModel)
           : providerData.cost_models.map(cm => cm.name).join(',');
       const isAssigned =
         providerData.cost_models.length &&
@@ -90,7 +90,7 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
       const warningIcon = isAssigned ? (
         <WarningIcon
           key={providerData.uuid}
-          text={intl.formatMessage(messages.CostModelsWizardSourceWarning, { costModel: provCostModels })}
+          text={intl.formatMessage(messages.costModelsWizardSourceWarning, { costModel: provCostModels })}
         />
       ) : null;
       const cellName = (
@@ -172,10 +172,10 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
         />
         {sources.length > 0 && (
           <Table
-            aria-label={intl.formatMessage(messages.CostModelsAssignSources, { count: 1 })}
+            aria-label={intl.formatMessage(messages.costModelsAssignSources, { count: 1 })}
             cells={[
-              intl.formatMessage(messages.Names, { count: 1 }),
-              intl.formatMessage(messages.CostModelsWizardSourceTableCostModel),
+              intl.formatMessage(messages.names, { count: 1 }),
+              intl.formatMessage(messages.costModelsWizardSourceTableCostModel),
             ]}
             rows={sources}
             onSelect={onSelect}
@@ -185,7 +185,7 @@ class AddSourcesStep extends React.Component<AddSourcesStepProps> {
           </Table>
         )}
         {sources.length === 0 && (
-          <EmptyFilterState filter={this.props.filter} subTitle={messages.EmptyFilterSourceStateSubtitle} />
+          <EmptyFilterState filter={this.props.filter} subTitle={messages.emptyFilterSourceStateSubtitle} />
         )}
         <Toolbar id="costmodels_details.sources_pagination_datatoolbar">
           <ToolbarContent style={{ flexDirection: 'row-reverse' }}>

--- a/src/pages/costModels/costModel/addSourceWizard.tsx
+++ b/src/pages/costModels/costModel/addSourceWizard.tsx
@@ -89,7 +89,7 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
     return (
       <Modal
         isOpen={isOpen}
-        title={intl.formatMessage(messages.CostModelsAssignSources, { count: 2 })}
+        title={intl.formatMessage(messages.costModelsAssignSources, { count: 2 })}
         onClose={onClose}
         variant="large"
         actions={[
@@ -105,10 +105,10 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
               onSave(Object.keys(this.state.checked).filter(uuid => this.state.checked[uuid].selected));
             }}
           >
-            {intl.formatMessage(messages.CostModelsAssignSourcesParen)}
+            {intl.formatMessage(messages.costModelsAssignSourcesParen)}
           </Button>,
           <Button key="cancel" variant="link" isDisabled={isUpdateInProgress} onClick={onClose}>
-            {intl.formatMessage(messages.Cancel)}
+            {intl.formatMessage(messages.cancel)}
           </Button>,
         ]}
       >
@@ -118,7 +118,7 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
             <Grid>
               <GridItem span={2}>
                 <TextContent>
-                  <Text component={TextVariants.h6}>{intl.formatMessage(messages.Names, { count: 1 })}</Text>
+                  <Text component={TextVariants.h6}>{intl.formatMessage(messages.names, { count: 1 })}</Text>
                 </TextContent>
               </GridItem>
               <GridItem span={10}>
@@ -128,7 +128,7 @@ class AddSourceWizardBase extends React.Component<Props, AddSourcesStepState> {
               </GridItem>
               <GridItem span={2}>
                 <TextContent>
-                  <Text component={TextVariants.h6}>{intl.formatMessage(messages.CostModelsSourceType)}</Text>
+                  <Text component={TextVariants.h6}>{intl.formatMessage(messages.costModelsSourceType)}</Text>
                 </TextContent>
               </GridItem>
               <GridItem span={10}>

--- a/src/pages/costModels/costModel/assignSourcesModalToolbar.tsx
+++ b/src/pages/costModels/costModel/assignSourcesModalToolbar.tsx
@@ -70,7 +70,7 @@ export const AssignSourcesToolbarBase: React.SFC<AssignSourcesToolbarBaseProps> 
           <ToolbarItem variant="search-filter">
             <ToolbarFilter deleteChip={filter.onRemove} chips={filter.query.name} categoryName="name">
               <FilterInput
-                placeholder={intl.formatMessage(messages.CostModelsFilterPlaceholder)}
+                placeholder={intl.formatMessage(messages.costModelsFilterPlaceholder)}
                 {...filterInputProps}
               />
             </ToolbarFilter>

--- a/src/pages/costModels/costModel/dialog.tsx
+++ b/src/pages/costModels/costModel/dialog.tsx
@@ -31,7 +31,7 @@ const DialogBase: React.SFC<Props> = ({
 }) => {
   const CancelButtonSecondary = (
     <Button key="cancel" variant="link" onClick={onClose} isDisabled={isProcessing}>
-      {intl.formatMessage(messages.Cancel)}
+      {intl.formatMessage(messages.cancel)}
     </Button>
   );
   const ProceedButton = (
@@ -41,7 +41,7 @@ const DialogBase: React.SFC<Props> = ({
   );
   const CloseButtonPrimary = (
     <Button key="close" variant="primary" onClick={onClose} isDisabled={isProcessing}>
-      {intl.formatMessage(messages.Close)}
+      {intl.formatMessage(messages.close)}
     </Button>
   );
   const actions = actionText !== '' ? [ProceedButton, CancelButtonSecondary] : [CloseButtonPrimary];

--- a/src/pages/costModels/costModel/distribution.tsx
+++ b/src/pages/costModels/costModel/distribution.tsx
@@ -40,7 +40,7 @@ const DistributionCardBase: React.FunctionComponent<Props> = ({
 }) => {
   const [dropdownIsOpen, setDropdownIsOpen] = React.useState(false);
   const distributionLabel =
-    current.distribution === 'cpu' ? intl.formatMessage(messages.CpuTitle) : intl.formatMessage(messages.MemoryTitle);
+    current.distribution === 'cpu' ? intl.formatMessage(messages.cpuTitle) : intl.formatMessage(messages.memoryTitle);
 
   return (
     <>
@@ -49,7 +49,7 @@ const DistributionCardBase: React.FunctionComponent<Props> = ({
         <CardHeader>
           <CardHeaderMain>
             <Title headingLevel="h2" size={TitleSizes.md}>
-              {intl.formatMessage(messages.DistributionType)}
+              {intl.formatMessage(messages.distributionType)}
             </Title>
           </CardHeaderMain>
           <CardActions>
@@ -66,14 +66,14 @@ const DistributionCardBase: React.FunctionComponent<Props> = ({
                     onClick={() => setCostModelDialog({ isOpen: true, name: 'updateDistribution' })}
                     component="button"
                   >
-                    {intl.formatMessage(messages.CostModelsDistributionEdit)}
+                    {intl.formatMessage(messages.costModelsDistributionEdit)}
                   </DropdownItem>
                 </ReadOnlyTooltip>,
               ]}
             />
           </CardActions>
         </CardHeader>
-        <CardBody style={styles.cardDescription}>{intl.formatMessage(messages.CostModelsDistributionDesc)}</CardBody>
+        <CardBody style={styles.cardDescription}>{intl.formatMessage(messages.costModelsDistributionDesc)}</CardBody>
         <CardBody isFilled />
         <CardBody style={styles.cardBody}>{distributionLabel}</CardBody>
         <CardBody isFilled />

--- a/src/pages/costModels/costModel/header.tsx
+++ b/src/pages/costModels/costModel/header.tsx
@@ -72,7 +72,7 @@ const Header: React.FunctionComponent<Props> = ({
       <Dialog
         isSmall
         isOpen={isDialogOpen.deleteCostModel}
-        title={intl.formatMessage(messages.CostModelsDelete)}
+        title={intl.formatMessage(messages.costModelsDelete)}
         onClose={() => setDialogOpen({ name: 'deleteCostModel', isOpen: false })}
         error={deleteError}
         isProcessing={isDeleteProcessing}
@@ -82,15 +82,15 @@ const Header: React.FunctionComponent<Props> = ({
         body={
           <>
             {current.sources.length === 0 &&
-              intl.formatMessage(messages.CostModelsDeleteDesc, {
+              intl.formatMessage(messages.costModelsDeleteDesc, {
                 costModel: current.name,
               })}
             {current.sources.length > 0 && (
               <>
-                {intl.formatMessage(messages.CostModelsDeleteSource)}
+                {intl.formatMessage(messages.costModelsDeleteSource)}
                 <br />
                 <br />
-                {intl.formatMessage(messages.CostModelsAvailableSources)}
+                {intl.formatMessage(messages.costModelsAvailableSources)}
                 <br />
                 <List>
                   {current.sources.map(provider => (
@@ -101,13 +101,13 @@ const Header: React.FunctionComponent<Props> = ({
             )}
           </>
         }
-        actionText={current.sources.length === 0 ? intl.formatMessage(messages.CostModelsDelete) : ''}
+        actionText={current.sources.length === 0 ? intl.formatMessage(messages.costModelsDelete) : ''}
       />
       <header style={styles.headerCostModel}>
         <div style={styles.headerContent}>
           <Breadcrumb style={styles.breadcrumb}>
             <BreadcrumbItem to={`${baseName}${paths.costModels}`}>
-              {intl.formatMessage(messages.CostModels)}
+              {intl.formatMessage(messages.costModels)}
             </BreadcrumbItem>
             <BreadcrumbItem isActive>{current.name}</BreadcrumbItem>
           </Breadcrumb>
@@ -137,7 +137,7 @@ const Header: React.FunctionComponent<Props> = ({
                       })
                     }
                   >
-                    {intl.formatMessage(messages.Edit)}
+                    {intl.formatMessage(messages.edit)}
                   </DropdownItem>
                 </ReadOnlyTooltip>,
                 <ReadOnlyTooltip key="delete" isDisabled={!isWritePermission}>
@@ -150,7 +150,7 @@ const Header: React.FunctionComponent<Props> = ({
                       })
                     }
                   >
-                    {intl.formatMessage(messages.Delete)}
+                    {intl.formatMessage(messages.delete)}
                   </DropdownItem>
                 </ReadOnlyTooltip>,
               ]}
@@ -159,9 +159,9 @@ const Header: React.FunctionComponent<Props> = ({
         </Split>
         <TextContent style={styles.currency}>
           <TextList component={TextListVariants.dl}>
-            <TextListItem component={TextListItemVariants.dt}>{intl.formatMessage(messages.Currency)}</TextListItem>
+            <TextListItem component={TextListItemVariants.dt}>{intl.formatMessage(messages.currency)}</TextListItem>
             <TextListItem component={TextListItemVariants.dd}>
-              {intl.formatMessage(messages.CurrencyOptions, { units: current.currency || 'USD' })}
+              {intl.formatMessage(messages.currencyOptions, { units: current.currency || 'USD' })}
             </TextListItem>
           </TextList>
         </TextContent>
@@ -169,19 +169,19 @@ const Header: React.FunctionComponent<Props> = ({
           <Tabs activeKey={tabIndex} onSelect={(_evt, index: number) => onSelectTab(index)}>
             <Tab
               eventKey={0}
-              title={<TabTitleText>{intl.formatMessage(messages.PriceList)}</TabTitleText>}
+              title={<TabTitleText>{intl.formatMessage(messages.priceList)}</TabTitleText>}
               tabContentId="refPriceList"
               tabContentRef={tabRefs[0]}
             />
             <Tab
               eventKey={1}
-              title={<TabTitleText>{intl.formatMessage(messages.CostCalculations)}</TabTitleText>}
+              title={<TabTitleText>{intl.formatMessage(messages.costCalculations)}</TabTitleText>}
               tabContentId="refMarkup"
               tabContentRef={tabRefs[1]}
             />
             <Tab
               eventKey={2}
-              title={<TabTitleText>{intl.formatMessage(messages.Sources)}</TabTitleText>}
+              title={<TabTitleText>{intl.formatMessage(messages.sources)}</TabTitleText>}
               tabContentId="refSources"
               tabContentRef={tabRefs[2]}
             />
@@ -190,13 +190,13 @@ const Header: React.FunctionComponent<Props> = ({
           <Tabs activeKey={tabIndex} onSelect={(_evt, index: number) => onSelectTab(index)}>
             <Tab
               eventKey={0}
-              title={<TabTitleText>{intl.formatMessage(messages.CostCalculations)}</TabTitleText>}
+              title={<TabTitleText>{intl.formatMessage(messages.costCalculations)}</TabTitleText>}
               tabContentId="refMarkup"
               tabContentRef={tabRefs[0]}
             />
             <Tab
               eventKey={1}
-              title={<TabTitleText>{intl.formatMessage(messages.Sources)}</TabTitleText>}
+              title={<TabTitleText>{intl.formatMessage(messages.sources)}</TabTitleText>}
               tabContentId="refSources"
               tabContentRef={tabRefs[1]}
             />

--- a/src/pages/costModels/costModel/index.tsx
+++ b/src/pages/costModels/costModel/index.tsx
@@ -76,7 +76,7 @@ class CostModelInformation extends React.Component<Props, State> {
       rbacStatus !== FetchStatus.complete ||
       costModelStatus !== FetchStatus.complete
     ) {
-      return <Loading title={intl.formatMessage(messages.CostModels)} />;
+      return <Loading title={intl.formatMessage(messages.costModels)} />;
     }
 
     const fetchError = metricsError || rbacError || costModelError;
@@ -87,16 +87,16 @@ class CostModelInformation extends React.Component<Props, State> {
           return (
             <>
               <PageHeader>
-                <PageHeaderTitle title={intl.formatMessage(messages.CostModels)} />
+                <PageHeaderTitle title={intl.formatMessage(messages.costModels)} />
               </PageHeader>
               <Main>
                 <EmptyState>
                   <EmptyStateIcon icon={ErrorCircleOIcon} />
                   <Title headingLevel="h2" size={TitleSizes.lg}>
-                    {intl.formatMessage(messages.CostModelsUUIDEmptyState)}
+                    {intl.formatMessage(messages.costModelsUUIDEmptyState)}
                   </Title>
                   <EmptyStateBody>
-                    {intl.formatMessage(messages.CostModelsUUIDEmptyStateDesc, {
+                    {intl.formatMessage(messages.costModelsUUIDEmptyStateDesc, {
                       uuid: this.props.match.params.uuid,
                     })}
                   </EmptyStateBody>
@@ -106,7 +106,7 @@ class CostModelInformation extends React.Component<Props, State> {
           );
         }
       }
-      return <NotAvailable title={intl.formatMessage(messages.CostModels)} />;
+      return <NotAvailable title={intl.formatMessage(messages.costModels)} />;
     }
 
     const current = costModels[0];

--- a/src/pages/costModels/costModel/markup.tsx
+++ b/src/pages/costModels/costModel/markup.tsx
@@ -51,7 +51,7 @@ const MarkupCardBase: React.FunctionComponent<Props> = ({
         <CardHeader>
           <CardHeaderMain>
             <Title headingLevel="h2" size={TitleSizes.md}>
-              {intl.formatMessage(messages.MarkupOrDiscount)}
+              {intl.formatMessage(messages.markupOrDiscount)}
             </Title>
           </CardHeaderMain>
           <CardActions>
@@ -68,16 +68,16 @@ const MarkupCardBase: React.FunctionComponent<Props> = ({
                     onClick={() => setCostModelDialog({ isOpen: true, name: 'updateMarkup' })}
                     component="button"
                   >
-                    {intl.formatMessage(messages.EditMarkup)}
+                    {intl.formatMessage(messages.editMarkup)}
                   </DropdownItem>
                 </ReadOnlyTooltip>,
               ]}
             />
           </CardActions>
         </CardHeader>
-        <CardBody style={styles.cardDescription}>{intl.formatMessage(messages.MarkupOrDiscountDesc)}</CardBody>
+        <CardBody style={styles.cardDescription}>{intl.formatMessage(messages.markupOrDiscountDesc)}</CardBody>
         <CardBody isFilled />
-        <CardBody style={styles.cardBody}>{intl.formatMessage(messages.Percent, { value: markupValue })}</CardBody>
+        <CardBody style={styles.cardBody}>{intl.formatMessage(messages.percent, { value: markupValue })}</CardBody>
         <CardBody isFilled />
       </Card>
     </>

--- a/src/pages/costModels/costModel/priceListTable.tsx
+++ b/src/pages/costModels/costModel/priceListTable.tsx
@@ -92,12 +92,12 @@ class PriceListTable extends React.Component<Props, State> {
     const getMetricLabel = m => {
       // Match message descriptor or default to API string
       const value = m.replace(/ /g, '_').toLowerCase();
-      const label = intl.formatMessage(messages.MetricValues, { value });
+      const label = intl.formatMessage(messages.metricValues, { value });
       return label ? label : m;
     };
     const getMeasurementLabel = m => {
       // Match message descriptor or default to API string
-      const label = intl.formatMessage(messages.MeasurementValues, {
+      const label = intl.formatMessage(messages.measurementValues, {
         value: m.toLowerCase().replace('-', '_'),
         count: 1,
       });
@@ -127,7 +127,7 @@ class PriceListTable extends React.Component<Props, State> {
         <Dialog
           isSmall
           isOpen={isDialogOpen.deleteRate}
-          title={intl.formatMessage(messages.PriceListDeleteRate)}
+          title={intl.formatMessage(messages.priceListDeleteRate)}
           onClose={() => {
             this.props.setDialogOpen({ name: 'deleteRate', isOpen: false });
             this.setState({ deleteRate: null });
@@ -146,7 +146,7 @@ class PriceListTable extends React.Component<Props, State> {
           }}
           body={
             <>
-              {intl.formatMessage(messages.PriceListDeleteRateDesc, {
+              {intl.formatMessage(messages.priceListDeleteRateDesc, {
                 metric: <b>{metric}</b>,
                 costModel: <b>{cm}</b>,
                 count: showAssignees ? 2 : 1,
@@ -160,14 +160,14 @@ class PriceListTable extends React.Component<Props, State> {
               )}
             </>
           }
-          actionText={intl.formatMessage(messages.PriceListDeleteRate)}
+          actionText={intl.formatMessage(messages.priceListDeleteRate)}
         />
         <WithPriceListSearch initialFilters={{ primary: 'metrics', metrics: [], measurements: [] }}>
           {({ search, setSearch, onRemove, onSelect, onClearAll }) => {
-            const getMetric = value => intl.formatMessage(messages.MetricValues, { value }) || value;
+            const getMetric = value => intl.formatMessage(messages.metricValues, { value }) || value;
             const getMeasurement = (measurement, units) => {
-              units = intl.formatMessage(messages.Units, { units: unitsLookupKey(units) }) || units;
-              return intl.formatMessage(messages.MeasurementValues, {
+              units = intl.formatMessage(messages.units, { units: unitsLookupKey(units) }) || units;
+              return intl.formatMessage(messages.measurementValues, {
                 value: measurement.toLowerCase().replace('-', '_'),
                 units,
                 count: 2,
@@ -201,11 +201,11 @@ class PriceListTable extends React.Component<Props, State> {
                       setPrimary={(primary: string) => setSearch({ primary })}
                       options={[
                         {
-                          label: intl.formatMessage(messages.Metric),
+                          label: intl.formatMessage(messages.metric),
                           value: 'metrics',
                         },
                         {
-                          label: intl.formatMessage(messages.Measurement),
+                          label: intl.formatMessage(messages.measurement),
                           value: 'measurements',
                         },
                       ]}
@@ -217,7 +217,7 @@ class PriceListTable extends React.Component<Props, State> {
                       component: (
                         <CheckboxSelector
                           isDisabled={this.props.current.rates.length === 0}
-                          placeholderText={intl.formatMessage(messages.MeasurementPlaceholder)}
+                          placeholderText={intl.formatMessage(messages.measurementPlaceholder)}
                           selections={search.measurements}
                           setSelections={(selection: string) => onSelect('measurements', selection)}
                           options={measurementOpts}
@@ -231,7 +231,7 @@ class PriceListTable extends React.Component<Props, State> {
                       component: (
                         <CheckboxSelector
                           isDisabled={this.props.current.rates.length === 0}
-                          placeholderText={intl.formatMessage(messages.MetricPlaceholder)}
+                          placeholderText={intl.formatMessage(messages.metricPlaceholder)}
                           selections={search.metrics}
                           setSelections={(selection: string) => onSelect('metrics', selection)}
                           options={metricOpts}
@@ -252,7 +252,7 @@ class PriceListTable extends React.Component<Props, State> {
                         })
                       }
                     >
-                      {intl.formatMessage(messages.PriceListAddRate)}
+                      {intl.formatMessage(messages.priceListAddRate)}
                     </Button>
                   }
                   onClear={onClearAll}
@@ -284,9 +284,9 @@ class PriceListTable extends React.Component<Props, State> {
                       <EmptyState>
                         <EmptyStateIcon icon={FileInvoiceDollarIcon} />
                         <Title headingLevel="h2" size={TitleSizes.lg}>
-                          {intl.formatMessage(messages.PriceListEmptyRate)}
+                          {intl.formatMessage(messages.priceListEmptyRate)}
                         </Title>
-                        <EmptyStateBody>{intl.formatMessage(messages.PriceListEmptyRateDesc)}</EmptyStateBody>
+                        <EmptyStateBody>{intl.formatMessage(messages.priceListEmptyRateDesc)}</EmptyStateBody>
                       </EmptyState>
                     </Bullseye>
                   )}
@@ -295,12 +295,12 @@ class PriceListTable extends React.Component<Props, State> {
                     <RateTable
                       actions={[
                         {
-                          title: intl.formatMessage(messages.PriceListEditRate),
+                          title: intl.formatMessage(messages.priceListEditRate),
                           isDisabled: !isWritePermission,
                           // HACK: to display tooltip on disable
                           style: !isWritePermission ? { pointerEvents: 'auto' } : undefined,
                           tooltip: !isWritePermission ? (
-                            <div>{intl.formatMessage(messages.CostModelsReadOnly)}</div>
+                            <div>{intl.formatMessage(messages.costModelsReadOnly)}</div>
                           ) : undefined,
                           onClick: (_evt, _rowIndex, rowData) => {
                             this.setState({
@@ -314,12 +314,12 @@ class PriceListTable extends React.Component<Props, State> {
                           },
                         },
                         {
-                          title: intl.formatMessage(messages.Delete),
+                          title: intl.formatMessage(messages.delete),
                           isDisabled: !isWritePermission,
                           // HACK: to display tooltip on disable
                           style: !isWritePermission ? { pointerEvents: 'auto' } : {},
                           tooltip: !isWritePermission ? (
-                            <div>{intl.formatMessage(messages.CostModelsReadOnly)}</div>
+                            <div>{intl.formatMessage(messages.costModelsReadOnly)}</div>
                           ) : undefined,
                           onClick: (_evt, _rowIndex, rowData) => {
                             const rowIndex = rowData.data.index;

--- a/src/pages/costModels/costModel/sourceTable.tsx
+++ b/src/pages/costModels/costModel/sourceTable.tsx
@@ -52,7 +52,7 @@ class SourceTableBase extends React.Component<Props, State> {
         <Dialog
           isSmall
           isOpen={isDialogOpen.deleteSource}
-          title={intl.formatMessage(messages.CostModelsSourceDeleteSource)}
+          title={intl.formatMessage(messages.costModelsSourceDeleteSource)}
           onClose={() => {
             setDialogOpen({ name: 'deleteSource', isOpen: false });
             this.setState({ dialogSource: null });
@@ -70,16 +70,16 @@ class SourceTableBase extends React.Component<Props, State> {
           }}
           body={
             <>
-              {intl.formatMessage(messages.CostModelsSourceDeleteSourceDesc, {
+              {intl.formatMessage(messages.costModelsSourceDeleteSourceDesc, {
                 source: this.state.dialogSource,
                 costModel: costModel.name,
               })}
             </>
           }
-          actionText={intl.formatMessage(messages.CostModelsSourceDeleteSource)}
+          actionText={intl.formatMessage(messages.costModelsSourceDeleteSource)}
         />
         <Table
-          onDeleteText={intl.formatMessage(messages.CostModelsSourceDelete)}
+          onDeleteText={intl.formatMessage(messages.costModelsSourceDelete)}
           onDelete={item => {
             this.setState({ dialogSource: item[0] });
             setDialogOpen({ name: 'deleteSource', isOpen: true });

--- a/src/pages/costModels/costModel/sourcesTable.tsx
+++ b/src/pages/costModels/costModel/sourcesTable.tsx
@@ -23,7 +23,7 @@ const SourcesTable: React.FunctionComponent<SourcesTableProps> = ({ canWrite, co
     if (canWrite) {
       return [
         {
-          title: intl.formatMessage(messages.CostModelsSourceDelete),
+          title: intl.formatMessage(messages.costModelsSourceDelete),
           onClick: (_evt, rowIndex: number) => showDeleteDialog(rowIndex),
         },
       ];
@@ -31,21 +31,21 @@ const SourcesTable: React.FunctionComponent<SourcesTableProps> = ({ canWrite, co
     return [
       {
         style: { pointerEvents: 'auto' },
-        tooltip: intl.formatMessage(messages.CostModelsReadOnly),
+        tooltip: intl.formatMessage(messages.costModelsReadOnly),
         isDisabled: true,
-        title: intl.formatMessage(messages.CostModelsSourceDelete),
+        title: intl.formatMessage(messages.costModelsSourceDelete),
       },
     ];
   };
 
   const actions = getActions();
-  const cells = [intl.formatMessage(messages.Names, { count: 1 })] as (string | ICell)[];
+  const cells = [intl.formatMessage(messages.names, { count: 1 })] as (string | ICell)[];
   const rows: (IRow | string[])[] = costModels.length > 0 ? costModels[0].sources.map(source => [source.name]) : [];
 
   return (
     <Table
       actions={actions}
-      aria-label={intl.formatMessage(messages.CostModelsSourceTableAriaLabel)}
+      aria-label={intl.formatMessage(messages.costModelsSourceTableAriaLabel)}
       cells={cells}
       gridBreakPoint={TableGridBreakpoint.grid2xl}
       rows={rows}

--- a/src/pages/costModels/costModel/table.tsx
+++ b/src/pages/costModels/costModel/table.tsx
@@ -64,13 +64,13 @@ class TableBase extends React.Component<Props, State> {
     return (
       <>
         <Title headingLevel="h2" size={TitleSizes.md} style={styles.sourceTypeTitle}>
-          {intl.formatMessage(messages.CostModelsSourceType)}: {current.source_type}
+          {intl.formatMessage(messages.costModelsSourceType)}: {current.source_type}
         </Title>
         <SourcesToolbar
           actionButtonProps={{
             isDisabled: !isWritePermission,
             onClick: onAdd,
-            children: intl.formatMessage(messages.CostModelsAssignSources, { count: 1 }),
+            children: intl.formatMessage(messages.costModelsAssignSources, { count: 1 }),
           }}
           filter={{
             onClearAll: () =>
@@ -85,7 +85,7 @@ class TableBase extends React.Component<Props, State> {
               });
             },
             query: this.state.query,
-            categoryNames: { name: intl.formatMessage(messages.Names, { count: 1 }) },
+            categoryNames: { name: intl.formatMessage(messages.names, { count: 1 }) },
           }}
           filterInputProps={{
             id: 'sources-tab-toolbar',
@@ -102,7 +102,7 @@ class TableBase extends React.Component<Props, State> {
               });
             },
             value: this.state.currentFilter,
-            placeholder: intl.formatMessage(messages.CostModelsFilterPlaceholder),
+            placeholder: intl.formatMessage(messages.costModelsFilterPlaceholder),
           }}
         />
         {res.length > 0 && (
@@ -117,14 +117,14 @@ class TableBase extends React.Component<Props, State> {
             <EmptyState>
               <EmptyStateIcon icon={DollarSignIcon} />
               <Title headingLevel="h2" size={TitleSizes.lg}>
-                {intl.formatMessage(messages.CostModelsSourceEmptyStateDesc)}
+                {intl.formatMessage(messages.costModelsSourceEmptyStateDesc)}
               </Title>
-              <EmptyStateBody>{intl.formatMessage(messages.CostModelsSourceEmptyStateTitle)}</EmptyStateBody>
+              <EmptyStateBody>{intl.formatMessage(messages.costModelsSourceEmptyStateTitle)}</EmptyStateBody>
             </EmptyState>
           </div>
         )}
         {filteredRows.length === 0 && rows.length > 0 && (
-          <EmptyFilterState filter={this.state.filter} subTitle={messages.EmptyFilterSourceStateSubtitle} />
+          <EmptyFilterState filter={this.state.filter} subTitle={messages.emptyFilterSourceStateSubtitle} />
         )}
       </>
     );

--- a/src/pages/costModels/costModel/updateCostModel.tsx
+++ b/src/pages/costModels/costModel/updateCostModel.tsx
@@ -35,7 +35,7 @@ class UpdateCostModelBase extends React.Component<Props, State> {
     const current = costModel[0];
     return (
       <Modal
-        title={intl.formatMessage(messages.EditCostModel)}
+        title={intl.formatMessage(messages.editCostModel)}
         isOpen
         onClose={() => setDialogOpen({ name: 'updateCostModel', isOpen: false })}
         variant="small"
@@ -61,7 +61,7 @@ class UpdateCostModelBase extends React.Component<Props, State> {
               isProcessing || (this.state.name === current.name && this.state.description === current.description)
             }
           >
-            {intl.formatMessage(messages.Save)}
+            {intl.formatMessage(messages.save)}
           </Button>,
           <Button
             key="cancel"
@@ -69,14 +69,14 @@ class UpdateCostModelBase extends React.Component<Props, State> {
             onClick={() => setDialogOpen({ name: 'updateCostModel', isOpen: false })}
             isDisabled={isProcessing}
           >
-            {intl.formatMessage(messages.Cancel)}
+            {intl.formatMessage(messages.cancel)}
           </Button>,
         ]}
       >
         <>
           {updateError && <Alert variant="danger" title={`${updateError}`} />}
           <Form>
-            <FormGroup label={intl.formatMessage(messages.Names, { count: 1 })} isRequired fieldId="name">
+            <FormGroup label={intl.formatMessage(messages.names, { count: 1 })} isRequired fieldId="name">
               <TextInput
                 isRequired
                 type="text"
@@ -86,7 +86,7 @@ class UpdateCostModelBase extends React.Component<Props, State> {
                 onChange={value => this.setState({ name: value })}
               />
             </FormGroup>
-            <FormGroup label={intl.formatMessage(messages.Description)} fieldId="description">
+            <FormGroup label={intl.formatMessage(messages.description)} fieldId="description">
               <TextArea
                 type="text"
                 id="description"

--- a/src/pages/costModels/costModel/updateDistributionDialog.tsx
+++ b/src/pages/costModels/costModel/updateDistributionDialog.tsx
@@ -50,7 +50,7 @@ class UpdateDistributionModelBase extends React.Component<Props, State> {
     const { error, current, intl, isLoading, onClose, updateCostModel } = this.props;
     return (
       <Modal
-        title={intl.formatMessage(messages.DistributionType)}
+        title={intl.formatMessage(messages.distributionType)}
         isOpen
         onClose={() => onClose({ name: 'updateDistribution', isOpen: false })}
         variant={ModalVariant.small}
@@ -69,7 +69,7 @@ class UpdateDistributionModelBase extends React.Component<Props, State> {
               updateCostModel(current.uuid, newState, 'updateDistribution');
             }}
           >
-            {intl.formatMessage(messages.Save)}
+            {intl.formatMessage(messages.save)}
           </Button>,
           <Button
             key="cancel"
@@ -77,7 +77,7 @@ class UpdateDistributionModelBase extends React.Component<Props, State> {
             onClick={() => onClose({ name: 'updateDistribution', isOpen: false })}
             isDisabled={isLoading}
           >
-            {intl.formatMessage(messages.Cancel)}
+            {intl.formatMessage(messages.cancel)}
           </Button>,
         ]}
       >
@@ -85,7 +85,7 @@ class UpdateDistributionModelBase extends React.Component<Props, State> {
           <StackItem>{error && <Alert variant="danger" title={`${error}`} />}</StackItem>
           <StackItem>
             <TextContent>
-              <Text style={styles.cardDescription}>{intl.formatMessage(messages.DistributionModelDesc)}</Text>
+              <Text style={styles.cardDescription}>{intl.formatMessage(messages.distributionModelDesc)}</Text>
             </TextContent>
           </StackItem>
           <StackItem>
@@ -94,8 +94,8 @@ class UpdateDistributionModelBase extends React.Component<Props, State> {
                 <Radio
                   isChecked={this.state.distribution === 'cpu'}
                   name="distribution"
-                  label={intl.formatMessage(messages.CpuTitle)}
-                  aria-label={intl.formatMessage(messages.CpuTitle)}
+                  label={intl.formatMessage(messages.cpuTitle)}
+                  aria-label={intl.formatMessage(messages.cpuTitle)}
                   id="cpuDistribution"
                   value="cpu"
                   onChange={this.handleDistributionChange}
@@ -103,8 +103,8 @@ class UpdateDistributionModelBase extends React.Component<Props, State> {
                 <Radio
                   isChecked={this.state.distribution === 'memory'}
                   name="distribution"
-                  label={intl.formatMessage(messages.MemoryTitle)}
-                  aria-label={intl.formatMessage(messages.MemoryTitle)}
+                  label={intl.formatMessage(messages.memoryTitle)}
+                  aria-label={intl.formatMessage(messages.memoryTitle)}
                   id="memoryDistribution"
                   value="memory"
                   onChange={this.handleDistributionChange}

--- a/src/pages/costModels/costModel/updateMarkupDialog.tsx
+++ b/src/pages/costModels/costModel/updateMarkupDialog.tsx
@@ -78,12 +78,12 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
     const { markup } = this.state;
 
     if (!isPercentageFormatValid(markup)) {
-      return messages.MarkupOrDiscountNumber;
+      return messages.markupOrDiscountNumber;
     }
     // Test number of decimals
     const decimals = countDecimals(markup);
     if (decimals > 10) {
-      return messages.MarkupOrDiscountTooLong;
+      return messages.markupOrDiscountTooLong;
     }
     return undefined;
   };
@@ -98,7 +98,7 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
 
     return (
       <Modal
-        title={intl.formatMessage(messages.EditMarkupOrDiscount)}
+        title={intl.formatMessage(messages.editMarkupOrDiscount)}
         isOpen
         onClose={() => onClose({ name: 'updateMarkup', isOpen: false })}
         variant={ModalVariant.medium}
@@ -125,7 +125,7 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
               Number(markup) === Number(current.markup.value)
             }
           >
-            {intl.formatMessage(messages.Save)}
+            {intl.formatMessage(messages.save)}
           </Button>,
           <Button
             key="cancel"
@@ -133,7 +133,7 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
             onClick={() => onClose({ name: 'updateMarkup', isOpen: false })}
             isDisabled={isLoading}
           >
-            {intl.formatMessage(messages.Cancel)}
+            {intl.formatMessage(messages.cancel)}
           </Button>,
         ]}
       >
@@ -141,13 +141,13 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
           <StackItem>{error && <Alert variant="danger" title={`${error}`} />}</StackItem>
           <StackItem>
             <TextContent>
-              <Text style={styles.cardDescription}>{intl.formatMessage(messages.MarkupOrDiscountModalDesc)}</Text>
+              <Text style={styles.cardDescription}>{intl.formatMessage(messages.markupOrDiscountModalDesc)}</Text>
             </TextContent>
           </StackItem>
           <StackItem>
             <TextContent>
               <Title headingLevel="h2" size="md">
-                {intl.formatMessage(messages.MarkupOrDiscount)}
+                {intl.formatMessage(messages.markupOrDiscount)}
               </Title>
             </TextContent>
             <Flex style={styles.markupRadioContainer}>
@@ -156,8 +156,8 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
                   <Radio
                     isChecked={!isDiscount}
                     name="discount"
-                    label={intl.formatMessage(messages.MarkupPlus)}
-                    aria-label={intl.formatMessage(messages.MarkupPlus)}
+                    label={intl.formatMessage(messages.markupPlus)}
+                    aria-label={intl.formatMessage(messages.markupPlus)}
                     id="markup"
                     value="false" // "+"
                     onChange={this.handleSignChange}
@@ -166,8 +166,8 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
                   <Radio
                     isChecked={isDiscount}
                     name="discount"
-                    label={intl.formatMessage(messages.DiscountMinus)}
-                    aria-label={intl.formatMessage(messages.DiscountMinus)}
+                    label={intl.formatMessage(messages.discountMinus)}
+                    aria-label={intl.formatMessage(messages.discountMinus)}
                     id="discount"
                     value="true" // '-'
                     onChange={this.handleSignChange}
@@ -186,11 +186,11 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
                       <InputGroup>
                         <InputGroupText style={styles.sign}>
                           {isDiscount
-                            ? intl.formatMessage(messages.DiscountMinus)
-                            : intl.formatMessage(messages.MarkupPlus)}
+                            ? intl.formatMessage(messages.discountMinus)
+                            : intl.formatMessage(messages.markupPlus)}
                         </InputGroupText>
                         <TextInput
-                          aria-label={intl.formatMessage(messages.Rate)}
+                          aria-label={intl.formatMessage(messages.rate)}
                           id="markup-input-box"
                           isRequired
                           onKeyDown={this.handleOnKeyDown}
@@ -202,7 +202,7 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
                           value={this.state.markup}
                         />
                         <InputGroupText style={styles.percent}>
-                          {intl.formatMessage(messages.PercentSymbol)}
+                          {intl.formatMessage(messages.percentSymbol)}
                         </InputGroupText>
                       </InputGroup>
                     </FormGroup>
@@ -215,14 +215,14 @@ class UpdateMarkupModelBase extends React.Component<Props, State> {
           <StackItem>
             <TextContent>
               <Title headingLevel="h3" size="md">
-                {intl.formatMessage(messages.ExamplesTitle)}
+                {intl.formatMessage(messages.examplesTitle)}
               </Title>
             </TextContent>
             <List>
-              <ListItem>{intl.formatMessage(messages.CostModelsExamplesNoAdjust)}</ListItem>
-              <ListItem>{intl.formatMessage(messages.CostModelsExamplesDoubleMarkup)}</ListItem>
-              <ListItem>{intl.formatMessage(messages.CostModelsExamplesReduceZero)}</ListItem>
-              <ListItem>{intl.formatMessage(messages.CostModelsExamplesReduceSeventyfive)}</ListItem>
+              <ListItem>{intl.formatMessage(messages.costModelsExamplesNoAdjust)}</ListItem>
+              <ListItem>{intl.formatMessage(messages.costModelsExamplesDoubleMarkup)}</ListItem>
+              <ListItem>{intl.formatMessage(messages.costModelsExamplesReduceZero)}</ListItem>
+              <ListItem>{intl.formatMessage(messages.costModelsExamplesReduceSeventyfive)}</ListItem>
             </List>
           </StackItem>
         </Stack>

--- a/src/pages/costModels/costModel/updateRateModel.test.tsx
+++ b/src/pages/costModels/costModel/updateRateModel.test.tsx
@@ -260,15 +260,15 @@ describe('update-rate', () => {
     render(<RenderFormDataUI index={0} />);
     userEvent.type(screen.getByDisplayValue(/openshift-aws-node/i), 'a new description');
     // eslint-disable-next-line testing-library/prefer-presence-queries
-    expect(screen.getByText(regExp(messages.Save)).getAttribute('disabled')).toBeNull();
-    userEvent.click(screen.getByText(regExp(messages.Save)));
+    expect(screen.getByText(regExp(messages.save)).getAttribute('disabled')).toBeNull();
+    userEvent.click(screen.getByText(regExp(messages.save)));
   });
 
   test('regular', async () => {
     let options = null;
     render(<RenderFormDataUI index={0} />);
     const descInput = screen.getByDisplayValue('openshift-aws-node');
-    const saveButton = screen.getByText(regExp(messages.Save));
+    const saveButton = screen.getByText(regExp(messages.save));
     expect(saveButton.getAttribute('disabled')).not.toBeNull();
     userEvent.clear(descInput);
     userEvent.type(descInput, 'a new description');
@@ -319,18 +319,18 @@ describe('update-rate', () => {
     userEvent.type(screen.getByDisplayValue(/55.3/i), '{backspace}{backspace}');
     expect(saveButton.getAttribute('disabled')).not.toBeNull();
 
-    userEvent.click(screen.getByLabelText(regExp(messages.CostModelsEnterTagRate)));
+    userEvent.click(screen.getByLabelText(regExp(messages.costModelsEnterTagRate)));
     expect(saveButton.getAttribute('disabled')).not.toBeNull();
-    userEvent.type(screen.getByLabelText(regExp(messages.CostModelsFilterTagKey)), 'openshift');
-    userEvent.type(screen.getByLabelText(regExp(messages.CostModelsTagRateTableValue)), 'worker');
-    userEvent.type(screen.getByLabelText(regExp(messages.Rate)), '0.321');
+    userEvent.type(screen.getByLabelText(regExp(messages.costModelsFilterTagKey)), 'openshift');
+    userEvent.type(screen.getByLabelText(regExp(messages.costModelsTagRateTableValue)), 'worker');
+    userEvent.type(screen.getByLabelText(regExp(messages.rate)), '0.321');
     expect(saveButton.getAttribute('disabled')).toBeNull();
     userEvent.click(saveButton);
   });
 
   test('tag', () => {
     render(<RenderFormDataUI index={1} />);
-    const saveButton = screen.getByText(regExp(messages.Save));
+    const saveButton = screen.getByText(regExp(messages.save));
     expect(saveButton.getAttribute('disabled')).not.toBeNull();
     userEvent.type(screen.getByDisplayValue(/^container$/i), '1');
     expect(saveButton.getAttribute('disabled')).toBeNull();
@@ -347,16 +347,16 @@ describe('update-rate', () => {
     userEvent.type(screen.getByDisplayValue(/^0.43$/i), '{backspace}');
     expect(saveButton.getAttribute('disabled')).not.toBeNull();
 
-    userEvent.click(screen.getAllByLabelText(regExp(messages.CostModelsTagRateTableDefault))[1]);
+    userEvent.click(screen.getAllByLabelText(regExp(messages.costModelsTagRateTableDefault))[1]);
     expect(saveButton.getAttribute('disabled')).toBeNull();
-    userEvent.click(screen.getAllByLabelText(regExp(messages.CostModelsTagRateTableDefault))[0]);
+    userEvent.click(screen.getAllByLabelText(regExp(messages.costModelsTagRateTableDefault))[0]);
     expect(saveButton.getAttribute('disabled')).not.toBeNull();
 
     userEvent.click(screen.getByText(/Add more tag values/i));
-    userEvent.type(screen.getAllByLabelText(regExp(messages.CostModelsTagRateTableValue))[4], 'something random');
-    userEvent.type(screen.getAllByLabelText(regExp(messages.Rate))[4], '1.01');
+    userEvent.type(screen.getAllByLabelText(regExp(messages.costModelsTagRateTableValue))[4], 'something random');
+    userEvent.type(screen.getAllByLabelText(regExp(messages.rate))[4], '1.01');
     expect(saveButton.getAttribute('disabled')).toBeNull();
-    userEvent.click(screen.getAllByLabelText(regExp(messages.CostModelsRemoveTagLabel))[4]);
+    userEvent.click(screen.getAllByLabelText(regExp(messages.costModelsRemoveTagLabel))[4]);
     expect(saveButton.getAttribute('disabled')).not.toBeNull();
 
     userEvent.type(screen.getByDisplayValue(/openshift-region-1/i), '2');
@@ -373,16 +373,16 @@ describe('update-rate', () => {
     options = await screen.findAllByRole('option');
     userEvent.click(options[1]);
 
-    userEvent.click(screen.getByLabelText(regExp(messages.CostModelsEnterTagRate)));
-    userEvent.type(screen.getByLabelText(regExp(messages.CostModelsFilterTagKey)), 'openshift-region-1');
-    expect(screen.getByText(regExp(messages.PriceListDuplicate))).not.toBeNull();
+    userEvent.click(screen.getByLabelText(regExp(messages.costModelsEnterTagRate)));
+    userEvent.type(screen.getByLabelText(regExp(messages.costModelsFilterTagKey)), 'openshift-region-1');
+    expect(screen.getByText(regExp(messages.priceListDuplicate))).not.toBeNull();
   });
 
   test('duplicate tag key from tag rate', () => {
     render(<RenderFormDataUI index={2} />);
-    const filterTagInput = screen.getByLabelText(regExp(messages.CostModelsFilterTagKey));
+    const filterTagInput = screen.getByLabelText(regExp(messages.costModelsFilterTagKey));
     userEvent.clear(filterTagInput);
     userEvent.type(filterTagInput, 'openshift-region-1');
-    expect(screen.getByText(regExp(messages.PriceListDuplicate))).not.toBeNull();
+    expect(screen.getByText(regExp(messages.priceListDuplicate))).not.toBeNull();
   });
 });

--- a/src/pages/costModels/costModel/updateRateModel.tsx
+++ b/src/pages/costModels/costModel/updateRateModel.tsx
@@ -95,7 +95,7 @@ const UpdateRateModalBase: React.FunctionComponent<UpdateRateModalBaseProps> = (
 
   return (
     <Modal
-      title={intl.formatMessage(messages.PriceListEditRate)}
+      title={intl.formatMessage(messages.priceListEditRate)}
       isOpen={isOpen}
       onClose={onClose}
       variant="large"
@@ -106,10 +106,10 @@ const UpdateRateModalBase: React.FunctionComponent<UpdateRateModalBaseProps> = (
           onClick={onProceed}
           isDisabled={!canSubmit || isProcessing || !gotDiffs}
         >
-          {intl.formatMessage(messages.Save)}
+          {intl.formatMessage(messages.save)}
         </Button>,
         <Button key="cancel" variant="link" onClick={onClose} isDisabled={isProcessing}>
-          {intl.formatMessage(messages.Cancel)}
+          {intl.formatMessage(messages.cancel)}
         </Button>,
       ]}
     >

--- a/src/pages/costModels/costModelsDetails/createCostModelButton.tsx
+++ b/src/pages/costModels/costModelsDetails/createCostModelButton.tsx
@@ -35,10 +35,10 @@ const buttonMergeProps = (
 
   return {
     isDisabled: !canWrite,
-    tooltip: intl.formatMessage(messages.CostModelsReadOnly),
+    tooltip: intl.formatMessage(messages.costModelsReadOnly),
     children: (
       <Button isDisabled={!canWrite} onClick={openWizard}>
-        {intl.formatMessage(messages.CostModelsWizardCreateCostModel)}
+        {intl.formatMessage(messages.costModelsWizardCreateCostModel)}
       </Button>
     ),
   };

--- a/src/pages/costModels/costModelsDetails/dialog.test.tsx
+++ b/src/pages/costModels/costModelsDetails/dialog.test.tsx
@@ -62,11 +62,11 @@ test('delete dialog open', () => {
     },
   };
   renderUI(state);
-  expect(screen.queryAllByText(regExp(messages.CostModelsDelete))).toHaveLength(2);
+  expect(screen.queryAllByText(regExp(messages.costModelsDelete))).toHaveLength(2);
   expect(screen.queryAllByText(/This action will delete/i)).toHaveLength(1);
   expect(screen.queryAllByText(/The following sources are assigned to/i)).toHaveLength(0);
-  userEvent.click(screen.getAllByText(regExp(messages.CostModelsDelete))[1]);
-  expect(screen.getAllByText(regExp(messages.CostModelsDelete))[1].getAttribute('disabled')).not.toBeNull();
+  userEvent.click(screen.getAllByText(regExp(messages.costModelsDelete))[1]);
+  expect(screen.getAllByText(regExp(messages.costModelsDelete))[1].getAttribute('disabled')).not.toBeNull();
 });
 
 test('delete dialog error', () => {
@@ -98,9 +98,9 @@ test('delete dialog error', () => {
     },
   };
   renderUI(state);
-  expect(screen.queryAllByText(regExp(messages.CostModelsDelete))).toHaveLength(1);
+  expect(screen.queryAllByText(regExp(messages.costModelsDelete))).toHaveLength(1);
   expect(screen.queryAllByText(/This action will delete/i)).toHaveLength(0);
   expect(screen.queryAllByText(/The following sources are assigned to/i)).toHaveLength(1);
-  userEvent.click(screen.getByText(regExp(messages.Cancel)));
-  expect(screen.queryAllByText(regExp(messages.CostModelsDelete))).toHaveLength(0);
+  userEvent.click(screen.getByText(regExp(messages.cancel)));
+  expect(screen.queryAllByText(regExp(messages.costModelsDelete))).toHaveLength(0);
 });

--- a/src/pages/costModels/costModelsDetails/dialog.tsx
+++ b/src/pages/costModels/costModelsDetails/dialog.tsx
@@ -39,9 +39,9 @@ const mergeProps = (
 
   const actions = DeleteDialogActions({
     status: stateName,
-    deleteText: intl.formatMessage(messages.CostModelsDelete),
+    deleteText: intl.formatMessage(messages.costModelsDelete),
     deleteAction: () => dispatchProps.deleteCostModel(uuid),
-    cancelText: intl.formatMessage(messages.Cancel),
+    cancelText: intl.formatMessage(messages.cancel),
     cancelAction: dispatchProps.closeDialog,
     sourcesNo: sources.length,
   });
@@ -50,17 +50,17 @@ const mergeProps = (
     status: stateName,
     sources,
     error: stateProps.deleteError,
-    cannotDeleteTitle: intl.formatMessage(messages.CostModelsDeleteSource),
-    cannotDeleteBody: intl.formatMessage(messages.CostModelsCanNotDelete, { name }),
-    canDeleteBody: intl.formatMessage(messages.CostModelsCanDelete, { name }),
+    cannotDeleteTitle: intl.formatMessage(messages.costModelsDeleteSource),
+    cannotDeleteBody: intl.formatMessage(messages.costModelsCanNotDelete, { name }),
+    canDeleteBody: intl.formatMessage(messages.costModelsCanDelete, { name }),
   });
 
   return {
     actions,
     isOpen: stateName !== 'close',
     variant: ModalVariant.small,
-    'aria-label': intl.formatMessage(messages.CostModelsDelete),
-    title: intl.formatMessage(messages.CostModelsDelete),
+    'aria-label': intl.formatMessage(messages.costModelsDelete),
+    title: intl.formatMessage(messages.costModelsDelete),
     titleIconVariant: 'warning',
     onClose: dispatchProps.closeDialog,
     children,

--- a/src/pages/costModels/costModelsDetails/header.tsx
+++ b/src/pages/costModels/costModelsDetails/header.tsx
@@ -29,13 +29,13 @@ const mapStateToProps = (state: RootState, ownProps: WrappedComponentProps) => {
 
   const children = (
     <>
-      {intl.formatMessage(messages.CostModels)}
+      {intl.formatMessage(messages.costModels)}
       <Popover
-        aria-label={intl.formatMessage(messages.CostModelsPopoverAriaLabel)}
-        bodyContent={intl.formatMessage(messages.CostModelsPopover, {
+        aria-label={intl.formatMessage(messages.costModelsPopoverAriaLabel)}
+        bodyContent={intl.formatMessage(messages.costModelsPopover, {
           learnMore: (
-            <a href={intl.formatMessage(messages.DocsUsingCostModels)} rel="noreferrer" target="_blank">
-              {intl.formatMessage(messages.LearnMore)}
+            <a href={intl.formatMessage(messages.docsUsingCostModels)} rel="noreferrer" target="_blank">
+              {intl.formatMessage(messages.learnMore)}
             </a>
           ),
         })}

--- a/src/pages/costModels/costModelsDetails/noCostModels.tsx
+++ b/src/pages/costModels/costModelsDetails/noCostModels.tsx
@@ -11,16 +11,16 @@ import EmptyStateBase from './emptyStateBase';
 // defaultIntl required for testing
 const NoCostModels = HookIntoProps(({ intl = defaultIntl }) => {
   return {
-    title: intl.formatMessage(messages.CostModelsEmptyState),
-    description: intl.formatMessage(messages.CostModelsEmptyStateDesc),
+    title: intl.formatMessage(messages.costModelsEmptyState),
+    description: intl.formatMessage(messages.costModelsEmptyStateDesc),
     icon: PlusCircleIcon,
     actions: (
       <>
         <CreateCostModelButton />
         <br />
         <br />
-        <a href={intl.formatMessage(messages.DocsConfigCostModels)} rel="noreferrer" target="_blank">
-          {intl.formatMessage(messages.CostModelsEmptyStateLearnMore)}
+        <a href={intl.formatMessage(messages.docsConfigCostModels)} rel="noreferrer" target="_blank">
+          {intl.formatMessage(messages.costModelsEmptyStateLearnMore)}
         </a>
       </>
     ),

--- a/src/pages/costModels/costModelsDetails/table.test.tsx
+++ b/src/pages/costModels/costModelsDetails/table.test.tsx
@@ -44,7 +44,7 @@ test('empty table', () => {
     },
   };
   renderUI(state);
-  expect(screen.queryAllByText(regExp(messages.CostModelsEmptyState))).toHaveLength(1);
+  expect(screen.queryAllByText(regExp(messages.costModelsEmptyState))).toHaveLength(1);
 });
 
 test('first page table', () => {

--- a/src/pages/costModels/costModelsDetails/table.tsx
+++ b/src/pages/costModels/costModelsDetails/table.tsx
@@ -50,19 +50,19 @@ class CostModelsTableBase extends React.Component<CostModelsTableProps> {
     const rows = getRowsByStateName(stateName, costData);
     const cells = [
       {
-        title: intl.formatMessage(messages.Names, { count: 1 }),
+        title: intl.formatMessage(messages.names, { count: 1 }),
         data: { orderName: 'name' },
         ...(rows.length && { transforms: [sortable] }),
       },
-      { title: intl.formatMessage(messages.Description) },
+      { title: intl.formatMessage(messages.description) },
       {
-        title: intl.formatMessage(messages.CostModelsSourceType),
+        title: intl.formatMessage(messages.costModelsSourceType),
         data: { orderName: 'source_type' },
         ...(rows.length && { transforms: [sortable] }),
       },
-      { title: intl.formatMessage(messages.CostModelsAssignedSources) },
+      { title: intl.formatMessage(messages.costModelsAssignedSources) },
       {
-        title: intl.formatMessage(messages.CostModelsLastChange),
+        title: intl.formatMessage(messages.costModelsLastChange),
         data: { orderName: 'updated_timestamp' },
         ...(rows.length && { transforms: [sortable] }),
       },
@@ -72,8 +72,8 @@ class CostModelsTableBase extends React.Component<CostModelsTableProps> {
     const onSort = createOnSort(cells, query, push);
     const actions = createActions(stateName, canWrite, [
       {
-        title: intl.formatMessage(messages.Delete),
-        tooltip: intl.formatMessage(messages.CostModelsReadOnly),
+        title: intl.formatMessage(messages.delete),
+        tooltip: intl.formatMessage(messages.costModelsReadOnly),
         onClick: (_evt: React.MouseEvent, _rowIx: number, rowData: IRowData) => {
           openDeleteDialog(rowData.data);
         },
@@ -90,7 +90,7 @@ class CostModelsTableBase extends React.Component<CostModelsTableProps> {
           cells={cells}
           onSort={onSort}
           sortBy={sortBy}
-          aria-label={intl.formatMessage(messages.CostModelsTableAriaLabel)}
+          aria-label={intl.formatMessage(messages.costModelsTableAriaLabel)}
         >
           <TableHeader />
           <TableBody />

--- a/src/pages/costModels/costModelsDetails/utils/filters.tsx
+++ b/src/pages/costModels/costModelsDetails/utils/filters.tsx
@@ -107,7 +107,7 @@ const descriptionMergeProps = (
   const children =
     filterType === 'description' ? (
       <FilterInput
-        placeholder={intl.formatMessage(messages.FilterByPlaceholder, { value: filterType })}
+        placeholder={intl.formatMessage(messages.filterByPlaceholder, { value: filterType })}
         value={value}
         onChange={(text: string) => setValue(text)}
         onKeyPress={onKeyPress(push, 'description', { ...initialCostModelsQuery, ...query }, { value, setValue })}
@@ -118,7 +118,7 @@ const descriptionMergeProps = (
     deleteChip: onDeleteChip(push, 'description', { ...initialCostModelsQuery, ...query }),
     deleteChipGroup: onDeleteChipGroup(push, { ...initialCostModelsQuery, ...query }, 'description'),
     chips,
-    categoryName: intl.formatMessage(messages.Description),
+    categoryName: intl.formatMessage(messages.description),
     children,
   } as ToolbarFilterProps;
 };
@@ -150,7 +150,7 @@ const nameFilterMergeProps = (
   const children =
     filterType === 'name' ? (
       <FilterInput
-        placeholder={intl.formatMessage(messages.FilterByPlaceholder, { value: filterType })}
+        placeholder={intl.formatMessage(messages.filterByPlaceholder, { value: filterType })}
         value={value}
         onChange={(text: string) => setValue(text)}
         onKeyPress={onKeyPress(push, 'name', { ...initialCostModelsQuery, ...query }, { value, setValue })}
@@ -161,7 +161,7 @@ const nameFilterMergeProps = (
     deleteChip: onDeleteChip(push, 'name', { ...initialCostModelsQuery, ...query }),
     deleteChipGroup: onDeleteChipGroup(push, { ...initialCostModelsQuery, ...query }, 'name'),
     chips,
-    categoryName: intl.formatMessage(messages.Names, { count: 1 }),
+    categoryName: intl.formatMessage(messages.names, { count: 1 }),
     children,
   } as ToolbarFilterProps;
 };
@@ -213,18 +213,18 @@ const sourceTypeFilterMergeProps = (
             }}
             id={id}
           >
-            {intl.formatMessage(messages.FilterByPlaceholder, { value: 'source_type' })}
+            {intl.formatMessage(messages.filterByPlaceholder, { value: 'source_type' })}
           </DropdownToggle>
         }
         dropdownItems={[
           <DropdownItem key="aws" component="button" onClick={() => onFilter('aws')}>
-            {intl.formatMessage(messages.AWS)}
+            {intl.formatMessage(messages.aws)}
           </DropdownItem>,
           <DropdownItem key="azure" component="button" onClick={() => onFilter('azure')}>
-            {intl.formatMessage(messages.Azure)}
+            {intl.formatMessage(messages.azure)}
           </DropdownItem>,
           <DropdownItem key="ocp" component="button" onClick={() => onFilter('ocp')}>
-            {intl.formatMessage(messages.OpenShift)}
+            {intl.formatMessage(messages.openShift)}
           </DropdownItem>,
         ]}
       />
@@ -233,7 +233,7 @@ const sourceTypeFilterMergeProps = (
   return {
     deleteChip: onDeleteChipGroup(push, { ...initialCostModelsQuery, ...query }, 'source_type'),
     chips,
-    categoryName: intl.formatMessage(messages.CostModelsSourceType),
+    categoryName: intl.formatMessage(messages.costModelsSourceType),
     children,
   } as ToolbarFilterProps;
 };

--- a/src/pages/costModels/costModelsDetails/utils/toolbar.tsx
+++ b/src/pages/costModels/costModelsDetails/utils/toolbar.tsx
@@ -48,13 +48,13 @@ const selectorMergeProps = (
   const { intl = defaultIntl } = ownProps; // Default required for testing
   const options = [
     <SelectOption key="name" value="name">
-      {intl.formatMessage(messages.Names, { count: 1 })}
+      {intl.formatMessage(messages.names, { count: 1 })}
     </SelectOption>,
     <SelectOption key="description" value="description">
-      {intl.formatMessage(messages.Description)}
+      {intl.formatMessage(messages.description)}
     </SelectOption>,
     <SelectOption key="sourceType" value="sourceType">
-      {intl.formatMessage(messages.CostModelsSourceType)}
+      {intl.formatMessage(messages.costModelsSourceType)}
     </SelectOption>,
   ];
   return {

--- a/src/pages/costModels/createCostModelWizard/assignSourcesToolbar.tsx
+++ b/src/pages/costModels/createCostModelWizard/assignSourcesToolbar.tsx
@@ -70,7 +70,7 @@ export const AssignSourcesToolbarBase: React.SFC<AssignSourcesToolbarBaseProps> 
           <ToolbarItem variant="search-filter">
             <ToolbarFilter deleteChip={filter.onRemove} chips={filter.query.name} categoryName="name">
               <FilterInput
-                placeholder={intl.formatMessage(messages.CostModelsFilterPlaceholder)}
+                placeholder={intl.formatMessage(messages.costModelsFilterPlaceholder)}
                 {...filterInputProps}
               />
             </ToolbarFilter>

--- a/src/pages/costModels/createCostModelWizard/generalInformation.tsx
+++ b/src/pages/costModels/createCostModelWizard/generalInformation.tsx
@@ -48,19 +48,19 @@ class GeneralInformation extends React.Component<GeneralInformationProps> {
     const { intl } = this.props;
     const sourceTypeOptions = [
       {
-        label: messages.CostModelsWizardOnboardAWS,
+        label: messages.costModelsWizardOnboardAws,
         value: 'AWS',
       },
       {
-        label: messages.Azure,
+        label: messages.azure,
         value: 'Azure',
       },
       {
-        label: messages.GCP,
+        label: messages.gcp,
         value: 'GCP',
       },
       {
-        label: messages.CostModelsWizardOnboardOCP,
+        label: messages.costModelsWizardOnboardOcp,
         value: 'OCP',
       },
     ];
@@ -81,12 +81,12 @@ class GeneralInformation extends React.Component<GeneralInformationProps> {
           <Stack hasGutter>
             <StackItem>
               <Title headingLevel="h2" size={TitleSizes.xl}>
-                {intl.formatMessage(messages.CostModelsWizardGeneralInfoTitle)}
+                {intl.formatMessage(messages.costModelsWizardGeneralInfoTitle)}
               </Title>
             </StackItem>
             <StackItem>
-              <a href={intl.formatMessage(messages.DocsConfigCostModels)} rel="noreferrer" target="_blank">
-                {intl.formatMessage(messages.LearnMore)}
+              <a href={intl.formatMessage(messages.docsConfigCostModels)} rel="noreferrer" target="_blank">
+                {intl.formatMessage(messages.learnMore)}
               </a>
             </StackItem>
             <StackItem>
@@ -94,7 +94,7 @@ class GeneralInformation extends React.Component<GeneralInformationProps> {
                 <FormGroup
                   helperTextInvalid={nameErrors(name)}
                   validated={nameErrors(name) === null || !dirtyName ? 'default' : 'error'}
-                  label={intl.formatMessage(messages.Names, { count: 1 })}
+                  label={intl.formatMessage(messages.names, { count: 1 })}
                   isRequired
                   fieldId="name"
                 >
@@ -111,7 +111,7 @@ class GeneralInformation extends React.Component<GeneralInformationProps> {
                 <FormGroup
                   helperTextInvalid={descriptionErrors(description)}
                   validated={descriptionErrors(description) === null ? 'default' : 'error'}
-                  label={intl.formatMessage(messages.Description)}
+                  label={intl.formatMessage(messages.description)}
                   fieldId="description"
                 >
                   <TextArea
@@ -130,9 +130,9 @@ class GeneralInformation extends React.Component<GeneralInformationProps> {
                   direction={SelectDirection.up}
                   appendMenuTo="inline"
                   maxHeight={styles.selector.maxHeight}
-                  label={messages.CostModelsSourceType}
-                  toggleAriaLabel={intl.formatMessage(messages.CostModelsWizardEmptySourceTypeLabel)}
-                  placeholderText={intl.formatMessage(messages.CostModelsWizardEmptySourceTypeLabel)}
+                  label={messages.costModelsSourceType}
+                  toggleAriaLabel={intl.formatMessage(messages.costModelsWizardEmptySourceTypeLabel)}
+                  placeholderText={intl.formatMessage(messages.costModelsWizardEmptySourceTypeLabel)}
                   value={getValueLabel(type, sourceTypeOptions)}
                   onChange={onTypeChange}
                   options={sourceTypeOptions}
@@ -141,11 +141,11 @@ class GeneralInformation extends React.Component<GeneralInformationProps> {
                   /* Todo: Show in-progress features in beta environment only */
                   isFeatureVisible(FeatureType.currency) && (
                     <Selector
-                      label={messages.Currency}
+                      label={messages.currency}
                       direction={SelectDirection.up}
                       appendMenuTo="inline"
                       maxHeight={styles.selector.maxHeight}
-                      toggleAriaLabel={intl.formatMessage(messages.CostModelsWizardCurrencyToggleLabel)}
+                      toggleAriaLabel={intl.formatMessage(messages.costModelsWizardCurrencyToggleLabel)}
                       value={getValueLabel(currencyUnits, currencyOptions)}
                       onChange={onCurrencyChange}
                       id="currency-units-selector"

--- a/src/pages/costModels/createCostModelWizard/index.tsx
+++ b/src/pages/costModels/createCostModelWizard/index.tsx
@@ -84,14 +84,14 @@ const InternalWizardBase: React.SFC<InternalWizardBaseProps> = ({
   newSteps[current - 1].enableNext = validators[current - 1](context);
   const isAddingRate = context.type === 'OCP' && current === 2 && !validators[current - 1](context);
   if (current === steps.length && context.type !== '') {
-    newSteps[current - 1].nextButtonText = intl.formatMessage(messages.Create);
+    newSteps[current - 1].nextButtonText = intl.formatMessage(messages.create);
   }
 
   return isOpen ? (
     <Wizard
       isOpen
-      title={intl.formatMessage(messages.CreateCostModelTitle)}
-      description={intl.formatMessage(messages.CreateCostModelDesc)}
+      title={intl.formatMessage(messages.createCostModelTitle)}
+      description={intl.formatMessage(messages.createCostModelDesc)}
       steps={newSteps}
       startAtStep={current}
       onNext={onMove}
@@ -224,100 +224,100 @@ class CostModelWizardBase extends React.Component<Props, State> {
       '': [
         {
           id: 1,
-          name: intl.formatMessage(messages.CostModelsWizardStepsGenInfo),
+          name: intl.formatMessage(messages.costModelsWizardStepsGenInfo),
           component: <GeneralInformation />,
         },
       ],
       Azure: [
         {
           id: 1,
-          name: intl.formatMessage(messages.CostModelsWizardStepsGenInfo),
+          name: intl.formatMessage(messages.costModelsWizardStepsGenInfo),
           component: <GeneralInformation />,
         },
         {
           id: 2,
-          name: intl.formatMessage(messages.CostCalculations),
+          name: intl.formatMessage(messages.costCalculations),
           component: <Markup />,
         },
         {
           id: 3,
-          name: intl.formatMessage(messages.CostModelsWizardStepsSources),
+          name: intl.formatMessage(messages.costModelsWizardStepsSources),
           component: <Sources />,
         },
         {
           id: 4,
-          name: intl.formatMessage(messages.CostModelsWizardStepsReview),
+          name: intl.formatMessage(messages.costModelsWizardStepsReview),
           component: <Review />,
         },
       ],
       AWS: [
         {
           id: 1,
-          name: intl.formatMessage(messages.CostModelsWizardStepsGenInfo),
+          name: intl.formatMessage(messages.costModelsWizardStepsGenInfo),
           component: <GeneralInformation />,
         },
         {
           id: 2,
-          name: intl.formatMessage(messages.CostCalculations),
+          name: intl.formatMessage(messages.costCalculations),
           component: <Markup />,
         },
         {
           id: 3,
-          name: intl.formatMessage(messages.CostModelsWizardStepsSources),
+          name: intl.formatMessage(messages.costModelsWizardStepsSources),
           component: <Sources />,
         },
         {
           id: 4,
-          name: intl.formatMessage(messages.CostModelsWizardStepsReview),
+          name: intl.formatMessage(messages.costModelsWizardStepsReview),
           component: <Review />,
         },
       ],
       GCP: [
         {
           id: 1,
-          name: intl.formatMessage(messages.CostModelsWizardStepsGenInfo),
+          name: intl.formatMessage(messages.costModelsWizardStepsGenInfo),
           component: <GeneralInformation />,
         },
         {
           id: 2,
-          name: intl.formatMessage(messages.CostCalculations),
+          name: intl.formatMessage(messages.costCalculations),
           component: <Markup />,
         },
         {
           id: 3,
-          name: intl.formatMessage(messages.CostModelsWizardStepsSources),
+          name: intl.formatMessage(messages.costModelsWizardStepsSources),
           component: <Sources />,
         },
         {
           id: 4,
-          name: intl.formatMessage(messages.CostModelsWizardStepsReview),
+          name: intl.formatMessage(messages.costModelsWizardStepsReview),
           component: <Review />,
         },
       ],
       OCP: [
         {
           id: 1,
-          name: intl.formatMessage(messages.CostModelsWizardStepsGenInfo),
+          name: intl.formatMessage(messages.costModelsWizardStepsGenInfo),
           component: <GeneralInformation />,
         },
         {
           id: 2,
-          name: intl.formatMessage(messages.PriceList),
+          name: intl.formatMessage(messages.priceList),
           component: <PriceList />,
         },
         {
           id: 3,
-          name: intl.formatMessage(messages.CostCalculations),
+          name: intl.formatMessage(messages.costCalculations),
           component: <Markup />,
         },
         {
           id: 4,
-          name: intl.formatMessage(messages.CostModelsWizardStepsSources),
+          name: intl.formatMessage(messages.costModelsWizardStepsSources),
           component: <Sources />,
         },
         {
           id: 5,
-          name: intl.formatMessage(messages.CostModelsWizardStepsReview),
+          name: intl.formatMessage(messages.costModelsWizardStepsReview),
           component: <Review />,
         },
       ],
@@ -325,12 +325,12 @@ class CostModelWizardBase extends React.Component<Props, State> {
 
     const CancelButton = (
       <Button key="cancel" variant="link" onClick={closeConfirmDialog}>
-        {intl.formatMessage(messages.CreateCostModelNoContinue)}
+        {intl.formatMessage(messages.createCostModelNoContinue)}
       </Button>
     );
     const OkButton = (
       <Button key="ok" variant="primary" onClick={() => this.setState({ ...defaultState })}>
-        {intl.formatMessage(messages.CreateCostModelExitYes)}
+        {intl.formatMessage(messages.createCostModelExitYes)}
       </Button>
     );
 
@@ -496,18 +496,18 @@ class CostModelWizardBase extends React.Component<Props, State> {
           }}
         />
         <Modal
-          aria-label={intl.formatMessage(messages.CreateCostModelExit)}
+          aria-label={intl.formatMessage(messages.createCostModelExit)}
           isOpen={this.state.isDialogOpen}
           header={
             <Title headingLevel="h1" size={TitleSizes['2xl']}>
-              <ExclamationTriangleIcon color="orange" /> {intl.formatMessage(messages.CreateCostModelExit)}
+              <ExclamationTriangleIcon color="orange" /> {intl.formatMessage(messages.createCostModelExit)}
             </Title>
           }
           onClose={closeConfirmDialog}
           actions={[OkButton, CancelButton]}
           variant="small"
         >
-          {intl.formatMessage(messages.CreateCostModelConfirmMsg)}
+          {intl.formatMessage(messages.createCostModelConfirmMsg)}
         </Modal>
       </CostModelContext.Provider>
     );

--- a/src/pages/costModels/createCostModelWizard/markup.tsx
+++ b/src/pages/costModels/createCostModelWizard/markup.tsx
@@ -38,12 +38,12 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
 
     const markupValidator = value => {
       if (!isPercentageFormatValid(value)) {
-        return messages.MarkupOrDiscountNumber;
+        return messages.markupOrDiscountNumber;
       }
       // Test number of decimals
       const decimals = countDecimals(value);
       if (decimals > 10) {
-        return messages.MarkupOrDiscountTooLong;
+        return messages.markupOrDiscountTooLong;
       }
       return undefined;
     };
@@ -66,14 +66,14 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
             <Stack hasGutter>
               <StackItem>
                 <Title headingLevel="h2" size={TitleSizes.xl}>
-                  {intl.formatMessage(messages.CostCalculations)}
+                  {intl.formatMessage(messages.costCalculations)}
                 </Title>
               </StackItem>
               <StackItem>
                 <Title headingLevel="h3" size="md">
-                  {intl.formatMessage(messages.MarkupOrDiscount)}
+                  {intl.formatMessage(messages.markupOrDiscount)}
                 </Title>
-                {intl.formatMessage(messages.MarkupOrDiscountModalDesc)}
+                {intl.formatMessage(messages.markupOrDiscountModalDesc)}
               </StackItem>
               <StackItem>
                 <Flex style={styles.markupRadioContainer}>
@@ -82,8 +82,8 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
                       <Radio
                         isChecked={!isDiscount}
                         name="discount"
-                        label={intl.formatMessage(messages.MarkupPlus)}
-                        aria-label={intl.formatMessage(messages.MarkupPlus)}
+                        label={intl.formatMessage(messages.markupPlus)}
+                        aria-label={intl.formatMessage(messages.markupPlus)}
                         id="markup"
                         value="false" // "+"
                         onChange={handleSignChange}
@@ -92,8 +92,8 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
                       <Radio
                         isChecked={isDiscount}
                         name="discount"
-                        label={intl.formatMessage(messages.DiscountMinus)}
-                        aria-label={intl.formatMessage(messages.DiscountMinus)}
+                        label={intl.formatMessage(messages.discountMinus)}
+                        aria-label={intl.formatMessage(messages.discountMinus)}
                         id="discount"
                         value="true" // '-'
                         onChange={handleSignChange}
@@ -112,11 +112,11 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
                           <InputGroup>
                             <InputGroupText style={styles.sign}>
                               {isDiscount
-                                ? intl.formatMessage(messages.DiscountMinus)
-                                : intl.formatMessage(messages.MarkupPlus)}
+                                ? intl.formatMessage(messages.discountMinus)
+                                : intl.formatMessage(messages.markupPlus)}
                             </InputGroupText>
                             <TextInput
-                              aria-label={intl.formatMessage(messages.Rate)}
+                              aria-label={intl.formatMessage(messages.rate)}
                               id="markup-input-box"
                               isRequired
                               onKeyDown={handleOnKeyDown}
@@ -128,7 +128,7 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
                               value={markup}
                             />
                             <InputGroupText style={styles.percent}>
-                              {intl.formatMessage(messages.PercentSymbol)}
+                              {intl.formatMessage(messages.percentSymbol)}
                             </InputGroupText>
                           </InputGroup>
                         </FormGroup>
@@ -140,13 +140,13 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
               <StackItem>
                 <div style={styles.exampleMargin}>
                   <TextContent>
-                    <Text component={TextVariants.h6}>{intl.formatMessage(messages.ExamplesTitle)}</Text>
+                    <Text component={TextVariants.h6}>{intl.formatMessage(messages.examplesTitle)}</Text>
                   </TextContent>
                   <List>
-                    <ListItem>{intl.formatMessage(messages.CostModelsExamplesNoAdjust)}</ListItem>
-                    <ListItem>{intl.formatMessage(messages.CostModelsExamplesDoubleMarkup)}</ListItem>
-                    <ListItem>{intl.formatMessage(messages.CostModelsExamplesReduceZero)}</ListItem>
-                    <ListItem>{intl.formatMessage(messages.CostModelsExamplesReduceSeventyfive)}</ListItem>
+                    <ListItem>{intl.formatMessage(messages.costModelsExamplesNoAdjust)}</ListItem>
+                    <ListItem>{intl.formatMessage(messages.costModelsExamplesDoubleMarkup)}</ListItem>
+                    <ListItem>{intl.formatMessage(messages.costModelsExamplesReduceZero)}</ListItem>
+                    <ListItem>{intl.formatMessage(messages.costModelsExamplesReduceSeventyfive)}</ListItem>
                   </List>
                 </div>
               </StackItem>
@@ -154,10 +154,10 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
                 <>
                   <StackItem>
                     <Title headingLevel="h3" size="md">
-                      {intl.formatMessage(messages.DistributionType)}
+                      {intl.formatMessage(messages.distributionType)}
                     </Title>
                     <TextContent>
-                      <Text style={styles.cardDescription}>{intl.formatMessage(messages.DistributionModelDesc)}</Text>
+                      <Text style={styles.cardDescription}>{intl.formatMessage(messages.distributionModelDesc)}</Text>
                     </TextContent>
                   </StackItem>
                   <StackItem isFilled>
@@ -166,8 +166,8 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
                         <Radio
                           isChecked={distribution === 'cpu'}
                           name="distribution"
-                          label={intl.formatMessage(messages.CpuTitle)}
-                          aria-label={intl.formatMessage(messages.CpuTitle)}
+                          label={intl.formatMessage(messages.cpuTitle)}
+                          aria-label={intl.formatMessage(messages.cpuTitle)}
                           id="cpuDistribution"
                           value="cpu"
                           onChange={handleDistributionChange}
@@ -175,8 +175,8 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
                         <Radio
                           isChecked={distribution === 'memory'}
                           name="distribution"
-                          label={intl.formatMessage(messages.MemoryTitle)}
-                          aria-label={intl.formatMessage(messages.MemoryTitle)}
+                          label={intl.formatMessage(messages.memoryTitle)}
+                          aria-label={intl.formatMessage(messages.memoryTitle)}
                           id="memoryDistribution"
                           value="memory"
                           onChange={handleDistributionChange}

--- a/src/pages/costModels/createCostModelWizard/priceListTable.tsx
+++ b/src/pages/costModels/createCostModelWizard/priceListTable.tsx
@@ -66,12 +66,12 @@ class PriceListTable extends React.Component<Props, State> {
     const getMetricLabel = m => {
       // Match message descriptor or default to API string
       const value = m.replace(/ /g, '_').toLowerCase();
-      const label = intl.formatMessage(messages.MetricValues, { value });
+      const label = intl.formatMessage(messages.metricValues, { value });
       return label ? label : m;
     };
     const getMeasurementLabel = m => {
       // Match message descriptor or default to API string
-      const label = intl.formatMessage(messages.MeasurementValues, {
+      const label = intl.formatMessage(messages.measurementValues, {
         value: m.toLowerCase().replace('-', '_'),
         count: 1,
       });
@@ -93,18 +93,18 @@ class PriceListTable extends React.Component<Props, State> {
         <EmptyState>
           <EmptyStateIcon icon={PlusCircleIcon} />
           <Title headingLevel="h2" size={TitleSizes.lg}>
-            {intl.formatMessage(messages.CostModelsWizardEmptyStateTitle)}
+            {intl.formatMessage(messages.costModelsWizardEmptyStateTitle)}
           </Title>
           <EmptyStateBody>
-            {intl.formatMessage(messages.CostModelsWizardEmptyStateSkipStep, {
-              value: <strong>{intl.formatMessage(messages.CreateRate)}</strong>,
+            {intl.formatMessage(messages.costModelsWizardEmptyStateSkipStep, {
+              value: <strong>{intl.formatMessage(messages.createRate)}</strong>,
             })}
             <br />
-            {intl.formatMessage(messages.CostModelsWizardEmptyStateSkipStep, {
-              value: <strong>{intl.formatMessage(messages.Next)}</strong>,
+            {intl.formatMessage(messages.costModelsWizardEmptyStateSkipStep, {
+              value: <strong>{intl.formatMessage(messages.next)}</strong>,
             })}
             <br />
-            {intl.formatMessage(messages.CostModelsWizardEmptyStateOtherTime)}
+            {intl.formatMessage(messages.costModelsWizardEmptyStateOtherTime)}
           </EmptyStateBody>
         </EmptyState>
       </Bullseye>
@@ -117,12 +117,12 @@ class PriceListTable extends React.Component<Props, State> {
             <Stack hasGutter>
               <StackItem>
                 <Title headingLevel="h2" size={TitleSizes.xl}>
-                  {intl.formatMessage(messages.CostModelsWizardCreatePriceList)}
+                  {intl.formatMessage(messages.costModelsWizardCreatePriceList)}
                 </Title>
               </StackItem>
               <StackItem>
                 <TextContent>
-                  <Text component={TextVariants.h6}>{intl.formatMessage(messages.CostModelsWizardSubTitleTable)}</Text>
+                  <Text component={TextVariants.h6}>{intl.formatMessage(messages.costModelsWizardSubTitleTable)}</Text>
                 </TextContent>
               </StackItem>
               <StackItem>
@@ -134,10 +134,10 @@ class PriceListTable extends React.Component<Props, State> {
                   }}
                 >
                   {({ search, setSearch, onRemove, onSelect, onClearAll }) => {
-                    const getMetric = value => intl.formatMessage(messages.MetricValues, { value }) || value;
+                    const getMetric = value => intl.formatMessage(messages.metricValues, { value }) || value;
                     const getMeasurement = (measurement, units) => {
-                      units = intl.formatMessage(messages.Units, { units: unitsLookupKey(units) }) || units;
-                      return intl.formatMessage(messages.MeasurementValues, {
+                      units = intl.formatMessage(messages.units, { units: unitsLookupKey(units) }) || units;
+                      return intl.formatMessage(messages.measurementValues, {
                         value: measurement.toLowerCase().replace('-', '_'),
                         units,
                         count: 2,
@@ -172,11 +172,11 @@ class PriceListTable extends React.Component<Props, State> {
                               setPrimary={(primary: string) => setSearch({ primary })}
                               options={[
                                 {
-                                  label: intl.formatMessage(messages.Metric),
+                                  label: intl.formatMessage(messages.metric),
                                   value: 'metrics',
                                 },
                                 {
-                                  label: intl.formatMessage(messages.Measurement),
+                                  label: intl.formatMessage(messages.measurement),
                                   value: 'measurements',
                                 },
                               ]}
@@ -188,7 +188,7 @@ class PriceListTable extends React.Component<Props, State> {
                               component: (
                                 <CheckboxSelector
                                   isDisabled={items.length === 0}
-                                  placeholderText={intl.formatMessage(messages.ToolBarPriceListMeasurementPlaceHolder)}
+                                  placeholderText={intl.formatMessage(messages.toolBarPriceListMeasurementPlaceHolder)}
                                   selections={search.measurements}
                                   setSelections={(selection: string) => onSelect('measurements', selection)}
                                   options={measurementOpts}
@@ -202,7 +202,7 @@ class PriceListTable extends React.Component<Props, State> {
                               component: (
                                 <CheckboxSelector
                                   isDisabled={items.length === 0}
-                                  placeholderText={intl.formatMessage(messages.ToolBarPriceListMetricPlaceHolder)}
+                                  placeholderText={intl.formatMessage(messages.toolBarPriceListMetricPlaceHolder)}
                                   selections={search.metrics}
                                   setSelections={(selection: string) => onSelect('metrics', selection)}
                                   options={metricOpts}
@@ -213,7 +213,7 @@ class PriceListTable extends React.Component<Props, State> {
                               filters: search.metrics,
                             },
                           ]}
-                          button={<Button onClick={addRateAction}>{intl.formatMessage(messages.CreateRate)}</Button>}
+                          button={<Button onClick={addRateAction}>{intl.formatMessage(messages.createRate)}</Button>}
                           onClear={onClearAll}
                           pagination={
                             <Pagination

--- a/src/pages/costModels/createCostModelWizard/review.tsx
+++ b/src/pages/costModels/createCostModelWizard/review.tsx
@@ -32,14 +32,14 @@ const ReviewSuccessBase: React.SFC<WrappedComponentProps> = ({ intl }) => (
       <EmptyState>
         <EmptyStateIcon icon={OkIcon} color="green" />
         <Title headingLevel="h2" size={TitleSizes.lg}>
-          {intl.formatMessage(messages.CostModelsWizardReviewStatusTitle)}
+          {intl.formatMessage(messages.costModelsWizardReviewStatusTitle)}
         </Title>
         <EmptyStateBody>
-          {intl.formatMessage(messages.CostModelsWizardReviewStatusSubTitle, { value: name })}
+          {intl.formatMessage(messages.costModelsWizardReviewStatusSubTitle, { value: name })}
         </EmptyStateBody>
         <EmptyStateSecondaryActions>
           <Button variant="link" onClick={onClose}>
-            {intl.formatMessage(messages.Close)}
+            {intl.formatMessage(messages.close)}
           </Button>
         </EmptyStateSecondaryActions>
       </EmptyState>
@@ -61,15 +61,15 @@ const ReviewDetailsBase: React.SFC<WrappedComponentProps> = ({ intl }) => (
           <Stack hasGutter>
             <StackItem>
               <Title headingLevel="h2" size={TitleSizes.xl}>
-                {intl.formatMessage(messages.CostModelsWizardStepsReview)}
+                {intl.formatMessage(messages.costModelsWizardStepsReview)}
               </Title>
             </StackItem>
             <StackItem>
               <TextContent>
                 <Text component={TextVariants.h6}>
-                  {intl.formatMessage(messages.CostModelsWizardReviewStatusSubDetails, {
-                    create: <strong>{intl.formatMessage(messages.Create)}</strong>,
-                    back: <strong>{intl.formatMessage(messages.Back)}</strong>,
+                  {intl.formatMessage(messages.costModelsWizardReviewStatusSubDetails, {
+                    create: <strong>{intl.formatMessage(messages.create)}</strong>,
+                    back: <strong>{intl.formatMessage(messages.back)}</strong>,
                   })}
                 </Text>
               </TextContent>
@@ -78,51 +78,51 @@ const ReviewDetailsBase: React.SFC<WrappedComponentProps> = ({ intl }) => (
               <TextContent>
                 <TextList component={TextListVariants.dl}>
                   <TextListItem component={TextListItemVariants.dt}>
-                    {intl.formatMessage(messages.Names, { count: 1 })}
+                    {intl.formatMessage(messages.names, { count: 1 })}
                   </TextListItem>
                   <TextListItem component={TextListItemVariants.dd}>{name}</TextListItem>
                   <TextListItem component={TextListItemVariants.dt}>
-                    {intl.formatMessage(messages.Description)}
+                    {intl.formatMessage(messages.description)}
                   </TextListItem>
                   <TextListItem component={TextListItemVariants.dd}>{description}</TextListItem>
                   <TextListItem component={TextListItemVariants.dt}>
-                    {intl.formatMessage(messages.Currency)}
+                    {intl.formatMessage(messages.currency)}
                   </TextListItem>
                   <TextListItem component={TextListItemVariants.dd}>
-                    {intl.formatMessage(messages.CurrencyOptions, { units: currencyUnits })}
+                    {intl.formatMessage(messages.currencyOptions, { units: currencyUnits })}
                   </TextListItem>
                   {type === 'OCP' && (
                     <>
                       <TextListItem component={TextListItemVariants.dt}>
-                        {intl.formatMessage(messages.PriceList)}
+                        {intl.formatMessage(messages.priceList)}
                       </TextListItem>
                       <TextListItem component={TextListItemVariants.dd}>
                         {tiers.length > 0 ? (
                           <RateTable tiers={tiers} />
                         ) : (
-                          intl.formatMessage(messages.CostModelsWizardNoRatesAdded)
+                          intl.formatMessage(messages.costModelsWizardNoRatesAdded)
                         )}
                       </TextListItem>
                     </>
                   )}
                   <TextListItem component={TextListItemVariants.dt}>
-                    {intl.formatMessage(messages.CostModelsWizardReviewMarkDiscount)}
+                    {intl.formatMessage(messages.costModelsWizardReviewMarkDiscount)}
                   </TextListItem>
                   <TextListItem component={TextListItemVariants.dd}>
-                    {intl.formatMessage(messages.Percent, { value: isDiscount ? '-' + markup : markup })}
+                    {intl.formatMessage(messages.percent, { value: isDiscount ? '-' + markup : markup })}
                   </TextListItem>
                   {type === 'OCP' && (
                     <>
                       <TextListItem component={TextListItemVariants.dt}>
-                        {intl.formatMessage(messages.DistributionType)}
+                        {intl.formatMessage(messages.distributionType)}
                       </TextListItem>
                       <TextListItem component={TextListItemVariants.dd}>{distribution}</TextListItem>
                     </>
                   )}
                   <TextListItem component={TextListItemVariants.dt}>
-                    {intl.formatMessage(messages.CostModelsAssignSources, { count: 2 })}{' '}
+                    {intl.formatMessage(messages.costModelsAssignSources, { count: 2 })}{' '}
                     {selectedSources.find(src => Boolean(src.costmodel)) && (
-                      <WarningIcon text={intl.formatMessage(messages.CostModelsWizardWarningSources)} />
+                      <WarningIcon text={intl.formatMessage(messages.costModelsWizardWarningSources)} />
                     )}
                   </TextListItem>
                   <TextListItem component={TextListItemVariants.dd}>

--- a/src/pages/costModels/createCostModelWizard/steps.tsx
+++ b/src/pages/costModels/createCostModelWizard/steps.tsx
@@ -4,17 +4,17 @@ import { countDecimals, isPercentageFormatValid } from 'utils/format';
 
 export const nameErrors = (name: string): MessageDescriptor | null => {
   if (name.length === 0) {
-    return messages.CostModelsRequiredField;
+    return messages.costModelsRequiredField;
   }
   if (name.length > 100) {
-    return messages.CostModelsInfoTooLong;
+    return messages.costModelsInfoTooLong;
   }
   return null;
 };
 
 export const descriptionErrors = (description: string): MessageDescriptor | null => {
   if (description.length > 500) {
-    return messages.CostModelsDescTooLong;
+    return messages.costModelsDescTooLong;
   }
   return null;
 };

--- a/src/pages/costModels/createCostModelWizard/table.tsx
+++ b/src/pages/costModels/createCostModelWizard/table.tsx
@@ -33,18 +33,18 @@ const SourcesTable: React.SFC<WrappedComponentProps> = ({ intl }) => {
           <Stack hasGutter>
             <StackItem>
               <Title headingLevel="h2" size={TitleSizes.xl}>
-                {intl.formatMessage(messages.CostModelsWizardSourceTitle)}
+                {intl.formatMessage(messages.costModelsWizardSourceTitle)}
               </Title>
             </StackItem>
             <StackItem>
               <TextContent>
-                <Text component={TextVariants.h6}>{intl.formatMessage(messages.CostModelsWizardSourceSubtitle)}</Text>
+                <Text component={TextVariants.h6}>{intl.formatMessage(messages.costModelsWizardSourceSubtitle)}</Text>
               </TextContent>
             </StackItem>
             <StackItem>
               <TextContent>
                 <Text component={TextVariants.h3}>
-                  {intl.formatMessage(messages.CostModelsWizardSourceCaption, {
+                  {intl.formatMessage(messages.costModelsWizardSourceCaption, {
                     value: type.toLowerCase(),
                   })}
                 </Text>
@@ -81,11 +81,11 @@ const SourcesTable: React.SFC<WrappedComponentProps> = ({ intl }) => {
                 <LoadingState />
               ) : (
                 <Table
-                  aria-label={intl.formatMessage(messages.CostModelsWizardSourceTableAriaLabel)}
+                  aria-label={intl.formatMessage(messages.costModelsWizardSourceTableAriaLabel)}
                   cells={[
                     '',
-                    intl.formatMessage(messages.Names, { count: 1 }),
-                    intl.formatMessage(messages.CostModelsWizardSourceTableCostModel),
+                    intl.formatMessage(messages.names, { count: 1 }),
+                    intl.formatMessage(messages.costModelsWizardSourceTableCostModel),
                   ]}
                   rows={sources.map((r, ix) => {
                     return {
@@ -106,7 +106,7 @@ const SourcesTable: React.SFC<WrappedComponentProps> = ({ intl }) => {
                           {Boolean(r.costmodel) && (
                             <WarningIcon
                               key={`wrng-${r.name}`}
-                              text={intl.formatMessage(messages.CostModelsWizardSourceWarning, {
+                              text={intl.formatMessage(messages.costModelsWizardSourceWarning, {
                                 costModel: r.costmodel,
                               })}
                             />

--- a/src/pages/state/maintenance/maintenanceState.tsx
+++ b/src/pages/state/maintenance/maintenanceState.tsx
@@ -14,17 +14,17 @@ class MaintenanceStateBase extends React.Component<MaintenanceStateBaseOwnProps>
       <Maintenance
         description={
           <Stack>
-            <StackItem>{intl.formatMessage(messages.MaintenanceEmptyStateDesc)}</StackItem>
+            <StackItem>{intl.formatMessage(messages.maintenanceEmptyStateDesc)}</StackItem>
             <StackItem>
-              {intl.formatMessage(messages.MaintenanceEmptyStateInfo, {
+              {intl.formatMessage(messages.maintenanceEmptyStateInfo, {
                 url: (
-                  <a href={intl.formatMessage(messages.RedHatStatusUrl)} rel="noreferrer" target="_blank">
+                  <a href={intl.formatMessage(messages.redHatStatusUrl)} rel="noreferrer" target="_blank">
                     "status page"
                   </a>
                 ),
               })}
             </StackItem>
-            <StackItem>{intl.formatMessage(messages.MaintenanceEmptyStateThanks)}</StackItem>
+            <StackItem>{intl.formatMessage(messages.maintenanceEmptyStateThanks)}</StackItem>
           </Stack>
         }
       />

--- a/src/pages/state/noData/noDataState.tsx
+++ b/src/pages/state/noData/noDataState.tsx
@@ -19,12 +19,12 @@ class NoDataStateBase extends React.Component<NoDataStateProps> {
       <EmptyState variant={EmptyStateVariant.large} className="pf-m-redhat-font">
         <EmptyStateIcon icon={FileInvoiceDollarIcon} />
         <Title headingLevel="h5" size="lg">
-          {intl.formatMessage(messages.NoDataStateTitle)}
+          {intl.formatMessage(messages.noDataStateTitle)}
         </Title>
-        <EmptyStateBody>{intl.formatMessage(messages.NoDataStateDesc)}</EmptyStateBody>
+        <EmptyStateBody>{intl.formatMessage(messages.noDataStateDesc)}</EmptyStateBody>
         {showReload && (
           <Button variant="primary" onClick={() => window.location.reload()}>
-            {intl.formatMessage(messages.NoDataStateRefresh)}
+            {intl.formatMessage(messages.noDataStateRefresh)}
           </Button>
         )}
       </EmptyState>

--- a/src/pages/state/noProviders/noProvidersState.tsx
+++ b/src/pages/state/noProviders/noProvidersState.tsx
@@ -40,8 +40,8 @@ class NoProvidersStateBase extends React.Component<NoProvidersStateProps> {
   public render() {
     const { intl, providerType } = this.props;
 
-    let descKey = messages.NoProvidersStateOverviewDesc;
-    let titleKey = messages.NoProvidersStateOverviewTitle;
+    let descKey = messages.noProvidersStateOverviewDesc;
+    let titleKey = messages.noProvidersStateOverviewTitle;
 
     let docUrlKey;
     let icon;
@@ -49,26 +49,26 @@ class NoProvidersStateBase extends React.Component<NoProvidersStateProps> {
 
     switch (providerType) {
       case ProviderType.aws:
-        descKey = messages.NoProvidersStateAwsDesc;
-        titleKey = messages.NoProvidersStateAwsTitle;
+        descKey = messages.noProvidersStateAwsDesc;
+        titleKey = messages.noProvidersStateAwsTitle;
         break;
       case ProviderType.azure:
-        descKey = messages.NoProvidersStateAzureDesc;
-        titleKey = messages.NoProvidersStateAzureTitle;
+        descKey = messages.noProvidersStateAzureDesc;
+        titleKey = messages.noProvidersStateAzureTitle;
         break;
       case ProviderType.gcp:
-        descKey = messages.NoProvidersStateGcpDesc;
-        titleKey = messages.NoProvidersStateGcpTitle;
+        descKey = messages.noProvidersStateGcpDesc;
+        titleKey = messages.noProvidersStateGcpTitle;
         break;
       case ProviderType.ibm:
-        descKey = messages.NoProvidersStateIbmDesc;
-        titleKey = messages.NoProvidersStateIbmTitle;
+        descKey = messages.noProvidersStateIbmDesc;
+        titleKey = messages.noProvidersStateIbmTitle;
         break;
       case ProviderType.ocp:
-        descKey = messages.NoProvidersStateOcpDesc;
-        docUrlKey = messages.DocsAddOcpSources;
-        textKey = messages.NoProvidersStateOcpAddSources;
-        titleKey = messages.NoProvidersStateOcpTitle;
+        descKey = messages.noProvidersStateOcpDesc;
+        docUrlKey = messages.docsAddOcpSources;
+        textKey = messages.noProvidersStateOcpAddSources;
+        titleKey = messages.noProvidersStateOcpTitle;
         break;
       default:
         icon = CostIcon;
@@ -84,7 +84,7 @@ class NoProvidersStateBase extends React.Component<NoProvidersStateProps> {
           <div style={styles.viewSources}>{this.getDocLink(textKey, docUrlKey)}</div>
         ) : (
           <Button variant="primary" component="a" href={this.getRouteToSources()}>
-            {intl.formatMessage(messages.NoProvidersStateGetStarted)}
+            {intl.formatMessage(messages.noProvidersStateGetStarted)}
           </Button>
         )}
       </EmptyState>

--- a/src/pages/state/notAuthorized/notAuthorizedState.tsx
+++ b/src/pages/state/notAuthorized/notAuthorizedState.tsx
@@ -20,30 +20,30 @@ class NotAuthorizedStateBase extends React.Component<NotAuthorizedStateProps> {
     switch (pathname) {
       case paths.awsDetails:
       case paths.awsDetailsBreakdown:
-        msg = messages.NotAuthorizedStateAws;
+        msg = messages.notAuthorizedStateAws;
         break;
       case paths.azureDetails:
       case paths.azureDetailsBreakdown:
-        msg = messages.NotAuthorizedStateAzure;
+        msg = messages.notAuthorizedStateAzure;
         break;
       case paths.costModels:
-        msg = messages.NotAuthorizedStateCostModels;
+        msg = messages.notAuthorizedStateCostModels;
         break;
       case paths.gcpDetails:
       case paths.gcpDetailsBreakdown:
-        msg = messages.NotAuthorizedStateGcp;
+        msg = messages.notAuthorizedStateGcp;
         break;
       case paths.ibmDetails:
       case paths.ibmDetailsBreakdown:
-        msg = messages.NotAuthorizedStateIbm;
+        msg = messages.notAuthorizedStateIbm;
         break;
       case paths.ocpDetails:
       case paths.ocpDetailsBreakdown:
-        msg = messages.NotAuthorizedStateOcp;
+        msg = messages.notAuthorizedStateOcp;
         break;
       case paths.explorer:
       default:
-        msg = messages.CostManagement;
+        msg = messages.costManagement;
         break;
     }
     return <_NotAuthorized serviceName={intl.formatMessage(msg)} />;

--- a/src/pages/views/components/charts/common/chartDatumUtils.test.ts
+++ b/src/pages/views/components/charts/common/chartDatumUtils.test.ts
@@ -25,9 +25,9 @@ describe('transformReport', () => {
 describe('getTooltipContent', () => {
   test('format hrs and gb', () => {
     [
-      { unit: 'hrs', withTranslation: messages.UnitTooltips },
-      { unit: 'gb', withTranslation: messages.UnitTooltips },
-      { unit: 'gb-mo', withTranslation: messages.UnitTooltips },
+      { unit: 'hrs', withTranslation: messages.unitTooltips },
+      { unit: 'gb', withTranslation: messages.unitTooltips },
+      { unit: 'gb-mo', withTranslation: messages.unitTooltips },
     ].forEach(tc => {
       labelFormatFunc(10, tc.unit);
       expect(intl.formatMessage).toBeCalledWith(tc.withTranslation, { units: 'hrs', value: 10 });

--- a/src/pages/views/components/charts/common/chartDatumUtils.ts
+++ b/src/pages/views/components/charts/common/chartDatumUtils.ts
@@ -360,7 +360,7 @@ export function getDateRangeString(
   const startDate = format(start, 'dd');
   const year = getYear(end);
 
-  return intl.formatMessage(messages.ChartDateRange, { count, startDate, endDate, month, year });
+  return intl.formatMessage(messages.chartDateRange, { count, startDate, endDate, month, year });
 }
 
 export function getMaxValue(datums: ChartDatum[]) {
@@ -397,7 +397,7 @@ export function getTooltipContent(formatter) {
   return function labelFormatter(value: number, unit: string = null, options: FormatOptions = {}) {
     const lookup = unitsLookupKey(unit);
     if (lookup) {
-      return intl.formatMessage(messages.UnitTooltips, {
+      return intl.formatMessage(messages.unitTooltips, {
         units: lookup,
         value: formatter(value, unit, options),
       });
@@ -408,11 +408,11 @@ export function getTooltipContent(formatter) {
 
 export function getCostRangeString(
   datums: ChartDatum[],
-  key: MessageDescriptor = messages.ChartCostLegendLabel,
+  key: MessageDescriptor = messages.chartCostLegendLabel,
   firstOfMonth: boolean = false,
   lastOfMonth: boolean = false,
   offset: number = 0,
-  noDataKey: MessageDescriptor = messages.ChartNoData
+  noDataKey: MessageDescriptor = messages.chartNoData
 ) {
   if (!(datums && datums.length)) {
     return intl.formatMessage(noDataKey);
@@ -434,11 +434,11 @@ export function getCostRangeString(
 
 export function getUsageRangeString(
   datums: ChartDatum[],
-  key: MessageDescriptor = messages.ChartUsageLegendLabel,
+  key: MessageDescriptor = messages.chartUsageLegendLabel,
   firstOfMonth: boolean = false,
   lastOfMonth: boolean = false,
   offset: number = 0,
-  noDataKey: MessageDescriptor = messages.ChartNoData
+  noDataKey: MessageDescriptor = messages.chartNoData
 ) {
   return getCostRangeString(datums, key, firstOfMonth, lastOfMonth, offset, noDataKey);
 }

--- a/src/pages/views/components/charts/common/chartUtils.ts
+++ b/src/pages/views/components/charts/common/chartUtils.ts
@@ -97,9 +97,9 @@ export const getTooltipLabel = (datum: any, formatter: Formatter, formatOptions:
     datum.y0 !== undefined && datum.y0 !== null ? tooltipFormatter(datum.y0, datum.units, formatOptions) : undefined;
 
   if (dy !== undefined && dy0 !== undefined) {
-    return intl.formatMessage(messages.ChartCostForecastConeTooltip, { value0: dy0, value1: dy });
+    return intl.formatMessage(messages.chartCostForecastConeTooltip, { value0: dy0, value1: dy });
   }
-  return dy !== undefined ? dy : intl.formatMessage(messages.ChartNoData);
+  return dy !== undefined ? dy : intl.formatMessage(messages.chartNoData);
 };
 
 export const getResizeObserver = (containerRef: HTMLDivElement, handleResize: () => void) => {

--- a/src/pages/views/components/charts/costChart/costChart.tsx
+++ b/src/pages/views/components/charts/costChart/costChart.tsx
@@ -109,10 +109,10 @@ class CostChartBase extends React.Component<CostChartProps, State> {
       showForecast,
     } = this.props;
 
-    const costKey = messages.ChartCostLegendLabel;
-    const costInfrastructureKey = messages.ChartCostInfrastructureLegendLabel;
-    const costInfrastructureTooltipKey = messages.ChartCostInfrastructureLegendTooltip;
-    const costTooltipKey = messages.ChartCostLegendTooltip;
+    const costKey = messages.chartCostLegendLabel;
+    const costInfrastructureKey = messages.chartCostInfrastructureLegendLabel;
+    const costInfrastructureTooltipKey = messages.chartCostInfrastructureLegendTooltip;
+    const costTooltipKey = messages.chartCostLegendTooltip;
 
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
@@ -121,7 +121,7 @@ class CostChartBase extends React.Component<CostChartProps, State> {
         childName: 'previousCost',
         data: previousCostData,
         legendItem: {
-          name: getCostRangeString(previousCostData, costKey, true, true, 1, messages.ChartCostLegendNoDataLabel),
+          name: getCostRangeString(previousCostData, costKey, true, true, 1, messages.chartCostLegendNoDataLabel),
           symbol: {
             fill: chartStyles.previousColorScale[0],
             type: 'minus',
@@ -139,7 +139,7 @@ class CostChartBase extends React.Component<CostChartProps, State> {
         childName: 'currentCost',
         data: currentCostData,
         legendItem: {
-          name: getCostRangeString(currentCostData, costKey, true, false, 0, messages.ChartCostLegendNoDataLabel),
+          name: getCostRangeString(currentCostData, costKey, true, false, 0, messages.chartCostLegendNoDataLabel),
           symbol: {
             fill: chartStyles.currentColorScale[0],
             type: 'minus',
@@ -163,7 +163,7 @@ class CostChartBase extends React.Component<CostChartProps, State> {
             true,
             true,
             1,
-            messages.ChartCostInfrastructureLegendNoDataLabel
+            messages.chartCostInfrastructureLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.previousColorScale[1],
@@ -188,7 +188,7 @@ class CostChartBase extends React.Component<CostChartProps, State> {
             true,
             false,
             0,
-            messages.ChartCostInfrastructureLegendNoDataLabel
+            messages.chartCostInfrastructureLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.currentInfrastructureColorScale[1],
@@ -212,17 +212,17 @@ class CostChartBase extends React.Component<CostChartProps, State> {
         legendItem: {
           name: getCostRangeString(
             forecastData,
-            messages.ChartCostForecastLegendLabel,
+            messages.chartCostForecastLegendLabel,
             false,
             false,
             0,
-            messages.ChartCostForecastLegendNoDataLabel
+            messages.chartCostForecastLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.forecastDataColorScale[0],
             type: 'minus',
           },
-          tooltip: getCostRangeString(forecastData, messages.ChartCostForecastLegendTooltip, false, false),
+          tooltip: getCostRangeString(forecastData, messages.chartCostForecastLegendTooltip, false, false),
         },
         style: {
           data: {
@@ -237,11 +237,11 @@ class CostChartBase extends React.Component<CostChartProps, State> {
         legendItem: {
           name: getCostRangeString(
             forecastInfrastructureData,
-            messages.ChartCostInfrastructureForecastLegendLabel,
+            messages.chartCostInfrastructureForecastLegendLabel,
             false,
             false,
             0,
-            messages.ChartCostInfrastructureForecastLegendNoDataLabel
+            messages.chartCostInfrastructureForecastLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.forecastInfrastructureDataColorScale[0],
@@ -249,7 +249,7 @@ class CostChartBase extends React.Component<CostChartProps, State> {
           },
           tooltip: getCostRangeString(
             forecastInfrastructureData,
-            messages.ChartCostInfrastructureForecastLegendTooltip,
+            messages.chartCostInfrastructureForecastLegendTooltip,
             false,
             false
           ),
@@ -267,11 +267,11 @@ class CostChartBase extends React.Component<CostChartProps, State> {
         legendItem: {
           name: getCostRangeString(
             forecastConeData,
-            messages.ChartCostInfrastructureForecastConeLegendLabel,
+            messages.chartCostInfrastructureForecastConeLegendLabel,
             false,
             false,
             0,
-            messages.ChartCostInfrastructureForecastConeLegendNoDataLabel
+            messages.chartCostInfrastructureForecastConeLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.forecastConeDataColorScale[0],
@@ -279,7 +279,7 @@ class CostChartBase extends React.Component<CostChartProps, State> {
           },
           tooltip: getCostRangeString(
             forecastConeData,
-            messages.ChartCostInfrastructureForecastConeLegendTooltip,
+            messages.chartCostInfrastructureForecastConeLegendTooltip,
             false,
             false
           ),
@@ -297,11 +297,11 @@ class CostChartBase extends React.Component<CostChartProps, State> {
         legendItem: {
           name: getCostRangeString(
             forecastInfrastructureConeData,
-            messages.ChartCostInfrastructureForecastConeLegendLabel,
+            messages.chartCostInfrastructureForecastConeLegendLabel,
             false,
             false,
             0,
-            messages.ChartCostInfrastructureForecastConeLegendNoDataLabel
+            messages.chartCostInfrastructureForecastConeLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.forecastInfrastructureConeDataColorScale[0],
@@ -309,7 +309,7 @@ class CostChartBase extends React.Component<CostChartProps, State> {
           },
           tooltip: getCostRangeString(
             forecastInfrastructureConeData,
-            messages.ChartCostInfrastructureForecastConeLegendTooltip,
+            messages.chartCostInfrastructureForecastConeLegendTooltip,
             false,
             false
           ),
@@ -491,7 +491,7 @@ class CostChartBase extends React.Component<CostChartProps, State> {
           labelComponent: (
             <ChartLegendTooltip
               legendData={getLegendData(series, hiddenSeries, true)}
-              title={datum => intl.formatMessage(messages.ChartDayOfTheMonth, { day: datum.x })}
+              title={datum => intl.formatMessage(messages.chartDayOfTheMonth, { day: datum.x })}
             />
           ),
         })

--- a/src/pages/views/components/charts/costExplorerChart/costExplorerChart.tsx
+++ b/src/pages/views/components/charts/costExplorerChart/costExplorerChart.tsx
@@ -438,7 +438,7 @@ class CostExplorerChartBase extends React.Component<CostExplorerChartProps, Stat
           labelComponent: (
             <ChartLegendTooltip
               legendData={getLegendData(series, hiddenSeries, true)}
-              title={datum => intl.formatMessage(messages.ChartDayOfTheMonth, { day: datum.x })}
+              title={datum => intl.formatMessage(messages.chartDayOfTheMonth, { day: datum.x })}
             />
           ),
         })

--- a/src/pages/views/components/charts/dailyCostChart/dailyCostChart.tsx
+++ b/src/pages/views/components/charts/dailyCostChart/dailyCostChart.tsx
@@ -112,10 +112,10 @@ class DailyCostChartBase extends React.Component<DailyCostChartProps, State> {
       showForecast,
     } = this.props;
 
-    const costKey = messages.ChartCostLegendLabel;
-    const costInfrastructureKey = messages.ChartCostInfrastructureLegendLabel;
-    const costInfrastructureTooltipKey = messages.ChartCostInfrastructureLegendTooltip;
-    const costTooltipKey = messages.ChartCostLegendTooltip;
+    const costKey = messages.chartCostLegendLabel;
+    const costInfrastructureKey = messages.chartCostInfrastructureLegendLabel;
+    const costInfrastructureTooltipKey = messages.chartCostInfrastructureLegendTooltip;
+    const costTooltipKey = messages.chartCostLegendTooltip;
 
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
@@ -124,7 +124,7 @@ class DailyCostChartBase extends React.Component<DailyCostChartProps, State> {
         childName: 'previousCost',
         data: this.initDatumChildName(previousCostData, 'previousCost'),
         legendItem: {
-          name: getCostRangeString(previousCostData, costKey, true, true, 1, messages.ChartCostLegendNoDataLabel),
+          name: getCostRangeString(previousCostData, costKey, true, true, 1, messages.chartCostLegendNoDataLabel),
           symbol: {
             fill: chartStyles.previousColorScale[0],
             type: 'minus',
@@ -142,7 +142,7 @@ class DailyCostChartBase extends React.Component<DailyCostChartProps, State> {
         childName: 'currentCost',
         data: this.initDatumChildName(currentCostData, 'currentCost'),
         legendItem: {
-          name: getCostRangeString(currentCostData, costKey, true, false, 0, messages.ChartCostLegendNoDataLabel),
+          name: getCostRangeString(currentCostData, costKey, true, false, 0, messages.chartCostLegendNoDataLabel),
           symbol: {
             fill: chartStyles.currentColorScale[0],
             type: 'minus',
@@ -166,7 +166,7 @@ class DailyCostChartBase extends React.Component<DailyCostChartProps, State> {
             true,
             true,
             1,
-            messages.ChartCostInfrastructureLegendNoDataLabel
+            messages.chartCostInfrastructureLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.previousColorScale[1],
@@ -191,7 +191,7 @@ class DailyCostChartBase extends React.Component<DailyCostChartProps, State> {
             true,
             false,
             0,
-            messages.ChartCostInfrastructureLegendNoDataLabel
+            messages.chartCostInfrastructureLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.currentInfrastructureColorScale[1],
@@ -215,17 +215,17 @@ class DailyCostChartBase extends React.Component<DailyCostChartProps, State> {
         legendItem: {
           name: getCostRangeString(
             forecastData,
-            messages.ChartCostForecastLegendLabel,
+            messages.chartCostForecastLegendLabel,
             false,
             false,
             0,
-            messages.ChartCostForecastLegendNoDataLabel
+            messages.chartCostForecastLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.forecastDataColorScale[0],
             type: 'minus',
           },
-          tooltip: getCostRangeString(forecastData, messages.ChartCostForecastLegendTooltip, false, false),
+          tooltip: getCostRangeString(forecastData, messages.chartCostForecastLegendTooltip, false, false),
         },
         isBar: true,
         isForecast: true,
@@ -241,11 +241,11 @@ class DailyCostChartBase extends React.Component<DailyCostChartProps, State> {
         legendItem: {
           name: getCostRangeString(
             forecastInfrastructureData,
-            messages.ChartCostInfrastructureForecastLegendLabel,
+            messages.chartCostInfrastructureForecastLegendLabel,
             false,
             false,
             0,
-            messages.ChartCostInfrastructureForecastLegendNoDataLabel
+            messages.chartCostInfrastructureForecastLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.forecastInfrastructureDataColorScale[0],
@@ -253,7 +253,7 @@ class DailyCostChartBase extends React.Component<DailyCostChartProps, State> {
           },
           tooltip: getCostRangeString(
             forecastInfrastructureData,
-            messages.ChartCostInfrastructureForecastLegendTooltip,
+            messages.chartCostInfrastructureForecastLegendTooltip,
             false,
             false
           ),
@@ -272,17 +272,17 @@ class DailyCostChartBase extends React.Component<DailyCostChartProps, State> {
         legendItem: {
           name: getCostRangeString(
             forecastConeData,
-            messages.ChartCostForecastConeLegendLabel,
+            messages.chartCostForecastConeLegendLabel,
             false,
             false,
             0,
-            messages.ChartCostForecastConeLegendNoDataLabel
+            messages.chartCostForecastConeLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.forecastConeDataColorScale[0],
             type: 'triangleLeft',
           },
-          tooltip: getCostRangeString(forecastConeData, messages.ChartCostForecastConeLegendTooltip, false, false),
+          tooltip: getCostRangeString(forecastConeData, messages.chartCostForecastConeLegendTooltip, false, false),
         },
         isForecast: true,
         isLine: true,
@@ -298,11 +298,11 @@ class DailyCostChartBase extends React.Component<DailyCostChartProps, State> {
         legendItem: {
           name: getCostRangeString(
             forecastInfrastructureConeData,
-            messages.ChartCostInfrastructureForecastConeLegendLabel,
+            messages.chartCostInfrastructureForecastConeLegendLabel,
             false,
             false,
             0,
-            messages.ChartCostInfrastructureForecastConeLegendNoDataLabel
+            messages.chartCostInfrastructureForecastConeLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.forecastInfrastructureConeDataColorScale[0],
@@ -310,7 +310,7 @@ class DailyCostChartBase extends React.Component<DailyCostChartProps, State> {
           },
           tooltip: getCostRangeString(
             forecastInfrastructureConeData,
-            messages.ChartCostInfrastructureForecastConeLegendTooltip,
+            messages.chartCostInfrastructureForecastConeLegendTooltip,
             false,
             false
           ),
@@ -539,7 +539,7 @@ class DailyCostChartBase extends React.Component<DailyCostChartProps, State> {
           labelComponent: (
             <ChartLegendTooltip
               legendData={getLegendData(series, hiddenSeries, true)}
-              title={datum => intl.formatMessage(messages.ChartDayOfTheMonth, { day: datum.x })}
+              title={datum => intl.formatMessage(messages.chartDayOfTheMonth, { day: datum.x })}
             />
           ),
         })

--- a/src/pages/views/components/charts/dailyTrendChart/dailyTrendChart.tsx
+++ b/src/pages/views/components/charts/dailyTrendChart/dailyTrendChart.tsx
@@ -108,28 +108,28 @@ class DailyTrendChartBase extends React.Component<DailyTrendChartProps, State> {
     } = this.props;
 
     const key = showUsageLegendLabel
-      ? messages.ChartUsageLegendLabel
+      ? messages.chartUsageLegendLabel
       : showSupplementaryLabel
-      ? messages.ChartCostSupplementaryLegendLabel
+      ? messages.chartCostSupplementaryLegendLabel
       : showInfrastructureLabel
-      ? messages.ChartCostInfrastructureLegendLabel
-      : messages.ChartCostLegendLabel;
+      ? messages.chartCostInfrastructureLegendLabel
+      : messages.chartCostLegendLabel;
 
     const tooltipKey = showUsageLegendLabel
-      ? messages.ChartUsageLegendTooltip
+      ? messages.chartUsageLegendTooltip
       : showSupplementaryLabel
-      ? messages.ChartCostSupplementaryLegendTooltip
+      ? messages.chartCostSupplementaryLegendTooltip
       : showInfrastructureLabel
-      ? messages.ChartCostInfrastructureLegendTooltip
-      : messages.ChartCostLegendTooltip;
+      ? messages.chartCostInfrastructureLegendTooltip
+      : messages.chartCostLegendTooltip;
 
     const noDataKey = showUsageLegendLabel
-      ? messages.ChartUsageLegendNoDataLabel
+      ? messages.chartUsageLegendNoDataLabel
       : showSupplementaryLabel
-      ? messages.ChartCostSupplementaryLegendNoDataLabel
+      ? messages.chartCostSupplementaryLegendNoDataLabel
       : showInfrastructureLabel
-      ? messages.ChartCostInfrastructureLegendNoDataLabel
-      : messages.ChartCostLegendNoDataLabel;
+      ? messages.chartCostInfrastructureLegendNoDataLabel
+      : messages.chartCostLegendNoDataLabel;
 
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
@@ -179,17 +179,17 @@ class DailyTrendChartBase extends React.Component<DailyTrendChartProps, State> {
         legendItem: {
           name: getCostRangeString(
             forecastData,
-            messages.ChartCostForecastLegendTooltip,
+            messages.chartCostForecastLegendTooltip,
             false,
             false,
             0,
-            messages.ChartCostForecastLegendNoDataLabel
+            messages.chartCostForecastLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.forecastDataColorScale[0],
             type: 'minus',
           },
-          tooltip: getCostRangeString(forecastData, messages.ChartCostForecastConeLegendTooltip, false, false),
+          tooltip: getCostRangeString(forecastData, messages.chartCostForecastConeLegendTooltip, false, false),
         },
         isBar: true,
         isForecast: true,
@@ -205,17 +205,17 @@ class DailyTrendChartBase extends React.Component<DailyTrendChartProps, State> {
         legendItem: {
           name: getCostRangeString(
             forecastConeData,
-            messages.ChartCostForecastConeLegendLabel,
+            messages.chartCostForecastConeLegendLabel,
             false,
             false,
             0,
-            messages.ChartCostForecastConeLegendNoDataLabel
+            messages.chartCostForecastConeLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.forecastConeDataColorScale[0],
             type: 'minus',
           },
-          tooltip: getCostRangeString(forecastConeData, messages.ChartCostForecastConeLegendTooltip, false, false),
+          tooltip: getCostRangeString(forecastConeData, messages.chartCostForecastConeLegendTooltip, false, false),
         },
         isForecast: true,
         isLine: true,
@@ -420,7 +420,7 @@ class DailyTrendChartBase extends React.Component<DailyTrendChartProps, State> {
           labelComponent: (
             <ChartLegendTooltip
               legendData={getLegendData(series, hiddenSeries, true)}
-              title={datum => intl.formatMessage(messages.ChartDayOfTheMonth, { day: datum.x })}
+              title={datum => intl.formatMessage(messages.chartDayOfTheMonth, { day: datum.x })}
             />
           ),
         })

--- a/src/pages/views/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/pages/views/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -94,10 +94,10 @@ class HistoricalCostChartBase extends React.Component<HistoricalCostChartProps, 
     const { currentCostData, currentInfrastructureCostData, previousCostData, previousInfrastructureCostData } =
       this.props;
 
-    const costKey = messages.ChartCostLegendLabel;
-    const costInfrastructureKey = messages.ChartCostInfrastructureLegendLabel;
-    const costInfrastructureTooltipKey = messages.ChartCostInfrastructureLegendTooltip;
-    const costTooltipKey = messages.ChartCostLegendTooltip;
+    const costKey = messages.chartCostLegendLabel;
+    const costInfrastructureKey = messages.chartCostInfrastructureLegendLabel;
+    const costInfrastructureTooltipKey = messages.chartCostInfrastructureLegendTooltip;
+    const costTooltipKey = messages.chartCostLegendTooltip;
 
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
@@ -106,7 +106,7 @@ class HistoricalCostChartBase extends React.Component<HistoricalCostChartProps, 
         childName: 'previousCost',
         data: previousCostData,
         legendItem: {
-          name: getCostRangeString(previousCostData, costKey, true, true, 1, messages.ChartCostLegendNoDataLabel),
+          name: getCostRangeString(previousCostData, costKey, true, true, 1, messages.chartCostLegendNoDataLabel),
           symbol: {
             fill: chartStyles.previousColorScale[0],
             type: 'minus',
@@ -124,7 +124,7 @@ class HistoricalCostChartBase extends React.Component<HistoricalCostChartProps, 
         childName: 'currentCost',
         data: currentCostData,
         legendItem: {
-          name: getCostRangeString(currentCostData, costKey, true, false, 0, messages.ChartCostLegendNoDataLabel),
+          name: getCostRangeString(currentCostData, costKey, true, false, 0, messages.chartCostLegendNoDataLabel),
           symbol: {
             fill: chartStyles.currentColorScale[0],
             type: 'minus',
@@ -148,7 +148,7 @@ class HistoricalCostChartBase extends React.Component<HistoricalCostChartProps, 
             true,
             true,
             1,
-            messages.ChartCostInfrastructureLegendNoDataLabel
+            messages.chartCostInfrastructureLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.previousColorScale[1],
@@ -173,7 +173,7 @@ class HistoricalCostChartBase extends React.Component<HistoricalCostChartProps, 
             true,
             false,
             0,
-            messages.ChartCostInfrastructureLegendNoDataLabel
+            messages.chartCostInfrastructureLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.currentColorScale[1],
@@ -320,7 +320,7 @@ class HistoricalCostChartBase extends React.Component<HistoricalCostChartProps, 
           labelComponent: (
             <ChartLegendTooltip
               legendData={getLegendData(series, hiddenSeries, true)}
-              title={datum => intl.formatMessage(messages.ChartDayOfTheMonth, { day: datum.x })}
+              title={datum => intl.formatMessage(messages.chartDayOfTheMonth, { day: datum.x })}
             />
           ),
         })

--- a/src/pages/views/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/pages/views/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -86,8 +86,8 @@ class HistoricalTrendChartBase extends React.Component<HistoricalTrendChartProps
   private initDatum = () => {
     const { currentData, previousData, showUsageLegendLabel = false } = this.props;
 
-    const key = showUsageLegendLabel ? messages.ChartUsageLegendLabel : messages.ChartCostLegendLabel;
-    const toolTipKey = showUsageLegendLabel ? messages.ChartUsageLegendTooltip : messages.ChartCostLegendTooltip;
+    const key = showUsageLegendLabel ? messages.chartUsageLegendLabel : messages.chartCostLegendLabel;
+    const toolTipKey = showUsageLegendLabel ? messages.chartUsageLegendTooltip : messages.chartCostLegendTooltip;
 
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
@@ -96,7 +96,7 @@ class HistoricalTrendChartBase extends React.Component<HistoricalTrendChartProps
         childName: 'previousCost',
         data: previousData,
         legendItem: {
-          name: getCostRangeString(previousData, key, true, true, 1, messages.ChartUsageLegendNoDataLabel),
+          name: getCostRangeString(previousData, key, true, true, 1, messages.chartUsageLegendNoDataLabel),
           symbol: {
             fill: chartStyles.previousColorScale[0],
             type: 'minus',
@@ -114,7 +114,7 @@ class HistoricalTrendChartBase extends React.Component<HistoricalTrendChartProps
         childName: 'currentCost',
         data: currentData,
         legendItem: {
-          name: getCostRangeString(currentData, key, true, false, 0, messages.ChartUsageLegendNoDataLabel),
+          name: getCostRangeString(currentData, key, true, false, 0, messages.chartUsageLegendNoDataLabel),
           symbol: {
             fill: chartStyles.currentColorScale[1],
             type: 'minus',
@@ -247,7 +247,7 @@ class HistoricalTrendChartBase extends React.Component<HistoricalTrendChartProps
           labelComponent: (
             <ChartLegendTooltip
               legendData={getLegendData(series, hiddenSeries, true)}
-              title={datum => intl.formatMessage(messages.ChartDayOfTheMonth, { day: datum.x })}
+              title={datum => intl.formatMessage(messages.chartDayOfTheMonth, { day: datum.x })}
             />
           ),
         })

--- a/src/pages/views/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/pages/views/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -104,12 +104,12 @@ class HistoricalUsageChartBase extends React.Component<HistoricalUsageChartProps
       previousUsageData,
     } = this.props;
 
-    const limitKey = messages.ChartLimitLegendLabel;
-    const limitTooltipKey = messages.ChartLimitLegendTooltip;
-    const requestKey = messages.ChartRequestsLegendLabel;
-    const requestTooltipKey = messages.ChartRequestsLegendTooltip;
-    const usageKey = messages.ChartUsageLegendLabel;
-    const usageTooltipKey = messages.ChartUsageLegendTooltip;
+    const limitKey = messages.chartLimitLegendLabel;
+    const limitTooltipKey = messages.chartLimitLegendTooltip;
+    const requestKey = messages.chartRequestsLegendLabel;
+    const requestTooltipKey = messages.chartRequestsLegendTooltip;
+    const usageKey = messages.chartUsageLegendLabel;
+    const usageTooltipKey = messages.chartUsageLegendTooltip;
 
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
@@ -118,7 +118,7 @@ class HistoricalUsageChartBase extends React.Component<HistoricalUsageChartProps
         childName: 'previousUsage',
         data: previousUsageData,
         legendItem: {
-          name: getUsageRangeString(previousUsageData, usageKey, true, true, 1, messages.ChartUsageLegendNoDataLabel),
+          name: getUsageRangeString(previousUsageData, usageKey, true, true, 1, messages.chartUsageLegendNoDataLabel),
           symbol: {
             fill: chartStyles.previousColorScale[0],
             type: 'minus',
@@ -136,7 +136,7 @@ class HistoricalUsageChartBase extends React.Component<HistoricalUsageChartProps
         childName: 'currentUsage',
         data: currentUsageData,
         legendItem: {
-          name: getUsageRangeString(currentUsageData, usageKey, true, false, 0, messages.ChartUsageLegendNoDataLabel),
+          name: getUsageRangeString(currentUsageData, usageKey, true, false, 0, messages.chartUsageLegendNoDataLabel),
           symbol: {
             fill: chartStyles.currentColorScale[0],
             type: 'minus',
@@ -160,7 +160,7 @@ class HistoricalUsageChartBase extends React.Component<HistoricalUsageChartProps
             true,
             true,
             1,
-            messages.ChartRequestsLegendNoDataLabel
+            messages.chartRequestsLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.previousColorScale[1],
@@ -185,7 +185,7 @@ class HistoricalUsageChartBase extends React.Component<HistoricalUsageChartProps
             true,
             false,
             0,
-            messages.ChartRequestsLegendNoDataLabel
+            messages.chartRequestsLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.currentColorScale[1],
@@ -204,7 +204,7 @@ class HistoricalUsageChartBase extends React.Component<HistoricalUsageChartProps
         childName: 'previousLimit',
         data: previousLimitData,
         legendItem: {
-          name: getUsageRangeString(previousLimitData, limitKey, true, true, 1, messages.ChartLimitLegendNoDataLabel),
+          name: getUsageRangeString(previousLimitData, limitKey, true, true, 1, messages.chartLimitLegendNoDataLabel),
           symbol: {
             fill: chartStyles.previousColorScale[2],
             type: 'minus',
@@ -222,7 +222,7 @@ class HistoricalUsageChartBase extends React.Component<HistoricalUsageChartProps
         childName: 'currentLimit',
         data: currentLimitData,
         legendItem: {
-          name: getUsageRangeString(currentLimitData, limitKey, true, false, 0, messages.ChartLimitLegendNoDataLabel),
+          name: getUsageRangeString(currentLimitData, limitKey, true, false, 0, messages.chartLimitLegendNoDataLabel),
           symbol: {
             fill: chartStyles.currentColorScale[2],
             type: 'minus',
@@ -367,7 +367,7 @@ class HistoricalUsageChartBase extends React.Component<HistoricalUsageChartProps
           labelComponent: (
             <ChartLegendTooltip
               legendData={getLegendData(series, hiddenSeries, true)}
-              title={datum => intl.formatMessage(messages.ChartDayOfTheMonth, { day: datum.x })}
+              title={datum => intl.formatMessage(messages.chartDayOfTheMonth, { day: datum.x })}
             />
           ),
         })

--- a/src/pages/views/components/charts/trendChart/trendChart.tsx
+++ b/src/pages/views/components/charts/trendChart/trendChart.tsx
@@ -105,28 +105,28 @@ class TrendChartBase extends React.Component<TrendChartProps, State> {
     } = this.props;
 
     const key = showUsageLegendLabel
-      ? messages.ChartUsageLegendLabel
+      ? messages.chartUsageLegendLabel
       : showSupplementaryLabel
-      ? messages.ChartCostSupplementaryLegendLabel
+      ? messages.chartCostSupplementaryLegendLabel
       : showInfrastructureLabel
-      ? messages.ChartCostInfrastructureLegendLabel
-      : messages.ChartCostLegendLabel;
+      ? messages.chartCostInfrastructureLegendLabel
+      : messages.chartCostLegendLabel;
 
     const tooltipKey = showUsageLegendLabel
-      ? messages.ChartUsageLegendTooltip
+      ? messages.chartUsageLegendTooltip
       : showSupplementaryLabel
-      ? messages.ChartCostSupplementaryLegendTooltip
+      ? messages.chartCostSupplementaryLegendTooltip
       : showInfrastructureLabel
-      ? messages.ChartCostInfrastructureLegendTooltip
-      : messages.ChartCostLegendTooltip;
+      ? messages.chartCostInfrastructureLegendTooltip
+      : messages.chartCostLegendTooltip;
 
     const noDataKey = showUsageLegendLabel
-      ? messages.ChartUsageLegendNoDataLabel
+      ? messages.chartUsageLegendNoDataLabel
       : showSupplementaryLabel
-      ? messages.ChartCostSupplementaryLegendNoDataLabel
+      ? messages.chartCostSupplementaryLegendNoDataLabel
       : showInfrastructureLabel
-      ? messages.ChartCostInfrastructureLegendNoDataLabel
-      : messages.ChartCostLegendNoDataLabel;
+      ? messages.chartCostInfrastructureLegendNoDataLabel
+      : messages.chartCostLegendNoDataLabel;
 
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
@@ -176,17 +176,17 @@ class TrendChartBase extends React.Component<TrendChartProps, State> {
         legendItem: {
           name: getCostRangeString(
             forecastData,
-            messages.ChartCostForecastLegendLabel,
+            messages.chartCostForecastLegendLabel,
             false,
             false,
             0,
-            messages.ChartCostForecastLegendNoDataLabel
+            messages.chartCostForecastLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.forecastDataColorScale[0],
             type: 'minus',
           },
-          tooltip: getCostRangeString(forecastData, messages.ChartCostForecastLegendTooltip, false, false),
+          tooltip: getCostRangeString(forecastData, messages.chartCostForecastLegendTooltip, false, false),
         },
         style: {
           data: {
@@ -201,17 +201,17 @@ class TrendChartBase extends React.Component<TrendChartProps, State> {
         legendItem: {
           name: getCostRangeString(
             forecastConeData,
-            messages.ChartCostForecastConeLegendLabel,
+            messages.chartCostForecastConeLegendLabel,
             false,
             false,
             0,
-            messages.ChartCostForecastConeLegendNoDataLabel
+            messages.chartCostForecastConeLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.forecastConeDataColorScale[0],
             type: 'triangleLeft',
           },
-          tooltip: getCostRangeString(forecastConeData, messages.ChartCostForecastConeLegendTooltip, false, false),
+          tooltip: getCostRangeString(forecastConeData, messages.chartCostForecastConeLegendTooltip, false, false),
         },
         style: {
           data: {
@@ -366,7 +366,7 @@ class TrendChartBase extends React.Component<TrendChartProps, State> {
           labelComponent: (
             <ChartLegendTooltip
               legendData={getLegendData(series, hiddenSeries, true)}
-              title={datum => intl.formatMessage(messages.ChartDayOfTheMonth, { day: datum.x })}
+              title={datum => intl.formatMessage(messages.chartDayOfTheMonth, { day: datum.x })}
             />
           ),
         })

--- a/src/pages/views/components/charts/usageChart/usageChart.tsx
+++ b/src/pages/views/components/charts/usageChart/usageChart.tsx
@@ -90,10 +90,10 @@ class UsageChartBase extends React.Component<UsageChartProps, State> {
   private initDatum = () => {
     const { currentRequestData, currentUsageData, previousRequestData, previousUsageData } = this.props;
 
-    const usageKey = messages.ChartUsageLegendLabel;
-    const usageTooltipKey = messages.ChartUsageLegendTooltip;
-    const requestKey = messages.ChartRequestsLegendLabel;
-    const requestTooltipKey = messages.ChartRequestsLegendTooltip;
+    const usageKey = messages.chartUsageLegendLabel;
+    const usageTooltipKey = messages.chartUsageLegendTooltip;
+    const requestKey = messages.chartRequestsLegendLabel;
+    const requestTooltipKey = messages.chartRequestsLegendTooltip;
 
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
 
@@ -102,7 +102,7 @@ class UsageChartBase extends React.Component<UsageChartProps, State> {
         childName: 'previousUsage',
         data: previousUsageData,
         legendItem: {
-          name: getUsageRangeString(previousUsageData, usageKey, true, true, 1, messages.ChartUsageLegendNoDataLabel),
+          name: getUsageRangeString(previousUsageData, usageKey, true, true, 1, messages.chartUsageLegendNoDataLabel),
           symbol: {
             fill: chartStyles.legendColorScale[0],
             type: 'minus',
@@ -115,7 +115,7 @@ class UsageChartBase extends React.Component<UsageChartProps, State> {
         childName: 'currentUsage',
         data: currentUsageData,
         legendItem: {
-          name: getUsageRangeString(currentUsageData, usageKey, true, false, 0, messages.ChartUsageLegendNoDataLabel),
+          name: getUsageRangeString(currentUsageData, usageKey, true, false, 0, messages.chartUsageLegendNoDataLabel),
           symbol: {
             fill: chartStyles.legendColorScale[1],
             type: 'minus',
@@ -134,7 +134,7 @@ class UsageChartBase extends React.Component<UsageChartProps, State> {
             true,
             true,
             1,
-            messages.ChartRequestsLegendNoDataLabel
+            messages.chartRequestsLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.legendColorScale[2],
@@ -154,7 +154,7 @@ class UsageChartBase extends React.Component<UsageChartProps, State> {
             true,
             false,
             0,
-            messages.ChartRequestsLegendNoDataLabel
+            messages.chartRequestsLegendNoDataLabel
           ),
           symbol: {
             fill: chartStyles.legendColorScale[3],
@@ -300,7 +300,7 @@ class UsageChartBase extends React.Component<UsageChartProps, State> {
           labelComponent: (
             <ChartLegendTooltip
               legendData={getLegendData(series, hiddenSeries, true)}
-              title={datum => intl.formatMessage(messages.ChartDayOfTheMonth, { day: datum.x })}
+              title={datum => intl.formatMessage(messages.chartDayOfTheMonth, { day: datum.x })}
             />
           ),
         })

--- a/src/pages/views/components/costType/costType.tsx
+++ b/src/pages/views/components/costType/costType.tsx
@@ -43,9 +43,9 @@ const costTypeOptions: {
   label: MessageDescriptor;
   value: string;
 }[] = [
-  { desc: messages.CostTypeAmortizedDesc, label: messages.CostTypeAmortized, value: CostTypes.amortized },
-  { desc: messages.CostTypeBlendedDesc, label: messages.CostTypeBlended, value: CostTypes.blended },
-  { desc: messages.CostTypeUnblendedDesc, label: messages.CostTypeUnblended, value: CostTypes.unblended },
+  { desc: messages.costTypeAmortizedDesc, label: messages.costTypeAmortized, value: CostTypes.amortized },
+  { desc: messages.costTypeBlendedDesc, label: messages.costTypeBlended, value: CostTypes.blended },
+  { desc: messages.costTypeUnblendedDesc, label: messages.costTypeUnblended, value: CostTypes.unblended },
 ];
 
 class CostTypeBase extends React.Component<CostTypeProps> {
@@ -127,7 +127,7 @@ class CostTypeBase extends React.Component<CostTypeProps> {
     return (
       <div style={styles.costSelector}>
         <Title headingLevel="h3" size="md" style={styles.costLabel}>
-          {intl.formatMessage(messages.CostTypeLabel)}
+          {intl.formatMessage(messages.costTypeLabel)}
         </Title>
         {this.getSelect()}
       </div>

--- a/src/pages/views/components/dataToolbar/dataToolbar.tsx
+++ b/src/pages/views/components/dataToolbar/dataToolbar.tsx
@@ -241,13 +241,13 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
 
     const dropdownItems = [
       <DropdownItem key="item-1" onClick={() => this.handleOnBulkSelectClicked('none')}>
-        {intl.formatMessage(messages.ToolBarBulkSelectNone)}
+        {intl.formatMessage(messages.toolBarBulkSelectNone)}
       </DropdownItem>,
       <DropdownItem key="item-2" onClick={() => this.handleOnBulkSelectClicked('page')}>
-        {intl.formatMessage(messages.ToolBarBulkSelectPage, { value: itemsPerPage })}
+        {intl.formatMessage(messages.toolBarBulkSelectPage, { value: itemsPerPage })}
       </DropdownItem>,
       <DropdownItem key="item-3" onClick={() => this.handleOnBulkSelectClicked('all')}>
-        {intl.formatMessage(messages.ToolBarBulkSelectAll, { value: itemsTotal })}
+        {intl.formatMessage(messages.toolBarBulkSelectAll, { value: itemsTotal })}
       </DropdownItem>,
     ];
 
@@ -263,7 +263,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
                 id="bulk-select"
                 key="bulk-select"
                 aria-label={intl.formatMessage(
-                  anySelected ? messages.ToolBarBulkSelectAriaDeselect : messages.ToolBarBulkSelectAriaSelect
+                  anySelected ? messages.toolBarBulkSelectAriaDeselect : messages.toolBarBulkSelectAriaSelect
                 )}
                 isChecked={isChecked}
                 onClick={() => {
@@ -274,7 +274,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
             onToggle={this.handleOnBulkSelectToggle}
           >
             {numSelected !== 0 && (
-              <React.Fragment>{intl.formatMessage(messages.Selected, { value: numSelected })}</React.Fragment>
+              <React.Fragment>{intl.formatMessage(messages.selected, { value: numSelected })}</React.Fragment>
             )}
           </DropdownToggle>
         }
@@ -394,16 +394,16 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
                 name={`category-input-${categoryOption.key}`}
                 id={`category-input-${categoryOption.key}`}
                 type="search"
-                aria-label={intl.formatMessage(messages.FilterByInputAriaLabel, { value: categoryOption.key })}
+                aria-label={intl.formatMessage(messages.filterByInputAriaLabel, { value: categoryOption.key })}
                 onChange={this.handleOnCategoryInputChange}
                 value={categoryInput}
-                placeholder={intl.formatMessage(messages.FilterByPlaceholder, { value: categoryOption.key })}
+                placeholder={intl.formatMessage(messages.filterByPlaceholder, { value: categoryOption.key })}
                 onKeyDown={evt => this.onCategoryInput(evt, categoryOption.key)}
               />
               <Button
                 isDisabled={isDisabled}
                 variant={ButtonVariant.control}
-                aria-label={intl.formatMessage(messages.FilterByButtonAriaLabel, { value: categoryOption.key })}
+                aria-label={intl.formatMessage(messages.filterByButtonAriaLabel, { value: categoryOption.key })}
                 onClick={evt => this.onCategoryInput(evt, categoryOption.key)}
               >
                 <SearchIcon />
@@ -418,7 +418,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
   private getDefaultCategoryOptions = (): ToolbarChipGroup[] => {
     const { intl } = this.props;
 
-    return [{ name: intl.formatMessage(messages.Names, { count: 1 }), key: 'name' }];
+    return [{ name: intl.formatMessage(messages.names, { count: 1 }), key: 'name' }];
   };
 
   private handleOnCategoryInputChange = (value: string) => {
@@ -512,7 +512,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
       <ToolbarFilter
         categoryName={{
           key: orgUnitIdKey,
-          name: intl.formatMessage(messages.FilterByValues, { value: 'org_unit_id' }),
+          name: intl.formatMessage(messages.filterByValues, { value: 'org_unit_id' }),
         }}
         chips={chips}
         deleteChip={this.onDelete}
@@ -523,12 +523,12 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
           isDisabled={isDisabled}
           className="selectOverride"
           variant={SelectVariant.checkbox}
-          aria-label={intl.formatMessage(messages.FilterByOrgUnitAriaLabel)}
+          aria-label={intl.formatMessage(messages.filterByOrgUnitAriaLabel)}
           onToggle={this.handleOnOrgUnitToggle}
           onSelect={this.handleOnOrgUnitSelect}
           selections={selections}
           isOpen={isOrgUnitSelectExpanded}
-          placeholderText={intl.formatMessage(messages.FilterByOrgUnitPlaceholder)}
+          placeholderText={intl.formatMessage(messages.filterByOrgUnitPlaceholder)}
         >
           {options.map(option => (
             <SelectOption description={option.id} key={option.id} value={option} />
@@ -630,12 +630,12 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
         <Select
           isDisabled={isDisabled}
           variant={SelectVariant.typeahead}
-          typeAheadAriaLabel={intl.formatMessage(messages.FilterByTagKeyAriaLabel)}
+          typeAheadAriaLabel={intl.formatMessage(messages.filterByTagKeyAriaLabel)}
           onClear={this.handleOnTagKeyClear}
           onToggle={this.handleOnTagKeyToggle}
           onSelect={this.handleOnTagKeySelect}
           isOpen={isTagKeySelectExpanded}
-          placeholderText={intl.formatMessage(messages.FilterByTagKeyPlaceholder)}
+          placeholderText={intl.formatMessage(messages.filterByTagKeyPlaceholder)}
           selections={currentTagKey}
         >
           {selectOptions}
@@ -814,7 +814,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
     return (
       <ToolbarItem>
         <Button onClick={this.handleColumnManagementClicked} variant={ButtonVariant.link}>
-          {intl.formatMessage(messages.DetailsColumnManagementTitle)}
+          {intl.formatMessage(messages.detailsColumnManagementTitle)}
         </Button>
       </ToolbarItem>
     );

--- a/src/pages/views/components/dataToolbar/tagValue.tsx
+++ b/src/pages/views/components/dataToolbar/tagValue.tsx
@@ -138,16 +138,16 @@ class TagValueBase extends React.Component<TagValueProps> {
             name="tagkeyvalue-input"
             id="tagkeyvalue-input"
             type="search"
-            aria-label={intl.formatMessage(messages.FilterByTagValueAriaLabel)}
+            aria-label={intl.formatMessage(messages.filterByTagValueAriaLabel)}
             onChange={this.onTagValueChange}
             value={tagKeyValue}
-            placeholder={intl.formatMessage(messages.FilterByTagValueInputPlaceholder)}
+            placeholder={intl.formatMessage(messages.filterByTagValueInputPlaceholder)}
             onKeyDown={evt => onTagValueInput(evt)}
           />
           <Button
             isDisabled={isDisabled}
             variant={ButtonVariant.control}
-            aria-label={intl.formatMessage(messages.FilterByTagValueButtonAriaLabel)}
+            aria-label={intl.formatMessage(messages.filterByTagValueButtonAriaLabel)}
             onClick={evt => onTagValueInput(evt)}
           >
             <SearchIcon />
@@ -159,12 +159,12 @@ class TagValueBase extends React.Component<TagValueProps> {
       <Select
         isDisabled={isDisabled}
         variant={SelectVariant.checkbox}
-        aria-label={intl.formatMessage(messages.FilterByTagValueAriaLabel)}
+        aria-label={intl.formatMessage(messages.filterByTagValueAriaLabel)}
         onToggle={this.onTagValueToggle}
         onSelect={onTagValueSelect}
         selections={selections}
         isOpen={isTagValueExpanded}
-        placeholderText={intl.formatMessage(messages.FilterByTagValuePlaceholder)}
+        placeholderText={intl.formatMessage(messages.filterByTagValuePlaceholder)}
       >
         {selectOptions}
       </Select>

--- a/src/pages/views/components/export/exportModal.tsx
+++ b/src/pages/views/components/export/exportModal.tsx
@@ -67,24 +67,24 @@ const formatTypeOptions: {
   label: MessageDescriptor;
   value: string;
 }[] = [
-  { label: messages.ExportFormatType, value: 'csv' },
-  { label: messages.ExportFormatType, value: 'json' },
+  { label: messages.exportFormatType, value: 'csv' },
+  { label: messages.exportFormatType, value: 'json' },
 ];
 
 const resolutionOptions: {
   label: MessageDescriptor;
   value: string;
 }[] = [
-  { label: messages.ExportResolution, value: 'daily' },
-  { label: messages.ExportResolution, value: 'monthly' },
+  { label: messages.exportResolution, value: 'daily' },
+  { label: messages.exportResolution, value: 'monthly' },
 ];
 
 const timeScopeOptions: {
   label: MessageDescriptor;
   value: string;
 }[] = [
-  { label: messages.ExportTimeScope, value: 'current' },
-  { label: messages.ExportTimeScope, value: 'previous' },
+  { label: messages.exportTimeScope, value: 'current' },
+  { label: messages.exportTimeScope, value: 'previous' },
 ];
 
 export class ExportModalBase extends React.Component<ExportModalProps, ExportModalState> {
@@ -132,11 +132,11 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
 
   private nameValidator = value => {
     if (value.trim().length === 0) {
-      return messages.ExportNameRequired;
+      return messages.exportNameRequired;
     }
     // Todo: what is the max length allowed?
     if (value.length > 50) {
-      return messages.ExportNameTooLong;
+      return messages.exportNameTooLong;
     }
     return undefined;
   };
@@ -161,7 +161,7 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
       if (items && items.length === 0 && isAllItems) {
         sortedItems = [
           {
-            label: intl.formatMessage(messages.ExportAll) as string,
+            label: intl.formatMessage(messages.exportAll) as string,
           },
         ];
       } else {
@@ -169,9 +169,9 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
       }
     }
 
-    let selectedLabel = intl.formatMessage(messages.ExportSelected, { groupBy, count });
+    let selectedLabel = intl.formatMessage(messages.exportSelected, { groupBy, count });
     if (groupBy.indexOf(tagPrefix) !== -1) {
-      selectedLabel = intl.formatMessage(messages.ExportSelected, { groupBy: 'tag', count });
+      selectedLabel = intl.formatMessage(messages.exportSelected, { groupBy: 'tag', count });
     }
 
     const thisMonth = new Date();
@@ -182,7 +182,7 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
     const defaultName =
       name !== undefined
         ? name
-        : intl.formatMessage(messages.ExportName, {
+        : intl.formatMessage(messages.exportName, {
             provider: reportPathsType,
             groupBy: groupBy.indexOf(tagPrefix) !== -1 ? 'tag' : groupBy,
           });
@@ -195,7 +195,7 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
         style={styles.modal}
         isOpen={this.props.isOpen}
         onClose={this.handleClose}
-        title={intl.formatMessage(messages.ExportTitle)}
+        title={intl.formatMessage(messages.exportTitle)}
         variant="small"
         actions={[
           <ExportSubmit
@@ -219,19 +219,19 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
             onClick={this.handleClose}
             variant={ButtonVariant.link}
           >
-            {intl.formatMessage(messages.Cancel)}
+            {intl.formatMessage(messages.cancel)}
           </Button>,
         ]}
       >
-        {error && <Alert variant="danger" style={styles.alert} title={intl.formatMessage(messages.ExportError)} />}
+        {error && <Alert variant="danger" style={styles.alert} title={intl.formatMessage(messages.exportError)} />}
         <div style={styles.title}>
           {/* Todo: Show in-progress features in beta environment only */}
           {isFeatureVisible(FeatureType.exports) ? (
             <span>
-              {intl.formatMessage(messages.ExportDesc, { value: <b>{intl.formatMessage(messages.ExportsTitle)}</b> })}
+              {intl.formatMessage(messages.exportDesc, { value: <b>{intl.formatMessage(messages.exportsTitle)}</b> })}
             </span>
           ) : (
-            <span>{intl.formatMessage(messages.ExportHeading, { groupBy })}</span>
+            <span>{intl.formatMessage(messages.exportHeading, { groupBy })}</span>
           )}
         </div>
         <Form style={styles.form}>
@@ -242,7 +242,7 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
                 <FormGroup
                   fieldId="exportName"
                   helperTextInvalid={helpText ? intl.formatMessage(helpText) : undefined}
-                  label={intl.formatMessage(messages.Names, { count: 1 })}
+                  label={intl.formatMessage(messages.names, { count: 1 })}
                   isRequired
                   validated={validated}
                 >
@@ -258,7 +258,7 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
               </GridItem>
             )}
             {showAggregateType && (
-              <FormGroup fieldId="aggregate-type" label={intl.formatMessage(messages.ExportAggregateType)} isRequired>
+              <FormGroup fieldId="aggregate-type" label={intl.formatMessage(messages.exportAggregateType)} isRequired>
                 <React.Fragment>
                   {resolutionOptions.map((option, index) => (
                     <Radio
@@ -277,7 +277,7 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
               </FormGroup>
             )}
             {showTimeScope && (
-              <FormGroup fieldId="timeScope" label={intl.formatMessage(messages.ExportTimeScopeTitle)} isRequired>
+              <FormGroup fieldId="timeScope" label={intl.formatMessage(messages.exportTimeScopeTitle)} isRequired>
                 <React.Fragment>
                   {timeScopeOptions.map((option, index) => (
                     <Radio
@@ -304,7 +304,7 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
             {/* Todo: Show in-progress features in beta environment only */}
             {showFormatType && isFeatureVisible(FeatureType.exports) && (
               <GridItem span={12}>
-                <FormGroup fieldId="formatType" label={intl.formatMessage(messages.ExportFormatTypeTitle)} isRequired>
+                <FormGroup fieldId="formatType" label={intl.formatMessage(messages.exportFormatTypeTitle)} isRequired>
                   {formatTypeOptions.map((option, index) => (
                     <Radio
                       key={index}

--- a/src/pages/views/components/export/exportSubmit.tsx
+++ b/src/pages/views/components/export/exportSubmit.tsx
@@ -89,7 +89,7 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
     const { endDate, groupBy, intl, reportPathsType, resolution, startDate } = this.props;
 
     // defaultMessage: '<provider>_<groupBy>_<resolution>_<start-date>_<end-date>',
-    const fileName = intl.formatMessage(messages.ExportFileName, {
+    const fileName = intl.formatMessage(messages.exportFileName, {
       endDate,
       provider: reportPathsType,
       groupBy: groupBy.indexOf(tagPrefix) !== -1 ? 'tag' : groupBy,
@@ -136,7 +136,7 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
         onClick={this.handleFetchReport}
         variant={ButtonVariant.primary}
       >
-        {intl.formatMessage(messages.ExportGenerate)}
+        {intl.formatMessage(messages.exportGenerate)}
       </Button>
     );
   }

--- a/src/pages/views/components/groupBy/groupBy.tsx
+++ b/src/pages/views/components/groupBy/groupBy.tsx
@@ -218,7 +218,7 @@ class GroupByBase extends React.Component<GroupByProps> {
       allOptions.push(...groupByTagOptions);
     }
     return allOptions.map(option => ({
-      toString: () => intl.formatMessage(messages.GroupByValuesTitleCase, { value: option.label, count: 1 }),
+      toString: () => intl.formatMessage(messages.groupByValuesTitleCase, { value: option.label, count: 1 }),
       value: option.value,
     }));
   };
@@ -263,7 +263,7 @@ class GroupByBase extends React.Component<GroupByProps> {
     return (
       <div style={styles.groupBySelector}>
         <Title headingLevel="h3" size="md" style={styles.groupBySelectorLabel}>
-          {intl.formatMessage(messages.GroupByLabel)}
+          {intl.formatMessage(messages.groupByLabel)}
         </Title>
         {this.getGroupBy()}
         {Boolean(isGroupByOrgVisible) && (

--- a/src/pages/views/components/groupBy/groupByOrg.tsx
+++ b/src/pages/views/components/groupBy/groupByOrg.tsx
@@ -140,13 +140,13 @@ class GroupByOrgBase extends React.Component<GroupByOrgProps> {
     return (
       <div style={styles.groupBySelector}>
         <Select
-          aria-label={intl.formatMessage(messages.FilterByOrgUnitAriaLabel)}
+          aria-label={intl.formatMessage(messages.filterByOrgUnitAriaLabel)}
           isDisabled={isDisabled}
           onClear={this.handleGroupByClear}
           onToggle={this.handleGroupByToggle}
           onSelect={this.handleGroupBySelected}
           isOpen={isGroupByOpen}
-          placeholderText={intl.formatMessage(messages.FilterByOrgUnitPlaceholder)}
+          placeholderText={intl.formatMessage(messages.filterByOrgUnitPlaceholder)}
           selections={selection}
           variant={SelectVariant.typeahead}
         >

--- a/src/pages/views/components/groupBy/groupByTag.tsx
+++ b/src/pages/views/components/groupBy/groupByTag.tsx
@@ -130,13 +130,13 @@ class GroupByTagBase extends React.Component<GroupByTagProps> {
     return (
       <div style={styles.groupBySelector}>
         <Select
-          aria-label={intl.formatMessage(messages.FilterByTagKeyAriaLabel)}
+          aria-label={intl.formatMessage(messages.filterByTagKeyAriaLabel)}
           isDisabled={isDisabled}
           onClear={this.handleGroupByClear}
           onToggle={this.handleGroupByToggle}
           onSelect={this.handleGroupBySelected}
           isOpen={isGroupByOpen}
-          placeholderText={intl.formatMessage(messages.FilterByTagKeyPlaceholder)}
+          placeholderText={intl.formatMessage(messages.filterByTagKeyPlaceholder)}
           selections={currentItem}
           variant={SelectVariant.typeahead}
         >

--- a/src/pages/views/components/perspective/perspective.tsx
+++ b/src/pages/views/components/perspective/perspective.tsx
@@ -100,7 +100,7 @@ class PerspectiveBase extends React.Component<PerspectiveProps> {
     return (
       <div style={styles.perspectiveSelector}>
         <Title headingLevel="h3" size="md" style={styles.perspectiveLabel}>
-          {intl.formatMessage(messages.Perspective)}
+          {intl.formatMessage(messages.perspective)}
         </Title>
         {this.getSelect()}
       </div>

--- a/src/pages/views/components/reports/reportSummary/reportSummaryDetails.tsx
+++ b/src/pages/views/components/reports/reportSummary/reportSummaryDetails.tsx
@@ -122,7 +122,7 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
       <div className="valueContainer">
         {showTooltip ? (
           <Tooltip
-            content={intl.formatMessage(messages.DashboardTotalCostTooltip, { infrastructureCost, supplementaryCost })}
+            content={intl.formatMessage(messages.dashboardTotalCostTooltip, { infrastructureCost, supplementaryCost })}
             enableFlip
           >
             <div className={`value${altHeroFont}`}>{value}</div>
@@ -142,7 +142,7 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
       return null;
     }
     const usageUnits: string = hasRequest ? report.meta.total.request.units : undefined;
-    const unitsLabel = intl.formatMessage(messages.Units, { units: unitsLookupKey(usageUnits) });
+    const unitsLabel = intl.formatMessage(messages.units, { units: unitsLookupKey(usageUnits) });
 
     return (
       <div className="valueContainer">
@@ -164,7 +164,7 @@ const ReportSummaryDetailsBase: React.SFC<ReportSummaryDetailsProps> = ({
     const usageUnits: string = hasUsage ? report.meta.total.usage.units : undefined;
     // added as a work-around for azure #1079
     const _units = unitsLookupKey(units ? units : usageUnits);
-    const unitsLabel = intl.formatMessage(messages.Units, { units: _units });
+    const unitsLabel = intl.formatMessage(messages.units, { units: _units });
 
     return (
       <div className="valueContainer">

--- a/src/pages/views/components/reports/reportSummary/reportSummaryItem.tsx
+++ b/src/pages/views/components/reports/reportSummary/reportSummaryItem.tsx
@@ -26,10 +26,10 @@ const ReportSummaryItemBase: React.SFC<ReportSummaryItemProps> = ({
   value,
   formatOptions,
 }) => {
-  const unitsLabel = intl.formatMessage(messages.Units, { units: unitsLookupKey(units) });
+  const unitsLabel = intl.formatMessage(messages.units, { units: unitsLookupKey(units) });
   const percent = !totalValue ? 0 : (value / totalValue) * 100;
   const percentVal = formatPercentage(percent);
-  const percentLabel = intl.formatMessage(messages.PercentTotalCost, {
+  const percentLabel = intl.formatMessage(messages.percentTotalCost, {
     percent: percentVal,
     units: unitsLabel,
     value: formatCurrency(value, units, formatOptions),

--- a/src/pages/views/components/resourceTypeahead/resourceInput.tsx
+++ b/src/pages/views/components/resourceTypeahead/resourceInput.tsx
@@ -151,7 +151,7 @@ class ResourceInputBase extends React.Component<ResourceInputProps> {
     // add a heading to the menu
     const headingItem = (
       <MenuItem isDisabled key="heading">
-        {menuItems.length ? intl.formatMessage(messages.Suggestions) : intl.formatMessage(messages.NoResultsFound)}
+        {menuItems.length ? intl.formatMessage(messages.suggestions) : intl.formatMessage(messages.noResultsFound)}
       </MenuItem>
     );
 

--- a/src/pages/views/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/pages/views/details/awsBreakdown/awsBreakdown.tsx
@@ -92,7 +92,7 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
     costType,
     description: query[breakdownDescKey],
     detailsURL,
-    emptyStateTitle: props.intl.formatMessage(messages.AWSDetailsTitle),
+    emptyStateTitle: props.intl.formatMessage(messages.awsDetailsTitle),
     groupBy,
     groupByValue,
     historicalDataComponent: <HistoricalData costType={costType} />,

--- a/src/pages/views/details/awsDetails/awsDetails.tsx
+++ b/src/pages/views/details/awsDetails/awsDetails.tsx
@@ -402,7 +402,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
-    const title = intl.formatMessage(messages.AWSDetailsTitle);
+    const title = intl.formatMessage(messages.awsDetailsTitle);
 
     // Note: Providers are fetched via the AccountSettings component used by all routes
     if (reportError) {

--- a/src/pages/views/details/awsDetails/detailsHeader.tsx
+++ b/src/pages/views/details/awsDetails/detailsHeader.tsx
@@ -83,7 +83,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       <header style={styles.header}>
         <div style={styles.headerContent}>
           <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
-            {intl.formatMessage(messages.AWSDetailsTitle)}
+            {intl.formatMessage(messages.awsDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
             {/* Todo: Show in-progress features in beta environment only */}

--- a/src/pages/views/details/awsDetails/detailsTable.tsx
+++ b/src/pages/views/details/awsDetails/detailsTable.tsx
@@ -96,15 +96,15 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         ? [
             {
               title: groupByOrg
-                ? intl.formatMessage(messages.Names, { count: 2 })
-                : intl.formatMessage(messages.TagNames),
+                ? intl.formatMessage(messages.names, { count: 2 })
+                : intl.formatMessage(messages.tagNames),
             },
             {
-              title: intl.formatMessage(messages.MonthOverMonthChange),
+              title: intl.formatMessage(messages.monthOverMonthChange),
             },
             {
               orderBy: 'cost',
-              title: intl.formatMessage(messages.Cost),
+              title: intl.formatMessage(messages.cost),
               ...(computedItems.length && { transforms: [sortable] }),
             },
             {
@@ -114,15 +114,15 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         : [
             {
               orderBy: groupById === 'account' ? 'account_alias' : groupById,
-              title: intl.formatMessage(messages.DetailsResourceNames, { value: groupById }),
+              title: intl.formatMessage(messages.detailsResourceNames, { value: groupById }),
               ...(computedItems.length && { transforms: [sortable] }),
             },
             {
-              title: intl.formatMessage(messages.MonthOverMonthChange),
+              title: intl.formatMessage(messages.monthOverMonthChange),
             },
             {
               orderBy: 'cost',
-              title: intl.formatMessage(messages.Cost),
+              title: intl.formatMessage(messages.cost),
               ...(computedItems.length && { transforms: [sortable] }),
             },
             {
@@ -226,7 +226,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <EmptyState>
         <EmptyStateIcon icon={CalculatorIcon} />
-        <EmptyStateBody>{intl.formatMessage(messages.DetailsEmptyState)}</EmptyStateBody>
+        <EmptyStateBody>{intl.formatMessage(messages.detailsEmptyState)}</EmptyStateBody>
       </EmptyState>
     );
   };
@@ -256,7 +256,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       return (
         <div className="monthOverMonthOverride">
           <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-            {showPercentage ? intl.formatMessage(messages.Percent, { value: percentage }) : <EmptyValueState />}
+            {showPercentage ? intl.formatMessage(messages.percent, { value: percentage }) : <EmptyValueState />}
             {Boolean(showPercentage && item.delta_percent !== null && item.delta_value > 0) && (
               <span className="fa fa-sort-up" style={styles.infoArrow} key={`month-over-month-icon-${index}`} />
             )}
@@ -312,7 +312,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       <>
         {formatCurrency(item.cost.total.value, item.cost.total.units)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
-          {intl.formatMessage(messages.PercentOfCost, { value: percentValue })}
+          {intl.formatMessage(messages.percentOfCost, { value: percentValue })}
         </div>
       </>
     );
@@ -358,7 +358,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <>
         <Table
-          aria-label={intl.formatMessage(messages.AWSDetailsTableAriaLabel)}
+          aria-label={intl.formatMessage(messages.awsDetailsTableAriaLabel)}
           canSelectAll={false}
           cells={columns}
           className="tableOverride"

--- a/src/pages/views/details/awsDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/awsDetails/detailsToolbar.tsx
@@ -113,18 +113,18 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     const { intl, orgReport, tagReport } = this.props;
 
     const options = [
-      { name: intl.formatMessage(messages.FilterByValues, { value: 'account' }), key: 'account' },
-      { name: intl.formatMessage(messages.FilterByValues, { value: 'service' }), key: 'service' },
-      { name: intl.formatMessage(messages.FilterByValues, { value: 'region' }), key: 'region' },
+      { name: intl.formatMessage(messages.filterByValues, { value: 'account' }), key: 'account' },
+      { name: intl.formatMessage(messages.filterByValues, { value: 'service' }), key: 'service' },
+      { name: intl.formatMessage(messages.filterByValues, { value: 'region' }), key: 'region' },
     ];
     if (orgReport && orgReport.data && orgReport.data.length) {
       options.push({
-        name: intl.formatMessage(messages.FilterByValues, { value: 'org_unit_id' }),
+        name: intl.formatMessage(messages.filterByValues, { value: 'org_unit_id' }),
         key: orgUnitIdKey,
       });
     }
     if (tagReport && tagReport.data && tagReport.data.length) {
-      options.push({ name: intl.formatMessage(messages.FilterByValues, { value: 'tag' }), key: tagKey });
+      options.push({ name: intl.formatMessage(messages.filterByValues, { value: 'tag' }), key: tagKey });
     }
     return options;
   };

--- a/src/pages/views/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/pages/views/details/azureBreakdown/azureBreakdown.tsx
@@ -86,7 +86,7 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateP
     costOverviewComponent: <CostOverview groupBy={groupBy} report={report} />,
     description: query[breakdownDescKey],
     detailsURL,
-    emptyStateTitle: props.intl.formatMessage(messages.AzureDetailsTitle),
+    emptyStateTitle: props.intl.formatMessage(messages.azureDetailsTitle),
     groupBy,
     groupByValue,
     historicalDataComponent: <HistoricalData />,

--- a/src/pages/views/details/azureDetails/azureDetails.tsx
+++ b/src/pages/views/details/azureDetails/azureDetails.tsx
@@ -375,7 +375,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
-    const title = intl.formatMessage(messages.AzureDetailsTitle);
+    const title = intl.formatMessage(messages.azureDetailsTitle);
 
     // Note: Providers are fetched via the AccountSettings component used by all routes
     if (reportError) {

--- a/src/pages/views/details/azureDetails/detailsHeader.tsx
+++ b/src/pages/views/details/azureDetails/detailsHeader.tsx
@@ -69,7 +69,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       <header style={styles.header}>
         <div style={styles.headerContent}>
           <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
-            {intl.formatMessage(messages.AzureDetailsTitle)}
+            {intl.formatMessage(messages.azureDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
             {/* Todo: Show in-progress features in beta environment only */}

--- a/src/pages/views/details/azureDetails/detailsTable.tsx
+++ b/src/pages/views/details/azureDetails/detailsTable.tsx
@@ -92,14 +92,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const columns = groupByTagKey
       ? [
           {
-            title: intl.formatMessage(messages.TagNames),
+            title: intl.formatMessage(messages.tagNames),
           },
           {
-            title: intl.formatMessage(messages.MonthOverMonthChange),
+            title: intl.formatMessage(messages.monthOverMonthChange),
           },
           {
             orderBy: 'cost',
-            title: intl.formatMessage(messages.Cost),
+            title: intl.formatMessage(messages.cost),
             ...(computedItems.length && { transforms: [sortable] }),
           },
           {
@@ -109,15 +109,15 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       : [
           {
             orderBy: groupById,
-            title: intl.formatMessage(messages.DetailsResourceNames, { value: groupById }),
+            title: intl.formatMessage(messages.detailsResourceNames, { value: groupById }),
             ...(computedItems.length && { transforms: [sortable] }),
           },
           {
-            title: intl.formatMessage(messages.MonthOverMonthChange),
+            title: intl.formatMessage(messages.monthOverMonthChange),
           },
           {
             orderBy: 'cost',
-            title: intl.formatMessage(messages.Cost),
+            title: intl.formatMessage(messages.cost),
             ...(computedItems.length && { transforms: [sortable] }),
           },
           {
@@ -216,7 +216,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <EmptyState>
         <EmptyStateIcon icon={CalculatorIcon} />
-        <EmptyStateBody>{intl.formatMessage(messages.DetailsEmptyState)}</EmptyStateBody>
+        <EmptyStateBody>{intl.formatMessage(messages.detailsEmptyState)}</EmptyStateBody>
       </EmptyState>
     );
   };
@@ -260,7 +260,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       return (
         <div className="monthOverMonthOverride">
           <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-            {showPercentage ? intl.formatMessage(messages.Percent, { value: percentage }) : <EmptyValueState />}
+            {showPercentage ? intl.formatMessage(messages.percent, { value: percentage }) : <EmptyValueState />}
             {Boolean(showPercentage && item.delta_percent !== null && item.delta_value > 0) && (
               <span className="fa fa-sort-up" style={styles.infoArrow} key={`month-over-month-icon-${index}`} />
             )}
@@ -316,7 +316,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       <>
         {formatCurrency(item.cost.total.value, item.cost.total.units)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
-          {intl.formatMessage(messages.PercentOfCost, { value: percentValue })}
+          {intl.formatMessage(messages.percentOfCost, { value: percentValue })}
         </div>
       </>
     );
@@ -362,7 +362,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <>
         <Table
-          aria-label={intl.formatMessage(messages.AzureDetailsTableAriaLabel)}
+          aria-label={intl.formatMessage(messages.azureDetailsTableAriaLabel)}
           canSelectAll={false}
           cells={columns}
           className="tableOverride"

--- a/src/pages/views/details/azureDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/azureDetails/detailsToolbar.tsx
@@ -97,18 +97,18 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 
     const options = [
       {
-        name: intl.formatMessage(messages.FilterByValues, { value: 'subscription_guid' }),
+        name: intl.formatMessage(messages.filterByValues, { value: 'subscription_guid' }),
         key: 'subscription_guid',
       },
-      { name: intl.formatMessage(messages.FilterByValues, { value: 'service_name' }), key: 'service_name' },
+      { name: intl.formatMessage(messages.filterByValues, { value: 'service_name' }), key: 'service_name' },
       {
-        name: intl.formatMessage(messages.FilterByValues, { value: 'resource_location' }),
+        name: intl.formatMessage(messages.filterByValues, { value: 'resource_location' }),
         key: 'resource_location',
       },
     ];
 
     if (tagReport && tagReport.data && tagReport.data.length) {
-      options.push({ name: intl.formatMessage(messages.FilterByValues, { value: tagKey }), key: tagKey });
+      options.push({ name: intl.formatMessage(messages.filterByValues, { value: tagKey }), key: tagKey });
     }
     return options;
   };

--- a/src/pages/views/details/components/actions/actions.tsx
+++ b/src/pages/views/details/components/actions/actions.tsx
@@ -103,7 +103,7 @@ class DetailsActionsBase extends React.Component<DetailsActionsProps> {
     // tslint:disable:jsx-wrap-multiline
     const items = [
       <DropdownItem component="button" isDisabled={isDisabled} key="export-action" onClick={this.handleExportModalOpen}>
-        {intl.formatMessage(messages.DetailsActionsExport)}
+        {intl.formatMessage(messages.detailsActionsExport)}
       </DropdownItem>,
     ];
 
@@ -115,7 +115,7 @@ class DetailsActionsBase extends React.Component<DetailsActionsProps> {
           isDisabled={isDisabled || groupBy.includes(tagPrefix) || source_uuid.length === 0}
           onClick={() => redirectToCostModel(source_uuid[0], history)}
         >
-          {intl.formatMessage(messages.DetailsActionsPriceList)}
+          {intl.formatMessage(messages.detailsActionsPriceList)}
         </DropdownItem>
       );
     }

--- a/src/pages/views/details/components/breakdown/breakdownBase.tsx
+++ b/src/pages/views/details/components/breakdown/breakdownBase.tsx
@@ -177,9 +177,9 @@ class BreakdownBase extends React.Component<BreakdownProps> {
     const { intl } = this.props;
 
     if (tab === BreakdownTab.costOverview) {
-      return intl.formatMessage(messages.BreakdownCostOverviewTitle);
+      return intl.formatMessage(messages.breakdownCostOverviewTitle);
     } else if (tab === BreakdownTab.historicalData) {
-      return intl.formatMessage(messages.BreakdownHistoricalDataTitle);
+      return intl.formatMessage(messages.breakdownHistoricalDataTitle);
     }
   };
 

--- a/src/pages/views/details/components/breakdown/breakdownHeader.tsx
+++ b/src/pages/views/details/components/breakdown/breakdownHeader.tsx
@@ -115,15 +115,15 @@ class BreakdownHeaderBase extends React.Component<BreakdownHeaderProps> {
     return (
       <header style={styles.header}>
         <div style={styles.headerContent}>
-          <nav aria-label={intl.formatMessage(messages.BreakdownBackToDetailsAriaLabel)} className="breadcrumbOverride">
+          <nav aria-label={intl.formatMessage(messages.breakdownBackToDetailsAriaLabel)} className="breadcrumbOverride">
             <ol className="pf-c-breadcrumb__list">
               <li className="pf-c-breadcrumb__item">
                 <span className="pf-c-breadcrumb__item-divider">
                   <AngleLeftIcon />
                 </span>
                 <Link to={this.buildDetailsLink()}>
-                  {intl.formatMessage(messages.BreakdownBackToDetails, {
-                    value: intl.formatMessage(messages.BreakdownBackToTitles, { value: tagReportPathsType }),
+                  {intl.formatMessage(messages.breakdownBackToDetails, {
+                    value: intl.formatMessage(messages.breakdownBackToTitles, { value: tagReportPathsType }),
                     groupBy: groupByKey,
                   })}
                 </Link>
@@ -138,7 +138,7 @@ class BreakdownHeaderBase extends React.Component<BreakdownHeaderProps> {
         <div style={styles.headerContent}>
           <div style={styles.title}>
             <Title headingLevel="h1" size={TitleSizes['2xl']}>
-              {intl.formatMessage(messages.BreakdownTitle, { value: title })}
+              {intl.formatMessage(messages.breakdownTitle, { value: title })}
               {description && <div style={styles.infoDescription}>{description}</div>}
             </Title>
             {showCostType && (
@@ -155,8 +155,8 @@ class BreakdownHeaderBase extends React.Component<BreakdownHeaderProps> {
             </div>
             <div style={styles.costLabelDate}>
               {getForDateRangeString(
-                intl.formatMessage(messages.GroupByValuesTitleCase, { value: groupByKey, count: 2 }),
-                messages.BreakdownTotalCostDate,
+                intl.formatMessage(messages.groupByValuesTitleCase, { value: groupByKey, count: 2 }),
+                messages.breakdownTotalCostDate,
                 0
               )}
             </div>

--- a/src/pages/views/details/components/cluster/cluster.tsx
+++ b/src/pages/views/details/components/cluster/cluster.tsx
@@ -88,7 +88,7 @@ class ClusterBase extends React.Component<ClusterProps> {
         {Boolean(someClusters) && someClusters.map((cluster, index) => <span key={index}>{cluster}</span>)}
         {Boolean(someClusters.length < allClusters.length) && (
           <a {...getTestProps(testIds.details.cluster_lnk)} href="#/" onClick={this.handleOpen}>
-            {intl.formatMessage(messages.DetailsMoreClusters, { value: allClusters.length - someClusters.length })}
+            {intl.formatMessage(messages.detailsMoreClusters, { value: allClusters.length - someClusters.length })}
           </a>
         )}
         <ClusterModal groupBy={groupBy} isOpen={isOpen} item={item} onClose={this.handleClose} />

--- a/src/pages/views/details/components/cluster/clusterModal.tsx
+++ b/src/pages/views/details/components/cluster/clusterModal.tsx
@@ -42,7 +42,7 @@ class ClusterModalBase extends React.Component<ClusterModalProps> {
         style={styles.modal}
         isOpen={isOpen}
         onClose={this.handleClose}
-        title={intl.formatMessage(messages.DetailsClustersModalTitle, { groupBy, name: item.label })}
+        title={intl.formatMessage(messages.detailsClustersModalTitle, { groupBy, name: item.label })}
         width={'50%'}
       >
         <ClusterContent item={item} />

--- a/src/pages/views/details/components/columnManagement/columnManagementModal.tsx
+++ b/src/pages/views/details/components/columnManagement/columnManagementModal.tsx
@@ -126,28 +126,28 @@ export class ColumnManagementModalBase extends React.Component<ColumnManagementM
       <Modal
         description={
           <TextContent>
-            <Text component={TextVariants.p}>{intl.formatMessage(messages.ManageColumnsDesc)}</Text>
+            <Text component={TextVariants.p}>{intl.formatMessage(messages.manageColumnsDesc)}</Text>
             <Button isInline onClick={this.selectAll} variant="link">
-              {intl.formatMessage(messages.SelectAll)}
+              {intl.formatMessage(messages.selectAll)}
             </Button>
           </TextContent>
         }
         // style={styles.modal}
         isOpen={this.props.isOpen}
         onClose={this.handleClose}
-        title={intl.formatMessage(messages.ManageColumnsTitle)}
+        title={intl.formatMessage(messages.manageColumnsTitle)}
         variant={ModalVariant.medium}
         actions={[
           <Button key="save" onClick={this.handleSave} variant={ButtonVariant.link}>
-            {intl.formatMessage(messages.Save)}
+            {intl.formatMessage(messages.save)}
           </Button>,
           <Button key="cancel" onClick={this.handleClose} variant={ButtonVariant.link}>
-            {intl.formatMessage(messages.Cancel)}
+            {intl.formatMessage(messages.cancel)}
           </Button>,
         ]}
       >
         <DataList
-          aria-label={intl.formatMessage(messages.ManageColumnsAriaLabel)}
+          aria-label={intl.formatMessage(messages.manageColumnsAriaLabel)}
           id="table-column-management"
           isCompact
         >

--- a/src/pages/views/details/components/costChart/costChart.tsx
+++ b/src/pages/views/details/components/costChart/costChart.tsx
@@ -66,9 +66,9 @@ class CostChartBase extends React.Component<CostChartProps> {
     const raw = formatCurrency(hasRaw ? report.meta.total.cost.raw.value : 0, rawUnits);
     const usage = formatCurrency(hasUsage ? report.meta.total.cost.usage.value : 0, usageUnits);
 
-    const markupLabel = intl.formatMessage(messages.MarkupTitle);
-    const rawLabel = intl.formatMessage(messages.RawCostTitle);
-    const usageLabel = intl.formatMessage(messages.UsageCostTitle);
+    const markupLabel = intl.formatMessage(messages.markupTitle);
+    const rawLabel = intl.formatMessage(messages.rawCostTitle);
+    const usageLabel = intl.formatMessage(messages.usageCostTitle);
 
     // Override legend label layout
     const LegendLabel = this.getLegendLabel();
@@ -87,8 +87,8 @@ class CostChartBase extends React.Component<CostChartProps> {
           this.getSkeleton()
         ) : (
           <ChartPie
-            ariaDesc={intl.formatMessage(messages.BreakdownCostChartAriaDesc)}
-            ariaTitle={intl.formatMessage(messages.BreakdownCostBreakdownTitle)}
+            ariaDesc={intl.formatMessage(messages.breakdownCostChartAriaDesc)}
+            ariaTitle={intl.formatMessage(messages.breakdownCostBreakdownTitle)}
             constrainToVisibleArea
             data={[
               { x: rawLabel, y: rawValue, units: rawUnits },
@@ -97,7 +97,7 @@ class CostChartBase extends React.Component<CostChartProps> {
             ]}
             height={chartStyles.chartHeight}
             labels={({ datum }) =>
-              intl.formatMessage(messages.BreakdownCostChartTooltip, {
+              intl.formatMessage(messages.breakdownCostChartTooltip, {
                 name: datum.x,
                 value: formatCurrency(datum.y, datum.units),
               })

--- a/src/pages/views/details/components/costOverview/costOverviewBase.tsx
+++ b/src/pages/views/details/components/costOverview/costOverviewBase.tsx
@@ -56,7 +56,7 @@ class CostOverviewsBase extends React.Component<CostOverviewProps> {
         <Card>
           <CardTitle>
             <Title headingLevel="h2" size={TitleSizes.lg}>
-              {intl.formatMessage(messages.Clusters)}
+              {intl.formatMessage(messages.clusters)}
             </Title>
           </CardTitle>
           <CardBody>
@@ -76,23 +76,23 @@ class CostOverviewsBase extends React.Component<CostOverviewProps> {
       <Card>
         <CardTitle>
           <Title headingLevel="h2" size={TitleSizes.lg}>
-            {intl.formatMessage(messages.BreakdownCostBreakdownTitle)}
+            {intl.formatMessage(messages.breakdownCostBreakdownTitle)}
             <Popover
-              aria-label={intl.formatMessage(messages.BreakdownCostBreakdownAriaLabel)}
+              aria-label={intl.formatMessage(messages.breakdownCostBreakdownAriaLabel)}
               enableFlip
               bodyContent={
                 <>
-                  <p style={styles.infoTitle}>{intl.formatMessage(messages.RawCostTitle)}</p>
-                  <p>{intl.formatMessage(messages.RawCostDescription)}</p>
+                  <p style={styles.infoTitle}>{intl.formatMessage(messages.rawCostTitle)}</p>
+                  <p>{intl.formatMessage(messages.rawCostDescription)}</p>
                   <br />
-                  <p style={styles.infoTitle}>{intl.formatMessage(messages.UsageCostTitle)}</p>
-                  <p>{intl.formatMessage(messages.UsageCostDescription)}</p>
+                  <p style={styles.infoTitle}>{intl.formatMessage(messages.usageCostTitle)}</p>
+                  <p>{intl.formatMessage(messages.usageCostDescription)}</p>
                   <br />
-                  <p style={styles.infoTitle}>{intl.formatMessage(messages.MarkupTitle)}</p>
-                  <p>{intl.formatMessage(messages.MarkupDescription)}</p>
+                  <p style={styles.infoTitle}>{intl.formatMessage(messages.markupTitle)}</p>
+                  <p>{intl.formatMessage(messages.markupDescription)}</p>
                   <br />
-                  <a href={intl.formatMessage(messages.DocsCostModelTerminology)} rel="noreferrer" target="_blank">
-                    {intl.formatMessage(messages.LearnMore)}
+                  <a href={intl.formatMessage(messages.docsCostModelTerminology)} rel="noreferrer" target="_blank">
+                    {intl.formatMessage(messages.learnMore)}
                   </a>
                 </>
               }
@@ -118,7 +118,7 @@ class CostOverviewsBase extends React.Component<CostOverviewProps> {
       <Card>
         <CardTitle>
           <Title headingLevel="h2" size={TitleSizes.lg}>
-            {intl.formatMessage(messages.CpuTitle)}
+            {intl.formatMessage(messages.cpuTitle)}
           </Title>
         </CardTitle>
         <CardBody>
@@ -136,7 +136,7 @@ class CostOverviewsBase extends React.Component<CostOverviewProps> {
       <Card>
         <CardTitle>
           <Title headingLevel="h2" size={TitleSizes.lg}>
-            {intl.formatMessage(messages.MemoryTitle)}
+            {intl.formatMessage(messages.memoryTitle)}
           </Title>
         </CardTitle>
         <CardBody>

--- a/src/pages/views/details/components/historicalData/historicalDataBase.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataBase.tsx
@@ -31,7 +31,7 @@ class HistoricalDatasBase extends React.Component<HistoricalDataProps> {
       <Card>
         <CardTitle>
           <Title headingLevel="h2" size={TitleSizes.lg}>
-            {intl.formatMessage(messages.HistoricalChartTitle, { value: widget.reportType })}
+            {intl.formatMessage(messages.historicalChartTitle, { value: widget.reportType })}
           </Title>
         </CardTitle>
         <CardBody>
@@ -53,7 +53,7 @@ class HistoricalDatasBase extends React.Component<HistoricalDataProps> {
       <Card>
         <CardTitle>
           <Title headingLevel="h2" size={TitleSizes.lg}>
-            {intl.formatMessage(messages.HistoricalChartTitle, { value: widget.reportType })}
+            {intl.formatMessage(messages.historicalChartTitle, { value: widget.reportType })}
           </Title>
         </CardTitle>
         <CardBody>
@@ -75,7 +75,7 @@ class HistoricalDatasBase extends React.Component<HistoricalDataProps> {
       <Card>
         <CardTitle>
           <Title headingLevel="h2" size={TitleSizes.lg}>
-            {intl.formatMessage(messages.HistoricalChartTitle, { value: widget.reportType })}
+            {intl.formatMessage(messages.historicalChartTitle, { value: widget.reportType })}
           </Title>
         </CardTitle>
         <CardBody>

--- a/src/pages/views/details/components/historicalData/historicalDataCostChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataCostChart.tsx
@@ -85,7 +85,7 @@ class HistoricalDataCostChartBase extends React.Component<HistoricalDataCostChar
         ? currentReport.meta.total.cost.total.units
         : 'USD';
 
-    const test = intl.formatMessage(messages.CurrencyUnits, { units: costUnits });
+    const test = intl.formatMessage(messages.currencyUnits, { units: costUnits });
 
     return (
       <div style={styles.chartContainer}>
@@ -104,8 +104,8 @@ class HistoricalDataCostChartBase extends React.Component<HistoricalDataCostChar
               height={chartStyles.chartHeight}
               previousCostData={previousData}
               previousInfrastructureCostData={previousInfrastructureCostData}
-              xAxisLabel={intl.formatMessage(messages.HistoricalChartDayOfMonthLabel)}
-              yAxisLabel={intl.formatMessage(messages.HistoricalChartCostLabel, {
+              xAxisLabel={intl.formatMessage(messages.historicalChartDayOfMonthLabel)}
+              yAxisLabel={intl.formatMessage(messages.historicalChartCostLabel, {
                 units: test,
               })}
             />

--- a/src/pages/views/details/components/historicalData/historicalDataTrendChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataTrendChart.tsx
@@ -101,13 +101,13 @@ class HistoricalDataTrendChartBase extends React.Component<HistoricalDataTrendCh
 
     let yAxisLabel;
     if (isCostChart) {
-      const units = intl.formatMessage(messages.CurrencyUnits, { units: costUnits });
-      yAxisLabel = intl.formatMessage(messages.HistoricalChartCostLabel, { units });
+      const units = intl.formatMessage(messages.currencyUnits, { units: costUnits });
+      yAxisLabel = intl.formatMessage(messages.historicalChartCostLabel, { units });
     } else if (usageUnits && Number.isNaN(Number(currentReport.meta.total.usage.units))) {
-      yAxisLabel = intl.formatMessage(messages.Units, { units: unitsLookupKey(usageUnits) });
+      yAxisLabel = intl.formatMessage(messages.units, { units: unitsLookupKey(usageUnits) });
     } else {
-      const units = intl.formatMessage(messages.HistoricalChartUsageLabel, { value: reportType });
-      yAxisLabel = intl.formatMessage(messages.Units, { units: unitsLookupKey(units) });
+      const units = intl.formatMessage(messages.historicalChartUsageLabel, { value: reportType });
+      yAxisLabel = intl.formatMessage(messages.units, { units: unitsLookupKey(units) });
     }
 
     return (
@@ -125,7 +125,7 @@ class HistoricalDataTrendChartBase extends React.Component<HistoricalDataTrendCh
               height={chartStyles.chartHeight}
               previousData={previousData}
               units={isCostChart ? costUnits : usageUnits}
-              xAxisLabel={intl.formatMessage(messages.HistoricalChartDayOfMonthLabel)}
+              xAxisLabel={intl.formatMessage(messages.historicalChartDayOfMonthLabel)}
               yAxisLabel={yAxisLabel}
             />
           )}

--- a/src/pages/views/details/components/historicalData/historicalDataUsageChart.tsx
+++ b/src/pages/views/details/components/historicalData/historicalDataUsageChart.tsx
@@ -105,8 +105,8 @@ class HistoricalDataUsageChartBase extends React.Component<HistoricalDataUsageCh
               previousLimitData={previousLimitData}
               previousRequestData={previousRequestData}
               previousUsageData={previousUsageData}
-              xAxisLabel={intl.formatMessage(messages.HistoricalChartDayOfMonthLabel)}
-              yAxisLabel={intl.formatMessage(messages.Units, { units: unitsLookupKey(usageUnits) })}
+              xAxisLabel={intl.formatMessage(messages.historicalChartDayOfMonthLabel)}
+              yAxisLabel={intl.formatMessage(messages.units, { units: unitsLookupKey(usageUnits) })}
             />
           )}
         </div>

--- a/src/pages/views/details/components/summary/summaryCard.tsx
+++ b/src/pages/views/details/components/summary/summaryCard.tsx
@@ -125,7 +125,7 @@ class SummaryBase extends React.Component<SummaryProps> {
             type={ButtonType.button}
             variant={ButtonVariant.link}
           >
-            {intl.formatMessage(messages.DetailsViewAll, { value: reportGroupBy })}
+            {intl.formatMessage(messages.detailsViewAll, { value: reportGroupBy })}
           </Button>
           <SummaryModal
             groupBy={groupBy}
@@ -159,7 +159,7 @@ class SummaryBase extends React.Component<SummaryProps> {
       <Card style={styles.card}>
         <CardTitle>
           <Title headingLevel="h2" size={TitleSizes.lg}>
-            {intl.formatMessage(messages.BreakdownSummaryTitle, { value: reportGroupBy })}
+            {intl.formatMessage(messages.breakdownSummaryTitle, { value: reportGroupBy })}
           </Title>
         </CardTitle>
         <CardBody>

--- a/src/pages/views/details/components/summary/summaryModal.tsx
+++ b/src/pages/views/details/components/summary/summaryModal.tsx
@@ -44,7 +44,7 @@ class SummaryModalBase extends React.Component<SummaryModalProps> {
         className="modalOverride"
         isOpen={isOpen}
         onClose={this.handleClose}
-        title={intl.formatMessage(messages.DetailsSummaryModalTitle, {
+        title={intl.formatMessage(messages.detailsSummaryModalTitle, {
           groupBy: reportGroupBy,
           name: groupByValue,
         })}

--- a/src/pages/views/details/components/summary/summaryModalContent.tsx
+++ b/src/pages/views/details/components/summary/summaryModalContent.tsx
@@ -65,7 +65,7 @@ class SummaryModalContentBase extends React.Component<SummaryModalContentProps> 
       <>
         <div style={styles.subTitle}>
           <Title headingLevel="h2" size={TitleSizes.xl}>
-            {intl.formatMessage(messages.DetailsCostValue, { value: cost })}
+            {intl.formatMessage(messages.detailsCostValue, { value: cost })}
           </Title>
         </div>
         <div style={styles.mainContent}>

--- a/src/pages/views/details/components/tag/tagContent.tsx
+++ b/src/pages/views/details/components/tag/tagContent.tsx
@@ -52,25 +52,25 @@ class TagContentBase extends React.Component<TagContentProps> {
       <>
         <div>
           <span style={styles.dataListHeading}>
-            {intl.formatMessage(messages.GroupByValues, { value: groupBy, count: 1 })}
+            {intl.formatMessage(messages.groupByValues, { value: groupBy, count: 1 })}
           </span>
         </div>
         <div style={styles.groupByHeading}>
           <span>{groupByValue}</span>
         </div>
-        <DataList aria-label={intl.formatMessage(messages.TagNames)} isCompact>
+        <DataList aria-label={intl.formatMessage(messages.tagNames)} isCompact>
           <DataListItem aria-labelledby="heading1">
             <DataListItemRow>
               <DataListItemCells
                 dataListCells={[
                   <DataListCell key="primary content">
                     <span id="heading1" style={styles.dataListHeading}>
-                      {intl.formatMessage(messages.TagHeadingKey)}
+                      {intl.formatMessage(messages.tagHeadingKey)}
                     </span>
                   </DataListCell>,
                   <DataListCell key="secondary content">
                     <span id="heading2" style={styles.dataListHeading}>
-                      {intl.formatMessage(messages.TagHeadingValue)}
+                      {intl.formatMessage(messages.tagHeadingValue)}
                     </span>
                   </DataListCell>,
                 ]}

--- a/src/pages/views/details/components/tag/tagModal.tsx
+++ b/src/pages/views/details/components/tag/tagModal.tsx
@@ -85,7 +85,7 @@ class TagModalBase extends React.Component<TagModalProps> {
       <Modal
         isOpen={isOpen}
         onClose={this.handleClose}
-        title={intl.formatMessage(messages.TagHeadingTitle, { value: this.getTagValueCount() })}
+        title={intl.formatMessage(messages.tagHeadingTitle, { value: this.getTagValueCount() })}
         width={'50%'}
       >
         <TagContent groupBy={groupBy} groupByValue={groupByValue} tagReport={tagReport} />

--- a/src/pages/views/details/components/usageChart/usageChart.tsx
+++ b/src/pages/views/details/components/usageChart/usageChart.tsx
@@ -97,15 +97,15 @@ class UsageChartBase extends React.Component<UsageChartProps> {
 
     const hasLimit = hasTotal && report.meta.total.limit && report.meta.total.limit !== null;
     const limit = Math.trunc(hasLimit ? report.meta.total.limit.value : 0);
-    const limitUnits = intl.formatMessage(messages.Units, {
+    const limitUnits = intl.formatMessage(messages.units, {
       units: unitsLookupKey(hasLimit ? report.meta.total.limit.units : undefined),
     });
     datum.limit = {
-      legend: intl.formatMessage(messages.DetailsUsageLimit, {
+      legend: intl.formatMessage(messages.detailsUsageLimit, {
         value: limit,
         units: limitUnits,
       }),
-      tooltip: intl.formatMessage(messages.DetailsUsageLimit, {
+      tooltip: intl.formatMessage(messages.detailsUsageLimit, {
         value: limit,
         units: limitUnits,
       }),
@@ -116,16 +116,16 @@ class UsageChartBase extends React.Component<UsageChartProps> {
     if (groupBy === 'cluster') {
       const hasCapacity = hasTotal && report.meta.total.request && report.meta.total.request !== null;
       const capacity = Math.trunc(hasCapacity ? report.meta.total.capacity.value : 0);
-      const capacityUnits = intl.formatMessage(messages.Units, {
+      const capacityUnits = intl.formatMessage(messages.units, {
         units: unitsLookupKey(hasCapacity ? report.meta.total.capacity.units : undefined),
       });
       datum.ranges = [
         {
-          legend: intl.formatMessage(messages.DetailsUsageCapacity, {
+          legend: intl.formatMessage(messages.detailsUsageCapacity, {
             value: capacity,
             units: capacityUnits,
           }),
-          tooltip: intl.formatMessage(messages.DetailsUsageCapacity, {
+          tooltip: intl.formatMessage(messages.detailsUsageCapacity, {
             value: capacity,
             units: capacityUnits,
           }),
@@ -137,31 +137,31 @@ class UsageChartBase extends React.Component<UsageChartProps> {
     const hasRequest = hasTotal && report.meta.total.request && report.meta.total.request !== null;
     const hasUsage = hasTotal && report.meta.total.usage && report.meta.total.usage !== null;
     const request = Math.trunc(hasRequest ? report.meta.total.request.value : 0);
-    const requestUnits = intl.formatMessage(messages.Units, {
+    const requestUnits = intl.formatMessage(messages.units, {
       units: unitsLookupKey(hasRequest ? report.meta.total.request.units : undefined),
     });
     const usage = Math.trunc(hasUsage ? report.meta.total.usage.value : 0);
-    const usageUnits = intl.formatMessage(messages.Units, {
+    const usageUnits = intl.formatMessage(messages.units, {
       units: unitsLookupKey(hasUsage ? report.meta.total.usage.units : undefined),
     });
     datum.usage = [
       {
-        legend: intl.formatMessage(messages.DetailsUsageUsage, {
+        legend: intl.formatMessage(messages.detailsUsageUsage, {
           value: usage,
           units: usageUnits,
         }),
-        tooltip: intl.formatMessage(messages.DetailsUsageUsage, {
+        tooltip: intl.formatMessage(messages.detailsUsageUsage, {
           value: usage,
           units: usageUnits,
         }),
         value: Math.trunc(usage),
       },
       {
-        legend: intl.formatMessage(messages.DetailsUsageRequests, {
+        legend: intl.formatMessage(messages.detailsUsageRequests, {
           value: request,
           units: requestUnits,
         }),
-        tooltip: intl.formatMessage(messages.DetailsUsageRequests, {
+        tooltip: intl.formatMessage(messages.detailsUsageRequests, {
           value: request,
           units: requestUnits,
         }),
@@ -259,11 +259,11 @@ class UsageChartBase extends React.Component<UsageChartProps> {
 
     const capacity = Math.trunc(hasCapacity ? report.meta.total.capacity.value : 0);
     const request = Math.trunc(hasRequest ? report.meta.total.request.value : 0);
-    const requestUnits = intl.formatMessage(messages.Units, {
+    const requestUnits = intl.formatMessage(messages.units, {
       units: unitsLookupKey(hasRequest ? report.meta.total.request.units : undefined),
     });
     const usage = Math.trunc(hasUsage ? report.meta.total.usage.value : 0);
-    const usageUnits = intl.formatMessage(messages.Units, {
+    const usageUnits = intl.formatMessage(messages.units, {
       units: unitsLookupKey(hasUsage ? report.meta.total.usage.units : undefined),
     });
 
@@ -283,10 +283,10 @@ class UsageChartBase extends React.Component<UsageChartProps> {
     return (
       <Grid hasGutter>
         <GridItem md={12} lg={6}>
-          <div>{intl.formatMessage(messages.DetailsUnusedUsageLabel)}</div>
+          <div>{intl.formatMessage(messages.detailsUnusedUsageLabel)}</div>
           <div style={styles.capacity}>{formatUnits(unusedUsageCapacity, usageUnits)}</div>
           <div>
-            {intl.formatMessage(messages.DetailsUnusedUnits, {
+            {intl.formatMessage(messages.detailsUnusedUnits, {
               percentage: formatPercentage(unusedUsageCapacityPercentage, {
                 minimumFractionDigits: 0,
                 maximumFractionDigits: 0,
@@ -296,10 +296,10 @@ class UsageChartBase extends React.Component<UsageChartProps> {
           </div>
         </GridItem>
         <GridItem md={12} lg={6}>
-          <div>{intl.formatMessage(messages.DetailsUnusedRequestsLabel)}</div>
+          <div>{intl.formatMessage(messages.detailsUnusedRequestsLabel)}</div>
           <div style={styles.capacity}>{formatUnits(unusedRequestCapacity, requestUnits)}</div>
           <div>
-            {intl.formatMessage(messages.DetailsUnusedUnits, {
+            {intl.formatMessage(messages.detailsUnusedUnits, {
               percentage: formatPercentage(unusedRequestCapacityPercentage, {
                 minimumFractionDigits: 0,
                 maximumFractionDigits: 0,

--- a/src/pages/views/details/gcpBreakdown/gcpBreakdown.tsx
+++ b/src/pages/views/details/gcpBreakdown/gcpBreakdown.tsx
@@ -86,7 +86,7 @@ const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, GcpBreakdown
     costOverviewComponent: <CostOverview groupBy={groupBy} query={query} report={report} />,
     description: query[breakdownDescKey],
     detailsURL,
-    emptyStateTitle: props.intl.formatMessage(messages.GCPDetailsTitle),
+    emptyStateTitle: props.intl.formatMessage(messages.gcpDetailsTitle),
     groupBy,
     groupByValue,
     historicalDataComponent: <HistoricalData />,

--- a/src/pages/views/details/gcpDetails/detailsHeader.tsx
+++ b/src/pages/views/details/gcpDetails/detailsHeader.tsx
@@ -70,7 +70,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       <header style={styles.header}>
         <div style={styles.headerContent}>
           <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
-            {intl.formatMessage(messages.GCPDetailsTitle)}
+            {intl.formatMessage(messages.gcpDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
             {/* Todo: Show in-progress features in beta environment only */}

--- a/src/pages/views/details/gcpDetails/detailsTable.tsx
+++ b/src/pages/views/details/gcpDetails/detailsTable.tsx
@@ -92,14 +92,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const columns = groupByTagKey
       ? [
           {
-            title: intl.formatMessage(messages.TagNames),
+            title: intl.formatMessage(messages.tagNames),
           },
           {
-            title: intl.formatMessage(messages.MonthOverMonthChange),
+            title: intl.formatMessage(messages.monthOverMonthChange),
           },
           {
             orderBy: 'cost',
-            title: intl.formatMessage(messages.Cost),
+            title: intl.formatMessage(messages.cost),
             ...(computedItems.length && { transforms: [sortable] }),
           },
           {
@@ -109,15 +109,15 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       : [
           {
             orderBy: groupById,
-            title: intl.formatMessage(messages.DetailsResourceNames, { value: groupById }),
+            title: intl.formatMessage(messages.detailsResourceNames, { value: groupById }),
             ...(computedItems.length && { transforms: [sortable] }),
           },
           {
-            title: intl.formatMessage(messages.MonthOverMonthChange),
+            title: intl.formatMessage(messages.monthOverMonthChange),
           },
           {
             orderBy: 'cost',
-            title: intl.formatMessage(messages.Cost),
+            title: intl.formatMessage(messages.cost),
             ...(computedItems.length && { transforms: [sortable] }),
           },
           {
@@ -216,7 +216,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <EmptyState>
         <EmptyStateIcon icon={CalculatorIcon} />
-        <EmptyStateBody>{intl.formatMessage(messages.DetailsEmptyState)}</EmptyStateBody>
+        <EmptyStateBody>{intl.formatMessage(messages.detailsEmptyState)}</EmptyStateBody>
       </EmptyState>
     );
   };
@@ -260,7 +260,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       return (
         <div className="monthOverMonthOverride">
           <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-            {showPercentage ? intl.formatMessage(messages.Percent, { value: percentage }) : <EmptyValueState />}
+            {showPercentage ? intl.formatMessage(messages.percent, { value: percentage }) : <EmptyValueState />}
             {Boolean(showPercentage && item.delta_percent !== null && item.delta_value > 0) && (
               <span className="fa fa-sort-up" style={styles.infoArrow} key={`month-over-month-icon-${index}`} />
             )}
@@ -316,7 +316,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       <>
         {formatCurrency(item.cost.total.value, item.cost.total.units)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
-          {intl.formatMessage(messages.PercentOfCost, { value: percentValue })}
+          {intl.formatMessage(messages.percentOfCost, { value: percentValue })}
         </div>
       </>
     );
@@ -362,7 +362,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <>
         <Table
-          aria-label={intl.formatMessage(messages.GCPDetailsTableAriaLabel)}
+          aria-label={intl.formatMessage(messages.gcpDetailsTableAriaLabel)}
           canSelectAll={false}
           cells={columns}
           className="tableOverride"

--- a/src/pages/views/details/gcpDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/gcpDetails/detailsToolbar.tsx
@@ -96,14 +96,14 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     const { intl, tagReport } = this.props;
 
     const options = [
-      { name: intl.formatMessage(messages.FilterByValues, { value: 'account' }), key: 'account' },
-      { name: intl.formatMessage(messages.FilterByValues, { value: 'gcp_project' }), key: 'gcp_project' },
-      { name: intl.formatMessage(messages.FilterByValues, { value: 'service' }), key: 'service' },
-      { name: intl.formatMessage(messages.FilterByValues, { value: 'region' }), key: 'region' },
+      { name: intl.formatMessage(messages.filterByValues, { value: 'account' }), key: 'account' },
+      { name: intl.formatMessage(messages.filterByValues, { value: 'gcp_project' }), key: 'gcp_project' },
+      { name: intl.formatMessage(messages.filterByValues, { value: 'service' }), key: 'service' },
+      { name: intl.formatMessage(messages.filterByValues, { value: 'region' }), key: 'region' },
     ];
 
     if (tagReport && tagReport.data && tagReport.data.length) {
-      options.push({ name: intl.formatMessage(messages.FilterByValues, { value: tagKey }), key: tagKey });
+      options.push({ name: intl.formatMessage(messages.filterByValues, { value: tagKey }), key: tagKey });
     }
     return options;
   };

--- a/src/pages/views/details/gcpDetails/gcpDetails.tsx
+++ b/src/pages/views/details/gcpDetails/gcpDetails.tsx
@@ -374,7 +374,7 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
-    const title = intl.formatMessage(messages.GCPDetailsTitle);
+    const title = intl.formatMessage(messages.gcpDetailsTitle);
 
     // Note: Providers are fetched via the AccountSettings component used by all routes
     if (reportError) {

--- a/src/pages/views/details/ibmBreakdown/ibmBreakdown.tsx
+++ b/src/pages/views/details/ibmBreakdown/ibmBreakdown.tsx
@@ -86,7 +86,7 @@ const mapStateToProps = createMapStateToProps<IbmBreakdownOwnProps, IbmBreakdown
     costOverviewComponent: <CostOverview groupBy={groupBy} query={query} report={report} />,
     description: query[breakdownDescKey],
     detailsURL,
-    emptyStateTitle: props.intl.formatMessage(messages.IBMDetailsTitle),
+    emptyStateTitle: props.intl.formatMessage(messages.ibmDetailsTitle),
     groupBy,
     groupByValue,
     historicalDataComponent: <HistoricalData />,

--- a/src/pages/views/details/ibmDetails/detailsHeader.tsx
+++ b/src/pages/views/details/ibmDetails/detailsHeader.tsx
@@ -70,7 +70,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       <header style={styles.header}>
         <div style={styles.headerContent}>
           <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
-            {intl.formatMessage(messages.IBMDetailsTitle)}
+            {intl.formatMessage(messages.ibmDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
             {/* Todo: Show in-progress features in beta environment only */}

--- a/src/pages/views/details/ibmDetails/detailsTable.tsx
+++ b/src/pages/views/details/ibmDetails/detailsTable.tsx
@@ -92,14 +92,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     const columns = groupByTagKey
       ? [
           {
-            title: intl.formatMessage(messages.TagNames),
+            title: intl.formatMessage(messages.tagNames),
           },
           {
-            title: intl.formatMessage(messages.MonthOverMonthChange),
+            title: intl.formatMessage(messages.monthOverMonthChange),
           },
           {
             orderBy: 'cost',
-            title: intl.formatMessage(messages.Cost),
+            title: intl.formatMessage(messages.cost),
             ...(computedItems.length && { transforms: [sortable] }),
           },
           {
@@ -109,15 +109,15 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       : [
           {
             orderBy: groupById,
-            title: intl.formatMessage(messages.DetailsResourceNames, { value: groupById }),
+            title: intl.formatMessage(messages.detailsResourceNames, { value: groupById }),
             ...(computedItems.length && { transforms: [sortable] }),
           },
           {
-            title: intl.formatMessage(messages.MonthOverMonthChange),
+            title: intl.formatMessage(messages.monthOverMonthChange),
           },
           {
             orderBy: 'cost',
-            title: intl.formatMessage(messages.Cost),
+            title: intl.formatMessage(messages.cost),
             ...(computedItems.length && { transforms: [sortable] }),
           },
           {
@@ -216,7 +216,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <EmptyState>
         <EmptyStateIcon icon={CalculatorIcon} />
-        <EmptyStateBody>{intl.formatMessage(messages.DetailsEmptyState)}</EmptyStateBody>
+        <EmptyStateBody>{intl.formatMessage(messages.detailsEmptyState)}</EmptyStateBody>
       </EmptyState>
     );
   };
@@ -260,7 +260,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       return (
         <div className="monthOverMonthOverride">
           <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-            {showPercentage ? intl.formatMessage(messages.Percent, { value: percentage }) : <EmptyValueState />}
+            {showPercentage ? intl.formatMessage(messages.percent, { value: percentage }) : <EmptyValueState />}
             {Boolean(showPercentage && item.delta_percent !== null && item.delta_value > 0) && (
               <span className="fa fa-sort-up" style={styles.infoArrow} key={`month-over-month-icon-${index}`} />
             )}
@@ -316,7 +316,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       <>
         {formatCurrency(item.cost.total.value, item.cost.total.units)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
-          {intl.formatMessage(messages.PercentOfCost, { value: percentValue })}
+          {intl.formatMessage(messages.percentOfCost, { value: percentValue })}
         </div>
       </>
     );
@@ -362,7 +362,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <>
         <Table
-          aria-label={intl.formatMessage(messages.IBMDetailsTableAriaLabel)}
+          aria-label={intl.formatMessage(messages.ibmDetailsTableAriaLabel)}
           canSelectAll={false}
           cells={columns}
           className="tableOverride"

--- a/src/pages/views/details/ibmDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ibmDetails/detailsToolbar.tsx
@@ -94,14 +94,14 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     const { intl, tagReport } = this.props;
 
     const options = [
-      { name: intl.formatMessage(messages.FilterByValues, { value: 'account' }), key: 'account' },
-      { name: intl.formatMessage(messages.FilterByValues, { value: 'project' }), key: 'project' },
-      { name: intl.formatMessage(messages.FilterByValues, { value: 'service' }), key: 'service' },
-      { name: intl.formatMessage(messages.FilterByValues, { value: 'region' }), key: 'region' },
+      { name: intl.formatMessage(messages.filterByValues, { value: 'account' }), key: 'account' },
+      { name: intl.formatMessage(messages.filterByValues, { value: 'project' }), key: 'project' },
+      { name: intl.formatMessage(messages.filterByValues, { value: 'service' }), key: 'service' },
+      { name: intl.formatMessage(messages.filterByValues, { value: 'region' }), key: 'region' },
     ];
 
     if (tagReport && tagReport.data && tagReport.data.length) {
-      options.push({ name: intl.formatMessage(messages.FilterByValues, { value: tagKey }), key: tagKey });
+      options.push({ name: intl.formatMessage(messages.filterByValues, { value: tagKey }), key: tagKey });
     }
     return options;
   };

--- a/src/pages/views/details/ibmDetails/ibmDetails.tsx
+++ b/src/pages/views/details/ibmDetails/ibmDetails.tsx
@@ -375,7 +375,7 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
-    const title = intl.formatMessage(messages.IBMDetailsTitle);
+    const title = intl.formatMessage(messages.ibmDetailsTitle);
 
     // Note: Providers are fetched via the AccountSettings component used by all routes
     if (reportError) {

--- a/src/pages/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/pages/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -82,7 +82,7 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
     costOverviewComponent: <CostOverview groupBy={groupBy} report={report} />,
     description: query[breakdownDescKey],
     detailsURL,
-    emptyStateTitle: props.intl.formatMessage(messages.OCPDetailsTitle),
+    emptyStateTitle: props.intl.formatMessage(messages.ocpDetailsTitle),
     groupBy,
     groupByValue,
     historicalDataComponent: <HistoricalData />,

--- a/src/pages/views/details/ocpDetails/detailsHeader.tsx
+++ b/src/pages/views/details/ocpDetails/detailsHeader.tsx
@@ -94,7 +94,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
       <header style={styles.header}>
         <div style={styles.headerContent}>
           <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
-            {intl.formatMessage(messages.OCPDetailsTitle)}
+            {intl.formatMessage(messages.ocpDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
             {/* Todo: Show in-progress features in beta environment only */}
@@ -117,7 +117,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
           {Boolean(showContent) && (
             <div>
               <Tooltip
-                content={intl.formatMessage(messages.DashboardTotalCostTooltip, {
+                content={intl.formatMessage(messages.dashboardTotalCostTooltip, {
                   infrastructureCost,
                   supplementaryCost,
                 })}

--- a/src/pages/views/details/ocpDetails/detailsTable.tsx
+++ b/src/pages/views/details/ocpDetails/detailsTable.tsx
@@ -102,22 +102,22 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       ? [
           // Sorting with tag keys is not supported
           {
-            title: intl.formatMessage(messages.TagNames),
+            title: intl.formatMessage(messages.tagNames),
           },
           {
-            title: intl.formatMessage(messages.MonthOverMonthChange),
+            title: intl.formatMessage(messages.monthOverMonthChange),
           },
           {
             id: DetailsTableColumnIds.infrastructure,
-            title: intl.formatMessage(messages.OCPDetailsInfrastructureCost),
+            title: intl.formatMessage(messages.ocpDetailsInfrastructureCost),
           },
           {
             id: DetailsTableColumnIds.supplementary,
-            title: intl.formatMessage(messages.OCPDetailsSupplementaryCost),
+            title: intl.formatMessage(messages.ocpDetailsSupplementaryCost),
           },
           {
             orderBy: 'cost',
-            title: intl.formatMessage(messages.Cost),
+            title: intl.formatMessage(messages.cost),
             ...(computedItems.length && { transforms: [sortable] }),
           },
           {
@@ -127,17 +127,17 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       : [
           {
             orderBy: groupById,
-            title: intl.formatMessage(messages.DetailsResourceNames, { value: groupById }),
+            title: intl.formatMessage(messages.detailsResourceNames, { value: groupById }),
             ...(computedItems.length && { transforms: [sortable] }),
           },
           {
             id: DetailsTableColumnIds.monthOverMonth,
-            title: intl.formatMessage(messages.MonthOverMonthChange),
+            title: intl.formatMessage(messages.monthOverMonthChange),
           },
           {
             id: DetailsTableColumnIds.infrastructure,
             orderBy: 'infrastructure_cost',
-            title: intl.formatMessage(messages.OCPDetailsInfrastructureCost),
+            title: intl.formatMessage(messages.ocpDetailsInfrastructureCost),
 
             // Sort by infrastructure_cost is not supported -- https://github.com/project-koku/koku/issues/796
             // ...(computedItems.length && { transforms: [sortable] }),
@@ -145,14 +145,14 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           {
             id: DetailsTableColumnIds.supplementary,
             orderBy: 'supplementary_cost',
-            title: intl.formatMessage(messages.OCPDetailsSupplementaryCost),
+            title: intl.formatMessage(messages.ocpDetailsSupplementaryCost),
 
             // Sort by supplementary_cost is not supported -- https://github.com/project-koku/koku/issues/796
             // ...(computedItems.length && { transforms: [sortable] }),
           },
           {
             orderBy: 'cost',
-            title: intl.formatMessage(messages.Cost),
+            title: intl.formatMessage(messages.cost),
             ...(computedItems.length && { transforms: [sortable] }),
           },
           {
@@ -270,7 +270,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <EmptyState>
         <EmptyStateIcon icon={CalculatorIcon} />
-        <EmptyStateBody>{intl.formatMessage(messages.DetailsEmptyState)}</EmptyStateBody>
+        <EmptyStateBody>{intl.formatMessage(messages.detailsEmptyState)}</EmptyStateBody>
       </EmptyState>
     );
   };
@@ -286,7 +286,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       <>
         {formatCurrency(item.supplementary.total.value, item.supplementary.total.units)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
-          {intl.formatMessage(messages.PercentOfCost, { value: percentValue })}
+          {intl.formatMessage(messages.percentOfCost, { value: percentValue })}
         </div>
       </>
     );
@@ -317,7 +317,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       <>
         {formatCurrency(item.infrastructure.total.value, item.infrastructure.total.units)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
-          {intl.formatMessage(messages.PercentOfCost, { value: percentValue })}
+          {intl.formatMessage(messages.percentOfCost, { value: percentValue })}
         </div>
       </>
     );
@@ -348,7 +348,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       return (
         <div className="monthOverMonthOverride">
           <div className={iconOverride} key={`month-over-month-cost-${index}`}>
-            {showPercentage ? intl.formatMessage(messages.Percent, { value: percentage }) : <EmptyValueState />}
+            {showPercentage ? intl.formatMessage(messages.percent, { value: percentage }) : <EmptyValueState />}
             {Boolean(showPercentage && item.delta_percent !== null && item.delta_value > 0) && (
               <span className="fa fa-sort-up" style={styles.infoArrow} key={`month-over-month-icon-${index}`} />
             )}
@@ -400,7 +400,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       <>
         {formatCurrency(item.cost.total.value, item.cost.total.units)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
-          {intl.formatMessage(messages.PercentOfCost, { value: percentValue })}
+          {intl.formatMessage(messages.percentOfCost, { value: percentValue })}
         </div>
       </>
     );
@@ -446,7 +446,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
     return (
       <>
         <Table
-          aria-label={intl.formatMessage(messages.GCPDetailsTableAriaLabel)}
+          aria-label={intl.formatMessage(messages.gcpDetailsTableAriaLabel)}
           canSelectAll={false}
           cells={columns}
           className="tableOverride"

--- a/src/pages/views/details/ocpDetails/detailsToolbar.tsx
+++ b/src/pages/views/details/ocpDetails/detailsToolbar.tsx
@@ -93,14 +93,14 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     const { intl, tagReport } = this.props;
 
     const options = [
-      { name: intl.formatMessage(messages.FilterByValues, { value: 'cluster' }), key: 'cluster' },
-      { name: intl.formatMessage(messages.FilterByValues, { value: 'node' }), key: 'node' },
-      { name: intl.formatMessage(messages.FilterByValues, { value: 'project' }), key: 'project' },
+      { name: intl.formatMessage(messages.filterByValues, { value: 'cluster' }), key: 'cluster' },
+      { name: intl.formatMessage(messages.filterByValues, { value: 'node' }), key: 'node' },
+      { name: intl.formatMessage(messages.filterByValues, { value: 'project' }), key: 'project' },
     ];
 
     if (tagReport && tagReport.data && tagReport.data.length) {
       options.push({
-        name: intl.formatMessage(messages.FilterByValues, { value: tagKey }),
+        name: intl.formatMessage(messages.filterByValues, { value: tagKey }),
         key: tagKey,
       });
     }

--- a/src/pages/views/details/ocpDetails/ocpDetails.tsx
+++ b/src/pages/views/details/ocpDetails/ocpDetails.tsx
@@ -83,16 +83,16 @@ const baseQuery: OcpQuery = {
 };
 
 const defaultColumnOptions: ColumnManagementModalOption[] = [
-  { label: messages.MonthOverMonthChange, value: DetailsTableColumnIds.monthOverMonth },
+  { label: messages.monthOverMonthChange, value: DetailsTableColumnIds.monthOverMonth },
   {
-    description: messages.OCPDetailsInfrastructureCostDesc,
-    label: messages.OCPDetailsInfrastructureCost,
+    description: messages.ocpDetailsInfrastructureCostDesc,
+    label: messages.ocpDetailsInfrastructureCost,
     value: DetailsTableColumnIds.infrastructure,
     hidden: true,
   },
   {
-    description: messages.OCPDetailsSupplementaryCostDesc,
-    label: messages.OCPDetailsSupplementaryCost,
+    description: messages.ocpDetailsSupplementaryCostDesc,
+    label: messages.ocpDetailsSupplementaryCost,
     value: DetailsTableColumnIds.supplementary,
     hidden: true,
   },
@@ -435,7 +435,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
-    const title = intl.formatMessage(messages.OCPDetailsTitle);
+    const title = intl.formatMessage(messages.ocpDetailsTitle);
 
     // Note: Providers are fetched via the AccountSettings component used by all routes
     if (reportError) {

--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -450,7 +450,7 @@ class Explorer extends React.Component<ExplorerProps> {
     const groupByTagKey = getGroupByTagKey(query);
     const computedItems = this.getComputedItems();
     const itemsTotal = report && report.meta ? report.meta.count : 0;
-    const title = intl.formatMessage(messages.ExplorerTitle);
+    const title = intl.formatMessage(messages.explorerTitle);
 
     // Note: Providers are fetched via the AccountSettings component used by all routes
     if (reportError) {

--- a/src/pages/views/explorer/explorerChart.tsx
+++ b/src/pages/views/explorer/explorerChart.tsx
@@ -95,7 +95,7 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
     const { intl } = this.props;
 
     const computedItemDate = new Date(computedItem.date + 'T00:00:00');
-    const xVal = intl.formatMessage(messages.ExplorerChartDate, {
+    const xVal = intl.formatMessage(messages.explorerChartDate, {
       date: getDate(computedItemDate),
       month: getMonth(computedItemDate),
     });
@@ -221,7 +221,7 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
       <>
         <div style={styles.titleContainer}>
           <Title headingLevel="h3" size="md">
-            {intl.formatMessage(messages.ExplorerChartTitle, { value: perspective })}
+            {intl.formatMessage(messages.explorerChartTitle, { value: perspective })}
           </Title>
         </div>
         <div style={styles.chartContainer}>

--- a/src/pages/views/explorer/explorerFilter.tsx
+++ b/src/pages/views/explorer/explorerFilter.tsx
@@ -128,18 +128,18 @@ export class ExplorerFilterBase extends React.Component<ExplorerFilterProps> {
     const groupByOptions = getGroupByOptions(perspective);
     groupByOptions.map(option => {
       options.push({
-        name: intl.formatMessage(messages.FilterByValues, { value: option.label }),
+        name: intl.formatMessage(messages.filterByValues, { value: option.label }),
         key: option.value,
       });
     });
     if (orgReport && orgReport.data && orgReport.data.length > 0) {
       options.push({
-        name: intl.formatMessage(messages.FilterByValues, { value: 'org_unit_id' }),
+        name: intl.formatMessage(messages.filterByValues, { value: 'org_unit_id' }),
         key: orgUnitIdKey,
       });
     }
     if (tagReport && tagReport.data && tagReport.data.length > 0) {
-      options.push({ name: intl.formatMessage(messages.FilterByValues, { value: 'tag' }), key: tagKey });
+      options.push({ name: intl.formatMessage(messages.filterByValues, { value: 'tag' }), key: tagKey });
     }
     return options;
   };

--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -289,7 +289,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
       <header style={styles.header}>
         <div style={styles.headerContent}>
           <Title headingLevel="h1" style={styles.title} size={TitleSizes['2xl']}>
-            {intl.formatMessage(messages.ExplorerTitle)}
+            {intl.formatMessage(messages.explorerTitle)}
           </Title>
           <div style={styles.headerContentRight}>
             {/* Todo: Show in-progress features in beta environment only */}

--- a/src/pages/views/explorer/explorerTable.tsx
+++ b/src/pages/views/explorer/explorerTable.tsx
@@ -122,8 +122,8 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
             {
               cellTransforms: [nowrap],
               title: groupByOrg
-                ? intl.formatMessage(messages.Names, { count: 2 })
-                : intl.formatMessage(messages.TagNames),
+                ? intl.formatMessage(messages.names, { count: 2 })
+                : intl.formatMessage(messages.tagNames),
             },
           ]
         : [
@@ -131,7 +131,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
               cellTransforms: [nowrap],
               date: undefined,
               orderBy: groupById === 'account' && perspective === PerspectiveType.aws ? 'account_alias' : groupById,
-              title: intl.formatMessage(messages.GroupByValueNames, { groupBy: groupById }),
+              title: intl.formatMessage(messages.groupByValueNames, { groupBy: groupById }),
               ...(computedItems.length && { transforms: [sortable] }),
             },
           ];
@@ -161,7 +161,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
       const month = getMonth(mapIdDate);
       columns.push({
         cellTransforms: [nowrap],
-        title: intl.formatMessage(messages.ExplorerChartDate, { date, month }),
+        title: intl.formatMessage(messages.explorerChartDate, { date, month }),
         ...(isSortable && {
           date: mapId,
           orderBy: 'cost',
@@ -206,7 +206,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
           title:
             item[reportItem] && item[reportItem][reportItemValue]
               ? formatCurrency(item[reportItem][reportItemValue].value, item[reportItem][reportItemValue].units)
-              : intl.formatMessage(messages.ChartNoData),
+              : intl.formatMessage(messages.chartNoData),
         });
       });
 
@@ -265,7 +265,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
     return (
       <EmptyState>
         <EmptyStateIcon icon={CalculatorIcon} />
-        <EmptyStateBody>{intl.formatMessage(messages.DetailsEmptyState)}</EmptyStateBody>
+        <EmptyStateBody>{intl.formatMessage(messages.detailsEmptyState)}</EmptyStateBody>
       </EmptyState>
     );
   };
@@ -337,7 +337,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
     return (
       <div style={styles.tableContainer}>
         <Table
-          aria-label={intl.formatMessage(messages.ExplorerTableAriaLabel)}
+          aria-label={intl.formatMessage(messages.explorerTableAriaLabel)}
           canSelectAll={false}
           cells={columns}
           className="explorerTableOverride"

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -70,11 +70,11 @@ export const dateRangeOptions: {
   label: MessageDescriptor;
   value: string;
 }[] = [
-  { label: messages.ExplorerDateRange, value: 'current_month_to_date' },
-  { label: messages.ExplorerDateRange, value: 'previous_month_to_date' },
-  { label: messages.ExplorerDateRange, value: 'last_thirty_days' },
-  { label: messages.ExplorerDateRange, value: 'last_sixty_days' },
-  { label: messages.ExplorerDateRange, value: 'last_ninety_days' },
+  { label: messages.explorerDateRange, value: 'current_month_to_date' },
+  { label: messages.explorerDateRange, value: 'previous_month_to_date' },
+  { label: messages.explorerDateRange, value: 'last_thirty_days' },
+  { label: messages.explorerDateRange, value: 'last_sixty_days' },
+  { label: messages.explorerDateRange, value: 'last_ninety_days' },
 ];
 
 export const groupByAwsOptions: {
@@ -135,34 +135,34 @@ export const groupByOcpOptions: {
 ];
 
 // Infrastructure AWS options
-export const infrastructureAwsOptions = [{ label: messages.PerspectiveValues, value: 'aws' }];
+export const infrastructureAwsOptions = [{ label: messages.perspectiveValues, value: 'aws' }];
 
 // Infrastructure AWS filtered by OpenShift options
-export const infrastructureAwsOcpOptions = [{ label: messages.PerspectiveValues, value: 'aws_ocp' }];
+export const infrastructureAwsOcpOptions = [{ label: messages.perspectiveValues, value: 'aws_ocp' }];
 
 // Infrastructure Azure options
-export const infrastructureAzureOptions = [{ label: messages.PerspectiveValues, value: 'azure' }];
+export const infrastructureAzureOptions = [{ label: messages.perspectiveValues, value: 'azure' }];
 
 // Infrastructure Azure filtered by OpenShift options
-export const infrastructureAzureOcpOptions = [{ label: messages.PerspectiveValues, value: 'azure_ocp' }];
+export const infrastructureAzureOcpOptions = [{ label: messages.perspectiveValues, value: 'azure_ocp' }];
 
 // Infrastructure GCP options
-export const infrastructureGcpOptions = [{ label: messages.PerspectiveValues, value: 'gcp' }];
+export const infrastructureGcpOptions = [{ label: messages.perspectiveValues, value: 'gcp' }];
 
 // Infrastructure GCP filtered by OpenShift options
-export const infrastructureGcpOcpOptions = [{ label: messages.PerspectiveValues, value: 'gcp_ocp' }];
+export const infrastructureGcpOcpOptions = [{ label: messages.perspectiveValues, value: 'gcp_ocp' }];
 
 // Infrastructure IBM options
-export const infrastructureIbmOptions = [{ label: messages.PerspectiveValues, value: 'ibm' }];
+export const infrastructureIbmOptions = [{ label: messages.perspectiveValues, value: 'ibm' }];
 
 // Infrastructure IBM filtered by OpenShift options
-export const infrastructureIbmOcpOptions = [{ label: messages.PerspectiveValues, value: 'ibm_ocp' }];
+export const infrastructureIbmOcpOptions = [{ label: messages.perspectiveValues, value: 'ibm_ocp' }];
 
 // Infrastructure Ocp cloud options
-export const infrastructureOcpCloudOptions = [{ label: messages.PerspectiveValues, value: 'ocp_cloud' }];
+export const infrastructureOcpCloudOptions = [{ label: messages.perspectiveValues, value: 'ocp_cloud' }];
 
 // Ocp options
-export const ocpOptions = [{ label: messages.PerspectiveValues, value: 'ocp' }];
+export const ocpOptions = [{ label: messages.perspectiveValues, value: 'ocp' }];
 
 export const getComputedReportItemType = (perspective: string) => {
   let result;

--- a/src/pages/views/overview/components/dashboardWidget.test.tsx
+++ b/src/pages/views/overview/components/dashboardWidget.test.tsx
@@ -33,10 +33,10 @@ const props: DashboardWidgetProps = {
   tabs: { data: [] },
   fetchReports: jest.fn(),
   updateTab: jest.fn(),
-  titleKey: tmessages.TestTitle,
+  titleKey: tmessages.testTitle,
   trend: {
     type: ChartType.rolling,
-    titleKey: tmessages.TestTrendTitle,
+    titleKey: tmessages.testTrendTitle,
     formatOptions: {},
   },
   status: FetchStatus.none,

--- a/src/pages/views/overview/components/dashboardWidgetBase.tsx
+++ b/src/pages/views/overview/components/dashboardWidgetBase.tsx
@@ -520,7 +520,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     const { getIdKeyForTab, intl } = this.props;
     const key = getIdKeyForTab(tab) || '';
 
-    return intl.formatMessage(messages.GroupByAll, { value: key, count: 2 });
+    return intl.formatMessage(messages.groupByAll, { value: key, count: 2 });
   };
 
   private getFormattedUnits = () => {
@@ -530,9 +530,9 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     const units = this.getUnits();
 
     if (computedReportItem === ComputedReportItemType.usage) {
-      return intl.formatMessage(messages.Units, { units: unitsLookupKey(units) });
+      return intl.formatMessage(messages.units, { units: unitsLookupKey(units) });
     }
-    return intl.formatMessage(messages.CurrencyUnits, { units });
+    return intl.formatMessage(messages.currencyUnits, { units });
   };
 
   private getHorizontalLayout = () => {
@@ -634,7 +634,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     const { getIdKeyForTab, intl } = this.props;
     const key = getIdKeyForTab(tab) || '';
 
-    return intl.formatMessage(messages.GroupByTop, { value: key, count: 2 });
+    return intl.formatMessage(messages.groupByTop, { value: key, count: 2 });
   };
 
   private getTitle = () => {

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -140,34 +140,34 @@ interface OverviewState {
 type OverviewProps = OverviewOwnProps & OverviewStateProps & OverviewDispatchProps;
 
 // Ocp options
-const ocpOptions = [{ label: messages.PerspectiveValues, value: 'ocp' }];
+const ocpOptions = [{ label: messages.perspectiveValues, value: 'ocp' }];
 
 // Infrastructure AWS options
-const infrastructureAwsOptions = [{ label: messages.PerspectiveValues, value: 'aws' }];
+const infrastructureAwsOptions = [{ label: messages.perspectiveValues, value: 'aws' }];
 
 // Infrastructure AWS filtered by OpenShift options
-const infrastructureAwsOcpOptions = [{ label: messages.PerspectiveValues, value: 'aws_ocp' }];
+const infrastructureAwsOcpOptions = [{ label: messages.perspectiveValues, value: 'aws_ocp' }];
 
 // Infrastructure Azure options
-const infrastructureAzureOptions = [{ label: messages.PerspectiveValues, value: 'azure' }];
+const infrastructureAzureOptions = [{ label: messages.perspectiveValues, value: 'azure' }];
 
 // Infrastructure Azure filtered by OpenShift options
-const infrastructureAzureOcpOptions = [{ label: messages.PerspectiveValues, value: 'azure_ocp' }];
+const infrastructureAzureOcpOptions = [{ label: messages.perspectiveValues, value: 'azure_ocp' }];
 
 // Infrastructure GCP options
-const infrastructureGcpOptions = [{ label: messages.PerspectiveValues, value: 'gcp' }];
+const infrastructureGcpOptions = [{ label: messages.perspectiveValues, value: 'gcp' }];
 
 // Infrastructure GCP filtered by OCP options
-const infrastructureGcpOcpOptions = [{ label: messages.PerspectiveValues, value: 'gcp_ocp' }];
+const infrastructureGcpOcpOptions = [{ label: messages.perspectiveValues, value: 'gcp_ocp' }];
 
 // Infrastructure IBM options
-const infrastructureIbmOptions = [{ label: messages.PerspectiveValues, value: 'ibm' }];
+const infrastructureIbmOptions = [{ label: messages.perspectiveValues, value: 'ibm' }];
 
 // Infrastructure IBM filtered by OCP options
-const infrastructureIbmOcpOptions = [{ label: messages.PerspectiveValues, value: 'ibm_ocp' }];
+const infrastructureIbmOcpOptions = [{ label: messages.perspectiveValues, value: 'ibm_ocp' }];
 
 // Infrastructure Ocp cloud options
-const infrastructureOcpCloudOptions = [{ label: messages.PerspectiveValues, value: 'ocp_cloud' }];
+const infrastructureOcpCloudOptions = [{ label: messages.perspectiveValues, value: 'ocp_cloud' }];
 
 class OverviewBase extends React.Component<OverviewProps> {
   protected defaultState: OverviewState = {
@@ -479,9 +479,9 @@ class OverviewBase extends React.Component<OverviewProps> {
     const { intl } = this.props;
 
     if (tab === OverviewTab.infrastructure) {
-      return intl.formatMessage(messages.Infrastructure);
+      return intl.formatMessage(messages.infrastructure);
     } else if (tab === OverviewTab.ocp) {
-      return intl.formatMessage(messages.OpenShift);
+      return intl.formatMessage(messages.openShift);
     }
   };
 
@@ -605,7 +605,7 @@ class OverviewBase extends React.Component<OverviewProps> {
       providersFetchStatus === FetchStatus.inProgress || userAccessFetchStatus === FetchStatus.inProgress;
 
     const availableTabs = this.getAvailableTabs();
-    const title = intl.formatMessage(messages.OverviewTitle);
+    const title = intl.formatMessage(messages.overviewTitle);
 
     if (isLoading) {
       return <Loading title={title} />;
@@ -620,32 +620,32 @@ class OverviewBase extends React.Component<OverviewProps> {
               {title}
               <span style={styles.infoIcon}>
                 <Popover
-                  aria-label={intl.formatMessage(messages.OverviewInfoArialLabel)}
+                  aria-label={intl.formatMessage(messages.overviewInfoArialLabel)}
                   enableFlip
                   bodyContent={
                     <>
-                      <p style={styles.infoTitle}>{intl.formatMessage(messages.OpenShiftCloudInfrastructure)}</p>
-                      <p>{intl.formatMessage(messages.OpenShiftCloudInfrastructureDesc)}</p>
+                      <p style={styles.infoTitle}>{intl.formatMessage(messages.openShiftCloudInfrastructure)}</p>
+                      <p>{intl.formatMessage(messages.openShiftCloudInfrastructureDesc)}</p>
                       <br />
-                      <p style={styles.infoTitle}>{intl.formatMessage(messages.OpenShift)}</p>
-                      <p>{intl.formatMessage(messages.OpenShiftDesc)}</p>
+                      <p style={styles.infoTitle}>{intl.formatMessage(messages.openShift)}</p>
+                      <p>{intl.formatMessage(messages.openShiftDesc)}</p>
                       <br />
-                      <p style={styles.infoTitle}>{intl.formatMessage(messages.GCP)}</p>
-                      <p>{intl.formatMessage(messages.GCPDesc)}</p>
+                      <p style={styles.infoTitle}>{intl.formatMessage(messages.gcp)}</p>
+                      <p>{intl.formatMessage(messages.gcpDesc)}</p>
                       {/* Todo: Show in-progress features in beta environment only */}
                       {isFeatureVisible(FeatureType.ibm) && (
                         <>
                           <br />
-                          <p style={styles.infoTitle}>{intl.formatMessage(messages.IBM)}</p>
-                          <p>{intl.formatMessage(messages.IBMDesc)}</p>
+                          <p style={styles.infoTitle}>{intl.formatMessage(messages.ibm)}</p>
+                          <p>{intl.formatMessage(messages.ibmDesc)}</p>
                         </>
                       )}
                       <br />
-                      <p style={styles.infoTitle}>{intl.formatMessage(messages.AWS)}</p>
-                      <p>{intl.formatMessage(messages.AWSDesc)}</p>
+                      <p style={styles.infoTitle}>{intl.formatMessage(messages.aws)}</p>
+                      <p>{intl.formatMessage(messages.awsDesc)}</p>
                       <br />
-                      <p style={styles.infoTitle}>{intl.formatMessage(messages.Azure)}</p>
-                      <p>{intl.formatMessage(messages.AzureDesc)}</p>
+                      <p style={styles.infoTitle}>{intl.formatMessage(messages.azure)}</p>
+                      <p>{intl.formatMessage(messages.azureDesc)}</p>
                     </>
                   }
                 >

--- a/src/store/costModels/actions.ts
+++ b/src/store/costModels/actions.ts
@@ -129,8 +129,8 @@ export const redirectToCostModelFromSourceUuid = (source_uuid: string, history: 
       .catch(() => {
         dispatch(
           addNotification({
-            title: intl.formatMessage(messages.CostModelsRouterErrorTitle),
-            description: intl.formatMessage(messages.CostModelsRouterServerError),
+            title: intl.formatMessage(messages.costModelsRouterErrorTitle),
+            description: intl.formatMessage(messages.costModelsRouterServerError),
             variant: AlertVariant.danger,
             dismissable: true,
           })

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -18,15 +18,15 @@ const getId = () => currrentId++;
 
 export const computeWidget: AwsDashboardWidget = {
   id: getId(),
-  titleKey: messages.AWSComputeTitle,
+  titleKey: messages.awsComputeTitle,
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.instanceType,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   filter: {
     service: 'AmazonEC2',
@@ -37,7 +37,7 @@ export const computeWidget: AwsDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
+    titleKey: messages.dashboardDailyUsageComparison,
     type: ChartType.daily,
   },
   chartFormatter: formatUnits,
@@ -46,14 +46,14 @@ export const computeWidget: AwsDashboardWidget = {
 
 export const costSummaryWidget: AwsDashboardWidget = {
   id: getId(),
-  titleKey: messages.AWSDashboardCostTitle,
+  titleKey: messages.awsDashboardCostTitle,
   forecastPathsType: ForecastPathsType.aws,
   forecastType: ForecastType.cost,
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.cost,
   details: {
     adjustContainerHeight: true,
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showHorizontal: true,
     viewAllPath: paths.awsDetails,
   },
@@ -64,8 +64,8 @@ export const costSummaryWidget: AwsDashboardWidget = {
     computedForecastItem: ComputedForecastItemType.cost,
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    dailyTitleKey: messages.AWSDailyCostTrendTitle,
-    titleKey: messages.AWSCostTrendTitle,
+    dailyTitleKey: messages.awsDailyCostTrendTitle,
+    titleKey: messages.awsCostTrendTitle,
     type: ChartType.rolling,
   },
   availableTabs: [AwsDashboardTab.services, AwsDashboardTab.accounts, AwsDashboardTab.regions],
@@ -77,11 +77,11 @@ export const costSummaryWidget: AwsDashboardWidget = {
 
 export const databaseWidget: AwsDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardDatabaseTitle,
+  titleKey: messages.dashboardDatabaseTitle,
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.database,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
   },
   filter: {
@@ -93,7 +93,7 @@ export const databaseWidget: AwsDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardCumulativeCostComparison,
+    titleKey: messages.dashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
   chartFormatter: formatCurrency,
@@ -103,11 +103,11 @@ export const databaseWidget: AwsDashboardWidget = {
 
 export const networkWidget: AwsDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardNetworkTitle,
+  titleKey: messages.dashboardNetworkTitle,
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.network,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
   },
   filter: {
@@ -119,7 +119,7 @@ export const networkWidget: AwsDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardCumulativeCostComparison,
+    titleKey: messages.dashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
   chartFormatter: formatCurrency,
@@ -129,20 +129,20 @@ export const networkWidget: AwsDashboardWidget = {
 
 export const storageWidget: AwsDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardStorageTitle,
+  titleKey: messages.dashboardStorageTitle,
   reportPathsType: ReportPathsType.aws,
   reportType: ReportType.storage,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
+    titleKey: messages.dashboardDailyUsageComparison,
     type: ChartType.daily,
   },
   chartFormatter: formatUnits,

--- a/src/store/dashboard/awsOcpDashboard/awsOcpDashboardWidgets.ts
+++ b/src/store/dashboard/awsOcpDashboard/awsOcpDashboardWidgets.ts
@@ -18,15 +18,15 @@ const getId = () => currrentId++;
 
 export const computeWidget: AwsOcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.AWSComputeTitle,
+  titleKey: messages.awsComputeTitle,
   reportPathsType: ReportPathsType.awsOcp,
   reportType: ReportType.instanceType,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   filter: {
     service: 'AmazonEC2',
@@ -37,7 +37,7 @@ export const computeWidget: AwsOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
+    titleKey: messages.dashboardDailyUsageComparison,
     type: ChartType.daily,
   },
   chartFormatter: formatUnits,
@@ -46,13 +46,13 @@ export const computeWidget: AwsOcpDashboardWidget = {
 
 export const costSummaryWidget: AwsOcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.AWSOcpDashboardCostTitle,
+  titleKey: messages.awsOcpDashboardCostTitle,
   forecastPathsType: ForecastPathsType.awsOcp,
   forecastType: ForecastType.cost,
   reportPathsType: ReportPathsType.awsOcp,
   reportType: ReportType.cost,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showHorizontal: true,
   },
   tabsFilter: {
@@ -62,8 +62,8 @@ export const costSummaryWidget: AwsOcpDashboardWidget = {
     computedForecastItem: ComputedForecastItemType.cost,
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    dailyTitleKey: messages.AWSDailyCostTrendTitle,
-    titleKey: messages.AWSCostTrendTitle,
+    dailyTitleKey: messages.awsDailyCostTrendTitle,
+    titleKey: messages.awsCostTrendTitle,
     type: ChartType.rolling,
   },
   availableTabs: [AwsOcpDashboardTab.services, AwsOcpDashboardTab.accounts, AwsOcpDashboardTab.regions],
@@ -74,11 +74,11 @@ export const costSummaryWidget: AwsOcpDashboardWidget = {
 
 export const databaseWidget: AwsOcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardDatabaseTitle,
+  titleKey: messages.dashboardDatabaseTitle,
   reportPathsType: ReportPathsType.awsOcp,
   reportType: ReportType.database,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
   },
   filter: {
@@ -90,7 +90,7 @@ export const databaseWidget: AwsOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardCumulativeCostComparison,
+    titleKey: messages.dashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
   chartFormatter: formatCurrency,
@@ -99,11 +99,11 @@ export const databaseWidget: AwsOcpDashboardWidget = {
 
 export const networkWidget: AwsOcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardNetworkTitle,
+  titleKey: messages.dashboardNetworkTitle,
   reportPathsType: ReportPathsType.awsOcp,
   reportType: ReportType.network,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
   },
   filter: {
@@ -115,7 +115,7 @@ export const networkWidget: AwsOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardCumulativeCostComparison,
+    titleKey: messages.dashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
   chartFormatter: formatCurrency,
@@ -124,20 +124,20 @@ export const networkWidget: AwsOcpDashboardWidget = {
 
 export const storageWidget: AwsOcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardStorageTitle,
+  titleKey: messages.dashboardStorageTitle,
   reportPathsType: ReportPathsType.awsOcp,
   reportType: ReportType.storage,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
+    titleKey: messages.dashboardDailyUsageComparison,
     type: ChartType.daily,
   },
   chartFormatter: formatUnits,

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -18,14 +18,14 @@ const getId = () => currrentId++;
 
 export const costSummaryWidget: AzureDashboardWidget = {
   id: getId(),
-  titleKey: messages.AzureDashboardCostTitle,
+  titleKey: messages.azureDashboardCostTitle,
   forecastPathsType: ForecastPathsType.azure,
   forecastType: ForecastType.cost,
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.cost,
   details: {
     adjustContainerHeight: true,
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showHorizontal: true,
     viewAllPath: paths.azureDetails,
   },
@@ -36,8 +36,8 @@ export const costSummaryWidget: AzureDashboardWidget = {
     computedForecastItem: ComputedForecastItemType.cost,
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    dailyTitleKey: messages.AzureDailyCostTrendTitle,
-    titleKey: messages.AzureCostTrendTitle,
+    dailyTitleKey: messages.azureDailyCostTrendTitle,
+    titleKey: messages.azureCostTrendTitle,
     type: ChartType.rolling,
   },
   availableTabs: [
@@ -51,11 +51,11 @@ export const costSummaryWidget: AzureDashboardWidget = {
 
 export const databaseWidget: AzureDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardDatabaseTitle,
+  titleKey: messages.dashboardDatabaseTitle,
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.database,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
   },
   filter: {
@@ -67,7 +67,7 @@ export const databaseWidget: AzureDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardCumulativeCostComparison,
+    titleKey: messages.dashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
   chartType: DashboardChartType.trend,
@@ -75,11 +75,11 @@ export const databaseWidget: AzureDashboardWidget = {
 
 export const networkWidget: AzureDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardNetworkTitle,
+  titleKey: messages.dashboardNetworkTitle,
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.network,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
   },
   filter: {
@@ -91,7 +91,7 @@ export const networkWidget: AzureDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardCumulativeCostComparison,
+    titleKey: messages.dashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
   chartType: DashboardChartType.trend,
@@ -99,15 +99,15 @@ export const networkWidget: AzureDashboardWidget = {
 
 export const storageWidget: AzureDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardStorageTitle,
+  titleKey: messages.dashboardStorageTitle,
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.storage,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   filter: {
     service_name: 'Storage',
@@ -118,7 +118,7 @@ export const storageWidget: AzureDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
+    titleKey: messages.dashboardDailyUsageComparison,
     type: ChartType.daily,
   },
   chartType: DashboardChartType.trend,
@@ -126,15 +126,15 @@ export const storageWidget: AzureDashboardWidget = {
 
 export const virtualMachineWidget: AzureDashboardWidget = {
   id: getId(),
-  titleKey: messages.AzureComputeTitle,
+  titleKey: messages.azureComputeTitle,
   reportPathsType: ReportPathsType.azure,
   reportType: ReportType.instanceType,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   filter: {
     service_name: 'Virtual Machines',
@@ -145,7 +145,7 @@ export const virtualMachineWidget: AzureDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
+    titleKey: messages.dashboardDailyUsageComparison,
     type: ChartType.daily,
   },
   chartFormatter: formatUnits,

--- a/src/store/dashboard/azureOcpDashboard/azureOcpDashboardWidgets.ts
+++ b/src/store/dashboard/azureOcpDashboard/azureOcpDashboardWidgets.ts
@@ -18,13 +18,13 @@ const getId = () => currrentId++;
 
 export const costSummaryWidget: AzureOcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.AzureOcpDashboardCostTitle,
+  titleKey: messages.azureOcpDashboardCostTitle,
   forecastPathsType: ForecastPathsType.azureOcp,
   forecastType: ForecastType.cost,
   reportPathsType: ReportPathsType.azureOcp,
   reportType: ReportType.cost,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showHorizontal: true,
   },
   tabsFilter: {
@@ -34,8 +34,8 @@ export const costSummaryWidget: AzureOcpDashboardWidget = {
     computedForecastItem: ComputedForecastItemType.cost,
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    dailyTitleKey: messages.AzureDailyCostTrendTitle,
-    titleKey: messages.AzureCostTrendTitle,
+    dailyTitleKey: messages.azureDailyCostTrendTitle,
+    titleKey: messages.azureCostTrendTitle,
     type: ChartType.rolling,
   },
   availableTabs: [
@@ -49,11 +49,11 @@ export const costSummaryWidget: AzureOcpDashboardWidget = {
 
 export const databaseWidget: AzureOcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardDatabaseTitle,
+  titleKey: messages.dashboardDatabaseTitle,
   reportPathsType: ReportPathsType.azureOcp,
   reportType: ReportType.database,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
   },
   filter: {
@@ -65,7 +65,7 @@ export const databaseWidget: AzureOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardCumulativeCostComparison,
+    titleKey: messages.dashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
   chartType: DashboardChartType.trend,
@@ -73,11 +73,11 @@ export const databaseWidget: AzureOcpDashboardWidget = {
 
 export const networkWidget: AzureOcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardNetworkTitle,
+  titleKey: messages.dashboardNetworkTitle,
   reportPathsType: ReportPathsType.azureOcp,
   reportType: ReportType.network,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
   },
   filter: {
@@ -89,7 +89,7 @@ export const networkWidget: AzureOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardCumulativeCostComparison,
+    titleKey: messages.dashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
   chartType: DashboardChartType.trend,
@@ -97,15 +97,15 @@ export const networkWidget: AzureOcpDashboardWidget = {
 
 export const storageWidget: AzureOcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardStorageTitle,
+  titleKey: messages.dashboardStorageTitle,
   reportPathsType: ReportPathsType.azureOcp,
   reportType: ReportType.storage,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   filter: {
     service_name: 'Storage',
@@ -116,7 +116,7 @@ export const storageWidget: AzureOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
+    titleKey: messages.dashboardDailyUsageComparison,
     type: ChartType.daily,
   },
   chartType: DashboardChartType.trend,
@@ -124,15 +124,15 @@ export const storageWidget: AzureOcpDashboardWidget = {
 
 export const virtualMachineWidget: AzureOcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.AzureComputeTitle,
+  titleKey: messages.azureComputeTitle,
   reportPathsType: ReportPathsType.azureOcp,
   reportType: ReportType.instanceType,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   filter: {
     service_name: 'Virtual Machines',
@@ -143,7 +143,7 @@ export const virtualMachineWidget: AzureOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
+    titleKey: messages.dashboardDailyUsageComparison,
     type: ChartType.daily,
   },
   chartFormatter: formatUnits,

--- a/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
@@ -18,16 +18,16 @@ const getId = () => currrentId++;
 
 export const computeWidget: GcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.GCPComputeTitle,
+  titleKey: messages.gcpComputeTitle,
   forecastPathsType: ForecastPathsType.gcp,
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.instanceType,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   filter: {
     service: 'Compute Engine',
@@ -38,7 +38,7 @@ export const computeWidget: GcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
+    titleKey: messages.dashboardDailyUsageComparison,
     type: ChartType.daily,
   },
   chartFormatter: formatUnits,
@@ -47,14 +47,14 @@ export const computeWidget: GcpDashboardWidget = {
 
 export const costSummaryWidget: GcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.GCPCostTitle,
+  titleKey: messages.gcpCostTitle,
   forecastPathsType: ForecastPathsType.gcp,
   forecastType: ForecastType.cost,
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.cost,
   details: {
     adjustContainerHeight: true,
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showHorizontal: true,
     viewAllPath: paths.gcpDetails,
   },
@@ -65,8 +65,8 @@ export const costSummaryWidget: GcpDashboardWidget = {
     computedForecastItem: ComputedForecastItemType.cost,
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    dailyTitleKey: messages.GCPDailyCostTrendTitle,
-    titleKey: messages.GCPCostTrendTitle,
+    dailyTitleKey: messages.gcpDailyCostTrendTitle,
+    titleKey: messages.gcpCostTrendTitle,
     type: ChartType.rolling,
   },
   availableTabs: [GcpDashboardTab.services, GcpDashboardTab.gcpProjects, GcpDashboardTab.regions],
@@ -77,11 +77,11 @@ export const costSummaryWidget: GcpDashboardWidget = {
 
 export const databaseWidget: GcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardDatabaseTitle,
+  titleKey: messages.dashboardDatabaseTitle,
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.database,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
   },
   filter: {
@@ -93,7 +93,7 @@ export const databaseWidget: GcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardCumulativeCostComparison,
+    titleKey: messages.dashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
   chartFormatter: formatCurrency,
@@ -102,11 +102,11 @@ export const databaseWidget: GcpDashboardWidget = {
 
 export const networkWidget: GcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardNetworkTitle,
+  titleKey: messages.dashboardNetworkTitle,
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.network,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
   },
   filter: {
@@ -120,7 +120,7 @@ export const networkWidget: GcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardCumulativeCostComparison,
+    titleKey: messages.dashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
   chartFormatter: formatCurrency,
@@ -129,20 +129,20 @@ export const networkWidget: GcpDashboardWidget = {
 
 export const storageWidget: GcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardStorageTitle,
+  titleKey: messages.dashboardStorageTitle,
   reportPathsType: ReportPathsType.gcp,
   reportType: ReportType.storage,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
+    titleKey: messages.dashboardDailyUsageComparison,
     type: ChartType.daily,
   },
   chartFormatter: formatUnits,

--- a/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardWidgets.ts
@@ -18,16 +18,16 @@ const getId = () => currrentId++;
 
 export const computeWidget: GcpOcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.GCPComputeTitle,
+  titleKey: messages.gcpComputeTitle,
   forecastPathsType: ForecastPathsType.gcpOcp,
   reportPathsType: ReportPathsType.gcpOcp,
   reportType: ReportType.instanceType,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   filter: {
     service: 'Compute Engine',
@@ -38,7 +38,7 @@ export const computeWidget: GcpOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
+    titleKey: messages.dashboardDailyUsageComparison,
     type: ChartType.daily,
   },
   chartFormatter: formatUnits,
@@ -47,14 +47,14 @@ export const computeWidget: GcpOcpDashboardWidget = {
 
 export const costSummaryWidget: GcpOcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.GCPCostTitle,
+  titleKey: messages.gcpCostTitle,
   forecastPathsType: ForecastPathsType.gcpOcp,
   forecastType: ForecastType.cost,
   reportPathsType: ReportPathsType.gcpOcp,
   reportType: ReportType.cost,
   details: {
     adjustContainerHeight: true,
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showHorizontal: true,
   },
   tabsFilter: {
@@ -64,8 +64,8 @@ export const costSummaryWidget: GcpOcpDashboardWidget = {
     computedForecastItem: ComputedForecastItemType.cost,
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    dailyTitleKey: messages.GCPDailyCostTrendTitle,
-    titleKey: messages.GCPCostTrendTitle,
+    dailyTitleKey: messages.gcpDailyCostTrendTitle,
+    titleKey: messages.gcpCostTrendTitle,
     type: ChartType.rolling,
   },
   availableTabs: [GcpOcpDashboardTab.services, GcpOcpDashboardTab.gcpProjects, GcpOcpDashboardTab.regions],
@@ -76,11 +76,11 @@ export const costSummaryWidget: GcpOcpDashboardWidget = {
 
 export const databaseWidget: GcpOcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardDatabaseTitle,
+  titleKey: messages.dashboardDatabaseTitle,
   reportPathsType: ReportPathsType.gcpOcp,
   reportType: ReportType.database,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
   },
   filter: {
@@ -92,7 +92,7 @@ export const databaseWidget: GcpOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardCumulativeCostComparison,
+    titleKey: messages.dashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
   chartFormatter: formatCurrency,
@@ -101,11 +101,11 @@ export const databaseWidget: GcpOcpDashboardWidget = {
 
 export const networkWidget: GcpOcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardNetworkTitle,
+  titleKey: messages.dashboardNetworkTitle,
   reportPathsType: ReportPathsType.gcpOcp,
   reportType: ReportType.network,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
   },
   filter: {
@@ -117,7 +117,7 @@ export const networkWidget: GcpOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardCumulativeCostComparison,
+    titleKey: messages.dashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
   chartFormatter: formatCurrency,
@@ -126,20 +126,20 @@ export const networkWidget: GcpOcpDashboardWidget = {
 
 export const storageWidget: GcpOcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardStorageTitle,
+  titleKey: messages.dashboardStorageTitle,
   reportPathsType: ReportPathsType.gcpOcp,
   reportType: ReportType.storage,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
+    titleKey: messages.dashboardDailyUsageComparison,
     type: ChartType.daily,
   },
   chartFormatter: formatUnits,

--- a/src/store/dashboard/ibmDashboard/ibmDashboardWidgets.ts
+++ b/src/store/dashboard/ibmDashboard/ibmDashboardWidgets.ts
@@ -18,16 +18,16 @@ const getId = () => currrentId++;
 
 export const computeWidget: IbmDashboardWidget = {
   id: getId(),
-  titleKey: messages.IBMComputeTitle,
+  titleKey: messages.ibmComputeTitle,
   forecastPathsType: ForecastPathsType.ibm,
   reportPathsType: ReportPathsType.ibm,
   reportType: ReportType.instanceType,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   filter: {
     service: 'Compute Engine',
@@ -38,7 +38,7 @@ export const computeWidget: IbmDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
+    titleKey: messages.dashboardDailyUsageComparison,
     type: ChartType.daily,
   },
   chartFormatter: formatUnits,
@@ -47,14 +47,14 @@ export const computeWidget: IbmDashboardWidget = {
 
 export const costSummaryWidget: IbmDashboardWidget = {
   id: getId(),
-  titleKey: messages.IBMCostTitle,
+  titleKey: messages.ibmCostTitle,
   forecastPathsType: ForecastPathsType.ibm,
   forecastType: ForecastType.cost,
   reportPathsType: ReportPathsType.ibm,
   reportType: ReportType.cost,
   details: {
     adjustContainerHeight: true,
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showHorizontal: true,
     viewAllPath: paths.ibmDetails,
   },
@@ -65,8 +65,8 @@ export const costSummaryWidget: IbmDashboardWidget = {
     computedForecastItem: ComputedForecastItemType.cost,
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    dailyTitleKey: messages.IBMDailyCostTrendTitle,
-    titleKey: messages.IBMCostTrendTitle,
+    dailyTitleKey: messages.ibmDailyCostTrendTitle,
+    titleKey: messages.ibmCostTrendTitle,
     type: ChartType.rolling,
   },
   availableTabs: [IbmDashboardTab.services, IbmDashboardTab.projects, IbmDashboardTab.regions],
@@ -77,11 +77,11 @@ export const costSummaryWidget: IbmDashboardWidget = {
 
 export const databaseWidget: IbmDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardDatabaseTitle,
+  titleKey: messages.dashboardDatabaseTitle,
   reportPathsType: ReportPathsType.ibm,
   reportType: ReportType.database,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
   },
   filter: {
@@ -93,7 +93,7 @@ export const databaseWidget: IbmDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardCumulativeCostComparison,
+    titleKey: messages.dashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
   chartFormatter: formatCurrency,
@@ -102,11 +102,11 @@ export const databaseWidget: IbmDashboardWidget = {
 
 export const networkWidget: IbmDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardNetworkTitle,
+  titleKey: messages.dashboardNetworkTitle,
   reportPathsType: ReportPathsType.ibm,
   reportType: ReportType.network,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
   },
   filter: {
@@ -120,7 +120,7 @@ export const networkWidget: IbmDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardCumulativeCostComparison,
+    titleKey: messages.dashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
   chartFormatter: formatCurrency,
@@ -129,20 +129,20 @@ export const networkWidget: IbmDashboardWidget = {
 
 export const storageWidget: IbmDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardStorageTitle,
+  titleKey: messages.dashboardStorageTitle,
   reportPathsType: ReportPathsType.ibm,
   reportType: ReportType.storage,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
+    titleKey: messages.dashboardDailyUsageComparison,
     type: ChartType.daily,
   },
   chartFormatter: formatUnits,

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
@@ -20,13 +20,13 @@ const getId = () => currrentId++;
 
 export const costSummaryWidget: OcpCloudDashboardWidget = {
   id: getId(),
-  titleKey: messages.OCPCloudDashboardCostTitle,
+  titleKey: messages.ocpCloudDashboardCostTitle,
   forecastPathsType: ForecastPathsType.ocpCloud,
   forecastType: ForecastType.cost,
   reportPathsType: ReportPathsType.ocpCloud,
   reportType: ReportType.cost,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showHorizontal: true,
   },
   tabsFilter: {
@@ -36,8 +36,8 @@ export const costSummaryWidget: OcpCloudDashboardWidget = {
     computedForecastItem: ComputedForecastItemType.cost,
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    dailyTitleKey: messages.OCPCloudDashboardDailyCostTrendTitle,
-    titleKey: messages.OCPCloudDashboardCostTrendTitle,
+    dailyTitleKey: messages.ocpCloudDashboardDailyCostTrendTitle,
+    titleKey: messages.ocpCloudDashboardCostTrendTitle,
     type: ChartType.rolling,
   },
   availableTabs: [OcpCloudDashboardTab.services, OcpCloudDashboardTab.accounts, OcpCloudDashboardTab.regions],
@@ -50,15 +50,15 @@ export const costSummaryWidget: OcpCloudDashboardWidget = {
 
 export const computeWidget: OcpCloudDashboardWidget = {
   id: getId(),
-  titleKey: messages.OCPCloudDashboardComputeTitle,
+  titleKey: messages.ocpCloudDashboardComputeTitle,
   reportPathsType: ReportPathsType.ocpCloud,
   reportType: ReportType.instanceType,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   filter: {
     service: 'AmazonEC2',
@@ -66,7 +66,7 @@ export const computeWidget: OcpCloudDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
+    titleKey: messages.dashboardDailyUsageComparison,
     type: ChartType.daily,
   },
   chartFormatter: formatUnits,
@@ -75,11 +75,11 @@ export const computeWidget: OcpCloudDashboardWidget = {
 
 export const databaseWidget: OcpCloudDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardDatabaseTitle,
+  titleKey: messages.dashboardDatabaseTitle,
   reportPathsType: ReportPathsType.ocpCloud,
   reportType: ReportType.database,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
   },
   filter: {
@@ -93,7 +93,7 @@ export const databaseWidget: OcpCloudDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardCumulativeCostComparison,
+    titleKey: messages.dashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
   chartFormatter: formatUnits,
@@ -102,11 +102,11 @@ export const databaseWidget: OcpCloudDashboardWidget = {
 
 export const networkWidget: OcpCloudDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardNetworkTitle,
+  titleKey: messages.dashboardNetworkTitle,
   reportPathsType: ReportPathsType.ocpCloud,
   reportType: ReportType.network,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
   },
   filter: {
@@ -120,7 +120,7 @@ export const networkWidget: OcpCloudDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardCumulativeCostComparison,
+    titleKey: messages.dashboardCumulativeCostComparison,
     type: ChartType.rolling,
   },
   chartFormatter: formatCurrency,
@@ -129,20 +129,20 @@ export const networkWidget: OcpCloudDashboardWidget = {
 
 export const storageWidget: OcpCloudDashboardWidget = {
   id: getId(),
-  titleKey: messages.DashboardStorageTitle,
+  titleKey: messages.dashboardStorageTitle,
   reportPathsType: ReportPathsType.ocpCloud,
   reportType: ReportType.storage,
   details: {
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showUnits: true,
     showUsageFirst: true,
     showUsageLegendLabel: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.DashboardDailyUsageComparison,
+    titleKey: messages.dashboardDailyUsageComparison,
     type: ChartType.daily,
   },
   chartFormatter: formatUnits,

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -18,14 +18,14 @@ const getId = () => currrentId++;
 
 export const costSummaryWidget: OcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.OCPDashboardCostTitle,
+  titleKey: messages.ocpDashboardCostTitle,
   forecastPathsType: ForecastPathsType.ocp,
   forecastType: ForecastType.cost,
   reportPathsType: ReportPathsType.ocp,
   reportType: ReportType.cost,
   details: {
     adjustContainerHeight: true,
-    costKey: messages.Cost,
+    costKey: messages.cost,
     showHorizontal: true,
     showTooltip: true,
     viewAllPath: paths.ocpDetails,
@@ -35,8 +35,8 @@ export const costSummaryWidget: OcpDashboardWidget = {
     computedForecastInfrastructureItem: ComputedForecastItemType.infrastructure,
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
-    dailyTitleKey: messages.OCPDashboardDailyCostTitle,
-    titleKey: messages.OCPDashboardCostTrendTitle,
+    dailyTitleKey: messages.ocpDashboardDailyCostTitle,
+    titleKey: messages.ocpDashboardCostTrendTitle,
     type: ChartType.rolling,
   },
   tabsFilter: {
@@ -50,19 +50,19 @@ export const costSummaryWidget: OcpDashboardWidget = {
 
 export const cpuWidget: OcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.OCPCPUUsageAndRequests,
+  titleKey: messages.ocpCpuUsageAndRequests,
   reportPathsType: ReportPathsType.ocp,
   reportType: ReportType.cpu,
   details: {
-    requestKey: messages.Requests,
+    requestKey: messages.requests,
     showUnits: true,
     showUsageFirst: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.OCPDailyUsageAndRequestComparison,
+    titleKey: messages.ocpDailyUsageAndRequestComparison,
     type: ChartType.daily,
   },
   chartFormatter: formatUnits,
@@ -71,19 +71,19 @@ export const cpuWidget: OcpDashboardWidget = {
 
 export const memoryWidget: OcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.OCPMemoryUsageAndRequests,
+  titleKey: messages.ocpMemoryUsageAndRequests,
   reportPathsType: ReportPathsType.ocp,
   reportType: ReportType.memory,
   details: {
-    requestKey: messages.Requests,
+    requestKey: messages.requests,
     showUnits: true,
     showUsageFirst: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.OCPDailyUsageAndRequestComparison,
+    titleKey: messages.ocpDailyUsageAndRequestComparison,
     type: ChartType.daily,
   },
   chartFormatter: formatUnits,
@@ -92,19 +92,19 @@ export const memoryWidget: OcpDashboardWidget = {
 
 export const volumeWidget: OcpDashboardWidget = {
   id: getId(),
-  titleKey: messages.OCPVolumeUsageAndRequests,
+  titleKey: messages.ocpVolumeUsageAndRequests,
   reportPathsType: ReportPathsType.ocp,
   reportType: ReportType.volume,
   details: {
-    requestKey: messages.Requests,
+    requestKey: messages.requests,
     showUnits: true,
     showUsageFirst: true,
-    usageKey: messages.Usage,
+    usageKey: messages.usage,
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
-    titleKey: messages.OCPDailyUsageAndRequestComparison,
+    titleKey: messages.ocpDailyUsageAndRequestComparison,
     type: ChartType.daily,
   },
   chartFormatter: formatUnits,

--- a/src/store/export/exportActions.tsx
+++ b/src/store/export/exportActions.tsx
@@ -49,9 +49,9 @@ export function exportReport(
 
         /* Todo: Show in-progress features in beta environment only */
         if (isFeatureVisible(FeatureType.exports)) {
-          const description = intl.formatMessage(messages.ExportsSuccessDesc, {
+          const description = intl.formatMessage(messages.exportsSuccessDesc, {
             link: <ExportsLink isActionLink onClick={() => dispatch(removeNotification(exportSuccessID))} />,
-            value: <b>{intl.formatMessage(messages.ExportsTitle)}</b>,
+            value: <b>{intl.formatMessage(messages.exportsTitle)}</b>,
           });
 
           dispatch(
@@ -59,7 +59,7 @@ export function exportReport(
               description,
               dismissable: true,
               id: exportSuccessID,
-              title: intl.formatMessage(messages.ExportsSuccess),
+              title: intl.formatMessage(messages.exportsSuccess),
               variant: AlertVariant.success,
             })
           );
@@ -72,9 +72,9 @@ export function exportReport(
         if (isFeatureVisible(FeatureType.exports)) {
           dispatch(
             addNotification({
-              description: intl.formatMessage(messages.ExportsFailedDesc),
+              description: intl.formatMessage(messages.exportsFailedDesc),
               dismissable: true,
-              title: intl.formatMessage(messages.ExportsUnavailable),
+              title: intl.formatMessage(messages.exportsUnavailable),
               variant: AlertVariant.danger,
             })
           );

--- a/src/store/rbac/actions.ts
+++ b/src/store/rbac/actions.ts
@@ -22,8 +22,8 @@ export const fetchRbac = (): any => {
       .catch(err => {
         dispatch(
           addNotification({
-            title: intl.formatMessage(messages.RbacErrorTitle),
-            description: intl.formatMessage(messages.RbacErrorDescription),
+            title: intl.formatMessage(messages.rbacErrorTitle),
+            description: intl.formatMessage(messages.rbacErrorDescription),
             variant: AlertVariant.danger,
             dismissable: true,
           })

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -161,7 +161,7 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
         let label;
         if (report.meta && report.meta.others && (id === 'Other' || id === 'Others')) {
           // Add count to "Others" label
-          label = intl.formatMessage(messages.ChartOthers, { count: report.meta.others });
+          label = intl.formatMessage(messages.chartOthers, { count: report.meta.others });
         } else {
           const itemLabelKey = getItemLabel({ report, idKey, value: val });
           if (itemLabelKey === 'org_entities' && val.alias) {

--- a/src/utils/dateRange.ts
+++ b/src/utils/dateRange.ts
@@ -13,7 +13,7 @@ export function getToday(hrs: number = 0, min: number = 0, sec: number = 0) {
   return today;
 }
 
-export function getNoDataForDateRangeString(message: MessageDescriptor = messages.NoDataForDate, offset: number = 1) {
+export function getNoDataForDateRangeString(message: MessageDescriptor = messages.noDataForDate, offset: number = 1) {
   const today = getToday();
 
   if (offset) {
@@ -29,7 +29,7 @@ export function getNoDataForDateRangeString(message: MessageDescriptor = message
 
 export function getForDateRangeString(
   value: string | number,
-  message: MessageDescriptor = messages.ForDate,
+  message: MessageDescriptor = messages.forDate,
   offset: number = 1
 ) {
   const today = getToday();
@@ -51,7 +51,7 @@ export function getForDateRangeString(
   });
 }
 
-export function getSinceDateRangeString(message: MessageDescriptor = messages.SinceDate) {
+export function getSinceDateRangeString(message: MessageDescriptor = messages.sinceDate) {
   const today = getToday();
   const month = getMonth(today);
   const endDate = format(today, 'd');

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -66,7 +66,7 @@ export const formatCurrencyAbbreviation: Formatter = (value, units = 'USD') => {
   // Apply format and insert symbol next to the numeric portion of the formatted string
   if (format != null) {
     const { val, symbol } = format;
-    return intl.formatMessage(messages.CurrencyAbbreviations, {
+    return intl.formatMessage(messages.currencyAbbreviations, {
       symbol,
       value: formatCurrency(fValue / val, units, {
         minimumFractionDigits: 0,


### PR DESCRIPTION
The Messages file uses a mix of pascal case and camel case. For example:

AWSOcpDashboardCostTitle
CostModelsWizardOnboardOCP
DocsAddOcpSources
OCPDashboardCostTitle

Want to clean that up to match the camel case used throughout the UI. For example:

awsOcpDashboardCostTitle
costModelsWizardOnboardOcp
docsAddOcpSources
ocpDashboardCostTitle

https://issues.redhat.com/browse/COST-2732