### PR TITLE
Volume usage card

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -20904,6 +20904,12 @@
         "value": "Various"
       }
     ],
+    "volumeTitle": [
+      {
+        "type": 0,
+        "value": "Volume"
+      }
+    ],
     "yes": [
       {
         "type": 0,

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -468,5 +468,6 @@
   "usageCostDescription": "The portion of cost calculated by applying hourly and/or monthly price list rates to metrics.",
   "usageCostTitle": "Usage cost",
   "various": "Various",
+  "volumeTitle": "Volume",
   "yes": "Yes"
 }

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -3231,6 +3231,11 @@ export default defineMessages({
     description: 'Various',
     id: 'various',
   },
+  volumeTitle: {
+    defaultMessage: 'Volume',
+    description: 'Volume',
+    id: 'volumeTitle',
+  },
   yes: {
     defaultMessage: 'Yes',
     description: 'Yes',

--- a/src/routes/views/details/components/costOverview/costOverviewBase.tsx
+++ b/src/routes/views/details/components/costOverview/costOverviewBase.tsx
@@ -176,6 +176,24 @@ class CostOverviewsBase extends React.Component<CostOverviewProps> {
     return null;
   };
 
+  // Returns volume usage chart
+  private getVolumeUsageChart = (widget: CostOverviewWidget) => {
+    const { intl } = this.props;
+
+    return (
+      <Card>
+        <CardTitle>
+          <Title headingLevel="h2" size={TitleSizes.lg}>
+            {intl.formatMessage(messages.volumeTitle)}
+          </Title>
+        </CardTitle>
+        <CardBody>
+          <UsageChart reportPathsType={widget.reportPathsType} reportType={widget.reportType} />
+        </CardBody>
+      </Card>
+    );
+  };
+
   // Helper to fill grid columns instead of rows, based on the order defined by the reducer
   private getWidgetsColumns = () => {
     const { selectWidgets, widgets } = this.props;
@@ -218,6 +236,8 @@ class CostOverviewsBase extends React.Component<CostOverviewProps> {
         return this.getMemoryUsageChart(widget);
       case CostOverviewWidgetType.reportSummary:
         return this.getSummaryCard(widget);
+      case CostOverviewWidgetType.volumeUsage:
+        return this.getVolumeUsageChart(widget);
       default:
         return null;
     }

--- a/src/routes/views/details/components/usageChart/usageChart.tsx
+++ b/src/routes/views/details/components/usageChart/usageChart.tsx
@@ -4,8 +4,7 @@ import { ChartBullet } from '@patternfly/react-charts';
 import { Grid, GridItem, Skeleton } from '@patternfly/react-core';
 import { OcpQuery, parseQuery } from 'api/queries/ocpQuery';
 import { getQuery, Query } from 'api/queries/query';
-import { Report } from 'api/reports/report';
-import { ReportPathsType, ReportType } from 'api/reports/report';
+import { Report, ReportPathsType, ReportType } from 'api/reports/report';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
@@ -85,7 +84,7 @@ class UsageChartBase extends React.Component<UsageChartProps> {
   };
 
   private getChartDatum(): ChartDatum {
-    const { groupBy, report, intl } = this.props;
+    const { groupBy, report, intl, reportType } = this.props;
     const datum: ChartDatum = {
       limit: {},
       ranges: [],
@@ -112,9 +111,9 @@ class UsageChartBase extends React.Component<UsageChartProps> {
       value: Math.trunc(limit),
     };
 
-    // Qualitative range included only when grouped by cluster
-    if (groupBy === 'cluster') {
-      const hasCapacity = hasTotal && report.meta.total.request && report.meta.total.request !== null;
+    // Qualitative range included when grouped by cluster and volume usage
+    if (groupBy === 'cluster' || reportType === ReportType.volume) {
+      const hasCapacity = hasTotal && report.meta.total.capacity && report.meta.total.capacity !== null;
       const capacity = Math.trunc(hasCapacity ? report.meta.total.capacity.value : 0);
       const capacityUnits = intl.formatMessage(messages.units, {
         units: unitsLookupKey(hasCapacity ? report.meta.total.capacity.units : undefined),
@@ -253,7 +252,7 @@ class UsageChartBase extends React.Component<UsageChartProps> {
   private getFreeSpace() {
     const { report, intl } = this.props;
     const hasTotal = report && report.meta && report.meta.total;
-    const hasCapacity = hasTotal && report.meta.total.request && report.meta.total.request !== null;
+    const hasCapacity = hasTotal && report.meta.total.capacity && report.meta.total.capacity !== null;
     const hasRequest = hasTotal && report.meta.total.request && report.meta.total.request !== null;
     const hasUsage = hasTotal && report.meta.total.usage && report.meta.total.usage !== null;
 

--- a/src/store/breakdown/costOverview/common/costOverviewCommon.ts
+++ b/src/store/breakdown/costOverview/common/costOverviewCommon.ts
@@ -7,6 +7,7 @@ export const enum CostOverviewWidgetType {
   cpuUsage = 'cpuUsage', // This type displays cpu usage as a bullet chart
   memoryUsage = 'memoryUsage', // This type displays memory usage as a bullet chart
   reportSummary = 'summary', // This type displays a cost report summary
+  volumeUsage = 'volumeUsage', // This type displays volume usage as a bullet chart
 }
 
 export interface CostOverviewWidget {

--- a/src/store/breakdown/costOverview/ocpCostOverview/ocpCostOverview.test.ts
+++ b/src/store/breakdown/costOverview/ocpCostOverview/ocpCostOverview.test.ts
@@ -12,6 +12,7 @@ import {
   cpuUsageWidget,
   memoryUsageWidget,
   projectSummaryWidget,
+  volumeUsageWidget,
 } from './ocpCostOverviewWidgets';
 
 const createOcpCostOverviewStore = createMockStoreCreator({
@@ -33,6 +34,7 @@ test('default state', () => {
     projectSummaryWidget.id,
     cpuUsageWidget.id,
     memoryUsageWidget.id,
+    volumeUsageWidget.id,
   ]);
   expect(selectors.selectWidget(state, costWidget.id)).toEqual(costWidget);
 });

--- a/src/store/breakdown/costOverview/ocpCostOverview/ocpCostOverviewReducer.ts
+++ b/src/store/breakdown/costOverview/ocpCostOverview/ocpCostOverviewReducer.ts
@@ -5,6 +5,7 @@ import {
   cpuUsageWidget,
   memoryUsageWidget,
   projectSummaryWidget,
+  volumeUsageWidget,
 } from './ocpCostOverviewWidgets';
 
 export type OcpCostOverviewState = Readonly<{
@@ -13,13 +14,21 @@ export type OcpCostOverviewState = Readonly<{
 }>;
 
 export const defaultState: OcpCostOverviewState = {
-  currentWidgets: [costWidget.id, clusterWidget.id, projectSummaryWidget.id, cpuUsageWidget.id, memoryUsageWidget.id],
+  currentWidgets: [
+    costWidget.id,
+    clusterWidget.id,
+    projectSummaryWidget.id,
+    cpuUsageWidget.id,
+    memoryUsageWidget.id,
+    volumeUsageWidget.id,
+  ],
   widgets: {
     [costWidget.id]: costWidget,
     [clusterWidget.id]: clusterWidget,
     [projectSummaryWidget.id]: projectSummaryWidget,
     [cpuUsageWidget.id]: cpuUsageWidget,
     [memoryUsageWidget.id]: memoryUsageWidget,
+    [volumeUsageWidget.id]: volumeUsageWidget,
   },
 };
 

--- a/src/store/breakdown/costOverview/ocpCostOverview/ocpCostOverviewWidgets.ts
+++ b/src/store/breakdown/costOverview/ocpCostOverview/ocpCostOverviewWidgets.ts
@@ -55,3 +55,10 @@ export const projectSummaryWidget: OcpCostOverviewWidget = {
   reportPathsType: ReportPathsType.ocp,
   type: CostOverviewWidgetType.reportSummary,
 };
+
+export const volumeUsageWidget: OcpCostOverviewWidget = {
+  id: getId(),
+  reportPathsType: ReportPathsType.ocp,
+  reportType: ReportType.volume,
+  type: CostOverviewWidgetType.volumeUsage,
+};


### PR DESCRIPTION
Adds a Volume usage card to the Ocp project breakdown page.

https://issues.redhat.com/browse/COST-2957

![poc](https://user-images.githubusercontent.com/17481322/187814430-013c612c-4285-41b4-b5e6-f69df3440e79.png)
