### PR TITLE
Simplify permission components to use React.FC

### DIFF
--- a/src/components/pageTitle/index.ts
+++ b/src/components/pageTitle/index.ts
@@ -1,0 +1,1 @@
+export { default as PageTitle } from './pageTitle';

--- a/src/components/pageTitle/pageTitle.tsx
+++ b/src/components/pageTitle/pageTitle.tsx
@@ -4,73 +4,34 @@ import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { RouteComponentProps, withRouter } from 'react-router';
 import { paths, routes } from 'routes';
 
-interface PageTitleOwnProps extends RouteComponentProps<void> {
+interface PageTitleOwnProps {
   children?: React.ReactNode;
 }
 
-interface PageTitleState {
-  // TBD...
-}
+type PageTitleProps = PageTitleOwnProps & RouteComponentProps<void> & WrappedComponentProps;
 
-type PageTitleProps = PageTitleOwnProps & WrappedComponentProps;
-
-class PageTitleBase extends React.Component<PageTitleProps> {
-  protected defaultState: PageTitleState = {
-    // TBD...
-  };
-  public state: PageTitleState = { ...this.defaultState };
-
-  private getPath() {
-    const { location }: any = this.props;
-
-    // cost models may include :uuid
-    const _pathname =
-      location.pathname && location.pathname.startsWith(paths.costModels) ? paths.costModels : location.pathname;
-    const currRoute = routes.find(({ path }) => path === _pathname);
-
+const PageTitleBase: React.FC<PageTitleProps> = ({ children = null, intl, location }) => {
+  const getPath = () => {
+    const currRoute = routes.find(({ path }) => path === location.pathname);
     return currRoute ? currRoute.path : undefined;
-  }
+  };
 
-  private getPageTitle() {
-    const path = this.getPath();
-
-    switch (path) {
+  const getPageTitle = () => {
+    switch (getPath()) {
       case paths.explorer:
         return messages.pageTitleExplorer;
       case paths.overview:
         return messages.pageTitleOverview;
-      case paths.awsDetails:
-      case paths.awsDetailsBreakdown:
-        return messages.pageTitleAws;
-      case paths.azureDetails:
-      case paths.azureDetailsBreakdown:
-        return messages.pageTitleAzure;
-      case paths.costModels:
-        return messages.pageTitleCostModels;
-      case paths.gcpDetails:
-      case paths.gcpDetailsBreakdown:
-        return messages.pageTitleGcp;
-      case paths.ibmDetails:
-      case paths.ibmDetailsBreakdown:
-        return messages.pageTitleIbm;
-      case paths.ocpDetails:
-      case paths.ocpDetailsBreakdown:
-        return messages.pageTitleOcp;
       default:
         return messages.pageTitleDefault;
     }
-  }
+  };
 
-  public render() {
-    const { children = null, intl } = this.props;
+  // Set page title
+  document.title = intl.formatMessage(getPageTitle());
 
-    // Set page title
-    document.title = intl.formatMessage(this.getPageTitle());
+  return <>{children}</>;
+};
 
-    return children;
-  }
-}
-
-const PageTitle = injectIntl(withRouter(PageTitleBase));
-
-export { PageTitle };
+const PageTitle = withRouter(PageTitleBase);
+export default injectIntl(PageTitle);

--- a/src/components/userAccess/permissionsWrapper.tsx
+++ b/src/components/userAccess/permissionsWrapper.tsx
@@ -6,7 +6,7 @@ import { UserAccess, UserAccessType } from 'api/userAccess';
 import { AxiosError } from 'axios';
 import { asyncComponent } from 'components/async';
 import { ExportsDrawer } from 'components/exports';
-import { PageTitle } from 'components/pageTitle/pageTitle';
+import { PageTitle } from 'components/pageTitle';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';

--- a/src/components/userAccess/userAccess.tsx
+++ b/src/components/userAccess/userAccess.tsx
@@ -5,20 +5,14 @@ const PermissionsWrapper = asyncComponent(
   () => import(/* webpackChunkName: "permissionsWrapper" */ './permissionsWrapper')
 );
 
-interface State {
-  // TBD...
-}
-
-// Permissions component wrapper for AsyncComponent
-export function userAccess<Props>(AysncComponent) {
-  class PermissionsComponent extends React.Component<Props, State> {
-    public render() {
-      return (
-        <PermissionsWrapper>
-          <AysncComponent {...this.props} />
-        </PermissionsWrapper>
-      );
-    }
-  }
+// Permissions component wrapper
+export function userAccess<Props>(Component) {
+  const PermissionsComponent: React.FC<Props> = props => {
+    return (
+      <PermissionsWrapper>
+        <Component {...props} />
+      </PermissionsWrapper>
+    );
+  };
   return PermissionsComponent;
 }


### PR DESCRIPTION
This simplifies the following to be functional components -- mimics the HCS UI. These components are used on every page and don't need state.

- PageTitle
- Permissions
- UserAccess

https://issues.redhat.com/browse/COST-2996