### PR TITLE
Fix ordering of items appearing in the overview info popup

### DIFF
--- a/src/pages/views/overview/overview.tsx
+++ b/src/pages/views/overview/overview.tsx
@@ -659,6 +659,9 @@ class OverviewBase extends React.Component<OverviewProps> {
                       <p style={styles.infoTitle}>{intl.formatMessage(messages.openShift)}</p>
                       <p>{intl.formatMessage(messages.openShiftDesc)}</p>
                       <br />
+                      <p style={styles.infoTitle}>{intl.formatMessage(messages.aws)}</p>
+                      <p>{intl.formatMessage(messages.awsDesc)}</p>
+                      <br />
                       <p style={styles.infoTitle}>{intl.formatMessage(messages.gcp)}</p>
                       <p>{intl.formatMessage(messages.gcpDesc)}</p>
                       {isFeatureVisible(FeatureType.ibm) && (
@@ -668,6 +671,9 @@ class OverviewBase extends React.Component<OverviewProps> {
                           <p>{intl.formatMessage(messages.ibmDesc)}</p>
                         </>
                       )}
+                      <br />
+                      <p style={styles.infoTitle}>{intl.formatMessage(messages.azure)}</p>
+                      <p>{intl.formatMessage(messages.azureDesc)}</p>
                       {isFeatureVisible(FeatureType.oci) && (
                         <>
                           <br />
@@ -675,12 +681,6 @@ class OverviewBase extends React.Component<OverviewProps> {
                           <p>{intl.formatMessage(messages.ociDesc)}</p>
                         </>
                       )}
-                      <br />
-                      <p style={styles.infoTitle}>{intl.formatMessage(messages.aws)}</p>
-                      <p>{intl.formatMessage(messages.awsDesc)}</p>
-                      <br />
-                      <p style={styles.infoTitle}>{intl.formatMessage(messages.azure)}</p>
-                      <p>{intl.formatMessage(messages.azureDesc)}</p>
                     </>
                   }
                 >


### PR DESCRIPTION
This adjusts the ordering of the items appearing in the overview's info popup.

"I think we want the OpenShift stuff at the top, but then all the clouds we can alphabetize them -- Natalie"

https://issues.redhat.com/browse/COST-2358

![Screen Shot 2022-07-29 at 10 21 53 AM](https://user-images.githubusercontent.com/17481322/181781261-03648eb6-42e1-4df4-8fdd-095b6740f152.png)

