### PR TITLE
add dependabot yml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,11 +2,15 @@
 
 version: 2
 updates:
-  - package-ecosystem: "npm" # See documentation for possible values
+  - package-ecosystem: "npm"
     directory: "/" # Location of package manifests
     schedule:
       interval: "daily"
     open-pull-requests-limit: 2
-    labels: ["dependency-bot"]
+    labels:
+      - "dependency-bot"
     commit-message:
       prefix: "(chore)"
+    reviewers:
+      - "gitdallas"
+      - "dlabrecq"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "daily"
+    open-pull-requests-limit: 2
+    labels: ["dependency-bot"]
+    commit-message:
+      prefix: "(chore)"


### PR DESCRIPTION
story: https://issues.redhat.com/browse/COST-2936

limiting PRs created by dependabot with max open PRs to 2 for now while we make sure things work well on the main repo

i add a "dependency-bot" label to dependabot PRs

after the dependabot.yml file is merged into main... this should automatically start running https://github.com/project-koku/koku-ui/network/updates