### PR TITLE
stub oci overview

### DIFF
--- a/src/api/providers.ts
+++ b/src/api/providers.ts
@@ -63,6 +63,7 @@ export const enum ProviderType {
   gcp = 'gcp',
   ibm = 'ibm',
   ocp = 'ocp',
+  oci = 'oci',
 }
 
 export function fetchProviders(query: string) {

--- a/src/api/queries/providersQuery.ts
+++ b/src/api/queries/providersQuery.ts
@@ -3,7 +3,7 @@ import { parse, stringify } from 'qs';
 export interface ProvidersQuery {
   limit?: number;
   page_size?: number;
-  type?: 'AWS' | 'Azure' | 'GCP' | 'IBM' | 'OCP';
+  type?: 'AWS' | 'Azure' | 'GCP' | 'IBM' | 'OCI' | 'OCP';
 }
 
 export function getProvidersQuery(query: ProvidersQuery) {

--- a/src/api/userAccess.ts
+++ b/src/api/userAccess.ts
@@ -22,6 +22,7 @@ export const enum UserAccessType {
   explorer = 'explorer',
   gcp = 'gcp',
   ibm = 'ibm',
+  oci = 'oci',
   ocp = 'ocp',
 }
 

--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -27,7 +27,14 @@ import { userAccessQuery, userAccessSelectors } from 'store/userAccess';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { CostTypes, getCostType } from 'utils/costType';
-import { isAwsAvailable, isAzureAvailable, isGcpAvailable, isIbmAvailable, isOcpAvailable } from 'utils/userAccess';
+import {
+  isAwsAvailable,
+  isAzureAvailable,
+  isGcpAvailable,
+  isIbmAvailable,
+  isOciAvailable,
+  isOcpAvailable,
+} from 'utils/userAccess';
 
 import { styles } from './explorer.styles';
 import { ExplorerChart } from './explorerChart';
@@ -389,7 +396,7 @@ class Explorer extends React.Component<ExplorerProps> {
 
   private isOciAvailable = () => {
     const { ociProviders, userAccess } = this.props;
-    return isAzureAvailable(userAccess, ociProviders);
+    return isOciAvailable(userAccess, ociProviders);
   };
 
   private isGcpAvailable = () => {

--- a/src/pages/views/explorer/explorer.tsx
+++ b/src/pages/views/explorer/explorer.tsx
@@ -52,6 +52,7 @@ import {
 interface ExplorerStateProps {
   awsProviders: Providers;
   azureProviders: Providers;
+  ociProviders: Providers;
   costType?: CostTypes;
   dateRange: DateRangeType;
   gcpProviders: Providers;
@@ -386,6 +387,11 @@ class Explorer extends React.Component<ExplorerProps> {
     return isAzureAvailable(userAccess, azureProviders);
   };
 
+  private isOciAvailable = () => {
+    const { ociProviders, userAccess } = this.props;
+    return isAzureAvailable(userAccess, ociProviders);
+  };
+
   private isGcpAvailable = () => {
     const { gcpProviders, userAccess } = this.props;
     return isGcpAvailable(userAccess, gcpProviders);
@@ -421,6 +427,7 @@ class Explorer extends React.Component<ExplorerProps> {
     const {
       awsProviders,
       azureProviders,
+      ociProviders,
       costType,
       gcpProviders,
       ibmProviders,
@@ -441,7 +448,9 @@ class Explorer extends React.Component<ExplorerProps> {
     const noGcpProviders = !this.isGcpAvailable() && providersFetchStatus === FetchStatus.complete;
     const noIbmProviders = !this.isIbmAvailable() && providersFetchStatus === FetchStatus.complete;
     const noOcpProviders = !this.isOcpAvailable() && providersFetchStatus === FetchStatus.complete;
-    const noProviders = noAwsProviders && noAzureProviders && noGcpProviders && noIbmProviders && noOcpProviders;
+    const noOciProviders = !this.isOciAvailable() && providersFetchStatus === FetchStatus.complete;
+    const noProviders =
+      noAwsProviders && noAzureProviders && noGcpProviders && noIbmProviders && noOcpProviders && noOciProviders;
 
     const isLoading =
       providersFetchStatus === FetchStatus.inProgress || userAccessFetchStatus === FetchStatus.inProgress;
@@ -463,6 +472,7 @@ class Explorer extends React.Component<ExplorerProps> {
       !(
         hasData(awsProviders) ||
         hasData(azureProviders) ||
+        hasData(ociProviders) ||
         hasData(gcpProviders) ||
         hasData(ibmProviders) ||
         hasData(ocpProviders)
@@ -525,6 +535,7 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
 
   const awsProviders = filterProviders(providers, ProviderType.aws);
   const azureProviders = filterProviders(providers, ProviderType.azure);
+  const ociProviders = filterProviders(providers, ProviderType.oci);
   const gcpProviders = filterProviders(providers, ProviderType.gcp);
   const ibmProviders = filterProviders(providers, ProviderType.ibm);
   const ocpProviders = filterProviders(providers, ProviderType.ocp);
@@ -546,6 +557,7 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
   const perspective = getPerspectiveDefault({
     awsProviders,
     azureProviders,
+    ociProviders,
     gcpProviders,
     ibmProviders,
     ocpProviders,
@@ -594,6 +606,7 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
     dateRange,
     gcpProviders,
     ibmProviders,
+    ociProviders,
     ocpProviders,
     perspective,
     providers,

--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -31,6 +31,7 @@ import {
   isAzureAvailable,
   isGcpAvailable,
   isIbmAvailable,
+  isOciAvailable,
   isOcpAvailable,
 } from 'utils/userAccess';
 
@@ -74,6 +75,7 @@ interface ExplorerHeaderStateProps {
   azureProviders?: Providers;
   gcpProviders?: Providers;
   ibmProviders?: Providers;
+  ociProviders?: Providers;
   ocpProviders?: Providers;
   providers: Providers;
   providersError: AxiosError;
@@ -123,12 +125,13 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
 
     const hasAws = this.isAwsAvailable();
     const hasAzure = this.isAzureAvailable();
+    const hasOci = this.isOciAvailable();
     const hasGcp = this.isGcpAvailable();
     const hasIbm = this.isIbmAvailable();
     const hasOcp = this.isOcpAvailable();
 
     // Note: No need to test OCP on cloud here, since that requires at least one provider
-    if (!(hasAws || hasAzure || hasGcp || hasIbm || hasOcp)) {
+    if (!(hasAws || hasAzure || hasOci || hasGcp || hasIbm || hasOcp)) {
       return null;
     }
 
@@ -218,6 +221,11 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
   private isAzureAvailable = () => {
     const { azureProviders, userAccess } = this.props;
     return isAzureAvailable(userAccess, azureProviders);
+  };
+
+  private isOciAvailable = () => {
+    const { ociProviders, userAccess } = this.props;
+    return isOciAvailable(userAccess, ociProviders);
   };
 
   private isAzureOcpAvailable = () => {
@@ -389,6 +397,7 @@ const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHe
       azureProviders: filterProviders(providers, ProviderType.azure),
       gcpProviders: filterProviders(providers, ProviderType.gcp),
       ibmProviders: filterProviders(providers, ProviderType.ibm),
+      ociProviders: filterProviders(providers, ProviderType.oci),
       ocpProviders: filterProviders(providers, ProviderType.ocp),
       providers,
       providersError,

--- a/src/pages/views/explorer/explorerHeader.tsx
+++ b/src/pages/views/explorer/explorerHeader.tsx
@@ -55,6 +55,7 @@ import {
   infrastructureGcpOptions,
   infrastructureIbmOcpOptions,
   infrastructureIbmOptions,
+  infrastructureOciOptions,
   infrastructureOcpCloudOptions,
   ocpOptions,
   PerspectiveType,
@@ -167,6 +168,9 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
     }
     if (this.isAzureOcpAvailable()) {
       options.push(...infrastructureAzureOcpOptions);
+    }
+    if (isFeatureVisible(FeatureType.oci) && hasOci) {
+      options.push(...infrastructureOciOptions);
     }
 
     return (

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -28,6 +28,7 @@ import {
   isAzureAvailable,
   isGcpAvailable,
   isIbmAvailable,
+  isOciAvailable,
   isOcpAvailable,
 } from 'utils/userAccess';
 
@@ -51,6 +52,7 @@ export const enum PerspectiveType {
   gcpOcp = 'gcp_ocp', // Gcp filtered by Ocp
   ibm = 'ibm',
   ibmOcp = 'ibm_ocp', // IBM filtered by Ocp
+  oci = 'oci',
   ocp = 'ocp',
   ocpCloud = 'ocp_cloud', // All filtered by Ocp
 }
@@ -225,6 +227,7 @@ export const getDateRangeDefault = (queryFromRoute: Query) => {
 export const getPerspectiveDefault = ({
   awsProviders,
   azureProviders,
+  ociProviders,
   gcpProviders,
   ibmProviders,
   ocpProviders,
@@ -233,6 +236,7 @@ export const getPerspectiveDefault = ({
 }: {
   awsProviders: Providers;
   azureProviders: Providers;
+  ociProviders: Providers;
   gcpProviders: Providers;
   ibmProviders: Providers;
   ocpProviders: Providers;
@@ -272,6 +276,9 @@ export const getPerspectiveDefault = ({
   }
   if (isAzureAvailable(userAccess, azureProviders)) {
     return PerspectiveType.azure;
+  }
+  if (isOciAvailable(userAccess, ociProviders)) {
+    return PerspectiveType.oci;
   }
   if (isGcpAvailable(userAccess, gcpProviders)) {
     return PerspectiveType.gcp;

--- a/src/pages/views/explorer/explorerUtils.ts
+++ b/src/pages/views/explorer/explorerUtils.ts
@@ -145,6 +145,9 @@ export const infrastructureAwsOcpOptions = [{ label: messages.perspectiveValues,
 // Infrastructure Azure options
 export const infrastructureAzureOptions = [{ label: messages.perspectiveValues, value: 'azure' }];
 
+// Infrastructure OCI options
+export const infrastructureOciOptions = [{ label: messages.perspectiveValues, value: 'oci' }];
+
 // Infrastructure Azure filtered by OpenShift options
 export const infrastructureAzureOcpOptions = [{ label: messages.perspectiveValues, value: 'azure_ocp' }];
 

--- a/src/pages/views/overview/ociDashboard/index.ts
+++ b/src/pages/views/overview/ociDashboard/index.ts
@@ -1,0 +1,3 @@
+import OciDashboard from './ociDashboard';
+
+export default OciDashboard;

--- a/src/pages/views/overview/ociDashboard/ociDashboard.tsx
+++ b/src/pages/views/overview/ociDashboard/ociDashboard.tsx
@@ -1,0 +1,26 @@
+import { DashboardBase } from 'pages/views/overview/components/dashboardBase';
+import { connect } from 'react-redux';
+import { createMapStateToProps } from 'store/common';
+import { ociDashboardSelectors } from 'store/dashboard/ociDashboard';
+
+import { OciDashboardWidget } from './ociDashboardWidget';
+
+type OciDashboardOwnProps = any;
+
+interface OciDashboardStateProps {
+  DashboardWidget: typeof OciDashboardWidget;
+  widgets: number[];
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+const mapStateToProps = createMapStateToProps<OciDashboardOwnProps, OciDashboardStateProps>((state, props) => {
+  return {
+    DashboardWidget: OciDashboardWidget,
+    selectWidgets: ociDashboardSelectors.selectWidgets(state),
+    widgets: ociDashboardSelectors.selectCurrentWidgets(state),
+  };
+});
+
+const OciDashboard = connect(mapStateToProps, {})(DashboardBase);
+
+export default OciDashboard;

--- a/src/pages/views/overview/ociDashboard/ociDashboardWidget.test.tsx
+++ b/src/pages/views/overview/ociDashboard/ociDashboardWidget.test.tsx
@@ -1,0 +1,34 @@
+jest.mock('date-fns');
+
+import { format, getDate, getMonth, startOfMonth } from 'date-fns';
+import { OciDashboardTab } from 'store/dashboard/ociDashboard';
+import { mockDate } from 'testUtils';
+
+import { getIdKeyForTab } from './ociDashboardWidget';
+
+const getDateMock = getDate as jest.Mock;
+const formatMock = format as jest.Mock;
+const startOfMonthMock = startOfMonth as jest.Mock;
+const getMonthMock = getMonth as jest.Mock;
+
+beforeEach(() => {
+  mockDate();
+  getDateMock.mockReturnValue(1);
+  formatMock.mockReturnValue('formated date');
+  startOfMonthMock.mockReturnValue(1);
+  getMonthMock.mockReturnValue(1);
+});
+
+test('id key for OciDashboardTab.product_service is correct', () => {
+  expect(getIdKeyForTab(OciDashboardTab.product_service).toEqual(OciDashboardTab.product_service));
+})
+
+test('id key for dashboard tab is the tab name in singular form', () => {
+  [OciDashboardTab.payer_tenant_ids, OciDashboardTab.resources].forEach(
+    value => {
+      expect(getIdKeyForTab(value)).toEqual(value.slice(0, -1));
+    }
+  );
+
+  expect(getIdKeyForTab(OciDashboardTab.instanceType)).toEqual(OciDashboardTab.instanceType);
+});

--- a/src/pages/views/overview/ociDashboard/ociDashboardWidget.test.tsx
+++ b/src/pages/views/overview/ociDashboard/ociDashboardWidget.test.tsx
@@ -20,7 +20,7 @@ beforeEach(() => {
 });
 
 test('id key for dashboard tab is the tab name in singular form', () => {
-  [OciDashboardTab.service_names, OciDashboardTab.payer_tenant_ids, OciDashboardTab.resources].forEach(value => {
+  [OciDashboardTab.product_services, OciDashboardTab.payer_tenant_ids, OciDashboardTab.regions].forEach(value => {
     expect(getIdKeyForTab(value)).toEqual(value.slice(0, -1));
   });
 

--- a/src/pages/views/overview/ociDashboard/ociDashboardWidget.test.tsx
+++ b/src/pages/views/overview/ociDashboard/ociDashboardWidget.test.tsx
@@ -19,16 +19,10 @@ beforeEach(() => {
   getMonthMock.mockReturnValue(1);
 });
 
-test('id key for OciDashboardTab.product_service is correct', () => {
-  expect(getIdKeyForTab(OciDashboardTab.product_service).toEqual(OciDashboardTab.product_service));
-})
-
 test('id key for dashboard tab is the tab name in singular form', () => {
-  [OciDashboardTab.payer_tenant_ids, OciDashboardTab.resources].forEach(
-    value => {
-      expect(getIdKeyForTab(value)).toEqual(value.slice(0, -1));
-    }
-  );
+  [OciDashboardTab.service_names, OciDashboardTab.payer_tenant_ids, OciDashboardTab.resources].forEach(value => {
+    expect(getIdKeyForTab(value)).toEqual(value.slice(0, -1));
+  });
 
   expect(getIdKeyForTab(OciDashboardTab.instanceType)).toEqual(OciDashboardTab.instanceType);
 });

--- a/src/pages/views/overview/ociDashboard/ociDashboardWidget.tsx
+++ b/src/pages/views/overview/ociDashboard/ociDashboardWidget.tsx
@@ -1,0 +1,75 @@
+import {
+  DashboardWidgetBase,
+  DashboardWidgetOwnProps,
+  DashboardWidgetStateProps,
+} from 'pages/views/overview/components/dashboardWidgetBase';
+import { injectIntl } from 'react-intl';
+import { connect } from 'react-redux';
+import { createMapStateToProps } from 'store/common';
+import { ociDashboardActions, ociDashboardSelectors, OciDashboardTab } from 'store/dashboard/ociDashboard';
+import { forecastSelectors } from 'store/forecasts';
+import { reportSelectors } from 'store/reports';
+import { ComputedOciReportItemsParams } from 'utils/computedReport/getComputedOciReportItems';
+
+interface OciDashboardWidgetDispatchProps {
+  fetchForecasts: typeof ociDashboardActions.fetchWidgetForecasts;
+  fetchReports: typeof ociDashboardActions.fetchWidgetReports;
+  updateTab: typeof ociDashboardActions.changeWidgetTab;
+}
+
+export const getIdKeyForTab = (tab: OciDashboardTab): ComputedOciReportItemsParams['idKey'] => {
+  switch (tab) {
+    case OciDashboardTab.service_names:
+      return 'service_name';
+    case OciDashboardTab.subscription_guids:
+      return 'subscription_guid';
+    case OciDashboardTab.resource_locations:
+      return 'resource_location';
+  }
+};
+
+const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, DashboardWidgetStateProps>(
+  (state, { widgetId }) => {
+    const widget = ociDashboardSelectors.selectWidget(state, widgetId);
+    const queries = ociDashboardSelectors.selectWidgetQueries(state, widgetId);
+    return {
+      ...widget,
+      getIdKeyForTab,
+      currentQuery: queries.current,
+      forecastQuery: queries.forecast,
+      previousQuery: queries.previous,
+      tabsQuery: queries.tabs,
+      currentReport: reportSelectors.selectReport(state, widget.reportPathsType, widget.reportType, queries.current),
+      currentReportFetchStatus: reportSelectors.selectReportFetchStatus(
+        state,
+        widget.reportPathsType,
+        widget.reportType,
+        queries.current
+      ),
+      forecast: forecastSelectors.selectForecast(
+        state,
+        widget.forecastPathsType,
+        widget.forecastType,
+        queries.forecast
+      ),
+      previousReport: reportSelectors.selectReport(state, widget.reportPathsType, widget.reportType, queries.previous),
+      tabsReport: reportSelectors.selectReport(state, widget.reportPathsType, widget.reportType, queries.tabs),
+      tabsReportFetchStatus: reportSelectors.selectReportFetchStatus(
+        state,
+        widget.reportPathsType,
+        widget.reportType,
+        queries.tabs
+      ),
+    };
+  }
+);
+
+const mapDispatchToProps: OciDashboardWidgetDispatchProps = {
+  fetchForecasts: ociDashboardActions.fetchWidgetForecasts,
+  fetchReports: ociDashboardActions.fetchWidgetReports,
+  updateTab: ociDashboardActions.changeWidgetTab,
+};
+
+const OciDashboardWidget = injectIntl(connect(mapStateToProps, mapDispatchToProps)(DashboardWidgetBase));
+
+export { OciDashboardWidget };

--- a/src/pages/views/overview/ociDashboard/ociDashboardWidget.tsx
+++ b/src/pages/views/overview/ociDashboard/ociDashboardWidget.tsx
@@ -19,11 +19,11 @@ interface OciDashboardWidgetDispatchProps {
 
 export const getIdKeyForTab = (tab: OciDashboardTab): ComputedOciReportItemsParams['idKey'] => {
   switch (tab) {
-    case OciDashboardTab.service_names:
+    case OciDashboardTab.product_services:
       return 'product_service';
     case OciDashboardTab.payer_tenant_ids:
       return 'payer_tenant_id';
-    case OciDashboardTab.resources:
+    case OciDashboardTab.regions:
       return 'region';
   }
 };

--- a/src/pages/views/overview/ociDashboard/ociDashboardWidget.tsx
+++ b/src/pages/views/overview/ociDashboard/ociDashboardWidget.tsx
@@ -20,11 +20,11 @@ interface OciDashboardWidgetDispatchProps {
 export const getIdKeyForTab = (tab: OciDashboardTab): ComputedOciReportItemsParams['idKey'] => {
   switch (tab) {
     case OciDashboardTab.service_names:
-      return 'service_name';
-    case OciDashboardTab.subscription_guids:
-      return 'subscription_guid';
-    case OciDashboardTab.resource_locations:
-      return 'resource_location';
+      return 'product_service';
+    case OciDashboardTab.payer_tenant_ids:
+      return 'payer_tenant_id';
+    case OciDashboardTab.resources:
+      return 'region';
   }
 };
 

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -66,6 +66,7 @@ import {
   isOcpAvailable,
 } from 'utils/userAccess';
 
+import OciDashboard from './ociDashboard';
 import { styles } from './overview.styles';
 
 // eslint-disable-next-line no-shadow
@@ -422,7 +423,8 @@ class OverviewBase extends React.Component<OverviewProps> {
   };
 
   private getTabItem = (tab: OverviewTab, index: number) => {
-    const { awsProviders, azureProviders, costType, gcpProviders, ibmProviders, ocpProviders } = this.props;
+    const { awsProviders, azureProviders, ociProviders, costType, gcpProviders, ibmProviders, ocpProviders } =
+      this.props;
     const { activeTabKey, currentInfrastructurePerspective, currentOcpPerspective } = this.state;
 
     const emptyTab = <></>; // Lazily load tabs
@@ -461,6 +463,9 @@ class OverviewBase extends React.Component<OverviewProps> {
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.azure) {
         const hasData = hasCurrentMonthData(azureProviders) || hasPreviousMonthData(azureProviders);
         return hasData ? <AzureDashboard /> : noData;
+      } else if (currentInfrastructurePerspective === InfrastructurePerspective.oci) {
+        const hasData = hasCurrentMonthData(ociProviders) || hasPreviousMonthData(ociProviders);
+        return hasData ? <OciDashboard /> : noData;
       } else if (currentInfrastructurePerspective === InfrastructurePerspective.azureOcp) {
         const hasData =
           hasCloudCurrentMonthData(azureProviders, ocpProviders) ||
@@ -735,6 +740,7 @@ const mapStateToProps = createMapStateToProps<OverviewOwnProps, OverviewStatePro
   return {
     awsProviders: filterProviders(providers, ProviderType.aws),
     azureProviders: filterProviders(providers, ProviderType.azure),
+    ociProviders: filterProviders(providers, ProviderType.oci),
     gcpProviders: filterProviders(providers, ProviderType.gcp),
     ibmProviders: filterProviders(providers, ProviderType.ibm),
     ocpProviders: filterProviders(providers, ProviderType.ocp),

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -60,9 +60,9 @@ import {
   hasIbmAccess,
   isAwsAvailable,
   isAzureAvailable,
-  isOciAvailable,
   isGcpAvailable,
   isIbmAvailable,
+  isOciAvailable,
   isOcpAvailable,
 } from 'utils/userAccess';
 
@@ -615,13 +615,14 @@ class OverviewBase extends React.Component<OverviewProps> {
     const { providersFetchStatus, intl, userAccessFetchStatus } = this.props;
 
     // Note: No need to test OCP on cloud here, since that requires at least one provider
-    const noProviders = providersFetchStatus === FetchStatus.complete
-      && !this.isAwsAvailable()
-      && !this.isAzureAvailable()
-      && !this.isGcpAvailable()
-      && !this.isIbmAvailable()
-      && !this.isOciAvailable()
-      && !this.isOcpAvailable()
+    const noProviders =
+      providersFetchStatus === FetchStatus.complete &&
+      !this.isAwsAvailable() &&
+      !this.isAzureAvailable() &&
+      !this.isGcpAvailable() &&
+      !this.isIbmAvailable() &&
+      !this.isOciAvailable() &&
+      !this.isOcpAvailable();
 
     const isLoading =
       providersFetchStatus === FetchStatus.inProgress || userAccessFetchStatus === FetchStatus.inProgress;

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -52,7 +52,7 @@ import { providersQuery, providersSelectors } from 'store/providers';
 import { userAccessQuery, userAccessSelectors } from 'store/userAccess';
 import { CostTypes, getCostType } from 'utils/costType';
 import { getSinceDateRangeString } from 'utils/dateRange';
-import { FeatureType, isFeatureVisible } from 'utils/feature';
+import { FeatureType, isFeatureVisible, isStageBeta } from 'utils/feature';
 import {
   hasAwsAccess,
   hasAzureAccess,
@@ -655,12 +655,14 @@ class OverviewBase extends React.Component<OverviewProps> {
                       <br />
                       <p style={styles.infoTitle}>{intl.formatMessage(messages.gcp)}</p>
                       <p>{intl.formatMessage(messages.gcpDesc)}</p>
-                      {/* Todo: Show in-progress features in beta environment only */}
-                      {isFeatureVisible(FeatureType.ibm) && (
+                      {isStageBeta() && (
                         <>
                           <br />
                           <p style={styles.infoTitle}>{intl.formatMessage(messages.ibm)}</p>
                           <p>{intl.formatMessage(messages.ibmDesc)}</p>
+                          <br />
+                          <p style={styles.infoTitle}>{intl.formatMessage(messages.oci)}</p>
+                          <p>{intl.formatMessage(messages.ociDesc)}</p>
                         </>
                       )}
                       <br />

--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -52,7 +52,7 @@ import { providersQuery, providersSelectors } from 'store/providers';
 import { userAccessQuery, userAccessSelectors } from 'store/userAccess';
 import { CostTypes, getCostType } from 'utils/costType';
 import { getSinceDateRangeString } from 'utils/dateRange';
-import { FeatureType, isFeatureVisible, isStageBeta } from 'utils/feature';
+import { FeatureType, isFeatureVisible } from 'utils/feature';
 import {
   hasAwsAccess,
   hasAzureAccess,
@@ -367,7 +367,7 @@ class OverviewBase extends React.Component<OverviewProps> {
       if (hasAzure) {
         options.push(...infrastructureAzureOptions);
       }
-      if (hasOci) {
+      if (isFeatureVisible(FeatureType.oci) && hasOci) {
         options.push(...infrastructureOciOptions);
       }
       if (this.isAzureOcpAvailable()) {
@@ -660,11 +660,15 @@ class OverviewBase extends React.Component<OverviewProps> {
                       <br />
                       <p style={styles.infoTitle}>{intl.formatMessage(messages.gcp)}</p>
                       <p>{intl.formatMessage(messages.gcpDesc)}</p>
-                      {isStageBeta() && (
+                      {isFeatureVisible(FeatureType.ibm) && (
                         <>
                           <br />
                           <p style={styles.infoTitle}>{intl.formatMessage(messages.ibm)}</p>
                           <p>{intl.formatMessage(messages.ibmDesc)}</p>
+                        </>
+                      )}
+                      {isFeatureVisible(FeatureType.oci) && (
+                        <>
                           <br />
                           <p style={styles.infoTitle}>{intl.formatMessage(messages.oci)}</p>
                           <p>{intl.formatMessage(messages.ociDesc)}</p>

--- a/src/store/dashboard/ociDashboard/ociDashboard.test.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboard.test.ts
@@ -71,7 +71,7 @@ describe('getGroupByForTab', () => {
 
   test('regions tab', () => {
     const widget = getGroupByForTab({
-      currentTab: OciDashboardTab.resource_locations,
+      currentTab: OciDashboardTab.resources,
     });
     expect(widget).toMatchSnapshot();
   });

--- a/src/store/dashboard/ociDashboard/ociDashboard.test.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboard.test.ts
@@ -48,9 +48,9 @@ test('fetch widget reports', () => {
 
 test('changeWidgetTab', () => {
   const store = createOciDashboardStore();
-  store.dispatch(actions.changeWidgetTab(costSummaryWidget.id, OciDashboardTab.resource_locations));
+  store.dispatch(actions.changeWidgetTab(costSummaryWidget.id, OciDashboardTab.resources));
   const widget = selectors.selectWidget(store.getState(), costSummaryWidget.id);
-  expect(widget.currentTab).toBe(OciDashboardTab.resource_locations);
+  expect(widget.currentTab).toBe(OciDashboardTab.resources);
   expect(fetchReportMock).toHaveBeenCalledTimes(3);
 });
 

--- a/src/store/dashboard/ociDashboard/ociDashboard.test.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboard.test.ts
@@ -48,16 +48,16 @@ test('fetch widget reports', () => {
 
 test('changeWidgetTab', () => {
   const store = createOciDashboardStore();
-  store.dispatch(actions.changeWidgetTab(costSummaryWidget.id, OciDashboardTab.resources));
+  store.dispatch(actions.changeWidgetTab(costSummaryWidget.id, OciDashboardTab.regions));
   const widget = selectors.selectWidget(store.getState(), costSummaryWidget.id);
-  expect(widget.currentTab).toBe(OciDashboardTab.resources);
+  expect(widget.currentTab).toBe(OciDashboardTab.regions);
   expect(fetchReportMock).toHaveBeenCalledTimes(3);
 });
 
 describe('getGroupByForTab', () => {
   test('services tab', () => {
     const widget = getGroupByForTab({
-      currentTab: OciDashboardTab.service_names,
+      currentTab: OciDashboardTab.product_services,
     });
     expect(widget).toMatchSnapshot();
   });
@@ -71,7 +71,7 @@ describe('getGroupByForTab', () => {
 
   test('regions tab', () => {
     const widget = getGroupByForTab({
-      currentTab: OciDashboardTab.resources,
+      currentTab: OciDashboardTab.regions,
     });
     expect(widget).toMatchSnapshot();
   });

--- a/src/store/dashboard/ociDashboard/ociDashboardCommon.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboardCommon.ts
@@ -14,16 +14,16 @@ export const ociDashboardTabFilters: OciFilters = {
 
 // eslint-disable-next-line no-shadow
 export const enum OciDashboardTab {
-  product_service = 'product_service',
+  service_names = 'product_services',
   payer_tenant_ids = 'payer_tenant_ids',
-  resources = 'resources',
+  resources = 'regions',
 }
 
 export interface OciDashboardWidget extends DashboardWidget<OciDashboardTab> {}
 
 export function getGroupByForTab(widget: OciDashboardWidget): OciQuery['group_by'] {
   switch (widget.currentTab) {
-    case OciDashboardTab.product_service:
+    case OciDashboardTab.service_names:
       // Use group_by for service tab and filter for others -- https://github.com/project-koku/koku-ui/issues/846
       return {
         product_service: widget.tabsFilter && widget.tabsFilter.service_name ? widget.tabsFilter.service_name : '*',
@@ -52,7 +52,7 @@ export function getQueryForWidgetTabs(widget: OciDashboardWidget, filter: OciFil
   };
 
   // Use group_by for service tab and filter for others -- https://github.com/project-koku/koku-ui/issues/846
-  if (widget.currentTab === OciDashboardTab.product_service && widget.tabsFilter && widget.tabsFilter.service_name) {
+  if (widget.currentTab === OciDashboardTab.service_names && widget.tabsFilter && widget.tabsFilter.service_name) {
     newFilter.service = undefined;
   }
   const query: OciQuery = {

--- a/src/store/dashboard/ociDashboard/ociDashboardCommon.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboardCommon.ts
@@ -14,23 +14,23 @@ export const ociDashboardTabFilters: OciFilters = {
 
 // eslint-disable-next-line no-shadow
 export const enum OciDashboardTab {
-  service_names = 'product_services',
+  product_services = 'product_services',
   payer_tenant_ids = 'payer_tenant_ids',
-  resources = 'regions',
+  regions = 'regions',
 }
 
 export interface OciDashboardWidget extends DashboardWidget<OciDashboardTab> {}
 
 export function getGroupByForTab(widget: OciDashboardWidget): OciQuery['group_by'] {
   switch (widget.currentTab) {
-    case OciDashboardTab.service_names:
+    case OciDashboardTab.product_services:
       // Use group_by for service tab and filter for others -- https://github.com/project-koku/koku-ui/issues/846
       return {
         product_service: widget.tabsFilter && widget.tabsFilter.service_name ? widget.tabsFilter.service_name : '*',
       };
     case OciDashboardTab.payer_tenant_ids:
       return { payer_tenant_id: '*' };
-    case OciDashboardTab.resources:
+    case OciDashboardTab.regions:
       return { region: '*' };
     default:
       return {};
@@ -52,7 +52,7 @@ export function getQueryForWidgetTabs(widget: OciDashboardWidget, filter: OciFil
   };
 
   // Use group_by for service tab and filter for others -- https://github.com/project-koku/koku-ui/issues/846
-  if (widget.currentTab === OciDashboardTab.service_names && widget.tabsFilter && widget.tabsFilter.service_name) {
+  if (widget.currentTab === OciDashboardTab.product_services && widget.tabsFilter && widget.tabsFilter.service_name) {
     newFilter.service = undefined;
   }
   const query: OciQuery = {

--- a/src/store/dashboard/ociDashboard/ociDashboardCommon.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboardCommon.ts
@@ -24,7 +24,10 @@ export interface OciDashboardWidget extends DashboardWidget<OciDashboardTab> {}
 export function getGroupByForTab(widget: OciDashboardWidget): OciQuery['group_by'] {
   switch (widget.currentTab) {
     case OciDashboardTab.product_services:
-      return { product_service: '*' };
+      return {
+        product_service:
+          widget.tabsFilter && widget.tabsFilter.product_service ? widget.tabsFilter.product_service : '*',
+      };
     case OciDashboardTab.payer_tenant_ids:
       return { payer_tenant_id: '*' };
     case OciDashboardTab.regions:
@@ -48,8 +51,11 @@ export function getQueryForWidgetTabs(widget: OciDashboardWidget, filter: OciFil
     ...JSON.parse(JSON.stringify(filter)),
   };
 
-  // Use group_by for service tab and filter for others -- https://github.com/project-koku/koku-ui/issues/846
-  if (widget.currentTab === OciDashboardTab.product_services && widget.tabsFilter && widget.tabsFilter.service_name) {
+  if (
+    widget.currentTab === OciDashboardTab.product_services &&
+    widget.tabsFilter &&
+    widget.tabsFilter.product_service
+  ) {
     newFilter.service = undefined;
   }
   const query: OciQuery = {

--- a/src/store/dashboard/ociDashboard/ociDashboardCommon.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboardCommon.ts
@@ -14,23 +14,23 @@ export const ociDashboardTabFilters: OciFilters = {
 
 // eslint-disable-next-line no-shadow
 export const enum OciDashboardTab {
-  service_names = 'service_names',
+  product_service = 'product_service',
   payer_tenant_ids = 'payer_tenant_ids',
-  resource_locations = 'resource_locations',
+  resources = 'resources',
 }
 
 export interface OciDashboardWidget extends DashboardWidget<OciDashboardTab> {}
 
 export function getGroupByForTab(widget: OciDashboardWidget): OciQuery['group_by'] {
   switch (widget.currentTab) {
-    case OciDashboardTab.service_names:
+    case OciDashboardTab.product_service:
       // Use group_by for service tab and filter for others -- https://github.com/project-koku/koku-ui/issues/846
       return {
         product_service: widget.tabsFilter && widget.tabsFilter.service_name ? widget.tabsFilter.service_name : '*',
       };
     case OciDashboardTab.payer_tenant_ids:
       return { payer_tenant_id: '*' };
-    case OciDashboardTab.resource_locations:
+    case OciDashboardTab.resources:
       return { region: '*' };
     default:
       return {};
@@ -52,7 +52,7 @@ export function getQueryForWidgetTabs(widget: OciDashboardWidget, filter: OciFil
   };
 
   // Use group_by for service tab and filter for others -- https://github.com/project-koku/koku-ui/issues/846
-  if (widget.currentTab === OciDashboardTab.service_names && widget.tabsFilter && widget.tabsFilter.service_name) {
+  if (widget.currentTab === OciDashboardTab.product_service && widget.tabsFilter && widget.tabsFilter.service_name) {
     newFilter.service = undefined;
   }
   const query: OciQuery = {

--- a/src/store/dashboard/ociDashboard/ociDashboardCommon.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboardCommon.ts
@@ -24,10 +24,7 @@ export interface OciDashboardWidget extends DashboardWidget<OciDashboardTab> {}
 export function getGroupByForTab(widget: OciDashboardWidget): OciQuery['group_by'] {
   switch (widget.currentTab) {
     case OciDashboardTab.product_services:
-      // Use group_by for service tab and filter for others -- https://github.com/project-koku/koku-ui/issues/846
-      return {
-        product_service: widget.tabsFilter && widget.tabsFilter.service_name ? widget.tabsFilter.service_name : '*',
-      };
+      return { product_service: '*' };
     case OciDashboardTab.payer_tenant_ids:
       return { payer_tenant_id: '*' };
     case OciDashboardTab.regions:

--- a/src/store/dashboard/ociDashboard/ociDashboardWidgets.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboardWidgets.ts
@@ -40,9 +40,9 @@ export const costSummaryWidget: OciDashboardWidget = {
     titleKey: messages.ociCostTrendTitle,
     type: ChartType.rolling,
   },
-  availableTabs: [OciDashboardTab.service_names, OciDashboardTab.payer_tenant_ids, OciDashboardTab.resources],
+  availableTabs: [OciDashboardTab.product_services, OciDashboardTab.payer_tenant_ids, OciDashboardTab.regions],
   chartType: DashboardChartType.dailyTrend,
-  currentTab: OciDashboardTab.service_names,
+  currentTab: OciDashboardTab.product_services,
 };
 
 export const databaseWidget: OciDashboardWidget = {

--- a/src/store/dashboard/ociDashboard/ociDashboardWidgets.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboardWidgets.ts
@@ -40,7 +40,7 @@ export const costSummaryWidget: OciDashboardWidget = {
     titleKey: messages.ociCostTrendTitle,
     type: ChartType.rolling,
   },
-  availableTabs: [OciDashboardTab.service_names, OciDashboardTab.payer_tenant_ids, OciDashboardTab.resource_locations],
+  availableTabs: [OciDashboardTab.service_names, OciDashboardTab.payer_tenant_ids, OciDashboardTab.resources],
   chartType: DashboardChartType.dailyTrend,
   currentTab: OciDashboardTab.service_names,
 };

--- a/src/store/providers/index.ts
+++ b/src/store/providers/index.ts
@@ -3,6 +3,7 @@ import {
   azureProvidersQuery,
   gcpProvidersQuery,
   ibmProvidersQuery,
+  ociProvidersQuery,
   ocpProvidersQuery,
   providersQuery,
 } from 'store/providers/providersCommon';
@@ -15,6 +16,7 @@ import * as providersSelectors from './providersSelectors';
 export {
   awsProvidersQuery,
   azureProvidersQuery,
+  ociProvidersQuery,
   gcpProvidersQuery,
   ibmProvidersQuery,
   ocpProvidersQuery,

--- a/src/store/providers/providersCommon.ts
+++ b/src/store/providers/providersCommon.ts
@@ -24,6 +24,11 @@ export const ibmProvidersQuery: ProvidersQuery = {
   type: 'IBM',
 };
 
+export const ociProvidersQuery: ProvidersQuery = {
+  limit: 100,
+  type: 'OCI',
+};
+
 export const ocpProvidersQuery: ProvidersQuery = {
   limit: 100,
   type: 'OCP',

--- a/src/utils/computedReport/getComputedOciReportItems.test.ts
+++ b/src/utils/computedReport/getComputedOciReportItems.test.ts
@@ -1,0 +1,13 @@
+import { getIdKeyForGroupBy } from './getComputedOciReportItems';
+
+test('get id key for groupBy', () => {
+  [
+    [{ payer_tenant_id: 's', product_service: 's' }, 'payer_tenant_id'],
+    [{ region: 's', product_service: 's' }, 'region'],
+    [{ product_service: 's' }, 'product_service'],
+    [{}, 'date'],
+    [undefined, 'date'],
+  ].forEach(value => {
+    expect(getIdKeyForGroupBy(value[0])).toEqual(value[1]);
+  });
+});

--- a/src/utils/computedReport/getComputedOciReportItems.ts
+++ b/src/utils/computedReport/getComputedOciReportItems.ts
@@ -1,0 +1,19 @@
+import { OciQuery } from 'api/queries/ociQuery';
+import { OciReport, OciReportItem } from 'api/reports/ociReports';
+
+import { ComputedReportItemsParams } from './getComputedReportItems';
+
+export interface ComputedOciReportItemsParams extends ComputedReportItemsParams<OciReport, OciReportItem> {}
+
+export function getIdKeyForGroupBy(groupBy: OciQuery['group_by'] = {}): ComputedOciReportItemsParams['idKey'] {
+  if (groupBy.payer_tenant_id) {
+    return 'payer_tenant_id';
+  }
+  if (groupBy.region) {
+    return 'region';
+  }
+  if (groupBy.product_service) {
+    return 'product_service';
+  }
+  return 'date';
+}

--- a/src/utils/feature.ts
+++ b/src/utils/feature.ts
@@ -5,7 +5,7 @@ export const enum FeatureType {
   exports = 'exports', // Async exports https://issues.redhat.com/browse/COST-2223
   gcpOcp = 'gcp_ocp', // GCP filtered by OpenShift https://issues.redhat.com/browse/COST-682
   ibm = 'ibm', // IBM https://issues.redhat.com/browse/COST-935
-  oci = 'oci', // Open Container Initiative
+  oci = 'oci', // Open Container Initiative / Oracle Cloud Infrastructure
 }
 
 // Show in-progress features for stage-beta environment only

--- a/src/utils/feature.ts
+++ b/src/utils/feature.ts
@@ -5,7 +5,7 @@ export const enum FeatureType {
   exports = 'exports', // Async exports https://issues.redhat.com/browse/COST-2223
   gcpOcp = 'gcp_ocp', // GCP filtered by OpenShift https://issues.redhat.com/browse/COST-682
   ibm = 'ibm', // IBM https://issues.redhat.com/browse/COST-935
-  oci = 'oci', // Open Container Initiative / Oracle Cloud Infrastructure
+  oci = 'oci', // Oracle Cloud Infrastructure
 }
 
 // Show in-progress features for stage-beta environment only

--- a/src/utils/userAccess.ts
+++ b/src/utils/userAccess.ts
@@ -45,12 +45,12 @@ export const isAzureAvailable = (userAccess: UserAccess, azureProviders: Provide
   return hasAzureAccess(userAccess) && hasProviders(azureProviders);
 };
 
-// Returns true if user has access to Azure
+// Returns true if user has access to Oci
 export const hasOciAccess = (userAccess: UserAccess) => {
   return hasAccess(userAccess, UserAccessType.oci);
 };
 
-// Returns true if user has access to Azure and at least one source provider
+// Returns true if user has access to Oci and at least one source provider
 export const isOciAvailable = (userAccess: UserAccess, ociProviders: Providers) => {
   return hasOciAccess(userAccess) && hasProviders(ociProviders);
 };

--- a/src/utils/userAccess.ts
+++ b/src/utils/userAccess.ts
@@ -45,6 +45,16 @@ export const isAzureAvailable = (userAccess: UserAccess, azureProviders: Provide
   return hasAzureAccess(userAccess) && hasProviders(azureProviders);
 };
 
+// Returns true if user has access to Azure
+export const hasOciAccess = (userAccess: UserAccess) => {
+  return hasAccess(userAccess, UserAccessType.oci);
+};
+
+// Returns true if user has access to Azure and at least one source provider
+export const isOciAvailable = (userAccess: UserAccess, ociProviders: Providers) => {
+  return hasOciAccess(userAccess) && hasProviders(ociProviders);
+};
+
 // Returns true if user has access to cost models
 export const hasCostModelAccess = (userAccess: UserAccess) => {
   return hasAccess(userAccess, UserAccessType.cost_model);


### PR DESCRIPTION
https://issues.redhat.com/browse/COST-2358 

in the story comments you say to map account to payer_tenant_id.. and in one of the PR comments you mention mapping subscription_guid to payer_tenant_id , service_name to product_service, and resource_location to region on ociQuery (https://github.com/project-koku/koku-ui/pull/2396#discussion_r903755616)

so in ociDashboardCommon, the mapping is a bit different in the getGroupByForTab.. like service_names returning a product_service object, etc (already committed, but seemed like i needed to make a couple changes)

and now working on ociDashboardWidget... in the getIdKeyForTab.. service_names will map to product_service,... resources to region and such..

i'm hoping i got it right