### PR TITLE
Fixed forecast API path for OCI overview

### DIFF
--- a/src/api/forecasts/forecastUtils.ts
+++ b/src/api/forecasts/forecastUtils.ts
@@ -33,6 +33,9 @@ export function runForecast(forecastPathsType: ForecastPathsType, forecastType: 
     case ForecastPathsType.ibm:
       forecast = runIbmForecast(forecastType, query);
       break;
+    case ForecastPathsType.oci:
+      forecast = runOcpForecast(forecastType, query);
+      break;
     case ForecastPathsType.ocp:
       forecast = runOcpForecast(forecastType, query);
       break;


### PR DESCRIPTION
The OCI overview page is still generating errors, related to the forecast API -- missing a mapping in `forecastUtils`.

https://issues.redhat.com/browse/COST-2358