### PR TITLE
Remove start_date & end_date from cost explorer URL

### DIFF
--- a/src/routes/views/explorer/explorer.tsx
+++ b/src/routes/views/explorer/explorer.tsx
@@ -561,8 +561,6 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
     order_by: queryFromRoute.order_by,
     perspective,
     dateRange,
-    start_date,
-    end_date,
     cost_type: costType,
     currency,
   };
@@ -570,6 +568,8 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
     ...query,
     perspective: undefined,
     dateRange: undefined,
+    end_date,
+    start_date,
   });
 
   const reportPathsType = getReportPathsType(perspective);

--- a/src/routes/views/explorer/explorerChart.tsx
+++ b/src/routes/views/explorer/explorerChart.tsx
@@ -277,8 +277,6 @@ const mapStateToProps = createMapStateToProps<ExplorerChartOwnProps, ExplorerCha
       group_by: groupBy,
       perspective,
       dateRange,
-      start_date,
-      end_date,
       cost_type: costType,
       currency,
     };
@@ -286,6 +284,8 @@ const mapStateToProps = createMapStateToProps<ExplorerChartOwnProps, ExplorerCha
       ...query,
       perspective: undefined,
       dateRange: undefined,
+      start_date,
+      end_date,
     });
 
     const reportPathsType = getReportPathsType(perspective);

--- a/src/routes/views/explorer/explorerHeader.tsx
+++ b/src/routes/views/explorer/explorerHeader.tsx
@@ -354,8 +354,6 @@ const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHe
       order_by: queryFromRoute.order_by,
       perspective,
       dateRange,
-      start_date,
-      end_date,
       cost_type: costType,
       currency,
     };
@@ -363,6 +361,8 @@ const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHe
       ...query,
       perspective: undefined,
       dateRange: undefined,
+      start_date,
+      end_date,
     });
 
     return {

--- a/src/routes/views/explorer/explorerTable.tsx
+++ b/src/routes/views/explorer/explorerTable.tsx
@@ -3,9 +3,8 @@ import './explorerTable.scss';
 import { Bullseye, EmptyState, EmptyStateBody, EmptyStateIcon, Spinner } from '@patternfly/react-core';
 import { CalculatorIcon } from '@patternfly/react-icons/dist/esm/icons/calculator-icon';
 import { nowrap, sortable, SortByDirection, Table, TableBody, TableHeader } from '@patternfly/react-table';
-import { AwsQuery, getQuery } from 'api/queries/awsQuery';
-import { parseQuery, Query } from 'api/queries/query';
-import { AwsReport } from 'api/reports/awsReports';
+import { getQuery, parseQuery, Query } from 'api/queries/query';
+import { Report } from 'api/reports/report';
 import { format, getDate, getMonth } from 'date-fns';
 import messages from 'locales/messages';
 import React from 'react';
@@ -20,7 +19,7 @@ import { ComputedReportItem, getUnsortedComputedReportItems } from 'utils/comput
 import { formatCurrency } from 'utils/format';
 
 import { styles } from './explorerTable.styles';
-import { DateRangeType, getDateRange, getDateRangeDefault, PerspectiveType } from './explorerUtils';
+import { getDateRange, getDateRangeDefault, PerspectiveType } from './explorerUtils';
 
 interface ExplorerTableOwnProps {
   computedReportItemType?: ComputedReportItemType;
@@ -31,13 +30,12 @@ interface ExplorerTableOwnProps {
   onSelected(items: ComputedReportItem[], isSelected: boolean);
   onSort(value: string, isSortAscending: boolean, date: string);
   perspective: PerspectiveType;
-  query: AwsQuery;
-  report: AwsReport;
+  query: Query;
+  report: Report;
   selectedItems?: ComputedReportItem[];
 }
 
 interface ExplorerTableStateProps {
-  dateRange: DateRangeType;
   end_date?: string;
   start_date?: string;
 }
@@ -360,7 +358,6 @@ const mapStateToProps = createMapStateToProps<ExplorerTableOwnProps, ExplorerTab
     const { end_date, start_date } = getDateRange(dateRange);
 
     return {
-      dateRange,
       end_date,
       perspective,
       start_date,


### PR DESCRIPTION
The Cost explorer URL currently contains a `start_date` and `end_date`; however, these query params are not used directly as the page is based on the `dateRange` param. (These params are only used for the API request itself.) Want to clean this up and remove `start_date` & `end_date` from Cost explorer URL.

https://issues.redhat.com/browse/COST-3149