### PR TITLE
Remove deprecated PatternFly ChartThemeVariant

### DIFF
--- a/src/routes/views/components/charts/chartTheme/theme-utils.ts
+++ b/src/routes/views/components/charts/chartTheme/theme-utils.ts
@@ -1,8 +1,8 @@
-import { ChartThemeColor, ChartThemeVariant, getCustomTheme } from '@patternfly/react-charts';
+import { ChartThemeColor, mergeTheme } from '@patternfly/react-charts';
 
 import { default as ChartTheme } from './theme-koku';
 
 // Applies theme color and variant to base theme
-const getTheme = () => getCustomTheme(ChartThemeColor.default, ChartThemeVariant.default, ChartTheme);
+const getTheme = () => mergeTheme(ChartThemeColor.default, ChartTheme);
 
 export default getTheme;


### PR DESCRIPTION
Removes the deprecated PatternFly `ChartThemeVariant` component and replaces `getCustomTheme` from PatternFly charts with `mergeTheme`

https://issues.redhat.com/browse/COST-3058