### PR TITLE
Feat/auto dep updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 6
+    labels: ["dependency-bot-wip"]
+    commit-message:
+      prefix: "(chore)"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,7 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
-    open-pull-requests-limit: 6
+    open-pull-requests-limit: 2
     labels: ["dependency-bot-wip"]
     commit-message:
       prefix: "(chore)"

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,10 @@ on:
     branches: [ main, master, prod-beta, prod-stable, stage-beta, stage-stable ]
 env:
   BRANCH: ${{ github.base_ref }}
-
+permissions:
+  pull-requests: write
+  packages: write
+  contents: write
 jobs:
   build:
     name: koku-ui build
@@ -17,6 +20,11 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+      - name: Checkout PR
+        if: ${{github.actor == 'dependabot[bot]' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh pr checkout ${{ github.event.pull_request.number }}
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
         with:
@@ -42,6 +50,30 @@ jobs:
       - name: Install Node.js packages
         if: ${{ steps.modules-cache.outputs.cache-hit != 'true' }}
         run: yarn --frozen-lockfile
+      - name: Set up git config
+        if: ${{github.actor == 'dependabot[bot]' }}
+        run: |
+          git config user.name "${GITHUB_ACTOR}"
+          git config user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          git remote set-url origin https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Update manifest
+        if: ${{github.actor == 'dependabot[bot]' }}
+        run: node scripts/createManifest.js
+      - name: Push koku-manifest changes
+        if: ${{github.actor == 'dependabot[bot]' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git add .
+          git commit --message "Update koku-manifest file"
+          git push
+      - name: Remove work-in-progress tag for dependabot
+        if: ${{github.actor == 'dependabot[bot]'}}
+        uses: actions-ecosystem/action-remove-labels@v1
+        with:
+          labels: dependency-bot-wip
       - name: Check manifest
         if: ${{ success() }}
         run: ${{ github.workspace }}/.travis/check_manifest.sh


### PR DESCRIPTION
story: https://issues.redhat.com/browse/COST-2936

moved this into the normal PR workflow with conditions as it seems to work well in that same order with some additions.

limiting PRs created by dependabot with max open PRs to 2 for now while we make sure things work well on the main repo

can see what a dependabot + manifest update PR should look like here: https://github.com/gitdallas/koku-ui/pull/6

and that a non-dependabot PR isn't affected here: https://github.com/gitdallas/koku-ui/pull/7

i add a "dependency-bot-wip" label to dependabot PRs, which my new actions remove after updating manifest.. although it shouldn't take long.

