### PR TITLE
Connect currency selection to cost report APIs

### DIFF
--- a/src/routes/components/currency/currency.tsx
+++ b/src/routes/components/currency/currency.tsx
@@ -7,11 +7,12 @@ import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
-import { getCurrency, invalidateSession, restoreCurrency, setCurrency } from 'utils/localStorage';
+import { invalidateSession, restoreCurrency, setCurrency } from 'utils/localStorage';
 
 import { styles } from './currency.styles';
 
 interface CurrencyOwnProps {
+  currency?: string;
   isDisabled?: boolean;
   onSelect?: (value: string) => void;
 }
@@ -63,13 +64,12 @@ class CurrencyBase extends React.Component<CurrencyProps> {
   public state: CurrencyState = { ...this.defaultState };
 
   private getSelect = () => {
-    const { isDisabled } = this.props;
+    const { currency, isDisabled } = this.props;
     const { isSelectOpen } = this.state;
 
     // Restore from query param if available
     restoreCurrency();
 
-    const currency = getCurrency(); // Get currency from local storage
     const selectOptions = this.getSelectOptions();
     const selection = selectOptions.find((option: CurrencyOption) => option.value === currency);
 

--- a/src/routes/costModels/costModel/priceListTable.tsx
+++ b/src/routes/costModels/costModel/priceListTable.tsx
@@ -14,7 +14,7 @@ import {
   ToolbarItem,
   ToolbarItemVariant,
 } from '@patternfly/react-core';
-import { FileInvoiceDollarIcon } from '@patternfly/react-icons/dist/esm/icons/file-invoice-dollar-icon';
+import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import { SortByDirection } from '@patternfly/react-table';
 import { Unavailable } from '@redhat-cloud-services/frontend-components/Unavailable';
 import { CostModel } from 'api/costModels';
@@ -288,7 +288,7 @@ class PriceListTable extends React.Component<Props, State> {
                   search.metrics.length === 0 && (
                     <Bullseye>
                       <EmptyState>
-                        <EmptyStateIcon icon={FileInvoiceDollarIcon} />
+                        <EmptyStateIcon icon={PlusCircleIcon} />
                         <Title headingLevel="h2" size={TitleSizes.lg}>
                           {intl.formatMessage(messages.priceListEmptyRate)}
                         </Title>

--- a/src/routes/costModels/costModel/table.tsx
+++ b/src/routes/costModels/costModel/table.tsx
@@ -1,5 +1,5 @@
 import { EmptyState, EmptyStateBody, EmptyStateIcon, Title, TitleSizes } from '@patternfly/react-core';
-import { DollarSignIcon } from '@patternfly/react-icons/dist/esm/icons/dollar-sign-icon';
+import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import { CostModel } from 'api/costModels';
 import messages from 'locales/messages';
 import React from 'react';
@@ -115,7 +115,7 @@ class TableBase extends React.Component<Props, State> {
         {rows.length === 0 && (
           <div style={styles.emptyState}>
             <EmptyState>
-              <EmptyStateIcon icon={DollarSignIcon} />
+              <EmptyStateIcon icon={PlusCircleIcon} />
               <Title headingLevel="h2" size={TitleSizes.lg}>
                 {intl.formatMessage(messages.costModelsSourceEmptyStateDesc)}
               </Title>

--- a/src/routes/state/noData/noDataState.tsx
+++ b/src/routes/state/noData/noDataState.tsx
@@ -1,5 +1,5 @@
 import { Button, EmptyState, EmptyStateBody, EmptyStateIcon, EmptyStateVariant, Title } from '@patternfly/react-core';
-import { FileInvoiceDollarIcon } from '@patternfly/react-icons/dist/esm/icons/file-invoice-dollar-icon';
+import { PlusCircleIcon } from '@patternfly/react-icons/dist/esm/icons/plus-circle-icon';
 import messages from 'locales/messages';
 import React from 'react';
 import { injectIntl, WrappedComponentProps } from 'react-intl';
@@ -17,7 +17,7 @@ class NoDataStateBase extends React.Component<NoDataStateProps> {
 
     return (
       <EmptyState variant={EmptyStateVariant.large} className="pf-m-redhat-font">
-        <EmptyStateIcon icon={FileInvoiceDollarIcon} />
+        <EmptyStateIcon icon={PlusCircleIcon} />
         <Title headingLevel="h5" size="lg">
           {intl.formatMessage(messages.noDataStateTitle)}
         </Title>

--- a/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
@@ -14,9 +14,11 @@ import BreakdownBase from 'routes/views/details/components/breakdown';
 import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'routes/views/utils/groupBy';
 import { filterProviders } from 'routes/views/utils/providers';
 import { createMapStateToProps, FetchStatus } from 'store/common';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCostType } from 'utils/costType';
+import { getCurrency } from 'utils/currency';
 
 import { CostOverview } from './costOverview';
 import { HistoricalData } from './historicalData';
@@ -54,6 +56,7 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
   const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
   const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
   const costType = getCostType();
+  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
 
   const newQuery: Query = {
     filter: {
@@ -71,6 +74,7 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
       ...(groupBy && { [groupBy]: groupByValue }),
     },
     cost_type: costType,
+    currency,
   };
   const queryString = getQuery(newQuery);
 
@@ -88,14 +92,17 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
   );
 
   return {
-    costOverviewComponent: <CostOverview costType={costType} groupBy={groupBy} query={query} report={report} />,
+    costOverviewComponent: (
+      <CostOverview costType={costType} currency={currency} groupBy={groupBy} query={query} report={report} />
+    ),
     costType,
+    currency,
     description: query[breakdownDescKey],
     detailsURL,
     emptyStateTitle: props.intl.formatMessage(messages.awsDetailsTitle),
     groupBy,
     groupByValue,
-    historicalDataComponent: <HistoricalData costType={costType} />,
+    historicalDataComponent: <HistoricalData costType={costType} currency={currency} />,
     providers: filterProviders(providers, ProviderType.aws),
     providersError,
     providersFetchStatus,

--- a/src/routes/views/details/awsDetails/detailsHeader.tsx
+++ b/src/routes/views/details/awsDetails/detailsHeader.tsx
@@ -102,7 +102,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             {intl.formatMessage(messages.awsDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency onSelect={onCurrencySelected} currency={currency} />}
+            {isCurrencyFeatureEnabled && <Currency currency={currency} onSelect={onCurrencySelected} />}
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>

--- a/src/routes/views/details/awsDetails/detailsHeader.tsx
+++ b/src/routes/views/details/awsDetails/detailsHeader.tsx
@@ -26,9 +26,11 @@ import { formatCurrency } from 'utils/format';
 import { styles } from './detailsHeader.styles';
 
 interface DetailsHeaderOwnProps {
+  currency?: string;
   costType?: CostTypes;
   groupBy?: string;
   onCostTypeSelected(value: string);
+  onCurrencySelected(value: string);
   onGroupBySelected(value: string);
   report: AwsReport;
 }
@@ -77,9 +79,11 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
   public render() {
     const {
       costType,
+      currency,
       groupBy,
       isCurrencyFeatureEnabled,
       isExportsFeatureEnabled,
+      onCurrencySelected,
       onGroupBySelected,
       providers,
       providersError,
@@ -98,7 +102,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             {intl.formatMessage(messages.awsDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency />}
+            {isCurrencyFeatureEnabled && <Currency onSelect={onCurrencySelected} currency={currency} />}
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>
@@ -116,7 +120,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
               tagReportPathsType={tagReportPathsType}
             />
             <div style={styles.costType}>
-              <CostType onSelect={this.handleCostTypeSelected} costType={costType} />
+              <CostType costType={costType} onSelect={this.handleCostTypeSelected} />
             </div>
           </div>
           {Boolean(showContent) && (

--- a/src/routes/views/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/routes/views/details/azureBreakdown/azureBreakdown.tsx
@@ -14,8 +14,10 @@ import BreakdownBase from 'routes/views/details/components/breakdown';
 import { getGroupById, getGroupByValue } from 'routes/views/utils/groupBy';
 import { filterProviders } from 'routes/views/utils/providers';
 import { createMapStateToProps, FetchStatus } from 'store/common';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
+import { getCurrency } from 'utils/currency';
 
 import { CostOverview } from './costOverview';
 import { HistoricalData } from './historicalData';
@@ -24,6 +26,7 @@ type AzureCostOwnProps = WrappedComponentProps;
 
 interface AzureCostStateProps {
   CostOverview?: React.ReactNode;
+  currency?: string;
   detailsURL: string;
   HistoricalData?: React.ReactNode;
   providers: Providers;
@@ -51,6 +54,7 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateP
   const query = parseQuery<OcpQuery>(location.search);
   const groupBy = getGroupById(query);
   const groupByValue = getGroupByValue(query);
+  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
 
   const newQuery: Query = {
     filter: {
@@ -66,6 +70,7 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateP
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
+    currency,
   };
   const queryString = getQuery(newQuery);
 
@@ -83,13 +88,14 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateP
   );
 
   return {
-    costOverviewComponent: <CostOverview groupBy={groupBy} report={report} />,
+    costOverviewComponent: <CostOverview currency={currency} groupBy={groupBy} report={report} />,
+    currency,
     description: query[breakdownDescKey],
     detailsURL,
     emptyStateTitle: props.intl.formatMessage(messages.azureDetailsTitle),
     groupBy,
     groupByValue,
-    historicalDataComponent: <HistoricalData />,
+    historicalDataComponent: <HistoricalData currency={currency} />,
     providers: filterProviders(providers, ProviderType.azure),
     providersError,
     providersFetchStatus,

--- a/src/routes/views/details/azureDetails/detailsHeader.tsx
+++ b/src/routes/views/details/azureDetails/detailsHeader.tsx
@@ -23,7 +23,9 @@ import { formatCurrency } from 'utils/format';
 import { styles } from './detailsHeader.styles';
 
 interface DetailsHeaderOwnProps {
+  currency?: string;
   groupBy?: string;
+  onCurrencySelected(value: string);
   onGroupBySelected(value: string);
   report: AzureReport;
 }
@@ -62,9 +64,11 @@ const tagReportPathsType = TagPathsType.azure;
 class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
   public render() {
     const {
+      currency,
       groupBy,
       isCurrencyFeatureEnabled,
       isExportsFeatureEnabled,
+      onCurrencySelected,
       onGroupBySelected,
       providers,
       providersError,
@@ -83,7 +87,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             {intl.formatMessage(messages.azureDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency />}
+            {isCurrencyFeatureEnabled && <Currency onSelect={onCurrencySelected} currency={currency} />}
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>

--- a/src/routes/views/details/azureDetails/detailsHeader.tsx
+++ b/src/routes/views/details/azureDetails/detailsHeader.tsx
@@ -87,7 +87,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             {intl.formatMessage(messages.azureDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency onSelect={onCurrencySelected} currency={currency} />}
+            {isCurrencyFeatureEnabled && <Currency currency={currency} onSelect={onCurrencySelected} />}
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>

--- a/src/routes/views/details/components/breakdown/breakdownBase.tsx
+++ b/src/routes/views/details/components/breakdown/breakdownBase.tsx
@@ -38,6 +38,7 @@ export const getIdKeyForTab = (tab: BreakdownTab) => {
 interface BreakdownStateProps {
   costOverviewComponent?: React.ReactNode;
   costType?: CostTypes;
+  currency?: string;
   description?: string;
   detailsURL: string;
   emptyStateTitle?: string;
@@ -194,6 +195,17 @@ class BreakdownBase extends React.Component<BreakdownProps> {
     history.replace(this.getRouteForQuery(newQuery));
   };
 
+  private handleCurrencySelected = (value: string) => {
+    const { history, query } = this.props;
+
+    // Need param to restore cost type upon page refresh
+    const newQuery = {
+      ...JSON.parse(JSON.stringify(query)),
+      currency: value,
+    };
+    history.replace(this.getRouteForQuery(newQuery));
+  };
+
   private handleTabClick = (event, tabIndex) => {
     const { activeTabKey } = this.state;
     if (activeTabKey !== tabIndex) {
@@ -213,6 +225,7 @@ class BreakdownBase extends React.Component<BreakdownProps> {
   public render() {
     const {
       costType,
+      currency,
       description,
       detailsURL,
       emptyStateTitle,
@@ -251,10 +264,12 @@ class BreakdownBase extends React.Component<BreakdownProps> {
       <>
         <BreakdownHeader
           costType={costType}
+          currency={currency}
           description={description}
           detailsURL={detailsURL}
           groupBy={groupBy}
           onCostTypeSelected={this.handleCostTypeSelected}
+          onCurrencySelected={this.handleCurrencySelected}
           query={query}
           report={report}
           showCostType={showCostType}

--- a/src/routes/views/details/components/breakdown/breakdownHeader.tsx
+++ b/src/routes/views/details/components/breakdown/breakdownHeader.tsx
@@ -24,10 +24,12 @@ import { styles } from './breakdownHeader.styles';
 
 interface BreakdownHeaderOwnProps {
   costType?: CostTypes;
+  currency?: string;
   detailsURL?: string;
   description?: string;
   groupBy?: string;
   onCostTypeSelected(value: string);
+  onCurrencySelected(value: string);
   query: Query;
   report: Report;
   showCostType?: boolean;
@@ -88,21 +90,16 @@ class BreakdownHeader extends React.Component<BreakdownHeaderProps> {
     return cost;
   };
 
-  private handleCostTypeSelected = (value: string) => {
-    const { onCostTypeSelected } = this.props;
-
-    if (onCostTypeSelected) {
-      onCostTypeSelected(value);
-    }
-  };
-
   public render() {
     const {
       costType,
+      currency,
       description,
       groupBy,
       intl,
       isCurrencyFeatureEnabled,
+      onCostTypeSelected,
+      onCurrencySelected,
       query,
       showCostType = false,
       tabs,
@@ -141,7 +138,9 @@ class BreakdownHeader extends React.Component<BreakdownHeaderProps> {
               </li>
             </ol>
           </nav>
-          <div style={styles.headerContentRight}>{isCurrencyFeatureEnabled && <Currency />}</div>
+          <div style={styles.headerContentRight}>
+            {isCurrencyFeatureEnabled && <Currency currency={currency} onSelect={onCurrencySelected} />}
+          </div>
         </div>
         <div style={styles.headerContent}>
           <div style={styles.title}>
@@ -151,7 +150,7 @@ class BreakdownHeader extends React.Component<BreakdownHeaderProps> {
             </Title>
             {showCostType && (
               <div style={styles.costType}>
-                <CostType onSelect={this.handleCostTypeSelected} costType={costType} />
+                <CostType onSelect={onCostTypeSelected} costType={costType} />
               </div>
             )}
           </div>

--- a/src/routes/views/details/components/costOverview/costOverviewBase.tsx
+++ b/src/routes/views/details/components/costOverview/costOverviewBase.tsx
@@ -25,6 +25,7 @@ import { CostOverviewWidget, CostOverviewWidgetType } from 'store/breakdown/cost
 
 interface CostOverviewOwnProps {
   costType?: string;
+  currency?: string;
   groupBy: string;
   query?: Query;
   report: Report;
@@ -148,7 +149,7 @@ class CostOverviewsBase extends React.Component<CostOverviewProps> {
 
   // Returns summary card widget
   private getSummaryCard = (widget: CostOverviewWidget) => {
-    const { costType, groupBy, query } = this.props;
+    const { costType, currency, groupBy, query } = this.props;
 
     let showWidget = false;
     for (const groupById of widget.reportSummary.showWidgetOnGroupBy) {
@@ -165,6 +166,7 @@ class CostOverviewsBase extends React.Component<CostOverviewProps> {
       return (
         <SummaryCard
           costType={costType}
+          currency={currency}
           reportGroupBy={widget.reportSummary.reportGroupBy}
           reportPathsType={widget.reportPathsType}
           reportType={widget.reportType}

--- a/src/routes/views/details/components/historicalData/historicalDataBase.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataBase.tsx
@@ -14,6 +14,7 @@ import { HistoricalDataUsageChart } from './historicalDataUsageChart';
 
 interface HistoricalDataOwnProps {
   costType?: string;
+  currency?: string;
 }
 
 interface HistoricalDataStateProps {
@@ -33,7 +34,7 @@ class HistoricalDatasBase extends React.Component<HistoricalDataProps> {
 
   // Returns cost chart
   private getCostChart = (widget: HistoricalDataWidget) => {
-    const { costType, intl } = this.props;
+    const { costType, currency, intl } = this.props;
 
     return (
       <Card>
@@ -48,6 +49,7 @@ class HistoricalDatasBase extends React.Component<HistoricalDataProps> {
           <HistoricalDataCostChart
             chartName={widget.chartName}
             costType={costType}
+            currency={currency}
             reportPathsType={widget.reportPathsType}
             reportType={widget.reportType}
           />
@@ -58,7 +60,7 @@ class HistoricalDatasBase extends React.Component<HistoricalDataProps> {
 
   // Returns trend chart
   private getTrendChart = (widget: HistoricalDataWidget) => {
-    const { costType, intl } = this.props;
+    const { costType, currency, intl } = this.props;
 
     return (
       <Card>
@@ -73,6 +75,7 @@ class HistoricalDatasBase extends React.Component<HistoricalDataProps> {
           <HistoricalDataTrendChart
             chartName={widget.chartName}
             costType={costType}
+            currency={currency}
             reportPathsType={widget.reportPathsType}
             reportType={widget.reportType}
           />

--- a/src/routes/views/details/components/historicalData/historicalDataCostChart.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataCostChart.tsx
@@ -18,6 +18,7 @@ import { chartStyles, styles } from './historicalChart.styles';
 interface HistoricalDataCostChartOwnProps {
   chartName?: string;
   costType?: string;
+  currency?: string;
   reportPathsType: ReportPathsType;
   reportType: ReportType;
 }
@@ -51,12 +52,21 @@ class HistoricalDataCostChartBase extends React.Component<HistoricalDataCostChar
   }
 
   public componentDidUpdate(prevProps: HistoricalDataCostChartProps) {
-    const { fetchReport, costType, currentQueryString, previousQueryString, reportPathsType, reportType } = this.props;
+    const { fetchReport, costType, currency, currentQueryString, previousQueryString, reportPathsType, reportType } =
+      this.props;
 
-    if (prevProps.currentQueryString !== currentQueryString || prevProps.costType !== costType) {
+    if (
+      prevProps.currentQueryString !== currentQueryString ||
+      prevProps.costType !== costType ||
+      prevProps.currency !== currency
+    ) {
       fetchReport(reportPathsType, reportType, currentQueryString);
     }
-    if (prevProps.previousQueryString !== previousQueryString || prevProps.costType !== costType) {
+    if (
+      prevProps.previousQueryString !== previousQueryString ||
+      prevProps.costType !== costType ||
+      prevProps.currency !== currency
+    ) {
       fetchReport(reportPathsType, reportType, previousQueryString);
     }
   }
@@ -130,13 +140,12 @@ class HistoricalDataCostChartBase extends React.Component<HistoricalDataCostChar
 }
 
 const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, HistoricalDataCostChartStateProps>(
-  (state, { costType, reportPathsType, reportType }) => {
+  (state, { costType, currency, reportPathsType, reportType }) => {
     const query = parseQuery<Query>(location.search);
     const groupBy = getGroupById(query);
     const groupByValue = getGroupByValue(query);
 
     const baseQuery: Query = {
-      cost_type: costType,
       filter_by: {
         // Add filters here to apply logical OR/AND
         ...(query && query.filter_by && query.filter_by),
@@ -145,6 +154,8 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
       group_by: {
         ...(groupBy && { [groupBy]: groupByValue }),
       },
+      cost_type: costType,
+      currency,
     };
     const currentQuery: Query = {
       ...baseQuery,

--- a/src/routes/views/details/components/historicalData/historicalDataTrendChart.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataTrendChart.tsx
@@ -18,6 +18,7 @@ import { chartStyles, styles } from './historicalChart.styles';
 interface HistoricalDataTrendChartOwnProps {
   chartName?: string;
   costType?: string;
+  currency?: string;
   reportPathsType: ReportPathsType;
   reportType: ReportType;
 }
@@ -51,12 +52,21 @@ class HistoricalDataTrendChartBase extends React.Component<HistoricalDataTrendCh
   }
 
   public componentDidUpdate(prevProps: HistoricalDataTrendChartProps) {
-    const { fetchReport, costType, currentQueryString, previousQueryString, reportPathsType, reportType } = this.props;
+    const { fetchReport, costType, currency, currentQueryString, previousQueryString, reportPathsType, reportType } =
+      this.props;
 
-    if (prevProps.currentQueryString !== currentQueryString || prevProps.costType !== costType) {
+    if (
+      prevProps.currentQueryString !== currentQueryString ||
+      prevProps.costType !== costType ||
+      prevProps.currency !== currency
+    ) {
       fetchReport(reportPathsType, reportType, currentQueryString);
     }
-    if (prevProps.previousQueryString !== previousQueryString || prevProps.costType !== costType) {
+    if (
+      prevProps.previousQueryString !== previousQueryString ||
+      prevProps.costType !== costType ||
+      prevProps.currency !== currency
+    ) {
       fetchReport(reportPathsType, reportType, previousQueryString);
     }
   }
@@ -145,14 +155,13 @@ class HistoricalDataTrendChartBase extends React.Component<HistoricalDataTrendCh
 }
 
 const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, HistoricalDataTrendChartStateProps>(
-  (state, { costType, reportPathsType, reportType }) => {
+  (state, { costType, currency, reportPathsType, reportType }) => {
     const query = parseQuery<Query>(location.search);
     const groupByOrgValue = getGroupByOrgValue(query);
     const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
     const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
 
     const baseQuery: Query = {
-      cost_type: costType,
       filter_by: {
         // Add filters here to apply logical OR/AND
         ...(query && query.filter_by && query.filter_by),
@@ -162,6 +171,8 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
       group_by: {
         ...(groupBy && { [groupBy]: groupByValue }),
       },
+      cost_type: costType,
+      currency,
     };
     const currentQuery: Query = {
       ...baseQuery,

--- a/src/routes/views/details/components/summary/summaryCard.tsx
+++ b/src/routes/views/details/components/summary/summaryCard.tsx
@@ -30,6 +30,7 @@ import { styles } from './summaryCard.styles';
 
 interface SummaryOwnProps {
   costType?: string;
+  currency?: string;
   reportGroupBy?: string;
   reportPathsType: ReportPathsType;
   reportType: ReportType;
@@ -65,8 +66,8 @@ class SummaryBase extends React.Component<SummaryProps> {
   }
 
   public componentDidUpdate(prevProps: SummaryProps) {
-    const { costType, fetchReport, queryString, reportPathsType, reportType } = this.props;
-    if (prevProps.queryString !== queryString || prevProps.costType !== costType) {
+    const { costType, currency, fetchReport, queryString, reportPathsType, reportType } = this.props;
+    if (prevProps.queryString !== queryString || prevProps.costType !== costType || prevProps.currency !== currency) {
       fetchReport(reportPathsType, reportType, queryString);
     }
   }
@@ -102,7 +103,7 @@ class SummaryBase extends React.Component<SummaryProps> {
   };
 
   private getViewAll = () => {
-    const { groupBy, query, reportGroupBy, reportPathsType, intl } = this.props;
+    const { costType, currency, groupBy, query, reportGroupBy, reportPathsType, intl } = this.props;
     const { isBulletChartModalOpen } = this.state;
 
     const computedItems = this.getItems();
@@ -128,6 +129,8 @@ class SummaryBase extends React.Component<SummaryProps> {
             {intl.formatMessage(messages.detailsViewAll, { value: reportGroupBy })}
           </Button>
           <SummaryModal
+            costType={costType}
+            currency={currency}
             groupBy={groupBy}
             groupByValue={groupByValue}
             isOpen={isBulletChartModalOpen}
@@ -181,14 +184,13 @@ class SummaryBase extends React.Component<SummaryProps> {
 }
 
 const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps>(
-  (state, { costType, reportGroupBy, reportPathsType, reportType }) => {
+  (state, { costType, currency, reportGroupBy, reportPathsType, reportType }) => {
     const query = parseQuery<Query>(location.search);
     const groupByOrgValue = getGroupByOrgValue(query);
     const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
     const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(query);
 
     const newQuery: Query = {
-      cost_type: costType,
       filter: {
         limit: 3,
         resolution: 'monthly',
@@ -205,6 +207,8 @@ const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps
       group_by: {
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.
       },
+      cost_type: costType,
+      currency,
     };
     const queryString = getQuery(newQuery);
 

--- a/src/routes/views/details/components/summary/summaryModal.tsx
+++ b/src/routes/views/details/components/summary/summaryModal.tsx
@@ -10,6 +10,8 @@ import { injectIntl, WrappedComponentProps } from 'react-intl';
 import { SummaryModalContent } from './summaryModalContent';
 
 interface SummaryModalOwnProps {
+  costType?: string;
+  currency?: string;
   groupBy: string;
   groupByValue: string | number;
   isOpen: boolean;
@@ -37,7 +39,7 @@ class SummaryModalBase extends React.Component<SummaryModalProps> {
   };
 
   public render() {
-    const { groupByValue, intl, isOpen, reportGroupBy, reportPathsType } = this.props;
+    const { costType, currency, groupByValue, intl, isOpen, reportGroupBy, reportPathsType } = this.props;
 
     return (
       <Modal
@@ -50,7 +52,12 @@ class SummaryModalBase extends React.Component<SummaryModalProps> {
         })}
         variant="large"
       >
-        <SummaryModalContent reportGroupBy={reportGroupBy} reportPathsType={reportPathsType} />
+        <SummaryModalContent
+          costType={costType}
+          currency={currency}
+          reportGroupBy={reportGroupBy}
+          reportPathsType={reportPathsType}
+        />
       </Modal>
     );
   }

--- a/src/routes/views/details/components/summary/summaryModalContent.tsx
+++ b/src/routes/views/details/components/summary/summaryModalContent.tsx
@@ -14,6 +14,8 @@ import { formatCurrency } from 'utils/format';
 import { styles } from './summaryModal.styles';
 
 interface SummaryModalContentOwnProps {
+  costType?: string;
+  currency?: string;
   reportGroupBy?: string;
   reportPathsType: ReportPathsType;
 }
@@ -90,7 +92,7 @@ class SummaryModalContentBase extends React.Component<SummaryModalContentProps> 
 }
 
 const mapStateToProps = createMapStateToProps<SummaryModalContentOwnProps, SummaryModalContentStateProps>(
-  (state, { reportGroupBy, reportPathsType }) => {
+  (state, { costType, currency, reportGroupBy, reportPathsType }) => {
     const query = parseQuery<Query>(location.search);
     const groupByOrgValue = getGroupByOrgValue(query);
     const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(query);
@@ -112,6 +114,8 @@ const mapStateToProps = createMapStateToProps<SummaryModalContentOwnProps, Summa
       group_by: {
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.
       },
+      cost_type: costType,
+      currency,
     };
     const queryString = getQuery(newQuery);
 

--- a/src/routes/views/details/gcpBreakdown/gcpBreakdown.tsx
+++ b/src/routes/views/details/gcpBreakdown/gcpBreakdown.tsx
@@ -14,8 +14,10 @@ import BreakdownBase from 'routes/views/details/components/breakdown';
 import { getGroupById, getGroupByValue } from 'routes/views/utils/groupBy';
 import { filterProviders } from 'routes/views/utils/providers';
 import { createMapStateToProps, FetchStatus } from 'store/common';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
+import { getCurrency } from 'utils/currency';
 
 import { CostOverview } from './costOverview';
 import { HistoricalData } from './historicalData';
@@ -24,6 +26,7 @@ type GcpBreakdownOwnProps = WrappedComponentProps;
 
 interface GcpBreakdownStateProps {
   CostOverview?: React.ReactNode;
+  currency?: string;
   detailsURL: string;
   HistoricalData?: React.ReactNode;
   providers: Providers;
@@ -51,6 +54,7 @@ const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, GcpBreakdown
   const query = parseQuery<GcpQuery>(location.search);
   const groupBy = getGroupById(query);
   const groupByValue = getGroupByValue(query);
+  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
 
   const newQuery: Query = {
     filter: {
@@ -66,6 +70,7 @@ const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, GcpBreakdown
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
+    currency,
   };
   const queryString = getQuery(newQuery);
 
@@ -83,13 +88,14 @@ const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, GcpBreakdown
   );
 
   return {
-    costOverviewComponent: <CostOverview groupBy={groupBy} query={query} report={report} />,
+    costOverviewComponent: <CostOverview currency={currency} groupBy={groupBy} query={query} report={report} />,
+    currency,
     description: query[breakdownDescKey],
     detailsURL,
     emptyStateTitle: props.intl.formatMessage(messages.gcpDetailsTitle),
     groupBy,
     groupByValue,
-    historicalDataComponent: <HistoricalData />,
+    historicalDataComponent: <HistoricalData currency={currency} />,
     providers: filterProviders(providers, ProviderType.gcp),
     providersError,
     providersFetchStatus,

--- a/src/routes/views/details/gcpDetails/detailsHeader.tsx
+++ b/src/routes/views/details/gcpDetails/detailsHeader.tsx
@@ -88,7 +88,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             {intl.formatMessage(messages.gcpDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency onSelect={onCurrencySelected} currency={currency} />}
+            {isCurrencyFeatureEnabled && <Currency currency={currency} onSelect={onCurrencySelected} />}
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>

--- a/src/routes/views/details/gcpDetails/detailsHeader.tsx
+++ b/src/routes/views/details/gcpDetails/detailsHeader.tsx
@@ -23,7 +23,9 @@ import { formatCurrency } from 'utils/format';
 import { styles } from './detailsHeader.styles';
 
 interface DetailsHeaderOwnProps {
+  currency?: string;
   groupBy?: string;
+  onCurrencySelected(value: string);
   onGroupBySelected(value: string);
   report: GcpReport;
 }
@@ -63,9 +65,11 @@ const tagReportPathsType = TagPathsType.gcp;
 class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
   public render() {
     const {
+      currency,
       groupBy,
       isCurrencyFeatureEnabled,
       isExportsFeatureEnabled,
+      onCurrencySelected,
       onGroupBySelected,
       providers,
       providersError,
@@ -84,7 +88,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             {intl.formatMessage(messages.gcpDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency />}
+            {isCurrencyFeatureEnabled && <Currency onSelect={onCurrencySelected} currency={currency} />}
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>

--- a/src/routes/views/details/ibmBreakdown/ibmBreakdown.tsx
+++ b/src/routes/views/details/ibmBreakdown/ibmBreakdown.tsx
@@ -14,8 +14,10 @@ import BreakdownBase from 'routes/views/details/components/breakdown/breakdownBa
 import { getGroupById, getGroupByValue } from 'routes/views/utils/groupBy';
 import { filterProviders } from 'routes/views/utils/providers';
 import { createMapStateToProps, FetchStatus } from 'store/common';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
+import { getCurrency } from 'utils/currency';
 
 import { CostOverview } from './costOverview';
 import { HistoricalData } from './historicalData';
@@ -24,6 +26,7 @@ type IbmBreakdownOwnProps = WrappedComponentProps;
 
 interface IbmBreakdownStateProps {
   CostOverview?: React.ReactNode;
+  currency?: string;
   detailsURL: string;
   HistoricalData?: React.ReactNode;
   providers: Providers;
@@ -51,6 +54,7 @@ const mapStateToProps = createMapStateToProps<IbmBreakdownOwnProps, IbmBreakdown
   const query = parseQuery<IbmQuery>(location.search);
   const groupBy = getGroupById(query);
   const groupByValue = getGroupByValue(query);
+  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
 
   const newQuery: Query = {
     filter: {
@@ -66,6 +70,7 @@ const mapStateToProps = createMapStateToProps<IbmBreakdownOwnProps, IbmBreakdown
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
+    currency,
   };
   const queryString = getQuery(newQuery);
 
@@ -83,13 +88,14 @@ const mapStateToProps = createMapStateToProps<IbmBreakdownOwnProps, IbmBreakdown
   );
 
   return {
-    costOverviewComponent: <CostOverview groupBy={groupBy} query={query} report={report} />,
+    costOverviewComponent: <CostOverview currency={currency} groupBy={groupBy} query={query} report={report} />,
+    currency,
     description: query[breakdownDescKey],
     detailsURL,
     emptyStateTitle: props.intl.formatMessage(messages.ibmDetailsTitle),
     groupBy,
     groupByValue,
-    historicalDataComponent: <HistoricalData />,
+    historicalDataComponent: <HistoricalData currency={currency} />,
     providers: filterProviders(providers, ProviderType.ibm),
     providersError,
     providersFetchStatus,

--- a/src/routes/views/details/ibmDetails/detailsHeader.tsx
+++ b/src/routes/views/details/ibmDetails/detailsHeader.tsx
@@ -23,7 +23,9 @@ import { formatCurrency } from 'utils/format';
 import { styles } from './detailsHeader.styles';
 
 interface DetailsHeaderOwnProps {
+  currency?: string;
   groupBy?: string;
+  onCurrencySelected(value: string);
   onGroupBySelected(value: string);
   report: IbmReport;
 }
@@ -63,9 +65,11 @@ const tagReportPathsType = TagPathsType.ibm;
 class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
   public render() {
     const {
+      currency,
       groupBy,
       isCurrencyFeatureEnabled,
       isExportsFeatureEnabled,
+      onCurrencySelected,
       onGroupBySelected,
       providers,
       providersError,
@@ -84,7 +88,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             {intl.formatMessage(messages.ibmDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency />}
+            {isCurrencyFeatureEnabled && <Currency onSelect={onCurrencySelected} currency={currency} />}
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>

--- a/src/routes/views/details/ibmDetails/detailsHeader.tsx
+++ b/src/routes/views/details/ibmDetails/detailsHeader.tsx
@@ -88,7 +88,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             {intl.formatMessage(messages.ibmDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency onSelect={onCurrencySelected} currency={currency} />}
+            {isCurrencyFeatureEnabled && <Currency currency={currency} onSelect={onCurrencySelected} />}
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>

--- a/src/routes/views/details/ibmDetails/ibmDetails.tsx
+++ b/src/routes/views/details/ibmDetails/ibmDetails.tsx
@@ -21,10 +21,12 @@ import { hasCurrentMonthData } from 'routes/views/utils/providers';
 import { filterProviders } from 'routes/views/utils/providers';
 import { addFilterToQuery, Filter, removeFilterFromQuery } from 'routes/views/utils/query';
 import { createMapStateToProps, FetchStatus } from 'store/common';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedIbmReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
+import { getCurrency } from 'utils/currency';
 
 import { DetailsHeader } from './detailsHeader';
 import { DetailsTable } from './detailsTable';
@@ -32,6 +34,7 @@ import { DetailsToolbar } from './detailsToolbar';
 import { styles } from './ibmDetails.styles';
 
 interface IbmDetailsStateProps {
+  currency?: string;
   providers: Providers;
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
@@ -92,6 +95,7 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
 
   constructor(stateProps, dispatchProps) {
     super(stateProps, dispatchProps);
+    this.handleCurrencySelected = this.handleCurrencySelected.bind(this);
     this.handleBulkSelected = this.handleBulkSelected.bind(this);
     this.handleExportModalClose = this.handleExportModalClose.bind(this);
     this.handleExportModalOpen = this.handleExportModalOpen.bind(this);
@@ -255,6 +259,16 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
     );
   };
 
+  private handleCurrencySelected = (value: string) => {
+    const { history, query } = this.props;
+
+    const newQuery = {
+      ...JSON.parse(JSON.stringify(query)),
+      currency: value,
+    };
+    history.replace(this.getRouteForQuery(newQuery));
+  };
+
   private handleBulkSelected = (action: string) => {
     const { isAllSelected } = this.state;
 
@@ -379,7 +393,8 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
   };
 
   public render() {
-    const { providers, providersFetchStatus, query, report, reportError, reportFetchStatus, intl } = this.props;
+    const { currency, providers, providersFetchStatus, query, report, reportError, reportFetchStatus, intl } =
+      this.props;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
@@ -403,7 +418,13 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
     }
     return (
       <div style={styles.ibmDetails}>
-        <DetailsHeader groupBy={groupById} onGroupBySelected={this.handleGroupBySelected} report={report} />
+        <DetailsHeader
+          currency={currency}
+          groupBy={groupById}
+          onCurrencySelected={this.handleCurrencySelected}
+          onGroupBySelected={this.handleGroupBySelected}
+          report={report}
+        />
         <div style={styles.content}>
           {this.getToolbar(computedItems)}
           {this.getExportModal(computedItems)}
@@ -426,16 +447,18 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<IbmDetailsOwnProps, IbmDetailsStateProps>((state, props) => {
   const queryFromRoute = parseQuery<IbmQuery>(location.search);
+  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
   const query = {
     delta: 'cost',
     filter: {
       ...baseQuery.filter,
       ...queryFromRoute.filter,
     },
-    exclude: queryFromRoute.exclude || baseQuery.exclude,
     filter_by: queryFromRoute.filter_by || baseQuery.filter_by,
+    exclude: queryFromRoute.exclude || baseQuery.exclude,
     group_by: queryFromRoute.group_by || baseQuery.group_by,
     order_by: queryFromRoute.order_by || baseQuery.order_by,
+    currency,
   };
   const queryString = getQuery(query);
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
@@ -452,6 +475,7 @@ const mapStateToProps = createMapStateToProps<IbmDetailsOwnProps, IbmDetailsStat
   );
 
   return {
+    currency,
     providers: filterProviders(providers, ProviderType.ibm),
     providersError,
     providersFetchStatus,

--- a/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
+++ b/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
@@ -24,6 +24,7 @@ type OciCostOwnProps = WrappedComponentProps;
 
 interface OciCostStateProps {
   CostOverview?: React.ReactNode;
+  currency?: string;
   detailsURL: string;
   HistoricalData?: React.ReactNode;
   providers: Providers;
@@ -51,6 +52,8 @@ const mapStateToProps = createMapStateToProps<OciCostOwnProps, OciCostStateProps
   const query = parseQuery<OcpQuery>(location.search);
   const groupBy = getGroupById(query);
   const groupByValue = getGroupByValue(query);
+  // Todo: Currency has not been implemented for OCI
+  const currency = /* featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : */ undefined;
 
   const newQuery: Query = {
     filter: {
@@ -66,6 +69,7 @@ const mapStateToProps = createMapStateToProps<OciCostOwnProps, OciCostStateProps
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
+    currency,
   };
   const queryString = getQuery(newQuery);
 
@@ -83,13 +87,14 @@ const mapStateToProps = createMapStateToProps<OciCostOwnProps, OciCostStateProps
   );
 
   return {
-    costOverviewComponent: <CostOverview groupBy={groupBy} report={report} />,
+    costOverviewComponent: <CostOverview currency={currency} groupBy={groupBy} report={report} />,
+    currency,
     description: query[breakdownDescKey],
     detailsURL,
     emptyStateTitle: props.intl.formatMessage(messages.ociDetailsTitle),
     groupBy,
     groupByValue,
-    historicalDataComponent: <HistoricalData />,
+    historicalDataComponent: <HistoricalData currency={currency} />,
     providers: filterProviders(providers, ProviderType.oci),
     providersError,
     providersFetchStatus,

--- a/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
+++ b/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
@@ -14,8 +14,10 @@ import BreakdownBase from 'routes/views/details/components/breakdown';
 import { getGroupById, getGroupByValue } from 'routes/views/utils/groupBy';
 import { filterProviders } from 'routes/views/utils/providers';
 import { createMapStateToProps, FetchStatus } from 'store/common';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
+import { getCurrency } from 'utils/currency';
 
 import { CostOverview } from './costOverview';
 import { HistoricalData } from './historicalData';
@@ -52,8 +54,7 @@ const mapStateToProps = createMapStateToProps<OciCostOwnProps, OciCostStateProps
   const query = parseQuery<OcpQuery>(location.search);
   const groupBy = getGroupById(query);
   const groupByValue = getGroupByValue(query);
-  // Todo: Currency has not been implemented for OCI
-  const currency = /* featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : */ undefined;
+  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
 
   const newQuery: Query = {
     filter: {

--- a/src/routes/views/details/ociDetails/detailsHeader.tsx
+++ b/src/routes/views/details/ociDetails/detailsHeader.tsx
@@ -87,7 +87,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             {intl.formatMessage(messages.ociDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency onSelect={onCurrencySelected} currency={currency} />}
+            {isCurrencyFeatureEnabled && <Currency currency={currency} onSelect={onCurrencySelected} />}
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>

--- a/src/routes/views/details/ociDetails/detailsHeader.tsx
+++ b/src/routes/views/details/ociDetails/detailsHeader.tsx
@@ -23,7 +23,9 @@ import { formatCurrency } from 'utils/format';
 import { styles } from './detailsHeader.styles';
 
 interface DetailsHeaderOwnProps {
+  currency?: string;
   groupBy?: string;
+  onCurrencySelected(value: string);
   onGroupBySelected(value: string);
   report: OciReport;
 }
@@ -62,9 +64,11 @@ const tagReportPathsType = TagPathsType.oci;
 class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
   public render() {
     const {
+      currency,
       groupBy,
       isCurrencyFeatureEnabled,
       isExportsFeatureEnabled,
+      onCurrencySelected,
       onGroupBySelected,
       providers,
       providersError,
@@ -83,7 +87,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             {intl.formatMessage(messages.ociDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency />}
+            {isCurrencyFeatureEnabled && <Currency onSelect={onCurrencySelected} currency={currency} />}
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>

--- a/src/routes/views/details/ociDetails/ociDetails.tsx
+++ b/src/routes/views/details/ociDetails/ociDetails.tsx
@@ -20,10 +20,12 @@ import { getGroupByTagKey } from 'routes/views/utils/groupBy';
 import { filterProviders, hasCurrentMonthData } from 'routes/views/utils/providers';
 import { addFilterToQuery, Filter, removeFilterFromQuery } from 'routes/views/utils/query';
 import { createMapStateToProps, FetchStatus } from 'store/common';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedOciReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
+import { getCurrency } from 'utils/currency';
 
 import { DetailsHeader } from './detailsHeader';
 import { DetailsTable } from './detailsTable';
@@ -445,8 +447,7 @@ class OciDetails extends React.Component<OciDetailsProps> {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<OciDetailsOwnProps, OciDetailsStateProps>((state, props) => {
   const queryFromRoute = parseQuery<OciQuery>(location.search);
-  // Todo: Currency has not been implemented for OCI
-  const currency = /* featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : */ undefined;
+  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
   const query = {
     delta: 'cost',
     filter: {

--- a/src/routes/views/details/ociDetails/ociDetails.tsx
+++ b/src/routes/views/details/ociDetails/ociDetails.tsx
@@ -31,6 +31,7 @@ import { DetailsToolbar } from './detailsToolbar';
 import { styles } from './ociDetails.styles';
 
 interface OciDetailsStateProps {
+  currency?: string;
   providers: Providers;
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
@@ -91,6 +92,7 @@ class OciDetails extends React.Component<OciDetailsProps> {
 
   constructor(stateProps, dispatchProps) {
     super(stateProps, dispatchProps);
+    this.handleCurrencySelected = this.handleCurrencySelected.bind(this);
     this.handleBulkSelected = this.handleBulkSelected.bind(this);
     this.handleExportModalClose = this.handleExportModalClose.bind(this);
     this.handleExportModalOpen = this.handleExportModalOpen.bind(this);
@@ -255,6 +257,16 @@ class OciDetails extends React.Component<OciDetailsProps> {
     );
   };
 
+  private handleCurrencySelected = (value: string) => {
+    const { history, query } = this.props;
+
+    const newQuery = {
+      ...JSON.parse(JSON.stringify(query)),
+      currency: value,
+    };
+    history.replace(this.getRouteForQuery(newQuery));
+  };
+
   private handleBulkSelected = (action: string) => {
     const { isAllSelected } = this.state;
 
@@ -379,7 +391,8 @@ class OciDetails extends React.Component<OciDetailsProps> {
   };
 
   public render() {
-    const { providers, providersFetchStatus, query, report, reportError, reportFetchStatus, intl } = this.props;
+    const { currency, providers, providersFetchStatus, query, report, reportError, reportFetchStatus, intl } =
+      this.props;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
@@ -403,7 +416,13 @@ class OciDetails extends React.Component<OciDetailsProps> {
     }
     return (
       <div style={styles.ociDetails}>
-        <DetailsHeader groupBy={groupById} onGroupBySelected={this.handleGroupBySelected} report={report} />
+        <DetailsHeader
+          currency={currency}
+          groupBy={groupById}
+          onCurrencySelected={this.handleCurrencySelected}
+          onGroupBySelected={this.handleGroupBySelected}
+          report={report}
+        />
         <div style={styles.content}>
           {this.getToolbar(computedItems)}
           {this.getExportModal(computedItems)}
@@ -426,16 +445,19 @@ class OciDetails extends React.Component<OciDetailsProps> {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<OciDetailsOwnProps, OciDetailsStateProps>((state, props) => {
   const queryFromRoute = parseQuery<OciQuery>(location.search);
+  // Todo: Currency has not been implemented for OCI
+  const currency = /* featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : */ undefined;
   const query = {
     delta: 'cost',
     filter: {
       ...baseQuery.filter,
       ...queryFromRoute.filter,
     },
-    exclude: queryFromRoute.exclude || baseQuery.exclude,
     filter_by: queryFromRoute.filter_by || baseQuery.filter_by,
+    exclude: queryFromRoute.exclude || baseQuery.exclude,
     group_by: queryFromRoute.group_by || baseQuery.group_by,
     order_by: queryFromRoute.order_by || baseQuery.order_by,
+    currency,
   };
   const queryString = getQuery(query);
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
@@ -452,6 +474,7 @@ const mapStateToProps = createMapStateToProps<OciDetailsOwnProps, OciDetailsStat
   );
 
   return {
+    currency,
     providers: filterProviders(providers, ProviderType.oci),
     providersError,
     providersFetchStatus,

--- a/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -14,8 +14,10 @@ import BreakdownBase from 'routes/views/details/components/breakdown';
 import { getGroupById, getGroupByValue } from 'routes/views/utils/groupBy';
 import { filterProviders } from 'routes/views/utils/providers';
 import { createMapStateToProps, FetchStatus } from 'store/common';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
+import { getCurrency } from 'utils/currency';
 
 import { CostOverview } from './costOverview';
 import { HistoricalData } from './historicalData';
@@ -24,6 +26,7 @@ type OcpBreakdownOwnProps = WrappedComponentProps;
 
 interface OcpBreakdownStateProps {
   CostOverview?: React.ReactNode;
+  currency?: string;
   detailsURL: string;
   HistoricalData?: React.ReactNode;
   query: Query;
@@ -48,6 +51,7 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
   const query = parseQuery<OcpQuery>(location.search);
   const groupBy = getGroupById(query);
   const groupByValue = getGroupByValue(query);
+  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
 
   const newQuery: Query = {
     filter: {
@@ -63,6 +67,7 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
+    currency,
   };
   const queryString = getQuery(newQuery);
 
@@ -79,13 +84,14 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
   );
 
   return {
-    costOverviewComponent: <CostOverview groupBy={groupBy} report={report} />,
+    costOverviewComponent: <CostOverview currency={currency} groupBy={groupBy} report={report} />,
+    currency,
     description: query[breakdownDescKey],
     detailsURL,
     emptyStateTitle: props.intl.formatMessage(messages.ocpDetailsTitle),
     groupBy,
     groupByValue,
-    historicalDataComponent: <HistoricalData />,
+    historicalDataComponent: <HistoricalData currency={currency} />,
     providers: filterProviders(providers, ProviderType.ocp),
     providersFetchStatus,
     providerType: ProviderType.ocp,

--- a/src/routes/views/details/ocpDetails/detailsHeader.tsx
+++ b/src/routes/views/details/ocpDetails/detailsHeader.tsx
@@ -24,7 +24,9 @@ import { formatCurrency } from 'utils/format';
 import { styles } from './detailsHeader.styles';
 
 interface DetailsHeaderOwnProps {
+  currency?: string;
   groupBy?: string;
+  onCurrencySelected(value: string);
   onGroupBySelected(value: string);
   report: OcpReport;
 }
@@ -68,9 +70,11 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
 
   public render() {
     const {
+      currency,
       groupBy,
       isCurrencyFeatureEnabled,
       isExportsFeatureEnabled,
+      onCurrencySelected,
       onGroupBySelected,
       providers,
       providersError,
@@ -108,7 +112,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             {intl.formatMessage(messages.ocpDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency />}
+            {isCurrencyFeatureEnabled && <Currency onSelect={onCurrencySelected} currency={currency} />}
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>

--- a/src/routes/views/details/ocpDetails/detailsHeader.tsx
+++ b/src/routes/views/details/ocpDetails/detailsHeader.tsx
@@ -112,7 +112,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             {intl.formatMessage(messages.ocpDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency onSelect={onCurrencySelected} currency={currency} />}
+            {isCurrencyFeatureEnabled && <Currency currency={currency} onSelect={onCurrencySelected} />}
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>

--- a/src/routes/views/explorer/explorer.tsx
+++ b/src/routes/views/explorer/explorer.tsx
@@ -448,7 +448,8 @@ class Explorer extends React.Component<ExplorerProps> {
   };
 
   private updateReport = () => {
-    const { dateRange, fetchReport, history, location, perspective, query, queryString } = this.props;
+    const { costType, currency, dateRange, fetchReport, history, location, perspective, query, queryString } =
+      this.props;
     if (!location.search) {
       history.replace(
         getRouteForQuery(history, {
@@ -457,6 +458,8 @@ class Explorer extends React.Component<ExplorerProps> {
           group_by: query ? query.group_by : undefined,
           order_by: query ? query.order_by : undefined,
           dateRange, // Preserve date range
+          cost_type: costType,
+          currency,
         })
       );
     } else if (perspective) {

--- a/src/routes/views/explorer/explorerChart.tsx
+++ b/src/routes/views/explorer/explorerChart.tsx
@@ -21,7 +21,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedExplorerReportItems';
 import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
-import { getCostType } from 'utils/costType';
+import { CostTypes } from 'utils/costType';
 import { formatUnits } from 'utils/format';
 import { skeletonWidth } from 'utils/skeleton';
 
@@ -37,6 +37,8 @@ import {
 } from './explorerUtils';
 
 interface ExplorerChartOwnProps extends RouteComponentProps<void>, WrappedComponentProps {
+  costType?: CostTypes;
+  currency?: string;
   computedReportItemType?: ComputedReportItemType;
   computedReportItemValueType?: ComputedReportItemValueType;
   perspective: PerspectiveType;
@@ -252,7 +254,7 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<ExplorerChartOwnProps, ExplorerChartStateProps>(
-  (state, { perspective }) => {
+  (state, { costType, currency, perspective }) => {
     const queryFromRoute = parseQuery<Query>(location.search);
     const dateRange = getDateRangeDefault(queryFromRoute);
     const { end_date, start_date } = getDateRange(dateRange);
@@ -276,7 +278,8 @@ const mapStateToProps = createMapStateToProps<ExplorerChartOwnProps, ExplorerCha
       dateRange,
       start_date,
       end_date,
-      ...(perspective === PerspectiveType.aws && { cost_type: getCostType() }),
+      cost_type: costType,
+      currency,
     };
     const queryString = getQuery({
       ...query,

--- a/src/routes/views/explorer/explorerFilter.tsx
+++ b/src/routes/views/explorer/explorerFilter.tsx
@@ -174,7 +174,7 @@ export class ExplorerFilterBase extends React.Component<ExplorerFilterProps> {
       dateRange: value,
     };
     this.setState({ currentDateRange: value }, () => {
-      history.replace(getRouteForQuery(history, newQuery, true));
+      history.replace(getRouteForQuery(history, newQuery));
     });
   };
 

--- a/src/routes/views/explorer/explorerHeader.tsx
+++ b/src/routes/views/explorer/explorerHeader.tsx
@@ -53,7 +53,10 @@ import {
 
 interface ExplorerHeaderOwnProps {
   costType?: CostTypes;
+  currency?: string;
   groupBy?: string;
+  onCostTypeSelected(value: string);
+  onCurrencySelected(value: string);
   onFilterAdded(filter: Filter);
   onFilterRemoved(filter: Filter);
   onGroupBySelected(value: string);
@@ -168,19 +171,8 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
       if (onPerspectiveClicked) {
         onPerspectiveClicked(value);
       }
-      history.replace(getRouteForQuery(history, newQuery, true));
+      history.replace(getRouteForQuery(history, newQuery));
     });
-  };
-
-  private handleCostTypeSelected = (value: string) => {
-    const { history, query } = this.props;
-
-    // Need param to restore cost type upon page refresh
-    const newQuery = {
-      ...JSON.parse(JSON.stringify(query)),
-      cost_type: value,
-    };
-    history.replace(getRouteForQuery(history, newQuery, false)); // Don't reset pagination
   };
 
   private isAwsAvailable = () => {
@@ -245,10 +237,13 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
   public render() {
     const {
       costType,
+      currency,
       groupBy,
       intl,
       isCurrencyFeatureEnabled,
       isExportsFeatureEnabled,
+      onCostTypeSelected,
+      onCurrencySelected,
       onFilterAdded,
       onFilterRemoved,
       onGroupBySelected,
@@ -277,7 +272,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
             {intl.formatMessage(messages.explorerTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency />}
+            {isCurrencyFeatureEnabled && <Currency currency={currency} onSelect={onCurrencySelected} />}
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>
@@ -299,7 +294,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
           </div>
           {perspective === PerspectiveType.aws && (
             <div style={styles.costType}>
-              <CostType onSelect={this.handleCostTypeSelected} costType={costType} />
+              <CostType costType={costType} onSelect={onCostTypeSelected} />
             </div>
           )}
         </div>
@@ -319,7 +314,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHeaderStateProps>(
-  (state, { costType, perspective }) => {
+  (state, { costType, currency, perspective }) => {
     const queryFromRoute = parseQuery<Query>(location.search);
     const dateRange = getDateRangeDefault(queryFromRoute);
     const { end_date, start_date } = getDateRange(dateRange);

--- a/src/routes/views/explorer/explorerHeader.tsx
+++ b/src/routes/views/explorer/explorerHeader.tsx
@@ -356,7 +356,8 @@ const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHe
       dateRange,
       start_date,
       end_date,
-      ...(perspective === PerspectiveType.aws && { cost_type: costType }),
+      cost_type: costType,
+      currency,
     };
     const queryString = getQuery({
       ...query,

--- a/src/routes/views/explorer/explorerUtils.ts
+++ b/src/routes/views/explorer/explorerUtils.ts
@@ -468,13 +468,6 @@ export const getTagReportPathsType = (perspective: string) => {
   return result;
 };
 
-export const getRouteForQuery = (history, query: Query, reset: boolean = false) => {
-  // Reset pagination
-  if (reset) {
-    query.filter = {
-      ...query.filter,
-      offset: baseQuery.filter.offset,
-    };
-  }
+export const getRouteForQuery = (history, query: Query) => {
   return `${history.location.pathname}?${getQueryRoute(query)}`;
 };

--- a/src/routes/views/overview/awsDashboard/awsDashboardWidget.tsx
+++ b/src/routes/views/overview/awsDashboard/awsDashboardWidget.tsx
@@ -7,10 +7,12 @@ import {
 } from 'routes/views/overview/components/dashboardWidgetBase';
 import { createMapStateToProps } from 'store/common';
 import { awsDashboardActions, awsDashboardSelectors, AwsDashboardTab } from 'store/dashboard/awsDashboard';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import { ComputedAwsReportItemsParams } from 'utils/computedReport/getComputedAwsReportItems';
 import { getCostType } from 'utils/costType';
+import { getCurrency } from 'utils/currency';
 
 interface AwsDashboardWidgetDispatchProps {
   fetchForecasts: typeof awsDashboardActions.fetchWidgetForecasts;
@@ -35,6 +37,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = awsDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
+      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
       costType: getCostType(),
       getIdKeyForTab,
       currentQuery: queries.current,

--- a/src/routes/views/overview/awsOcpDashboard/awsOcpDashboardWidget.tsx
+++ b/src/routes/views/overview/awsOcpDashboard/awsOcpDashboardWidget.tsx
@@ -7,9 +7,11 @@ import {
 } from 'routes/views/overview/components/dashboardWidgetBase';
 import { createMapStateToProps } from 'store/common';
 import { awsOcpDashboardActions, awsOcpDashboardSelectors, AwsOcpDashboardTab } from 'store/dashboard/awsOcpDashboard';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import { ComputedAwsReportItemsParams } from 'utils/computedReport/getComputedAwsReportItems';
+import { getCurrency } from 'utils/currency';
 
 interface AwsOcpDashboardWidgetDispatchProps {
   fetchForecasts: typeof awsOcpDashboardActions.fetchWidgetForecasts;
@@ -34,6 +36,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = awsOcpDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
+      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
       getIdKeyForTab,
       currentQuery: queries.current,
       forecastQuery: queries.forecast,

--- a/src/routes/views/overview/azureDashboard/azureDashboardWidget.tsx
+++ b/src/routes/views/overview/azureDashboard/azureDashboardWidget.tsx
@@ -7,9 +7,11 @@ import {
 } from 'routes/views/overview/components/dashboardWidgetBase';
 import { createMapStateToProps } from 'store/common';
 import { azureDashboardActions, azureDashboardSelectors, AzureDashboardTab } from 'store/dashboard/azureDashboard';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import { ComputedAzureReportItemsParams } from 'utils/computedReport/getComputedAzureReportItems';
+import { getCurrency } from 'utils/currency';
 
 interface AzureDashboardWidgetDispatchProps {
   fetchForecasts: typeof azureDashboardActions.fetchWidgetForecasts;
@@ -34,6 +36,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = azureDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
+      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
       getIdKeyForTab,
       currentQuery: queries.current,
       forecastQuery: queries.forecast,

--- a/src/routes/views/overview/azureOcpDashboard/azureOcpDashboardWidget.tsx
+++ b/src/routes/views/overview/azureOcpDashboard/azureOcpDashboardWidget.tsx
@@ -11,9 +11,11 @@ import {
   azureOcpDashboardSelectors,
   AzureOcpDashboardTab,
 } from 'store/dashboard/azureOcpDashboard';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import { ComputedAzureReportItemsParams } from 'utils/computedReport/getComputedAzureReportItems';
+import { getCurrency } from 'utils/currency';
 
 interface AzureOcpDashboardWidgetDispatchProps {
   fetchForecasts: typeof azureOcpDashboardActions.fetchWidgetForecasts;
@@ -38,6 +40,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = azureOcpDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
+      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
       getIdKeyForTab,
       currentQuery: queries.current,
       forecastQuery: queries.forecast,

--- a/src/routes/views/overview/components/dashboardBase.tsx
+++ b/src/routes/views/overview/components/dashboardBase.tsx
@@ -6,6 +6,7 @@ type DashboardOwnProps = WrappedComponentProps;
 
 interface DashboardStateProps {
   costType?: string;
+  currency?: string;
   DashboardWidget: any;
   widgets: number[];
 }
@@ -16,18 +17,18 @@ interface DashboardDispatchProps {
 
 type DashboardProps = DashboardOwnProps & DashboardStateProps & DashboardDispatchProps;
 
-const DashboardBase: React.FC<DashboardProps> = ({ costType, DashboardWidget, selectWidgets, widgets }) => (
+const DashboardBase: React.FC<DashboardProps> = ({ costType, currency, DashboardWidget, selectWidgets, widgets }) => (
   <div>
     <Grid hasGutter>
       {widgets.map(widgetId => {
         const widget = selectWidgets[widgetId];
         return widget.details.showHorizontal ? (
           <GridItem sm={12} key={widgetId}>
-            <DashboardWidget widgetId={widgetId} {...(costType && { costType })} />
+            <DashboardWidget widgetId={widgetId} {...(costType && { costType })} {...(currency && { currency })} />
           </GridItem>
         ) : (
           <GridItem lg={12} xl={6} xl2={4} key={widgetId}>
-            <DashboardWidget widgetId={widgetId} {...(costType && { costType })} />
+            <DashboardWidget widgetId={widgetId} {...(costType && { costType })} {...(currency && { currency })} />
           </GridItem>
         );
       })}

--- a/src/routes/views/overview/components/dashboardWidgetBase.tsx
+++ b/src/routes/views/overview/components/dashboardWidgetBase.tsx
@@ -43,6 +43,7 @@ interface DashboardWidgetOwnProps {
   chartAltHeight?: number;
   containerAltHeight?: number;
   costType?: string;
+  currency?: string;
   getIdKeyForTab: <T extends DashboardWidget<any>>(tab: T) => string;
   widgetId: number;
 }
@@ -91,9 +92,9 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
   }
 
   public componentDidUpdate(prevProps: DashboardWidgetProps) {
-    const { costType, fetchReports, fetchForecasts, trend, widgetId } = this.props;
+    const { costType, currency, fetchReports, fetchForecasts, trend, widgetId } = this.props;
 
-    if (prevProps.costType !== costType) {
+    if (prevProps.costType !== costType || prevProps.currency !== currency) {
       fetchReports(widgetId);
       if (trend.computedForecastItem !== undefined) {
         fetchForecasts(widgetId);

--- a/src/routes/views/overview/gcpDashboard/gcpDashboardWidget.tsx
+++ b/src/routes/views/overview/gcpDashboard/gcpDashboardWidget.tsx
@@ -7,9 +7,11 @@ import {
 } from 'routes/views/overview/components/dashboardWidgetBase';
 import { createMapStateToProps } from 'store/common';
 import { gcpDashboardActions, gcpDashboardSelectors, GcpDashboardTab } from 'store/dashboard/gcpDashboard';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import { ComputedGcpReportItemsParams } from 'utils/computedReport/getComputedGcpReportItems';
+import { getCurrency } from 'utils/currency';
 
 interface GcpDashboardWidgetDispatchProps {
   fetchForecasts: typeof gcpDashboardActions.fetchWidgetForecasts;
@@ -34,6 +36,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = gcpDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
+      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
       getIdKeyForTab,
       currentQuery: queries.current,
       previousQuery: queries.previous,

--- a/src/routes/views/overview/gcpOcpDashboard/gcpOcpDashboardWidget.tsx
+++ b/src/routes/views/overview/gcpOcpDashboard/gcpOcpDashboardWidget.tsx
@@ -7,9 +7,11 @@ import {
 } from 'routes/views/overview/components/dashboardWidgetBase';
 import { createMapStateToProps } from 'store/common';
 import { gcpOcpDashboardActions, gcpOcpDashboardSelectors, GcpOcpDashboardTab } from 'store/dashboard/gcpOcpDashboard';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import { ComputedGcpReportItemsParams } from 'utils/computedReport/getComputedGcpReportItems';
+import { getCurrency } from 'utils/currency';
 
 interface GcpOcpDashboardWidgetDispatchProps {
   fetchForecasts: typeof gcpOcpDashboardActions.fetchWidgetForecasts;
@@ -34,6 +36,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = gcpOcpDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
+      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
       getIdKeyForTab,
       currentQuery: queries.current,
       previousQuery: queries.previous,

--- a/src/routes/views/overview/ibmDashboard/ibmDashboardWidget.tsx
+++ b/src/routes/views/overview/ibmDashboard/ibmDashboardWidget.tsx
@@ -7,9 +7,11 @@ import {
 } from 'routes/views/overview/components/dashboardWidgetBase';
 import { createMapStateToProps } from 'store/common';
 import { ibmDashboardActions, ibmDashboardSelectors, IbmDashboardTab } from 'store/dashboard/ibmDashboard';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import { ComputedIbmReportItemsParams } from 'utils/computedReport/getComputedIbmReportItems';
+import { getCurrency } from 'utils/currency';
 
 interface IbmDashboardWidgetDispatchProps {
   fetchForecasts: typeof ibmDashboardActions.fetchWidgetForecasts;
@@ -34,6 +36,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = ibmDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
+      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
       getIdKeyForTab,
       currentQuery: queries.current,
       previousQuery: queries.previous,

--- a/src/routes/views/overview/ociDashboard/ociDashboardWidget.tsx
+++ b/src/routes/views/overview/ociDashboard/ociDashboardWidget.tsx
@@ -34,6 +34,8 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = ociDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
+      // Todo: Currency has not been implemented for OCI
+      // ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
       getIdKeyForTab,
       currentQuery: queries.current,
       forecastQuery: queries.forecast,

--- a/src/routes/views/overview/ociDashboard/ociDashboardWidget.tsx
+++ b/src/routes/views/overview/ociDashboard/ociDashboardWidget.tsx
@@ -7,9 +7,11 @@ import {
 } from 'routes/views/overview/components/dashboardWidgetBase';
 import { createMapStateToProps } from 'store/common';
 import { ociDashboardActions, ociDashboardSelectors, OciDashboardTab } from 'store/dashboard/ociDashboard';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import { ComputedOciReportItemsParams } from 'utils/computedReport/getComputedOciReportItems';
+import { getCurrency } from 'utils/currency';
 
 interface OciDashboardWidgetDispatchProps {
   fetchForecasts: typeof ociDashboardActions.fetchWidgetForecasts;
@@ -34,8 +36,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = ociDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
-      // Todo: Currency has not been implemented for OCI
-      // ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
       getIdKeyForTab,
       currentQuery: queries.current,
       forecastQuery: queries.forecast,

--- a/src/routes/views/overview/ocpCloudDashboard/ocpCloudDashboardWidget.tsx
+++ b/src/routes/views/overview/ocpCloudDashboard/ocpCloudDashboardWidget.tsx
@@ -11,9 +11,11 @@ import {
   ocpCloudDashboardSelectors,
   OcpCloudDashboardTab,
 } from 'store/dashboard/ocpCloudDashboard';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import { ComputedOcpCloudReportItemsParams } from 'utils/computedReport/getComputedOcpCloudReportItems';
+import { getCurrency } from 'utils/currency';
 
 interface OcpCloudDashboardWidgetDispatchProps {
   fetchForecasts: typeof ocpCloudDashboardActions.fetchWidgetForecasts;
@@ -38,6 +40,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = ocpCloudDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
+      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
       getIdKeyForTab,
       currentQuery: queries.current,
       forecastQuery: queries.forecast,

--- a/src/routes/views/overview/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/routes/views/overview/ocpDashboard/ocpDashboardWidget.tsx
@@ -7,9 +7,11 @@ import {
 } from 'routes/views/overview/components/dashboardWidgetBase';
 import { createMapStateToProps } from 'store/common';
 import { ocpDashboardActions, ocpDashboardSelectors, OcpDashboardTab } from 'store/dashboard/ocpDashboard';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import { ComputedOcpReportItemsParams } from 'utils/computedReport/getComputedOcpReportItems';
+import { getCurrency } from 'utils/currency';
 
 import { chartStyles } from './ocpDashboardWidget.styles';
 
@@ -36,6 +38,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = ocpDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
+      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
       getIdKeyForTab,
       chartAltHeight: chartStyles.chartAltHeight,
       containerAltHeight: chartStyles.containerAltHeight,

--- a/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
@@ -43,7 +43,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       props
     ),
     current: getQueryForWidget(widget, filter, props),
-    forecast: getQueryForWidget(widget, {}), // Todo: Currency has not been implemented for forecast
+    forecast: getQueryForWidget(widget, {}, props),
     tabs: getQueryForWidgetTabs(
       widget,
       {

--- a/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
@@ -1,4 +1,6 @@
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { RootState } from 'store/rootReducer';
+import { getCurrency } from 'utils/currency';
 
 import {
   awsDashboardDefaultFilters,
@@ -27,17 +29,28 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...awsDashboardTabFilters,
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
+  const props = {
+    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+  };
 
   return {
-    previous: getQueryForWidget(widget, {
-      ...filter,
-      time_scope_value: -2,
-    }),
-    current: getQueryForWidget(widget, filter),
-    forecast: getQueryForWidget(widget, {}),
-    tabs: getQueryForWidgetTabs(widget, {
-      ...tabsFilter,
-      resolution: 'monthly',
-    }),
+    previous: getQueryForWidget(
+      widget,
+      {
+        ...filter,
+        time_scope_value: -2,
+      },
+      props
+    ),
+    current: getQueryForWidget(widget, filter, props),
+    forecast: getQueryForWidget(widget, {}), // Todo: Currency has not been implemented for forecast
+    tabs: getQueryForWidgetTabs(
+      widget,
+      {
+        ...tabsFilter,
+        resolution: 'monthly',
+      },
+      props
+    ),
   };
 };

--- a/src/store/dashboard/awsOcpDashboard/awsOcpDashboardCommon.ts
+++ b/src/store/dashboard/awsOcpDashboard/awsOcpDashboardCommon.ts
@@ -47,7 +47,8 @@ export function getQueryForWidget(filter: AwsFilters = awsOcpDashboardDefaultFil
 
 export function getQueryForWidgetTabs(
   widget: AwsOcpDashboardWidget,
-  filter: AwsFilters = awsOcpDashboardDefaultFilters
+  filter: AwsFilters = awsOcpDashboardDefaultFilters,
+  props?
 ) {
   const group_by = getGroupByForTab(widget);
   const newFilter = {
@@ -61,6 +62,7 @@ export function getQueryForWidgetTabs(
   const query: AwsQuery = {
     filter: newFilter,
     group_by,
+    ...(props ? props : {}),
   };
   return getQuery(query);
 }

--- a/src/store/dashboard/awsOcpDashboard/awsOcpDashboardSelectors.ts
+++ b/src/store/dashboard/awsOcpDashboard/awsOcpDashboardSelectors.ts
@@ -1,4 +1,6 @@
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { RootState } from 'store/rootReducer';
+import { getCurrency } from 'utils/currency';
 
 import {
   awsOcpDashboardDefaultFilters,
@@ -27,17 +29,27 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...awsOcpDashboardTabFilters,
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
+  const props = {
+    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+  };
 
   return {
-    previous: getQueryForWidget({
-      ...filter,
-      time_scope_value: -2,
-    }),
-    current: getQueryForWidget(filter),
-    forecast: getQueryForWidget({}, { limit: 31 }),
-    tabs: getQueryForWidgetTabs(widget, {
-      ...tabsFilter,
-      resolution: 'monthly',
-    }),
+    previous: getQueryForWidget(
+      {
+        ...filter,
+        time_scope_value: -2,
+      },
+      props
+    ),
+    current: getQueryForWidget(filter, props),
+    forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
+    tabs: getQueryForWidgetTabs(
+      widget,
+      {
+        ...tabsFilter,
+        resolution: 'monthly',
+      },
+      props
+    ),
   };
 };

--- a/src/store/dashboard/awsOcpDashboard/awsOcpDashboardSelectors.ts
+++ b/src/store/dashboard/awsOcpDashboard/awsOcpDashboardSelectors.ts
@@ -42,7 +42,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       props
     ),
     current: getQueryForWidget(filter, props),
-    forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
+    forecast: getQueryForWidget({}, { limit: 31, ...props }),
     tabs: getQueryForWidgetTabs(
       widget,
       {

--- a/src/store/dashboard/azureDashboard/azureDashboardCommon.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardCommon.ts
@@ -47,7 +47,8 @@ export function getQueryForWidget(filter: AzureFilters = azureDashboardDefaultFi
 
 export function getQueryForWidgetTabs(
   widget: AzureDashboardWidget,
-  filter: AzureFilters = azureDashboardDefaultFilters
+  filter: AzureFilters = azureDashboardDefaultFilters,
+  props?
 ) {
   const group_by = getGroupByForTab(widget);
   const newFilter = {
@@ -61,6 +62,7 @@ export function getQueryForWidgetTabs(
   const query: AzureQuery = {
     filter: newFilter,
     group_by,
+    ...(props ? props : {}),
   };
   return getQuery(query);
 }

--- a/src/store/dashboard/azureDashboard/azureDashboardSelectors.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardSelectors.ts
@@ -1,4 +1,6 @@
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { RootState } from 'store/rootReducer';
+import { getCurrency } from 'utils/currency';
 
 import {
   azureDashboardDefaultFilters,
@@ -27,17 +29,27 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...azureDashboardTabFilters,
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
+  const props = {
+    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+  };
 
   return {
-    previous: getQueryForWidget({
-      ...filter,
-      time_scope_value: -2,
-    }),
-    current: getQueryForWidget(filter),
-    forecast: getQueryForWidget({}, { limit: 31 }),
-    tabs: getQueryForWidgetTabs(widget, {
-      ...tabsFilter,
-      resolution: 'monthly',
-    }),
+    previous: getQueryForWidget(
+      {
+        ...filter,
+        time_scope_value: -2,
+      },
+      props
+    ),
+    current: getQueryForWidget(filter, props),
+    forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
+    tabs: getQueryForWidgetTabs(
+      widget,
+      {
+        ...tabsFilter,
+        resolution: 'monthly',
+      },
+      props
+    ),
   };
 };

--- a/src/store/dashboard/azureDashboard/azureDashboardSelectors.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardSelectors.ts
@@ -42,7 +42,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       props
     ),
     current: getQueryForWidget(filter, props),
-    forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
+    forecast: getQueryForWidget({}, { limit: 31, ...props }),
     tabs: getQueryForWidgetTabs(
       widget,
       {

--- a/src/store/dashboard/azureOcpDashboard/azureOcpDashboardCommon.ts
+++ b/src/store/dashboard/azureOcpDashboard/azureOcpDashboardCommon.ts
@@ -47,7 +47,8 @@ export function getQueryForWidget(filter: AzureFilters = azureOcpDashboardDefaul
 
 export function getQueryForWidgetTabs(
   widget: AzureOcpDashboardWidget,
-  filter: AzureFilters = azureOcpDashboardDefaultFilters
+  filter: AzureFilters = azureOcpDashboardDefaultFilters,
+  props?
 ) {
   const group_by = getGroupByForTab(widget);
   const newFilter = {
@@ -61,6 +62,7 @@ export function getQueryForWidgetTabs(
   const query: AzureQuery = {
     filter: newFilter,
     group_by,
+    ...(props ? props : {}),
   };
   return getQuery(query);
 }

--- a/src/store/dashboard/azureOcpDashboard/azureOcpDashboardSelectors.ts
+++ b/src/store/dashboard/azureOcpDashboard/azureOcpDashboardSelectors.ts
@@ -1,4 +1,6 @@
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { RootState } from 'store/rootReducer';
+import { getCurrency } from 'utils/currency';
 
 import {
   azureOcpDashboardDefaultFilters,
@@ -27,17 +29,27 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...azureOcpDashboardTabFilters,
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
+  const props = {
+    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+  };
 
   return {
-    previous: getQueryForWidget({
-      ...filter,
-      time_scope_value: -2,
-    }),
-    current: getQueryForWidget(filter),
-    forecast: getQueryForWidget({}, { limit: 31 }),
-    tabs: getQueryForWidgetTabs(widget, {
-      ...tabsFilter,
-      resolution: 'monthly',
-    }),
+    previous: getQueryForWidget(
+      {
+        ...filter,
+        time_scope_value: -2,
+      },
+      props
+    ),
+    current: getQueryForWidget(filter, props),
+    forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
+    tabs: getQueryForWidgetTabs(
+      widget,
+      {
+        ...tabsFilter,
+        resolution: 'monthly',
+      },
+      props
+    ),
   };
 };

--- a/src/store/dashboard/azureOcpDashboard/azureOcpDashboardSelectors.ts
+++ b/src/store/dashboard/azureOcpDashboard/azureOcpDashboardSelectors.ts
@@ -42,7 +42,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       props
     ),
     current: getQueryForWidget(filter, props),
-    forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
+    forecast: getQueryForWidget({}, { limit: 31, ...props }),
     tabs: getQueryForWidgetTabs(
       widget,
       {

--- a/src/store/dashboard/gcpDashboard/gcpDashboardCommon.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardCommon.ts
@@ -48,7 +48,11 @@ export function getQueryForWidget(filter: GcpFilters = gcpDashboardDefaultFilter
   return getQuery(query);
 }
 
-export function getQueryForWidgetTabs(widget: GcpDashboardWidget, filter: GcpFilters = gcpDashboardDefaultFilters) {
+export function getQueryForWidgetTabs(
+  widget: GcpDashboardWidget,
+  filter: GcpFilters = gcpDashboardDefaultFilters,
+  props?
+) {
   const group_by = getGroupByForTab(widget);
   const newFilter = {
     ...JSON.parse(JSON.stringify(filter)),
@@ -61,6 +65,7 @@ export function getQueryForWidgetTabs(widget: GcpDashboardWidget, filter: GcpFil
   const query: GcpQuery = {
     filter: newFilter,
     group_by,
+    ...(props ? props : {}),
   };
   return getQuery(query);
 }

--- a/src/store/dashboard/gcpDashboard/gcpDashboardSelectors.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardSelectors.ts
@@ -1,4 +1,6 @@
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { RootState } from 'store/rootReducer';
+import { getCurrency } from 'utils/currency';
 
 import {
   gcpDashboardDefaultFilters,
@@ -27,17 +29,27 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...gcpDashboardTabFilters,
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
+  const props = {
+    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+  };
 
   return {
-    previous: getQueryForWidget({
-      ...filter,
-      time_scope_value: -2,
-    }),
-    current: getQueryForWidget(filter),
-    forecast: getQueryForWidget({}, { limit: 31 }),
-    tabs: getQueryForWidgetTabs(widget, {
-      ...tabsFilter,
-      resolution: 'monthly',
-    }),
+    previous: getQueryForWidget(
+      {
+        ...filter,
+        time_scope_value: -2,
+      },
+      props
+    ),
+    current: getQueryForWidget(filter, props),
+    forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
+    tabs: getQueryForWidgetTabs(
+      widget,
+      {
+        ...tabsFilter,
+        resolution: 'monthly',
+      },
+      props
+    ),
   };
 };

--- a/src/store/dashboard/gcpDashboard/gcpDashboardSelectors.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardSelectors.ts
@@ -42,7 +42,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       props
     ),
     current: getQueryForWidget(filter, props),
-    forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
+    forecast: getQueryForWidget({}, { limit: 31, ...props }),
     tabs: getQueryForWidgetTabs(
       widget,
       {

--- a/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardCommon.ts
+++ b/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardCommon.ts
@@ -50,7 +50,8 @@ export function getQueryForWidget(filter: GcpFilters = gcpOcpDashboardDefaultFil
 
 export function getQueryForWidgetTabs(
   widget: GcpOcpDashboardWidget,
-  filter: GcpFilters = gcpOcpDashboardDefaultFilters
+  filter: GcpFilters = gcpOcpDashboardDefaultFilters,
+  props?
 ) {
   const group_by = getGroupByForTab(widget);
   const newFilter = {
@@ -64,6 +65,7 @@ export function getQueryForWidgetTabs(
   const query: GcpQuery = {
     filter: newFilter,
     group_by,
+    ...(props ? props : {}),
   };
   return getQuery(query);
 }

--- a/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardSelectors.ts
+++ b/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardSelectors.ts
@@ -1,4 +1,6 @@
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { RootState } from 'store/rootReducer';
+import { getCurrency } from 'utils/currency';
 
 import {
   gcpOcpDashboardDefaultFilters,
@@ -27,17 +29,27 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...gcpOcpDashboardTabFilters,
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
+  const props = {
+    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+  };
 
   return {
-    previous: getQueryForWidget({
-      ...filter,
-      time_scope_value: -2,
-    }),
-    current: getQueryForWidget(filter),
-    forecast: getQueryForWidget({}, { limit: 31 }),
-    tabs: getQueryForWidgetTabs(widget, {
-      ...tabsFilter,
-      resolution: 'monthly',
-    }),
+    previous: getQueryForWidget(
+      {
+        ...filter,
+        time_scope_value: -2,
+      },
+      props
+    ),
+    current: getQueryForWidget(filter, props),
+    forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
+    tabs: getQueryForWidgetTabs(
+      widget,
+      {
+        ...tabsFilter,
+        resolution: 'monthly',
+      },
+      props
+    ),
   };
 };

--- a/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardSelectors.ts
+++ b/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardSelectors.ts
@@ -42,7 +42,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       props
     ),
     current: getQueryForWidget(filter, props),
-    forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
+    forecast: getQueryForWidget({}, { limit: 31, ...props }),
     tabs: getQueryForWidgetTabs(
       widget,
       {

--- a/src/store/dashboard/ibmDashboard/ibmDashboardCommon.ts
+++ b/src/store/dashboard/ibmDashboard/ibmDashboardCommon.ts
@@ -48,7 +48,11 @@ export function getQueryForWidget(filter: IbmFilters = ibmDashboardDefaultFilter
   return getQuery(query);
 }
 
-export function getQueryForWidgetTabs(widget: IbmDashboardWidget, filter: IbmFilters = ibmDashboardDefaultFilters) {
+export function getQueryForWidgetTabs(
+  widget: IbmDashboardWidget,
+  filter: IbmFilters = ibmDashboardDefaultFilters,
+  props?
+) {
   const group_by = getGroupByForTab(widget);
   const newFilter = {
     ...JSON.parse(JSON.stringify(filter)),
@@ -61,6 +65,7 @@ export function getQueryForWidgetTabs(widget: IbmDashboardWidget, filter: IbmFil
   const query: IbmQuery = {
     filter: newFilter,
     group_by,
+    ...(props ? props : {}),
   };
   return getQuery(query);
 }

--- a/src/store/dashboard/ibmDashboard/ibmDashboardSelectors.ts
+++ b/src/store/dashboard/ibmDashboard/ibmDashboardSelectors.ts
@@ -1,4 +1,6 @@
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { RootState } from 'store/rootReducer';
+import { getCurrency } from 'utils/currency';
 
 import {
   getQueryForWidget,
@@ -27,17 +29,27 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...ibmDashboardTabFilters,
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
+  const props = {
+    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+  };
 
   return {
-    previous: getQueryForWidget({
-      ...filter,
-      time_scope_value: -2,
-    }),
-    current: getQueryForWidget(filter),
-    forecast: getQueryForWidget({}, { limit: 31 }),
-    tabs: getQueryForWidgetTabs(widget, {
-      ...tabsFilter,
-      resolution: 'monthly',
-    }),
+    previous: getQueryForWidget(
+      {
+        ...filter,
+        time_scope_value: -2,
+      },
+      props
+    ),
+    current: getQueryForWidget(filter, props),
+    forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
+    tabs: getQueryForWidgetTabs(
+      widget,
+      {
+        ...tabsFilter,
+        resolution: 'monthly',
+      },
+      props
+    ),
   };
 };

--- a/src/store/dashboard/ibmDashboard/ibmDashboardSelectors.ts
+++ b/src/store/dashboard/ibmDashboard/ibmDashboardSelectors.ts
@@ -42,7 +42,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       props
     ),
     current: getQueryForWidget(filter, props),
-    forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
+    forecast: getQueryForWidget({}, { limit: 31, ...props }),
     tabs: getQueryForWidgetTabs(
       widget,
       {

--- a/src/store/dashboard/ociDashboard/ociDashboardCommon.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboardCommon.ts
@@ -45,7 +45,11 @@ export function getQueryForWidget(filter: OciFilters = ociDashboardDefaultFilter
   return getQuery(query);
 }
 
-export function getQueryForWidgetTabs(widget: OciDashboardWidget, filter: OciFilters = ociDashboardDefaultFilters) {
+export function getQueryForWidgetTabs(
+  widget: OciDashboardWidget,
+  filter: OciFilters = ociDashboardDefaultFilters,
+  props?
+) {
   const group_by = getGroupByForTab(widget);
   const newFilter = {
     ...JSON.parse(JSON.stringify(filter)),
@@ -61,6 +65,7 @@ export function getQueryForWidgetTabs(widget: OciDashboardWidget, filter: OciFil
   const query: OciQuery = {
     filter: newFilter,
     group_by,
+    ...(props ? props : {}),
   };
   return getQuery(query);
 }

--- a/src/store/dashboard/ociDashboard/ociDashboardSelectors.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboardSelectors.ts
@@ -1,4 +1,6 @@
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { RootState } from 'store/rootReducer';
+import { getCurrency } from 'utils/currency';
 
 import {
   getQueryForWidget,
@@ -27,21 +29,27 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...ociDashboardTabFilters,
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
-  // Todo: Currency has not been implemented for OCI
-  // const props = {
-  //   ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
-  // };
+  const props = {
+    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+  };
 
   return {
-    previous: getQueryForWidget({
-      ...filter,
-      time_scope_value: -2,
-    }),
-    current: getQueryForWidget(filter),
+    previous: getQueryForWidget(
+      {
+        ...filter,
+        time_scope_value: -2,
+      },
+      props
+    ),
+    current: getQueryForWidget(filter, props),
     forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
-    tabs: getQueryForWidgetTabs(widget, {
-      ...tabsFilter,
-      resolution: 'monthly',
-    }),
+    tabs: getQueryForWidgetTabs(
+      widget,
+      {
+        ...tabsFilter,
+        resolution: 'monthly',
+      },
+      props
+    ),
   };
 };

--- a/src/store/dashboard/ociDashboard/ociDashboardSelectors.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboardSelectors.ts
@@ -42,7 +42,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       props
     ),
     current: getQueryForWidget(filter, props),
-    forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
+    forecast: getQueryForWidget({}, { limit: 31, ...props }),
     tabs: getQueryForWidgetTabs(
       widget,
       {

--- a/src/store/dashboard/ociDashboard/ociDashboardSelectors.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboardSelectors.ts
@@ -27,6 +27,10 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...ociDashboardTabFilters,
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
+  // Todo: Currency has not been implemented for OCI
+  // const props = {
+  //   ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+  // };
 
   return {
     previous: getQueryForWidget({
@@ -34,7 +38,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       time_scope_value: -2,
     }),
     current: getQueryForWidget(filter),
-    forecast: getQueryForWidget({}, { limit: 31 }),
+    forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
     tabs: getQueryForWidgetTabs(widget, {
       ...tabsFilter,
       resolution: 'monthly',

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardCommon.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardCommon.ts
@@ -48,7 +48,8 @@ export function getQueryForWidget(filter: OcpCloudFilters = ocpCloudDashboardDef
 
 export function getQueryForWidgetTabs(
   widget: OcpCloudDashboardWidget,
-  filter: OcpCloudFilters = ocpCloudDashboardDefaultFilters
+  filter: OcpCloudFilters = ocpCloudDashboardDefaultFilters,
+  props?
 ) {
   const group_by = getGroupByForTab(widget);
   const newFilter = {
@@ -62,6 +63,7 @@ export function getQueryForWidgetTabs(
   const query: OcpCloudQuery = {
     filter: newFilter,
     group_by,
+    ...(props ? props : {}),
   };
   return getQuery(query);
 }

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardSelectors.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardSelectors.ts
@@ -1,4 +1,6 @@
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { RootState } from 'store/rootReducer';
+import { getCurrency } from 'utils/currency';
 
 import {
   getQueryForWidget,
@@ -27,17 +29,27 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...ocpCloudDashboardTabFilters,
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
+  const props = {
+    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+  };
 
   return {
-    previous: getQueryForWidget({
-      ...defaultFilter,
-      time_scope_value: -2,
-    }),
-    current: getQueryForWidget(defaultFilter),
-    forecast: getQueryForWidget({}, { limit: 31 }),
-    tabs: getQueryForWidgetTabs(widget, {
-      ...tabsFilter,
-      resolution: 'monthly',
-    }),
+    previous: getQueryForWidget(
+      {
+        ...defaultFilter,
+        time_scope_value: -2,
+      },
+      props
+    ),
+    current: getQueryForWidget(defaultFilter, props),
+    forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
+    tabs: getQueryForWidgetTabs(
+      widget,
+      {
+        ...tabsFilter,
+        resolution: 'monthly',
+      },
+      props
+    ),
   };
 };

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardSelectors.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardSelectors.ts
@@ -42,7 +42,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       props
     ),
     current: getQueryForWidget(defaultFilter, props),
-    forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
+    forecast: getQueryForWidget({}, { limit: 31, ...props }),
     tabs: getQueryForWidgetTabs(
       widget,
       {

--- a/src/store/dashboard/ocpDashboard/ocpDashboardCommon.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardCommon.ts
@@ -43,10 +43,15 @@ export function getQueryForWidget(filter: OcpFilters = ocpDashboardDefaultFilter
   return getQuery(query);
 }
 
-export function getQueryForWidgetTabs(widget: OcpDashboardWidget, filter: OcpFilters = ocpDashboardDefaultFilters) {
+export function getQueryForWidgetTabs(
+  widget: OcpDashboardWidget,
+  filter: OcpFilters = ocpDashboardDefaultFilters,
+  props?
+) {
   const query: OcpQuery = {
     filter,
     group_by: getGroupByForTab(widget.currentTab),
+    ...(props ? props : {}),
   };
   return getQuery(query);
 }

--- a/src/store/dashboard/ocpDashboard/ocpDashboardSelectors.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardSelectors.ts
@@ -42,7 +42,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       props
     ),
     current: getQueryForWidget(defaultFilter, props),
-    forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
+    forecast: getQueryForWidget({}, { limit: 31, ...props }),
     tabs: getQueryForWidgetTabs(
       widget,
       {

--- a/src/store/dashboard/ocpDashboard/ocpDashboardSelectors.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardSelectors.ts
@@ -1,4 +1,6 @@
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { RootState } from 'store/rootReducer';
+import { getCurrency } from 'utils/currency';
 
 import {
   getQueryForWidget,
@@ -27,17 +29,27 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...ocpDashboardTabFilters,
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
+  const props = {
+    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+  };
 
   return {
-    previous: getQueryForWidget({
-      ...defaultFilter,
-      time_scope_value: -2,
-    }),
-    current: getQueryForWidget(defaultFilter),
-    forecast: getQueryForWidget({}, { limit: 31 }),
-    tabs: getQueryForWidgetTabs(widget, {
-      ...tabsFilter,
-      resolution: 'monthly',
-    }),
+    previous: getQueryForWidget(
+      {
+        ...defaultFilter,
+        time_scope_value: -2,
+      },
+      props
+    ),
+    current: getQueryForWidget(defaultFilter, props),
+    forecast: getQueryForWidget({}, { limit: 31 }), // Todo: Currency has not been implemented for forecast
+    tabs: getQueryForWidgetTabs(
+      widget,
+      {
+        ...tabsFilter,
+        resolution: 'monthly',
+      },
+      props
+    ),
   };
 };

--- a/src/store/featureFlags/featureFlagsSelectors.ts
+++ b/src/store/featureFlags/featureFlagsSelectors.ts
@@ -5,7 +5,7 @@ import { stateKey } from './featureFlagsReducer';
 export const selectFeatureFlagsState = (state: RootState) => state[stateKey];
 
 export const selectIsCurrencyFeatureEnabled = (state: RootState) =>
-  selectFeatureFlagsState(state).isCurrencyFeatureEnabled;
+  selectFeatureFlagsState(state)?.isCurrencyFeatureEnabled;
 export const selectIsExcludesFeatureEnabled = (state: RootState) =>
   selectFeatureFlagsState(state).isExcludesFeatureEnabled;
 export const selectIsExportsFeatureEnabled = (state: RootState) =>

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -1,0 +1,8 @@
+import { parseQuery, Query } from 'api/queries/query';
+import { getCurrency as getCurrencyFromLocaleStorage } from 'utils/localStorage';
+
+// Returns cost type
+export const getCurrency = () => {
+  const query = parseQuery<Query>(location.search);
+  return query.currency ? query.currency : getCurrencyFromLocaleStorage();
+};

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -78,7 +78,7 @@ export const formatCurrencyAbbreviation: Formatter = (value, units = 'USD') => {
   // If no format was found, format value without abbreviation
   return formatCurrency(value, units, {
     minimumFractionDigits: 0,
-    maximumFractionDigits: 0,
+    maximumFractionDigits: 2,
   });
 };
 


### PR DESCRIPTION
This adds the user's currency selection to our report API requests.

Note: Currency support has not been added to the forecast APIs, which should be available soon. And OCI has no currency support.

https://issues.redhat.com/browse/COST-1906
https://issues.redhat.com/browse/COST-2517 (forecasts)