### PR TITLE
Remove unused eslint-plugin-cypress pkg

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,6 @@
     "aphrodite": "^2.4.0",
     "copy-webpack-plugin": "^11.0.0",
     "eslint": "^8.25.0",
-    "eslint-plugin-cypress": "^2.12.1",
     "eslint-plugin-formatjs": "^4.3.4",
     "eslint-plugin-jest-dom": "^4.0.2",
     "eslint-plugin-jsdoc": "^39.3.14",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4003,13 +4003,6 @@ eslint-module-utils@^2.7.3:
   dependencies:
     debug "^3.2.7"
 
-eslint-plugin-cypress@^2.12.1:
-  version "2.12.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-cypress/-/eslint-plugin-cypress-2.12.1.tgz#9aeee700708ca8c058e00cdafe215199918c2632"
-  integrity sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==
-  dependencies:
-    globals "^11.12.0"
-
 eslint-plugin-formatjs@^4.3.4:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/eslint-plugin-formatjs/-/eslint-plugin-formatjs-4.3.4.tgz#f54ffc4aa4507243c1f3ef503f9c7abda28c696e"
@@ -4806,7 +4799,7 @@ global-dirs@^3.0.0:
   dependencies:
     ini "2.0.0"
 
-globals@^11.1.0, globals@^11.12.0:
+globals@^11.1.0:
   version "11.12.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.12.0.tgz#ab8795338868a0babd8525758018c2a7eb95c42e"
   integrity sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==


### PR DESCRIPTION
The eslint-plugin-cypress package was added because @redhat-cloud-services/frontend-components-config pkg had a missing dependency. The Insights team recently removed this dependency, so we should remove it as well.

https://issues.redhat.com/browse/COST-3183