### PR TITLE
Use react-intl instead of date-fns-tz

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "@unleash/proxy-client-react": "^3.3.0",
     "axios": "^0.27.2",
     "date-fns": "^2.29.3",
-    "date-fns-tz": "^1.3.7",
     "hook-into-props": "^4.0.1",
     "js-file-download": "^0.4.12",
     "lodash": "^4.17.21",

--- a/src/__mocks__/react-intl.tsx
+++ b/src/__mocks__/react-intl.tsx
@@ -1,6 +1,7 @@
 const mockedReactIntl = jest.genMockFromModule('react-intl') as any;
 
 const intl = {
+  formatDate: () => jest.fn(v => v),
   formatMessage: ({ defaultMessage }, params?) => {
     if (!params) {
       return defaultMessage;

--- a/src/routes/costModels/costModelsDetails/utils/table.tsx
+++ b/src/routes/costModels/costModelsDetails/utils/table.tsx
@@ -2,7 +2,7 @@ import { Bullseye } from '@patternfly/react-core';
 import { IAction, ICell, SortByDirection } from '@patternfly/react-table';
 import { Unavailable } from '@redhat-cloud-services/frontend-components/Unavailable';
 import { CostModel } from 'api/costModels';
-import { format, utcToZonedTime } from 'date-fns-tz';
+import { intl } from 'components/i18n';
 import React from 'react';
 import { Link } from 'react-router-dom';
 import { EmptyFilterState } from 'routes/components/state/emptyFilterState/emptyFilterState';
@@ -40,9 +40,17 @@ export function getRowsByStateName(stateName: string, data: any) {
     ];
   }
   return data.map((item: CostModel) => {
-    const dateTime = format(utcToZonedTime(item.updated_timestamp, 'UTC'), 'dd LLL yyyy kk:mm zzz', {
+    const dateTime = intl.formatDate(item.updated_timestamp, {
+      day: 'numeric',
+      hour: 'numeric',
+      hour12: false,
+      minute: 'numeric',
+      month: 'short',
       timeZone: 'UTC',
+      timeZoneName: 'short',
+      year: 'numeric',
     });
+
     return {
       cells: [
         {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3067,11 +3067,6 @@ data-urls@^3.0.2:
     whatwg-mimetype "^3.0.0"
     whatwg-url "^11.0.0"
 
-date-fns-tz@^1.3.7:
-  version "1.3.7"
-  resolved "https://registry.yarnpkg.com/date-fns-tz/-/date-fns-tz-1.3.7.tgz#e8e9d2aaceba5f1cc0e677631563081fdcb0e69a"
-  integrity sha512-1t1b8zyJo+UI8aR+g3iqr5fkUHWpd58VBx8J/ZSQ+w7YrGlw80Ag4sA86qkfCXRBLmMc4I2US+aPMd4uKvwj5g==
-
 date-fns@^2.29.3:
   version "2.29.3"
   resolved "https://registry.npmjs.org/date-fns/-/date-fns-2.29.3.tgz"


### PR DESCRIPTION
Instead of using `date-fns-tz` to convert the timezone prior to formatting, this change uses the existing the `formatDate` function of `react-intl`.

The advantage here is that these functions do not require a Locale object to be provided – the locale has already been set via `IntlProvider`. We also don't need to hard code a date format (e.g., "dd LLL yyyy hh:mm, x"), where dates are expected to be formatted differently for European and Asian locales.

Spoke with Natalie and showing the month before the day is acceptable.

![sfter](https://user-images.githubusercontent.com/17481322/192810739-8074d716-c902-4ee0-bd47-914b4d0b9731.png)

https://issues.redhat.com/browse/COST-3031