### PR TITLE
GCP compute card shows negative zero value

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -31,7 +31,8 @@ export const countDecimals = (value: string, useLocale: boolean = true) => {
 // See https://docs.adyen.com/development-resources/currency-codes
 export const formatCurrency: Formatter = (value: number, units: string, options: FormatOptions = {}) => {
   let fValue = value;
-  if (!value) {
+  // Don't show negative zero -- https://issues.redhat.com/browse/COST-3087
+  if (!value || Number(value.toFixed(2)) === 0) {
     fValue = 0;
   }
   // Don't specify default fraction digits here, rely on react-intl instead


### PR DESCRIPTION
Modified the code to not show a negative zero as the card’s hero number. It’s possible you could see -100, but not -0

https://issues.redhat.com/browse/COST-3087

![Screen Shot 2022-10-05 at 3 46 19 PM](https://user-images.githubusercontent.com/17481322/194149157-a371faca-23ed-4e7e-a95c-dcc71acdc70c.png)
