### PR TITLE
Check multiple cost-management roles

### DIFF
--- a/src/store/rbac/selectors.ts
+++ b/src/store/rbac/selectors.ts
@@ -17,10 +17,14 @@ export const isCostModelWritePermission = (state: RootState) => {
     return false;
   }
   const [app, resource, operation] = costModelPermissions.permission.split(':');
-  if (app === 'cost-management' && resource === '*' && operation === '*') {
+  if (
+    app === 'cost-management' &&
+    (resource === 'write' || resource === '*') &&
+    (operation === 'write' || operation === '*')
+  ) {
     return true;
   }
-  if ((resource === 'rate' || resource === 'cost_model') && operation === 'write') {
+  if ((resource === 'rate' || resource === 'cost_model') && (operation === 'write' || operation === '*')) {
     return true;
   }
   return false;

--- a/src/store/rbac/selectors.ts
+++ b/src/store/rbac/selectors.ts
@@ -12,10 +12,21 @@ export const isCostModelWritePermission = (state: RootState) => {
   if (!permissions) {
     return false;
   }
-  const costModelPermissions = permissions.find(item => item.permission.startsWith('cost-management'));
+  const costModelPermissions = permissions.filter(item => item.permission.startsWith('cost-management'));
   if (!costModelPermissions) {
     return false;
   }
+  // Check for multiple roles; cost-management:cost-model:read and cost-management:cost-model:write
+  // See https://issues.redhat.com/browse/COST-2816
+  for (const item of costModelPermissions) {
+    if (hasWritePermission(item)) {
+      return true;
+    }
+  }
+  return false;
+};
+
+const hasWritePermission = costModelPermissions => {
   const [app, resource, operation] = costModelPermissions.permission.split(':');
   if (
     app === 'cost-management' &&


### PR DESCRIPTION
Currently, the cost models page only tests the first `cost-management` role it finds. We want to check if the user created multiple roles (e.g., `cost-management:cost-model:read`, `cost-management:cost-model:write`, etc.)

https://issues.redhat.com/browse/COST-2816