### PR TITLE
Explorer chart doesn't update when exclude filters are applied

### DIFF
--- a/src/routes/views/explorer/explorerChart.tsx
+++ b/src/routes/views/explorer/explorerChart.tsx
@@ -273,6 +273,7 @@ const mapStateToProps = createMapStateToProps<ExplorerChartOwnProps, ExplorerCha
         offset: undefined,
       },
       filter_by: queryFromRoute.filter_by || baseQuery.filter_by,
+      exclude: queryFromRoute.exclude || baseQuery.exclude,
       group_by: groupBy,
       perspective,
       dateRange,


### PR DESCRIPTION
The explorer chart was not updating when exclude filters are applied.

https://issues.redhat.com/browse/COST-3146

![chrome-capture-2022-9-12](https://user-images.githubusercontent.com/17481322/195463675-4e075002-d57c-46c2-904b-1657286fb6ec.gif)
