### PR TITLE
Add excludes filter to breakdown pages

### DIFF
--- a/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
@@ -76,6 +76,9 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
       ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
       ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
     },
+    exclude: {
+      ...(query && query.exclude && query.exclude),
+    },
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },

--- a/src/routes/views/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/routes/views/details/azureBreakdown/azureBreakdown.tsx
@@ -73,6 +73,9 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateP
       ...(query && query.filter_by && query.filter_by),
       ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
     },
+    exclude: {
+      ...(query && query.exclude && query.exclude),
+    },
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },

--- a/src/routes/views/details/components/historicalData/historicalDataCostChart.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataCostChart.tsx
@@ -154,6 +154,9 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
         ...(query && query.filter_by && query.filter_by),
         ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
       },
+      exclude: {
+        ...(query && query.exclude && query.exclude),
+      },
       group_by: {
         ...(groupBy && { [groupBy]: groupByValue }),
       },

--- a/src/routes/views/details/components/historicalData/historicalDataTrendChart.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataTrendChart.tsx
@@ -171,6 +171,9 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
         ...(query && query.filter && query.filter.account && { [`${logicalAndPrefix}account`]: query.filter.account }),
         ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
       },
+      exclude: {
+        ...(query && query.exclude && query.exclude),
+      },
       group_by: {
         ...(groupBy && { [groupBy]: groupByValue }),
       },

--- a/src/routes/views/details/components/historicalData/historicalDataUsageChart.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataUsageChart.tsx
@@ -139,6 +139,9 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
         ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
         ...(groupByOrgValue && useFilter && { [orgUnitIdKey]: groupByOrgValue }),
       },
+      exclude: {
+        ...(query && query.exclude && query.exclude),
+      },
       group_by: {
         ...(groupByOrgValue && !useFilter && { [orgUnitIdKey]: groupByOrgValue }),
         ...(groupBy && !groupByOrgValue && { [groupBy]: groupByValue }),

--- a/src/routes/views/details/components/summary/summaryCard.tsx
+++ b/src/routes/views/details/components/summary/summaryCard.tsx
@@ -206,6 +206,9 @@ const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps
         ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
         ...(groupBy && { [groupBy]: groupByValue }), // group bys must appear in filter to show costs by regions, accounts, etc
       },
+      exclude: {
+        ...(query && query.exclude && query.exclude),
+      },
       group_by: {
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.
       },

--- a/src/routes/views/details/components/summary/summaryModalContent.tsx
+++ b/src/routes/views/details/components/summary/summaryModalContent.tsx
@@ -115,6 +115,9 @@ const mapStateToProps = createMapStateToProps<SummaryModalContentOwnProps, Summa
         ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
         ...(groupBy && { [groupBy]: groupByValue }), // group bys must appear in filter to show costs by regions, accounts, etc
       },
+      exclude: {
+        ...(query && query.exclude && query.exclude),
+      },
       group_by: {
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.
       },

--- a/src/routes/views/details/components/usageChart/usageChart.tsx
+++ b/src/routes/views/details/components/usageChart/usageChart.tsx
@@ -386,6 +386,9 @@ const mapStateToProps = createMapStateToProps<UsageChartOwnProps, UsageChartStat
         ...(query && query.filter_by && query.filter_by),
         ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
       },
+      exclude: {
+        ...(query && query.exclude && query.exclude),
+      },
       group_by: {
         ...(groupBy && { [groupBy]: groupByValue }),
       },

--- a/src/routes/views/details/gcpBreakdown/gcpBreakdown.tsx
+++ b/src/routes/views/details/gcpBreakdown/gcpBreakdown.tsx
@@ -73,6 +73,9 @@ const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, GcpBreakdown
       ...(query && query.filter_by && query.filter_by),
       ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
     },
+    exclude: {
+      ...(query && query.exclude && query.exclude),
+    },
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },

--- a/src/routes/views/details/ibmBreakdown/ibmBreakdown.tsx
+++ b/src/routes/views/details/ibmBreakdown/ibmBreakdown.tsx
@@ -73,6 +73,9 @@ const mapStateToProps = createMapStateToProps<IbmBreakdownOwnProps, IbmBreakdown
       ...(query && query.filter_by && query.filter_by),
       ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
     },
+    exclude: {
+      ...(query && query.exclude && query.exclude),
+    },
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },

--- a/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
+++ b/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
@@ -73,6 +73,9 @@ const mapStateToProps = createMapStateToProps<OciCostOwnProps, OciCostStateProps
       ...(query && query.filter_by && query.filter_by),
       ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
     },
+    exclude: {
+      ...(query && query.exclude && query.exclude),
+    },
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },

--- a/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -69,6 +69,9 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
       ...(query && query.filter_by && query.filter_by),
       ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
     },
+    exclude: {
+      ...(query && query.exclude && query.exclude),
+    },
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },


### PR DESCRIPTION
Currently, the UI provides the details page filters to the breakdown page. However, we're not providing the excludes filter.

https://issues.redhat.com/browse/COST-3204

**AWS excluded by AmazonEC2**
![Screen Shot 2022-10-28 at 12 02 48 PM](https://user-images.githubusercontent.com/17481322/198682573-577aec0b-72a3-4f80-8b26-35b77c5aa427.png)
