### PR TITLE
Unleash feature lag

### DIFF
--- a/src/components/featureFlags/featureFlags.tsx
+++ b/src/components/featureFlags/featureFlags.tsx
@@ -1,5 +1,5 @@
 import { useFlag } from '@unleash/proxy-client-react';
-import { FunctionComponent, useEffect } from 'react';
+import { FunctionComponent } from 'react';
 import { useDispatch } from 'react-redux';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { featureFlagsActions } from 'store/featureFlags';
@@ -16,24 +16,19 @@ const enum FeatureToggle {
   oci = 'cost-management.ui.oci', // Oracle Cloud Infrastructure https://issues.redhat.com/browse/COST-2358
 }
 
+const getFlags = (): featureFlagsActions.FeatureFlagsActionMeta => {
+  return {
+    isCurrencyFeatureEnabled: useFlag(FeatureToggle.currency),
+    isExportsFeatureEnabled: useFlag(FeatureToggle.exports),
+    isIbmFeatureEnabled: useFlag(FeatureToggle.ibm),
+    isOciFeatureEnabled: useFlag(FeatureToggle.oci),
+  };
+};
+
 const FeatureFlagsBase: FunctionComponent<FeatureFlagsProps> = ({ children = null }): any => {
   const dispatch = useDispatch();
-  const isCurrencyFeatureEnabled = useFlag(FeatureToggle.currency);
-  const isExportsFeatureEnabled = useFlag(FeatureToggle.exports);
-  const isIbmFeatureEnabled = useFlag(FeatureToggle.ibm);
-  const isOciFeatureEnabled = useFlag(FeatureToggle.oci);
 
-  useEffect(() => {
-    dispatch(
-      featureFlagsActions.setFeatureFlags({
-        isCurrencyFeatureEnabled,
-        isExportsFeatureEnabled,
-        isIbmFeatureEnabled,
-        isOciFeatureEnabled,
-      })
-    );
-  }, []);
-
+  dispatch(featureFlagsActions.setFeatureFlags(getFlags()));
   return children;
 };
 

--- a/src/store/featureFlags/featureFlagsActions.ts
+++ b/src/store/featureFlags/featureFlagsActions.ts
@@ -1,6 +1,6 @@
 import { createAction } from 'typesafe-actions';
 
-interface FeatureFlagsActionMeta {
+export interface FeatureFlagsActionMeta {
   isCurrencyFeatureEnabled?: boolean;
   isExportsFeatureEnabled?: boolean;
   isIbmFeatureEnabled?: boolean;


### PR DESCRIPTION
The Unlesash feature flags are lagging a bit. This change removes the `UseEffect` hook, to ensure the dispatch (to set flags) happens before children are rendered.

https://issues.redhat.com/browse/COST-2952