### PR TITLE
Add option to start UI with local cloud services config route

### DIFF
--- a/scripts/start-dev-server.js
+++ b/scripts/start-dev-server.js
@@ -7,6 +7,12 @@ async function setEnv() {
   return inquirer
     .prompt([
       {
+        name: 'localCloudServicesConfig',
+        message: 'Do you want to use local cloud services config?',
+        type: 'confirm',
+        default: false,
+      },
+      {
         name: 'localApi',
         message: 'Do you want to use local API?',
         type: 'confirm',
@@ -26,11 +32,12 @@ async function setEnv() {
       },
     ])
     .then(answers => {
-      const { uiEnv, clouddotEnv, insightsProxy, localApi } = answers;
+      const { uiEnv, clouddotEnv, insightsProxy, localApi, localCloudServicesConfig } = answers;
       process.env.BETA_ENV = uiEnv === 'beta' ? 'true' : 'false';
       process.env.CLOUDOT_ENV = clouddotEnv ? clouddotEnv : 'stage';
       process.env.USE_PROXY = 'true';
       process.env.USE_LOCAL_ROUTES = localApi.toString();
+      process.env.USE_LOCAL_CLOUD_SERVICES_CONFIG = localCloudServicesConfig.toString();
       if (localApi) {
         process.env.USE_PROXY = 'false';
         process.env.KEYCLOAK_PORT = 4020;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,9 +19,6 @@ const distDir = path.resolve(__dirname, './dist/');
 const betaEnv = process.env.BETA_ENV;
 const nodeEnv = process.env.NODE_ENV;
 
-// Set `true` for testing cloud-services-config https://github.com/RedHatInsights/cloud-services-config#testing-your-changes-locally
-const useLocalCloudServicesConfig = process.env.USE_LOCAL_CLOUD_SERVICES_CONFIG === 'true';
-
 const {
   rbac,
   backofficeProxy,
@@ -35,6 +32,7 @@ const gitRevisionPlugin = new GitRevisionPlugin({
 const betaBranches = ['main', 'master', 'stage-beta', 'prod-beta'];
 const moduleName = insights.appname.replace(/-(\w)/g, (_, match) => match.toUpperCase());
 
+const useLocalCloudServicesConfig = process.env.USE_LOCAL_CLOUD_SERVICES_CONFIG === 'true';
 const localhost =
   process.env.PLATFORM === 'linux' || useLocalCloudServicesConfig ? 'localhost' : 'host.docker.internal';
 
@@ -87,6 +85,7 @@ module.exports = (_env, argv) => {
 
   const routes = {};
 
+  // See https://github.com/RedHatInsights/cloud-services-config#testing-your-changes-locally
   if (useLocalCloudServicesConfig) {
     routes['/beta/config'] = {
       host: `http://${localhost}:8889`,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -20,7 +20,7 @@ const betaEnv = process.env.BETA_ENV;
 const nodeEnv = process.env.NODE_ENV;
 
 // Set `true` for testing cloud-services-config https://github.com/RedHatInsights/cloud-services-config#testing-your-changes-locally
-const useLocalCloudServicesConfig = false;
+const useLocalCloudServicesConfig = process.env.USE_LOCAL_CLOUD_SERVICES_CONFIG === 'true';
 
 const {
   rbac,
@@ -75,6 +75,7 @@ module.exports = (_env, argv) => {
   console.log(`Using deployments: ${appDeployment}`);
   console.log(`Using proxy: ${useProxy}`);
   console.log(`Using local API: ${useLocalRoutes}`);
+  console.log(`Using local cloud services config: ${useLocalCloudServicesConfig}`);
   console.log(`Public path: ${publicPath}`);
   console.log('~~~~~~~~~~~~~~~~~~~~~');
 


### PR DESCRIPTION
This adds a script option to start the UI with a local Insights cloud services config route. The script generates the prompt below.

"Do you want to use local cloud services config? y/N"

This will option will set the `useLocalCloudServicesConfig` env variable. That is, instead of manually editing our `webpack.config` file to apply the route below.

```
if (useLocalCloudServicesConfig) {
  routes['/beta/config'] = {
    host: `http://$/{localhost}:8889`,
  };
}
```

https://issues.redhat.com/browse/COST-2910