### PR TITLE
Allow cost_managment:cost-model:* role

### DIFF
--- a/src/store/rbac/selectors.ts
+++ b/src/store/rbac/selectors.ts
@@ -17,10 +17,14 @@ export const isCostModelWritePermission = (state: RootState) => {
     return false;
   }
   const [app, resource, operation] = costModelPermissions.permission.split(':');
-  if (app === 'cost-management' && resource === '*' && operation === '*') {
+  if (
+    app === 'cost-management' &&
+    (resource === 'write' || resource === '*') &&
+    (operation === 'write' || operation === '*')
+  ) {
     return true;
   }
-  if ((resource === 'rate' || resource === 'cost_model') && operation === 'write') {
+  if ((resource === 'rate' || resource === 'cost_model') && (operation === 'write' || operation === '*')) {
     return true;
   }
   return false;


### PR DESCRIPTION
Currently, the cost models page only tests for the `cost_managment:cost-model:write` role. This change allows for the `cost_managment:cost-model:*` role.

https://issues.redhat.com/browse/COST-2816

**Prod env using cost-admin:**
![Screen Shot 2022-07-21 at 7 41 31 PM](https://user-images.githubusercontent.com/17481322/180332983-089227cc-af03-4122-8ed8-2c533ccbf3d9.png)

