### PR TITLE
Clarify when cumulative data is used

### DIFF
--- a/src/modules/ocpOverviewWidget/ocpOverviewChart.tsx
+++ b/src/modules/ocpOverviewWidget/ocpOverviewChart.tsx
@@ -5,11 +5,11 @@ import { AxiosError } from 'axios';
 import React from 'react';
 import { connect } from 'react-redux';
 import {
-  ChartType,
   ComputedReportItemType,
   ComputedReportItemValueType,
+  DatumType,
   transformReport,
-} from 'routes/views/components/charts/common/chartDatumUtils';
+} from 'routes/views/components/charts/common/chartDatum';
 import { TrendChart } from 'routes/views/components/charts/trendChart';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
@@ -90,14 +90,14 @@ class OcpOverviewChartBase extends React.Component<OcpOverviewChartProps> {
 
     const currentData = transformReport(
       currentReport,
-      ChartType.rolling,
+      DatumType.cumulative,
       'date',
       computedReportItem,
       computedReportItemValue
     );
     const previousData = transformReport(
       previousReport,
-      ChartType.rolling,
+      DatumType.cumulative,
       'date',
       computedReportItem,
       computedReportItemValue

--- a/src/routes/views/components/charts/common/chartDatum.test.ts
+++ b/src/routes/views/components/charts/common/chartDatum.test.ts
@@ -1,7 +1,7 @@
 import { intl } from 'components/i18n';
 import messages from 'locales/messages';
 
-import { getTooltipContent, transformReport } from './chartDatumUtils';
+import { getTooltipContent, transformReport } from './chartDatum';
 import { transformReportProps } from './testProps/transformReportProps';
 import { transformReportReturns } from './testProps/transformReportReturns';
 

--- a/src/routes/views/components/charts/common/chartUtils.ts
+++ b/src/routes/views/components/charts/common/chartUtils.ts
@@ -4,7 +4,7 @@ import messages from 'locales/messages';
 import { FormatOptions, Formatter } from 'utils/format';
 import { DomainTuple, VictoryStyleInterface } from 'victory-core';
 
-import { getMaxMinValues, getTooltipContent } from './chartDatumUtils';
+import { getMaxMinValues, getTooltipContent } from './chartDatum';
 
 export interface ChartData {
   childName?: string;

--- a/src/routes/views/components/charts/common/index.ts
+++ b/src/routes/views/components/charts/common/index.ts
@@ -1,1 +1,1 @@
-export { ChartDatum } from './chartDatumUtils';
+export { ChartDatum } from './chartDatum';

--- a/src/routes/views/components/charts/costChart/costChart.tsx
+++ b/src/routes/views/components/charts/costChart/costChart.tsx
@@ -15,7 +15,7 @@ import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { default as ChartTheme } from 'routes/views/components/charts/chartTheme';
-import { getCostRangeString, getDateRange } from 'routes/views/components/charts/common/chartDatumUtils';
+import { getCostRangeString, getDateRange } from 'routes/views/components/charts/common/chartDatum';
 import {
   ChartSeries,
   getChartNames,

--- a/src/routes/views/components/charts/costExplorerChart/costExplorerChart.tsx
+++ b/src/routes/views/components/charts/costExplorerChart/costExplorerChart.tsx
@@ -15,7 +15,7 @@ import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { default as ChartTheme } from 'routes/views/components/charts/chartTheme';
-import { getMaxValue } from 'routes/views/components/charts/common/chartDatumUtils';
+import { getMaxValue } from 'routes/views/components/charts/common/chartDatum';
 import {
   ChartSeries,
   getChartNames,

--- a/src/routes/views/components/charts/dailyCostChart/dailyCostChart.tsx
+++ b/src/routes/views/components/charts/dailyCostChart/dailyCostChart.tsx
@@ -17,7 +17,7 @@ import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { default as ChartTheme } from 'routes/views/components/charts/chartTheme';
-import { getCostRangeString, getDateRange } from 'routes/views/components/charts/common/chartDatumUtils';
+import { getCostRangeString, getDateRange } from 'routes/views/components/charts/common/chartDatum';
 import {
   ChartSeries,
   getChartNames,

--- a/src/routes/views/components/charts/dailyTrendChart/dailyTrendChart.tsx
+++ b/src/routes/views/components/charts/dailyTrendChart/dailyTrendChart.tsx
@@ -17,7 +17,7 @@ import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { default as ChartTheme } from 'routes/views/components/charts/chartTheme';
-import { getCostRangeString, getDateRange } from 'routes/views/components/charts/common/chartDatumUtils';
+import { getCostRangeString, getDateRange } from 'routes/views/components/charts/common/chartDatum';
 import {
   ChartSeries,
   getChartNames,

--- a/src/routes/views/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/routes/views/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -15,8 +15,8 @@ import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { default as ChartTheme } from 'routes/views/components/charts/chartTheme';
-import { getCostRangeString } from 'routes/views/components/charts/common/chartDatumUtils';
-import { getDateRange } from 'routes/views/components/charts/common/chartDatumUtils';
+import { getCostRangeString } from 'routes/views/components/charts/common/chartDatum';
+import { getDateRange } from 'routes/views/components/charts/common/chartDatum';
 import {
   ChartSeries,
   getChartNames,

--- a/src/routes/views/components/charts/historicalTrendChart/historicalTrendChart.test.tsx
+++ b/src/routes/views/components/charts/historicalTrendChart/historicalTrendChart.test.tsx
@@ -1,15 +1,15 @@
 import { render, screen } from '@testing-library/react';
 import { AwsReport, AwsReportData } from 'api/reports/awsReports';
 import React from 'react';
-import * as utils from 'routes/views/components/charts/common/chartDatumUtils';
+import * as utils from 'routes/views/components/charts/common/chartDatum';
 
 import { HistoricalTrendChart, HistoricalTrendChartProps } from './historicalTrendChart';
 
 const currentMonthReport: AwsReport = createReport('2018-01-01');
 const previousMonthReport: AwsReport = createReport('2017-12-01');
 
-const currentData = utils.transformReport(currentMonthReport, utils.ChartType.daily);
-const previousData = utils.transformReport(previousMonthReport, utils.ChartType.daily);
+const currentData = utils.transformReport(currentMonthReport, utils.DatumType.rolling);
+const previousData = utils.transformReport(previousMonthReport, utils.DatumType.rolling);
 
 const props: HistoricalTrendChartProps = {
   currentData,

--- a/src/routes/views/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/routes/views/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -15,7 +15,7 @@ import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { default as ChartTheme } from 'routes/views/components/charts/chartTheme';
-import { getCostRangeString, getDateRange } from 'routes/views/components/charts/common/chartDatumUtils';
+import { getCostRangeString, getDateRange } from 'routes/views/components/charts/common/chartDatum';
 import {
   ChartSeries,
   getChartNames,

--- a/src/routes/views/components/charts/historicalUsageChart/historicalUsageChart.test.tsx
+++ b/src/routes/views/components/charts/historicalUsageChart/historicalUsageChart.test.tsx
@@ -1,17 +1,17 @@
 import { render, screen } from '@testing-library/react';
 import { OcpReport, OcpReportData } from 'api/reports/ocpReports';
 import React from 'react';
-import * as utils from 'routes/views/components/charts/common/chartDatumUtils';
+import * as utils from 'routes/views/components/charts/common/chartDatum';
 
 import { HistoricalUsageChart, HistoricalUsageChartProps } from './historicalUsageChart';
 
 const currentMonthReport: OcpReport = createReport('2018-01-15');
 const previousMonthReport: OcpReport = createReport('2017-12-15');
 
-const currentRequestData = utils.transformReport(currentMonthReport, utils.ChartType.daily, 'date', 'request');
-const currentUsageData = utils.transformReport(currentMonthReport, utils.ChartType.daily, 'date', 'usage');
-const previousRequestData = utils.transformReport(previousMonthReport, utils.ChartType.daily, 'date', 'request');
-const previousUsageData = utils.transformReport(previousMonthReport, utils.ChartType.daily, 'date', 'usage');
+const currentRequestData = utils.transformReport(currentMonthReport, utils.DatumType.rolling, 'date', 'request');
+const currentUsageData = utils.transformReport(currentMonthReport, utils.DatumType.rolling, 'date', 'usage');
+const previousRequestData = utils.transformReport(previousMonthReport, utils.DatumType.rolling, 'date', 'request');
+const previousUsageData = utils.transformReport(previousMonthReport, utils.DatumType.rolling, 'date', 'usage');
 
 const props: HistoricalUsageChartProps = {
   currentRequestData,

--- a/src/routes/views/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/routes/views/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -15,8 +15,8 @@ import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { default as ChartTheme } from 'routes/views/components/charts/chartTheme';
-import { getDateRange } from 'routes/views/components/charts/common/chartDatumUtils';
-import { getUsageRangeString } from 'routes/views/components/charts/common/chartDatumUtils';
+import { getDateRange } from 'routes/views/components/charts/common/chartDatum';
+import { getUsageRangeString } from 'routes/views/components/charts/common/chartDatum';
 import {
   ChartSeries,
   getChartNames,

--- a/src/routes/views/components/charts/trendChart/trendChart.test.tsx
+++ b/src/routes/views/components/charts/trendChart/trendChart.test.tsx
@@ -1,15 +1,15 @@
 import { render, screen } from '@testing-library/react';
 import { AwsReport, AwsReportData } from 'api/reports/awsReports';
 import React from 'react';
-import * as utils from 'routes/views/components/charts/common/chartDatumUtils';
+import * as utils from 'routes/views/components/charts/common/chartDatum';
 
 import { TrendChart, TrendChartProps } from './trendChart';
 
 const currentMonthReport: AwsReport = createReport('2018-01-15');
 const previousMonthReport: AwsReport = createReport('2017-12-15');
 
-const currentData = utils.transformReport(currentMonthReport, utils.ChartType.daily);
-const previousData = utils.transformReport(previousMonthReport, utils.ChartType.daily);
+const currentData = utils.transformReport(currentMonthReport, utils.DatumType.rolling);
+const previousData = utils.transformReport(previousMonthReport, utils.DatumType.rolling);
 
 const props: TrendChartProps = {
   currentData,

--- a/src/routes/views/components/charts/trendChart/trendChart.tsx
+++ b/src/routes/views/components/charts/trendChart/trendChart.tsx
@@ -15,7 +15,7 @@ import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { default as ChartTheme } from 'routes/views/components/charts/chartTheme';
-import { getCostRangeString, getDateRange } from 'routes/views/components/charts/common/chartDatumUtils';
+import { getCostRangeString, getDateRange } from 'routes/views/components/charts/common/chartDatum';
 import {
   ChartSeries,
   getChartNames,

--- a/src/routes/views/components/charts/usageChart/usageChart.test.tsx
+++ b/src/routes/views/components/charts/usageChart/usageChart.test.tsx
@@ -1,17 +1,17 @@
 import { render, screen } from '@testing-library/react';
 import { OcpReport, OcpReportData } from 'api/reports/ocpReports';
 import React from 'react';
-import * as utils from 'routes/views/components/charts/common/chartDatumUtils';
+import * as utils from 'routes/views/components/charts/common/chartDatum';
 
 import { UsageChart, UsageChartProps } from './usageChart';
 
 const currentMonthReport: OcpReport = createReport('2018-01-15');
 const previousMonthReport: OcpReport = createReport('2017-12-15');
 
-const currentRequestData = utils.transformReport(currentMonthReport, utils.ChartType.daily, 'date', 'request');
-const currentUsageData = utils.transformReport(currentMonthReport, utils.ChartType.daily, 'date', 'usage');
-const previousRequestData = utils.transformReport(previousMonthReport, utils.ChartType.daily, 'date', 'request');
-const previousUsageData = utils.transformReport(previousMonthReport, utils.ChartType.daily, 'date', 'usage');
+const currentRequestData = utils.transformReport(currentMonthReport, utils.DatumType.rolling, 'date', 'request');
+const currentUsageData = utils.transformReport(currentMonthReport, utils.DatumType.rolling, 'date', 'usage');
+const previousRequestData = utils.transformReport(previousMonthReport, utils.DatumType.rolling, 'date', 'request');
+const previousUsageData = utils.transformReport(previousMonthReport, utils.DatumType.rolling, 'date', 'usage');
 
 const props: UsageChartProps = {
   currentRequestData,

--- a/src/routes/views/components/charts/usageChart/usageChart.tsx
+++ b/src/routes/views/components/charts/usageChart/usageChart.tsx
@@ -15,7 +15,7 @@ import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { default as ChartTheme } from 'routes/views/components/charts/chartTheme';
-import { getDateRange, getUsageRangeString } from 'routes/views/components/charts/common/chartDatumUtils';
+import { getDateRange, getUsageRangeString } from 'routes/views/components/charts/common/chartDatum';
 import {
   ChartSeries,
   getChartNames,

--- a/src/routes/views/components/reports/reportSummary/reportSummaryDetails.tsx
+++ b/src/routes/views/components/reports/reportSummary/reportSummaryDetails.tsx
@@ -6,7 +6,7 @@ import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { EmptyValueState } from 'routes/components/state/emptyValueState/emptyValueState';
-import { ComputedReportItemType } from 'routes/views/components/charts/common/chartDatumUtils';
+import { ComputedReportItemType } from 'routes/views/components/charts/common/chartDatum';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { formatCurrency, FormatOptions, formatUnits, unitsLookupKey } from 'utils/format';
 

--- a/src/routes/views/details/components/historicalData/historicalDataCostChart.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataCostChart.tsx
@@ -5,7 +5,7 @@ import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
-import { ChartType, transformReport } from 'routes/views/components/charts/common/chartDatumUtils';
+import { DatumType, transformReport } from 'routes/views/components/charts/common/chartDatum';
 import { HistoricalCostChart } from 'routes/views/components/charts/historicalCostChart';
 import { getGroupById, getGroupByValue } from 'routes/views/utils/groupBy';
 import { createMapStateToProps, FetchStatus } from 'store/common';
@@ -75,12 +75,22 @@ class HistoricalDataCostChartBase extends React.Component<HistoricalDataCostChar
       this.props;
 
     // Current data
-    const currentData = transformReport(currentReport, ChartType.rolling, 'date', 'cost');
-    const currentInfrastructureCostData = transformReport(currentReport, ChartType.rolling, 'date', 'infrastructure');
+    const currentData = transformReport(currentReport, DatumType.cumulative, 'date', 'cost');
+    const currentInfrastructureCostData = transformReport(
+      currentReport,
+      DatumType.cumulative,
+      'date',
+      'infrastructure'
+    );
 
     // Previous data
-    const previousData = transformReport(previousReport, ChartType.rolling, 'date', 'cost');
-    const previousInfrastructureCostData = transformReport(previousReport, ChartType.rolling, 'date', 'infrastructure');
+    const previousData = transformReport(previousReport, DatumType.cumulative, 'date', 'cost');
+    const previousInfrastructureCostData = transformReport(
+      previousReport,
+      DatumType.cumulative,
+      'date',
+      'infrastructure'
+    );
 
     const costUnits =
       currentReport && currentReport.meta && currentReport.meta.total && currentReport.meta.total.cost

--- a/src/routes/views/details/components/historicalData/historicalDataTrendChart.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataTrendChart.tsx
@@ -5,7 +5,7 @@ import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
-import { ChartType, transformReport } from 'routes/views/components/charts/common/chartDatumUtils';
+import { DatumType, transformReport } from 'routes/views/components/charts/common/chartDatum';
 import { HistoricalTrendChart } from 'routes/views/components/charts/historicalTrendChart';
 import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'routes/views/utils/groupBy';
 import { createMapStateToProps, FetchStatus } from 'store/common';
@@ -86,13 +86,13 @@ class HistoricalDataTrendChartBase extends React.Component<HistoricalDataTrendCh
     // Current data
     const currentData = transformReport(
       currentReport,
-      isCostChart ? ChartType.rolling : ChartType.daily,
+      isCostChart ? DatumType.cumulative : DatumType.rolling,
       'date',
       isCostChart ? 'cost' : 'usage'
     );
     const previousData = transformReport(
       previousReport,
-      isCostChart ? ChartType.rolling : ChartType.daily,
+      isCostChart ? DatumType.cumulative : DatumType.rolling,
       'date',
       isCostChart ? 'cost' : 'usage'
     );

--- a/src/routes/views/details/components/historicalData/historicalDataUsageChart.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataUsageChart.tsx
@@ -5,7 +5,7 @@ import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
-import { ChartType, transformReport } from 'routes/views/components/charts/common/chartDatumUtils';
+import { DatumType, transformReport } from 'routes/views/components/charts/common/chartDatum';
 import { HistoricalUsageChart } from 'routes/views/components/charts/historicalUsageChart';
 import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'routes/views/utils/groupBy';
 import { createMapStateToProps, FetchStatus } from 'store/common';
@@ -74,14 +74,14 @@ class HistoricalDataUsageChartBase extends React.Component<HistoricalDataUsageCh
       this.props;
 
     // Current data
-    const currentLimitData = transformReport(currentReport, ChartType.daily, 'date', 'limit');
-    const currentRequestData = transformReport(currentReport, ChartType.daily, 'date', 'request');
-    const currentUsageData = transformReport(currentReport, ChartType.daily, 'date', 'usage');
+    const currentLimitData = transformReport(currentReport, DatumType.rolling, 'date', 'limit');
+    const currentRequestData = transformReport(currentReport, DatumType.rolling, 'date', 'request');
+    const currentUsageData = transformReport(currentReport, DatumType.rolling, 'date', 'usage');
 
     // Previous data
-    const previousLimitData = transformReport(previousReport, ChartType.daily, 'date', 'limit');
-    const previousRequestData = transformReport(previousReport, ChartType.daily, 'date', 'request');
-    const previousUsageData = transformReport(previousReport, ChartType.daily, 'date', 'usage');
+    const previousLimitData = transformReport(previousReport, DatumType.rolling, 'date', 'limit');
+    const previousRequestData = transformReport(previousReport, DatumType.rolling, 'date', 'request');
+    const previousUsageData = transformReport(previousReport, DatumType.rolling, 'date', 'usage');
 
     const usageUnits =
       currentReport && currentReport.meta && currentReport.meta.total && currentReport.meta.total.usage

--- a/src/routes/views/explorer/explorer.tsx
+++ b/src/routes/views/explorer/explorer.tsx
@@ -150,7 +150,7 @@ class Explorer extends React.Component<ExplorerProps> {
     const computedItems = getUnsortedComputedReportItems({
       report,
       idKey: groupByTagKey ? groupByTagKey : groupByOrg ? 'org_entities' : groupById,
-      daily: false, // Don't use daily here, so we can use a flattened data structure with row selection
+      isDateMap: false, // Don't use isDateMap here, so we can use a flattened data structure with row selection
     });
     return computedItems;
   };

--- a/src/routes/views/explorer/explorerChart.tsx
+++ b/src/routes/views/explorer/explorerChart.tsx
@@ -14,7 +14,7 @@ import {
   ComputedReportItemValueType,
   isFloat,
   isInt,
-} from 'routes/views/components/charts/common/chartDatumUtils';
+} from 'routes/views/components/charts/common/chartDatum';
 import { CostExplorerChart } from 'routes/views/components/charts/costExplorerChart';
 import { getGroupByOrgValue, getGroupByTagKey } from 'routes/views/utils/groupBy';
 import { createMapStateToProps, FetchStatus } from 'store/common';
@@ -157,7 +157,7 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
     return getUnsortedComputedReportItems({
       report,
       idKey: this.getGroupBy(),
-      daily: true,
+      isDateMap: true,
     });
   };
 

--- a/src/routes/views/explorer/explorerTable.tsx
+++ b/src/routes/views/explorer/explorerTable.tsx
@@ -12,10 +12,7 @@ import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { EmptyFilterState } from 'routes/components/state/emptyFilterState/emptyFilterState';
-import {
-  ComputedReportItemType,
-  ComputedReportItemValueType,
-} from 'routes/views/components/charts/common/chartDatumUtils';
+import { ComputedReportItemType, ComputedReportItemValueType } from 'routes/views/components/charts/common/chartDatum';
 import { getGroupByOrgValue, getGroupByTagKey } from 'routes/views/utils/groupBy';
 import { createMapStateToProps } from 'store/common';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
@@ -112,7 +109,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
     const computedItems = getUnsortedComputedReportItems({
       report,
       idKey: groupByTagKey ? groupByTagKey : groupByOrg ? 'org_entities' : groupById,
-      daily: true,
+      isDateMap: true,
     });
 
     // Add first column heading (i.e., name)

--- a/src/routes/views/explorer/explorerUtils.ts
+++ b/src/routes/views/explorer/explorerUtils.ts
@@ -8,10 +8,7 @@ import { TagPathsType } from 'api/tags/tag';
 import { UserAccess } from 'api/userAccess';
 import { format } from 'date-fns';
 import messages from 'locales/messages';
-import {
-  ComputedReportItemType,
-  ComputedReportItemValueType,
-} from 'routes/views/components/charts/common/chartDatumUtils';
+import { ComputedReportItemType, ComputedReportItemValueType } from 'routes/views/components/charts/common/chartDatum';
 import { hasCloudProvider } from 'routes/views/utils/providers';
 import { ComputedAwsReportItemsParams } from 'utils/computedReport/getComputedAwsReportItems';
 import { ComputedAzureReportItemsParams } from 'utils/computedReport/getComputedAzureReportItems';

--- a/src/routes/views/overview/components/dashboardWidget.test.tsx
+++ b/src/routes/views/overview/components/dashboardWidget.test.tsx
@@ -6,7 +6,7 @@ import { intl } from 'components/i18n';
 import { format, getDate, getMonth, startOfMonth } from 'date-fns';
 import React from 'react';
 import { defineMessages } from 'react-intl';
-import { ChartType } from 'routes/views/components/charts/common/chartDatumUtils';
+import { DatumType } from 'routes/views/components/charts/common/chartDatum';
 import { DashboardWidgetBase, DashboardWidgetProps } from 'routes/views/overview/components/dashboardWidgetBase';
 import { FetchStatus } from 'store/common';
 import { mockDate } from 'testUtils';
@@ -35,7 +35,7 @@ const props: DashboardWidgetProps = {
   updateTab: jest.fn(),
   titleKey: tmessages.testTitle,
   trend: {
-    type: ChartType.rolling,
+    datumType: DatumType.cumulative,
     titleKey: tmessages.testTrendTitle,
     formatOptions: {},
   },

--- a/src/routes/views/overview/components/dashboardWidgetBase.tsx
+++ b/src/routes/views/overview/components/dashboardWidgetBase.tsx
@@ -9,12 +9,12 @@ import React from 'react';
 import { WrappedComponentProps } from 'react-intl';
 import { Link } from 'react-router-dom';
 import {
-  ChartType,
   ComputedReportItemType,
+  DatumType,
   transformForecast,
   transformForecastCone,
   transformReport,
-} from 'routes/views/components/charts/common/chartDatumUtils';
+} from 'routes/views/components/charts/common/chartDatum';
 import {
   ReportSummary,
   ReportSummaryAlt,
@@ -171,7 +171,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     const computedReportItemValue = trend.computedReportItemValue; // infrastructure usage cost
 
     const daily = currentComparison === Comparison.daily;
-    const type = daily ? ChartType.daily : trend.type;
+    const type = daily ? DatumType.rolling : trend.datumType;
 
     // Infrastructure data
     const currentInfrastructureData = transformReport(
@@ -238,7 +238,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     const computedReportItemValue = trend.computedReportItemValue; // infrastructure usage cost
 
     const daily = currentComparison === Comparison.daily;
-    const type = daily ? ChartType.daily : trend.type;
+    const type = daily ? DatumType.rolling : trend.datumType;
 
     // Cost data
     const currentData = transformReport(currentReport, type, 'date', computedReportItem, computedReportItemValue);
@@ -280,7 +280,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
 
     // Todo: Add cumulative / daily prop
     const daily = currentComparison === Comparison.daily;
-    const type = daily ? ChartType.daily : trend.type;
+    const type = daily ? DatumType.rolling : trend.datumType;
 
     let forecastData;
     let forecastConeData;
@@ -321,7 +321,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
           }
 
           // For cumulative data, forecast values should begin at last reported total with zero confidence values
-          if (type === ChartType.rolling) {
+          if (type === DatumType.cumulative) {
             const firstReported =
               forecast.data[0].values && forecast.data[0].values.length > 0
                 ? forecast.data[0].values[0].date
@@ -413,10 +413,16 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     const title = intl.formatMessage(trend.titleKey, { units: this.getFormattedUnits() });
 
     // Cost data
-    const currentData = transformReport(currentReport, trend.type, 'date', computedReportItem, computedReportItemValue);
+    const currentData = transformReport(
+      currentReport,
+      trend.datumType,
+      'date',
+      computedReportItem,
+      computedReportItemValue
+    );
     const previousData = transformReport(
       previousReport,
-      trend.type,
+      trend.datumType,
       'date',
       computedReportItem,
       computedReportItemValue
@@ -456,12 +462,12 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
     });
 
     // Request data
-    const currentRequestData = transformReport(currentReport, trend.type, 'date', 'request');
-    const previousRequestData = transformReport(previousReport, trend.type, 'date', 'request');
+    const currentRequestData = transformReport(currentReport, trend.datumType, 'date', 'request');
+    const previousRequestData = transformReport(previousReport, trend.datumType, 'date', 'request');
 
     // Usage data
-    const currentUsageData = transformReport(currentReport, trend.type, 'date', 'usage');
-    const previousUsageData = transformReport(previousReport, trend.type, 'date', 'usage');
+    const currentUsageData = transformReport(currentReport, trend.datumType, 'date', 'usage');
+    const previousUsageData = transformReport(previousReport, trend.datumType, 'date', 'usage');
 
     return (
       <ReportSummaryUsage

--- a/src/routes/views/utils/providers.ts
+++ b/src/routes/views/utils/providers.ts
@@ -44,12 +44,12 @@ export const filterProviders = (providers: Providers, sourceType: ProviderType) 
 };
 
 // Ensure at least one source provider has data available
-const _hasData = (providers: Providers, dataType: DataType) => {
+const _hasData = (providers: Providers, datumType: DataType) => {
   let result = false;
 
   if (providers && providers.data) {
     for (const provider of providers.data) {
-      if (provider[dataType]) {
+      if (provider[datumType]) {
         result = true;
         break;
       }

--- a/src/store/dashboard/awsDashboard/awsDashboard.test.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboard.test.ts
@@ -1,7 +1,7 @@
 jest.mock('store/reports/reportActions');
 
 import { ReportType } from 'api/reports/report';
-import { ChartType } from 'routes/views/components/charts/common/chartDatumUtils';
+import { DatumType } from 'routes/views/components/charts/common/chartDatum';
 import { createMockStoreCreator } from 'store/mockStore';
 import { reportActions } from 'store/reports';
 
@@ -75,8 +75,8 @@ test('getQueryForWidget', () => {
     currentTab: AwsDashboardTab.accounts,
     details: { formatOptions: {} },
     trend: {
+      datumType: DatumType.rolling,
       titleKey: '',
-      type: ChartType.daily,
       formatOptions: {},
     },
     topItems: {

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -3,11 +3,11 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import messages from 'locales/messages';
 import { paths } from 'routes';
 import {
-  ChartType,
   ComputedForecastItemType,
   ComputedReportItemType,
   ComputedReportItemValueType,
-} from 'routes/views/components/charts/common/chartDatumUtils';
+  DatumType,
+} from 'routes/views/components/charts/common/chartDatum';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { formatCurrency, formatUnits } from 'utils/format';
 
@@ -40,8 +40,8 @@ export const computeWidget: AwsDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.dashboardDailyUsageComparison,
-    type: ChartType.daily,
   },
 };
 
@@ -72,8 +72,8 @@ export const costSummaryWidget: AwsDashboardWidget = {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
     dailyTitleKey: messages.awsDailyCostTrendTitle,
+    datumType: DatumType.cumulative,
     titleKey: messages.awsCostTrendTitle,
-    type: ChartType.rolling,
   },
 };
 
@@ -99,8 +99,8 @@ export const databaseWidget: AwsDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.cumulative,
     titleKey: messages.dashboardCumulativeCostComparison,
-    type: ChartType.rolling,
   },
 };
 
@@ -126,8 +126,8 @@ export const networkWidget: AwsDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.cumulative,
     titleKey: messages.dashboardCumulativeCostComparison,
-    type: ChartType.rolling,
   },
 };
 
@@ -149,7 +149,7 @@ export const storageWidget: AwsDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.dashboardDailyUsageComparison,
-    type: ChartType.daily,
   },
 };

--- a/src/store/dashboard/awsOcpDashboard/awsOcpDashboardWidgets.ts
+++ b/src/store/dashboard/awsOcpDashboard/awsOcpDashboardWidgets.ts
@@ -2,11 +2,11 @@ import { ForecastPathsType, ForecastType } from 'api/forecasts/forecast';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import messages from 'locales/messages';
 import {
-  ChartType,
   ComputedForecastItemType,
   ComputedReportItemType,
   ComputedReportItemValueType,
-} from 'routes/views/components/charts/common/chartDatumUtils';
+  DatumType,
+} from 'routes/views/components/charts/common/chartDatum';
 import { awsDashboardWidgets } from 'store/dashboard/awsDashboard';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { formatCurrency, formatUnits } from 'utils/format';
@@ -40,8 +40,8 @@ export const computeWidget: AwsOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.dashboardDailyUsageComparison,
-    type: ChartType.daily,
   },
 };
 
@@ -69,8 +69,8 @@ export const costSummaryWidget: AwsOcpDashboardWidget = {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
     dailyTitleKey: messages.awsDailyCostTrendTitle,
+    datumType: DatumType.cumulative,
     titleKey: messages.awsCostTrendTitle,
-    type: ChartType.rolling,
   },
 };
 
@@ -95,8 +95,8 @@ export const databaseWidget: AwsOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.cumulative,
     titleKey: messages.dashboardCumulativeCostComparison,
-    type: ChartType.rolling,
   },
 };
 
@@ -121,8 +121,8 @@ export const networkWidget: AwsOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.cumulative,
     titleKey: messages.dashboardCumulativeCostComparison,
-    type: ChartType.rolling,
   },
 };
 
@@ -144,7 +144,7 @@ export const storageWidget: AwsOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.dashboardDailyUsageComparison,
-    type: ChartType.daily,
   },
 };

--- a/src/store/dashboard/azureDashboard/azureDashboard.test.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboard.test.ts
@@ -1,7 +1,7 @@
 jest.mock('store/reports/reportActions');
 
 import { ReportType } from 'api/reports/report';
-import { ChartType } from 'routes/views/components/charts/common/chartDatumUtils';
+import { DatumType } from 'routes/views/components/charts/common/chartDatum';
 import { createMockStoreCreator } from 'store/mockStore';
 import { reportActions } from 'store/reports';
 
@@ -95,9 +95,9 @@ test('getQueryForWidget', () => {
     currentTab: AzureDashboardTab.subscription_guids,
     details: { formatOptions: {} },
     trend: {
+      datumType: DatumType.rolling,
       formatOptions: {},
       titleKey: '',
-      type: ChartType.daily,
     },
     topItems: {
       formatOptions: {},

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -3,11 +3,11 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import messages from 'locales/messages';
 import { paths } from 'routes';
 import {
-  ChartType,
   ComputedForecastItemType,
   ComputedReportItemType,
   ComputedReportItemValueType,
-} from 'routes/views/components/charts/common/chartDatumUtils';
+  DatumType,
+} from 'routes/views/components/charts/common/chartDatum';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { formatUnits } from 'utils/format';
 
@@ -45,8 +45,8 @@ export const costSummaryWidget: AzureDashboardWidget = {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
     dailyTitleKey: messages.azureDailyCostTrendTitle,
+    datumType: DatumType.cumulative,
     titleKey: messages.azureCostTrendTitle,
-    type: ChartType.rolling,
   },
 };
 
@@ -70,8 +70,8 @@ export const databaseWidget: AzureDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.cumulative,
     titleKey: messages.dashboardCumulativeCostComparison,
-    type: ChartType.rolling,
   },
 };
 
@@ -95,8 +95,8 @@ export const networkWidget: AzureDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.cumulative,
     titleKey: messages.dashboardCumulativeCostComparison,
-    type: ChartType.rolling,
   },
 };
 
@@ -117,8 +117,8 @@ export const storageWidget: AzureDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.dashboardDailyUsageComparison,
-    type: ChartType.daily,
   },
 };
 
@@ -146,7 +146,7 @@ export const virtualMachineWidget: AzureDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.dashboardDailyUsageComparison,
-    type: ChartType.daily,
   },
 };

--- a/src/store/dashboard/azureOcpDashboard/azureOcpDashboardWidgets.ts
+++ b/src/store/dashboard/azureOcpDashboard/azureOcpDashboardWidgets.ts
@@ -2,11 +2,11 @@ import { ForecastPathsType, ForecastType } from 'api/forecasts/forecast';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import messages from 'locales/messages';
 import {
-  ChartType,
   ComputedForecastItemType,
   ComputedReportItemType,
   ComputedReportItemValueType,
-} from 'routes/views/components/charts/common/chartDatumUtils';
+  DatumType,
+} from 'routes/views/components/charts/common/chartDatum';
 import { azureDashboardWidgets } from 'store/dashboard/azureDashboard';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { formatUnits } from 'utils/format';
@@ -43,8 +43,8 @@ export const costSummaryWidget: AzureOcpDashboardWidget = {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
     dailyTitleKey: messages.azureDailyCostTrendTitle,
+    datumType: DatumType.cumulative,
     titleKey: messages.azureCostTrendTitle,
-    type: ChartType.rolling,
   },
 };
 
@@ -68,8 +68,8 @@ export const databaseWidget: AzureOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.cumulative,
     titleKey: messages.dashboardCumulativeCostComparison,
-    type: ChartType.rolling,
   },
 };
 
@@ -93,8 +93,8 @@ export const networkWidget: AzureOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.cumulative,
     titleKey: messages.dashboardCumulativeCostComparison,
-    type: ChartType.rolling,
   },
 };
 
@@ -121,8 +121,8 @@ export const storageWidget: AzureOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.dashboardDailyUsageComparison,
-    type: ChartType.daily,
   },
 };
 
@@ -150,7 +150,7 @@ export const virtualMachineWidget: AzureOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.dashboardDailyUsageComparison,
-    type: ChartType.daily,
   },
 };

--- a/src/store/dashboard/common/dashboardCommon.ts
+++ b/src/store/dashboard/common/dashboardCommon.ts
@@ -63,11 +63,11 @@ export interface DashboardWidget<T> {
     computedReportItem: string; // The computed report item to use in charts, summary, etc.
     computedReportItemValue: string; // The computed report value (e.g., raw, markup, total, or usage)
     dailyTitleKey?: MessageDescriptor;
+    datumType: number;
     formatOptions?: FormatOptions;
     showInfrastructureLabel?: boolean; // Trend chart legend items show "Infrastructure cost" instead of "cost"
     showSupplementaryLabel?: boolean; // Trend chart legend items show "Supplementary cost" instead of "cost"
     titleKey: MessageDescriptor;
-    type: number;
   };
   topItems?: {
     formatOptions?: FormatOptions;

--- a/src/store/dashboard/gcpDashboard/gcpDashboard.test.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboard.test.ts
@@ -1,7 +1,7 @@
 jest.mock('store/reports/reportActions');
 
 import { ReportType } from 'api/reports/report';
-import { ChartType } from 'routes/views/components/charts/common/chartDatumUtils';
+import { DatumType } from 'routes/views/components/charts/common/chartDatum';
 import { createMockStoreCreator } from 'store/mockStore';
 import { reportActions } from 'store/reports';
 
@@ -75,8 +75,8 @@ test('getQueryForWidget', () => {
     currentTab: GcpDashboardTab.accounts,
     details: { formatOptions: {} },
     trend: {
+      datumType: DatumType.rolling,
       titleKey: '',
-      type: ChartType.daily,
       formatOptions: {},
     },
     topItems: {

--- a/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
@@ -3,11 +3,11 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import messages from 'locales/messages';
 import { paths } from 'routes';
 import {
-  ChartType,
   ComputedForecastItemType,
   ComputedReportItemType,
   ComputedReportItemValueType,
-} from 'routes/views/components/charts/common/chartDatumUtils';
+  DatumType,
+} from 'routes/views/components/charts/common/chartDatum';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { formatCurrency, formatUnits } from 'utils/format';
 
@@ -41,8 +41,8 @@ export const computeWidget: GcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.dashboardDailyUsageComparison,
-    type: ChartType.daily,
   },
 };
 
@@ -72,8 +72,8 @@ export const costSummaryWidget: GcpDashboardWidget = {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
     dailyTitleKey: messages.gcpDailyCostTrendTitle,
+    datumType: DatumType.cumulative,
     titleKey: messages.gcpCostTrendTitle,
-    type: ChartType.rolling,
   },
 };
 
@@ -98,8 +98,8 @@ export const databaseWidget: GcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.cumulative,
     titleKey: messages.dashboardCumulativeCostComparison,
-    type: ChartType.rolling,
   },
 };
 
@@ -126,8 +126,8 @@ export const networkWidget: GcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.cumulative,
     titleKey: messages.dashboardCumulativeCostComparison,
-    type: ChartType.rolling,
   },
 };
 
@@ -149,7 +149,7 @@ export const storageWidget: GcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.dashboardDailyUsageComparison,
-    type: ChartType.daily,
   },
 };

--- a/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboard.test.ts
+++ b/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboard.test.ts
@@ -1,7 +1,7 @@
 jest.mock('store/reports/reportActions');
 
 import { ReportType } from 'api/reports/report';
-import { ChartType } from 'routes/views/components/charts/common/chartDatumUtils';
+import { DatumType } from 'routes/views/components/charts/common/chartDatum';
 import { createMockStoreCreator } from 'store/mockStore';
 import { reportActions } from 'store/reports';
 
@@ -86,8 +86,8 @@ test('getQueryForWidget', () => {
     currentTab: GcpOcpDashboardTab.accounts,
     details: { formatOptions: {} },
     trend: {
+      datumType: DatumType.rolling,
       titleKey: '',
-      type: ChartType.daily,
       formatOptions: {},
     },
     topItems: {

--- a/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardWidgets.ts
@@ -2,11 +2,11 @@ import { ForecastPathsType, ForecastType } from 'api/forecasts/forecast';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import messages from 'locales/messages';
 import {
-  ChartType,
   ComputedForecastItemType,
   ComputedReportItemType,
   ComputedReportItemValueType,
-} from 'routes/views/components/charts/common/chartDatumUtils';
+  DatumType,
+} from 'routes/views/components/charts/common/chartDatum';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { gcpDashboardWidgets } from 'store/dashboard/gcpDashboard';
 import { formatCurrency, formatUnits } from 'utils/format';
@@ -41,8 +41,8 @@ export const computeWidget: GcpOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.dashboardDailyUsageComparison,
-    type: ChartType.daily,
   },
 };
 
@@ -71,8 +71,8 @@ export const costSummaryWidget: GcpOcpDashboardWidget = {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
     dailyTitleKey: messages.gcpDailyCostTrendTitle,
+    datumType: DatumType.cumulative,
     titleKey: messages.gcpCostTrendTitle,
-    type: ChartType.rolling,
   },
 };
 
@@ -97,8 +97,8 @@ export const databaseWidget: GcpOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.cumulative,
     titleKey: messages.dashboardCumulativeCostComparison,
-    type: ChartType.rolling,
   },
 };
 
@@ -123,8 +123,8 @@ export const networkWidget: GcpOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.cumulative,
     titleKey: messages.dashboardCumulativeCostComparison,
-    type: ChartType.rolling,
   },
 };
 
@@ -146,7 +146,7 @@ export const storageWidget: GcpOcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.dashboardDailyUsageComparison,
-    type: ChartType.daily,
   },
 };

--- a/src/store/dashboard/ibmDashboard/ibmDashboard.test.ts
+++ b/src/store/dashboard/ibmDashboard/ibmDashboard.test.ts
@@ -1,7 +1,7 @@
 jest.mock('store/reports/reportActions');
 
 import { ReportType } from 'api/reports/report';
-import { ChartType } from 'routes/views/components/charts/common/chartDatumUtils';
+import { DatumType } from 'routes/views/components/charts/common/chartDatum';
 import { createMockStoreCreator } from 'store/mockStore';
 import { reportActions } from 'store/reports';
 
@@ -75,8 +75,8 @@ test('getQueryForWidget', () => {
     currentTab: IbmDashboardTab.accounts,
     details: { formatOptions: {} },
     trend: {
+      datumType: DatumType.rolling,
       titleKey: '',
-      type: ChartType.daily,
       formatOptions: {},
     },
     topItems: {

--- a/src/store/dashboard/ibmDashboard/ibmDashboardWidgets.ts
+++ b/src/store/dashboard/ibmDashboard/ibmDashboardWidgets.ts
@@ -3,11 +3,11 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import messages from 'locales/messages';
 import { paths } from 'routes';
 import {
-  ChartType,
   ComputedForecastItemType,
   ComputedReportItemType,
   ComputedReportItemValueType,
-} from 'routes/views/components/charts/common/chartDatumUtils';
+  DatumType,
+} from 'routes/views/components/charts/common/chartDatum';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { formatCurrency, formatUnits } from 'utils/format';
 
@@ -41,8 +41,8 @@ export const computeWidget: IbmDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.dashboardDailyUsageComparison,
-    type: ChartType.daily,
   },
 };
 
@@ -72,8 +72,8 @@ export const costSummaryWidget: IbmDashboardWidget = {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
     dailyTitleKey: messages.ibmDailyCostTrendTitle,
+    datumType: DatumType.cumulative,
     titleKey: messages.ibmCostTrendTitle,
-    type: ChartType.rolling,
   },
 };
 
@@ -98,8 +98,8 @@ export const databaseWidget: IbmDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.cumulative,
     titleKey: messages.dashboardCumulativeCostComparison,
-    type: ChartType.rolling,
   },
 };
 
@@ -126,8 +126,8 @@ export const networkWidget: IbmDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.cumulative,
     titleKey: messages.dashboardCumulativeCostComparison,
-    type: ChartType.rolling,
   },
 };
 
@@ -149,7 +149,7 @@ export const storageWidget: IbmDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.dashboardDailyUsageComparison,
-    type: ChartType.daily,
   },
 };

--- a/src/store/dashboard/ociDashboard/ociDashboard.test.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboard.test.ts
@@ -1,7 +1,7 @@
 jest.mock('store/reports/reportActions');
 
 import { ReportType } from 'api/reports/report';
-import { ChartType } from 'routes/views/components/charts/common/chartDatumUtils';
+import { DatumType } from 'routes/views/components/charts/common/chartDatum';
 import { createMockStoreCreator } from 'store/mockStore';
 import { reportActions } from 'store/reports';
 
@@ -90,9 +90,9 @@ test('getQueryForWidget', () => {
     currentTab: OciDashboardTab.payer_tenant_ids,
     details: { formatOptions: {} },
     trend: {
+      datumType: DatumType.rolling,
       formatOptions: {},
       titleKey: '',
-      type: ChartType.daily,
     },
     topItems: {
       formatOptions: {},

--- a/src/store/dashboard/ociDashboard/ociDashboardWidgets.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboardWidgets.ts
@@ -3,11 +3,11 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import messages from 'locales/messages';
 import { paths } from 'routes';
 import {
-  ChartType,
   ComputedForecastItemType,
   ComputedReportItemType,
   ComputedReportItemValueType,
-} from 'routes/views/components/charts/common/chartDatumUtils';
+  DatumType,
+} from 'routes/views/components/charts/common/chartDatum';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { formatUnits } from 'utils/format';
 
@@ -41,8 +41,8 @@ export const costSummaryWidget: OciDashboardWidget = {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
     dailyTitleKey: messages.ociDailyCostTrendTitle,
+    datumType: DatumType.cumulative,
     titleKey: messages.ociCostTrendTitle,
-    type: ChartType.rolling,
   },
 };
 
@@ -68,8 +68,8 @@ export const databaseWidget: OciDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.cumulative,
     titleKey: messages.dashboardCumulativeCostComparison,
-    type: ChartType.rolling,
   },
 };
 
@@ -95,8 +95,8 @@ export const networkWidget: OciDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.cumulative,
     titleKey: messages.dashboardCumulativeCostComparison,
-    type: ChartType.rolling,
   },
 };
 
@@ -117,8 +117,8 @@ export const storageWidget: OciDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.dashboardDailyUsageComparison,
-    type: ChartType.daily,
   },
 };
 
@@ -146,7 +146,7 @@ export const virtualMachineWidget: OciDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.dashboardDailyUsageComparison,
-    type: ChartType.daily,
   },
 };

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboard.test.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboard.test.ts
@@ -1,7 +1,7 @@
 jest.mock('store/reports/reportActions');
 
 import { ReportType } from 'api/reports/report';
-import { ChartType, ComputedReportItemType } from 'routes/views/components/charts/common/chartDatumUtils';
+import { ComputedReportItemType, DatumType } from 'routes/views/components/charts/common/chartDatum';
 import { createMockStoreCreator } from 'store/mockStore';
 import { reportActions } from 'store/reports';
 
@@ -87,9 +87,9 @@ test('getQueryForWidget', () => {
     details: { formatOptions: {} },
     trend: {
       computedReportItem: ComputedReportItemType.cost,
+      datumType: DatumType.rolling,
       formatOptions: {},
       titleKey: '',
-      type: ChartType.daily,
     },
     topItems: {
       formatOptions: {},

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
@@ -2,11 +2,11 @@ import { ForecastPathsType, ForecastType } from 'api/forecasts/forecast';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import messages from 'locales/messages';
 import {
-  ChartType,
   ComputedForecastItemType,
   ComputedReportItemType,
   ComputedReportItemValueType,
-} from 'routes/views/components/charts/common/chartDatumUtils';
+  DatumType,
+} from 'routes/views/components/charts/common/chartDatum';
 import { awsDashboardWidgets } from 'store/dashboard/awsDashboard';
 import { azureDashboardWidgets } from 'store/dashboard/azureDashboard';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
@@ -42,8 +42,8 @@ export const costSummaryWidget: OcpCloudDashboardWidget = {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
     dailyTitleKey: messages.ocpCloudDashboardDailyCostTrendTitle,
+    datumType: DatumType.cumulative,
     titleKey: messages.ocpCloudDashboardCostTrendTitle,
-    type: ChartType.rolling,
   },
 };
 
@@ -70,8 +70,8 @@ export const computeWidget: OcpCloudDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.dashboardDailyUsageComparison,
-    type: ChartType.daily,
   },
 };
 
@@ -98,8 +98,8 @@ export const databaseWidget: OcpCloudDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.cumulative,
     titleKey: messages.dashboardCumulativeCostComparison,
-    type: ChartType.rolling,
   },
 };
 
@@ -126,8 +126,8 @@ export const networkWidget: OcpCloudDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.cumulative,
     titleKey: messages.dashboardCumulativeCostComparison,
-    type: ChartType.rolling,
   },
 };
 
@@ -149,7 +149,7 @@ export const storageWidget: OcpCloudDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.dashboardDailyUsageComparison,
-    type: ChartType.daily,
   },
 };

--- a/src/store/dashboard/ocpDashboard/ocpDashboard.test.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboard.test.ts
@@ -1,7 +1,7 @@
 jest.mock('store/reports/reportActions');
 
 import { ReportType } from 'api/reports/report';
-import { ChartType, ComputedReportItemType } from 'routes/views/components/charts/common/chartDatumUtils';
+import { ComputedReportItemType, DatumType } from 'routes/views/components/charts/common/chartDatum';
 import { createMockStoreCreator } from 'store/mockStore';
 import { reportActions } from 'store/reports';
 
@@ -75,9 +75,9 @@ test('getQueryForWidget', () => {
     details: { formatOptions: {} },
     trend: {
       computedReportItem: ComputedReportItemType.cost,
+      datumType: DatumType.rolling,
       formatOptions: {},
       titleKey: '',
-      type: ChartType.daily,
     },
     topItems: {
       formatOptions: {},

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -3,11 +3,11 @@ import { ReportPathsType, ReportType } from 'api/reports/report';
 import messages from 'locales/messages';
 import { paths } from 'routes';
 import {
-  ChartType,
   ComputedForecastItemType,
   ComputedReportItemType,
   ComputedReportItemValueType,
-} from 'routes/views/components/charts/common/chartDatumUtils';
+  DatumType,
+} from 'routes/views/components/charts/common/chartDatum';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { formatCurrency, formatUnits } from 'utils/format';
 
@@ -41,8 +41,8 @@ export const costSummaryWidget: OcpDashboardWidget = {
     computedReportItem: ComputedReportItemType.cost,
     computedReportItemValue: ComputedReportItemValueType.total,
     dailyTitleKey: messages.ocpDashboardDailyCostTitle,
+    datumType: DatumType.cumulative,
     titleKey: messages.ocpDashboardCostTrendTitle,
-    type: ChartType.rolling,
   },
   tabsFilter: {
     limit: 3,
@@ -66,8 +66,8 @@ export const cpuWidget: OcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.ocpDailyUsageAndRequestComparison,
-    type: ChartType.daily,
   },
 };
 
@@ -88,8 +88,8 @@ export const memoryWidget: OcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.ocpDailyUsageAndRequestComparison,
-    type: ChartType.daily,
   },
 };
 
@@ -110,7 +110,7 @@ export const volumeWidget: OcpDashboardWidget = {
   trend: {
     computedReportItem: ComputedReportItemType.usage,
     computedReportItemValue: ComputedReportItemValueType.total,
+    datumType: DatumType.rolling,
     titleKey: messages.ocpDailyUsageAndRequestComparison,
-    type: ChartType.daily,
   },
 };

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -43,24 +43,24 @@ export interface ComputedReportItem extends ComputedReportOcpItem, ComputedRepor
 }
 
 export interface ComputedReportItemsParams<R extends Report, T extends ReportItem> {
-  daily?: boolean;
   idKey: keyof T;
+  isDateMap?: boolean;
   report: R;
   sortKey?: keyof ComputedReportItem;
   sortDirection?: SortDirection;
 }
 
 export function getComputedReportItems<R extends Report, T extends ReportItem>({
-  daily,
   idKey,
+  isDateMap,
   report,
   sortDirection = SortDirection.asc,
   sortKey = 'date',
 }: ComputedReportItemsParams<R, T>) {
   return sort(
     getUnsortedComputedReportItems<R, T>({
-      daily,
       idKey,
+      isDateMap,
       report,
       sortDirection,
       sortKey,
@@ -124,7 +124,7 @@ function getUsageData(val, item?: any) {
 
 // Details pages typically use this function with filter[resolution]=monthly
 export function getUnsortedComputedReportItems<R extends Report, T extends ReportItem>({
-  daily = false,
+  isDateMap = false,
   report,
   idKey, // Note: The idKey must use org_entities for reports, while group_by uses org_unit_id
 }: ComputedReportItemsParams<R, T>) {
@@ -180,7 +180,7 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
           }
         }
 
-        if (daily) {
+        if (isDateMap) {
           const data = {
             ...getUsageData(val), // capacity, limit, request, & usage
             cluster,


### PR DESCRIPTION
In `chartDayumUtils`, `ChartType.daily` is used to represent cumulative data, while `ChartType.rolling` is the default. This is confusing because data is transformed based on a chart view, which can be cumulative for both daily and monthly data. For example, in the HCS UI, we're now showing cumulative monthly data.

That said, this PR refactors the code to use `DatumType.cumulative` and `DatumType.rolling`, which can be applied to both daily and monthly data. This will make it clear when cumulative data is being used.

https://issues.redhat.com/browse/COST-3063