### PR TITLE
Export dialog button remains disabled

### DIFF
--- a/src/routes/views/components/export/exportModal.tsx
+++ b/src/routes/views/components/export/exportModal.tsx
@@ -188,7 +188,7 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
             groupBy: groupBy.indexOf(tagPrefix) !== -1 ? 'tag' : groupBy,
           });
 
-    const helpText = this.nameValidator(defaultName);
+    const helpText = isExportsFeatureEnabled ? this.nameValidator(defaultName) : undefined;
     const validated = helpText ? 'error' : 'default';
 
     return (


### PR DESCRIPTION
The submit button in the export dialog remains disabled. It's not obvious to users why the button is disabled, but it prevents exporting data.

https://issues.redhat.com/browse/COST-3064