### PR TITLE
Reset currency selection when the default is updated via settings page

### DIFF
--- a/src/routes/components/currency/currency.tsx
+++ b/src/routes/components/currency/currency.tsx
@@ -9,7 +9,7 @@ import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
-import { invalidateSession, restoreCurrency, setCurrency } from 'utils/localStorage';
+import { invalidateSession, setCurrency } from 'utils/localStorage';
 
 import { styles } from './currency.styles';
 
@@ -68,9 +68,6 @@ class CurrencyBase extends React.Component<CurrencyProps> {
   private getSelect = () => {
     const { currency, isDisabled } = this.props;
     const { isSelectOpen } = this.state;
-
-    // Restore from query param if available
-    restoreCurrency();
 
     const selectOptions = this.getSelectOptions();
     const selection = selectOptions.find((option: CurrencyOption) => option.value === currency);

--- a/src/routes/costModels/createCostModelWizard/index.tsx
+++ b/src/routes/costModels/createCostModelWizard/index.tsx
@@ -15,8 +15,8 @@ import { createMapStateToProps } from 'store/common';
 import { costModelsActions } from 'store/costModels';
 import { metricsSelectors } from 'store/metrics';
 import { unFormat } from 'utils/format';
+import { getAccountCurrency } from 'utils/localStorage';
 
-import { getAccountCurrency } from '../../../utils/localStorage';
 import { fetchSources as apiSources } from './api';
 import { CostModelContext } from './context';
 import GeneralInformation from './generalInformation';

--- a/src/routes/costModels/createCostModelWizard/index.tsx
+++ b/src/routes/costModels/createCostModelWizard/index.tsx
@@ -16,6 +16,7 @@ import { costModelsActions } from 'store/costModels';
 import { metricsSelectors } from 'store/metrics';
 import { unFormat } from 'utils/format';
 
+import { getAccountCurrency } from '../../../utils/localStorage';
 import { fetchSources as apiSources } from './api';
 import { CostModelContext } from './context';
 import GeneralInformation from './generalInformation';
@@ -134,7 +135,7 @@ const defaultState = {
   createError: null,
   createProcess: false,
   createSuccess: false,
-  currencyUnits: 'USD',
+  currencyUnits: getAccountCurrency(),
   dataFetched: false,
   description: '',
   distribution: 'cpu',

--- a/src/routes/views/components/costType/costType.tsx
+++ b/src/routes/views/components/costType/costType.tsx
@@ -10,7 +10,7 @@ import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { CostTypes } from 'utils/costType';
-import { invalidateSession, restoreCostType, setCostType } from 'utils/localStorage';
+import { invalidateSession, setCostType } from 'utils/localStorage';
 
 import { styles } from './costType.styles';
 
@@ -59,9 +59,6 @@ class CostTypeBase extends React.Component<CostTypeProps> {
   private getSelect = () => {
     const { costType, isDisabled } = this.props;
     const { isSelectOpen } = this.state;
-
-    // Restore from query param if available
-    restoreCostType();
 
     const selectOptions = this.getSelectOptions();
     const selection = selectOptions.find((option: CostTypeOption) => option.value === costType);

--- a/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
@@ -82,10 +82,12 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
+  };
+  const queryString = getQuery({
+    ...newQuery,
     cost_type: costType,
     currency,
-  };
-  const queryString = getQuery(newQuery);
+  });
 
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);

--- a/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
@@ -24,7 +24,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCostType } from 'utils/costType';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import { CostOverview } from './costOverview';
 import { HistoricalData } from './historicalData';

--- a/src/routes/views/details/awsDetails/awsDetails.tsx
+++ b/src/routes/views/details/awsDetails/awsDetails.tsx
@@ -324,7 +324,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
   };
 
   private updateReport = () => {
-    const { costType, query, location, fetchReport, history, queryString } = this.props;
+    const { query, location, fetchReport, history, queryString } = this.props;
     if (!location.search) {
       history.replace(
         getRouteForQuery(history, {
@@ -332,7 +332,6 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
           filter_by: query ? query.filter_by : undefined,
           group_by: query ? query.group_by : undefined,
           order_by: { cost: 'desc' },
-          cost_type: costType,
         })
       );
     } else {
@@ -419,10 +418,10 @@ const mapStateToProps = createMapStateToProps<AwsDetailsOwnProps, AwsDetailsStat
     exclude: queryFromRoute.exclude || baseQuery.exclude,
     group_by: queryFromRoute.group_by || baseQuery.group_by,
     order_by: queryFromRoute.order_by || baseQuery.order_by,
-    cost_type: costType,
   };
   const queryString = getQuery({
     ...query,
+    cost_type: costType,
     currency,
   });
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);

--- a/src/routes/views/details/awsDetails/awsDetails.tsx
+++ b/src/routes/views/details/awsDetails/awsDetails.tsx
@@ -40,7 +40,7 @@ import type { ComputedReportItem } from 'utils/computedReport/getComputedReportI
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import type { CostTypes } from 'utils/costType';
 import { getCostType } from 'utils/costType';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import { styles } from './awsDetails.styles';
 import { DetailsHeader } from './detailsHeader';
@@ -420,9 +420,11 @@ const mapStateToProps = createMapStateToProps<AwsDetailsOwnProps, AwsDetailsStat
     group_by: queryFromRoute.group_by || baseQuery.group_by,
     order_by: queryFromRoute.order_by || baseQuery.order_by,
     cost_type: costType,
-    currency,
   };
-  const queryString = getQuery(query);
+  const queryString = getQuery({
+    ...query,
+    currency,
+  });
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);

--- a/src/routes/views/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/routes/views/details/azureBreakdown/azureBreakdown.tsx
@@ -79,9 +79,11 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateP
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
-    currency,
   };
-  const queryString = getQuery(newQuery);
+  const queryString = getQuery({
+    ...newQuery,
+    currency,
+  });
 
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);

--- a/src/routes/views/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/routes/views/details/azureBreakdown/azureBreakdown.tsx
@@ -23,7 +23,7 @@ import { createMapStateToProps } from 'store/common';
 import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import { CostOverview } from './costOverview';
 import { HistoricalData } from './historicalData';

--- a/src/routes/views/details/azureDetails/azureDetails.tsx
+++ b/src/routes/views/details/azureDetails/azureDetails.tsx
@@ -389,9 +389,11 @@ const mapStateToProps = createMapStateToProps<AzureDetailsOwnProps, AzureDetails
     exclude: queryFromRoute.exclude || baseQuery.exclude,
     group_by: queryFromRoute.group_by || baseQuery.group_by,
     order_by: queryFromRoute.order_by || baseQuery.order_by,
-    currency,
   };
-  const queryString = getQuery(query);
+  const queryString = getQuery({
+    ...query,
+    currency,
+  });
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);

--- a/src/routes/views/details/azureDetails/azureDetails.tsx
+++ b/src/routes/views/details/azureDetails/azureDetails.tsx
@@ -37,7 +37,7 @@ import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedAzureReportItems';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import { styles } from './azureDetails.styles';
 import { DetailsHeader } from './detailsHeader';

--- a/src/routes/views/details/components/historicalData/historicalDataCostChart.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataCostChart.tsx
@@ -160,8 +160,6 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
       group_by: {
         ...(groupBy && { [groupBy]: groupByValue }),
       },
-      cost_type: costType,
-      currency,
     };
     const currentQuery: Query = {
       ...baseQuery,
@@ -171,7 +169,11 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
         time_scope_value: -1,
       },
     };
-    const currentQueryString = getQuery(currentQuery);
+    const currentQueryString = getQuery({
+      ...currentQuery,
+      cost_type: costType,
+      currency,
+    });
     const previousQuery: Query = {
       ...baseQuery,
       filter: {
@@ -180,7 +182,11 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
         time_scope_value: -2,
       },
     };
-    const previousQueryString = getQuery(previousQuery);
+    const previousQueryString = getQuery({
+      ...previousQuery,
+      cost_type: costType,
+      currency,
+    });
 
     // Current report
     const currentReport = reportSelectors.selectReport(state, reportPathsType, reportType, currentQueryString);

--- a/src/routes/views/details/components/historicalData/historicalDataTrendChart.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataTrendChart.tsx
@@ -177,8 +177,6 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
       group_by: {
         ...(groupBy && { [groupBy]: groupByValue }),
       },
-      cost_type: costType,
-      currency,
     };
     const currentQuery: Query = {
       ...baseQuery,
@@ -188,7 +186,11 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
         time_scope_value: -1,
       },
     };
-    const currentQueryString = getQuery(currentQuery);
+    const currentQueryString = getQuery({
+      ...currentQuery,
+      cost_type: costType,
+      currency,
+    });
     const previousQuery: Query = {
       ...baseQuery,
       filter: {
@@ -197,7 +199,11 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
         time_scope_value: -2,
       },
     };
-    const previousQueryString = getQuery(previousQuery);
+    const previousQueryString = getQuery({
+      ...previousQuery,
+      cost_type: costType,
+      currency,
+    });
 
     // Current report
     const currentReport = reportSelectors.selectReport(state, reportPathsType, reportType, currentQueryString);

--- a/src/routes/views/details/components/summary/summaryCard.tsx
+++ b/src/routes/views/details/components/summary/summaryCard.tsx
@@ -212,10 +212,10 @@ const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps
       group_by: {
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.
       },
-      cost_type: costType,
     };
     const queryString = getQuery({
       ...newQuery,
+      cost_type: costType,
       currency,
     });
 

--- a/src/routes/views/details/components/summary/summaryCard.tsx
+++ b/src/routes/views/details/components/summary/summaryCard.tsx
@@ -213,9 +213,11 @@ const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.
       },
       cost_type: costType,
-      currency,
     };
-    const queryString = getQuery(newQuery);
+    const queryString = getQuery({
+      ...newQuery,
+      currency,
+    });
 
     const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
     const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);

--- a/src/routes/views/details/components/summary/summaryModalContent.tsx
+++ b/src/routes/views/details/components/summary/summaryModalContent.tsx
@@ -122,9 +122,11 @@ const mapStateToProps = createMapStateToProps<SummaryModalContentOwnProps, Summa
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.
       },
       cost_type: costType,
-      currency,
     };
-    const queryString = getQuery(newQuery);
+    const queryString = getQuery({
+      ...newQuery,
+      currency,
+    });
 
     const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
     const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);

--- a/src/routes/views/details/components/summary/summaryModalContent.tsx
+++ b/src/routes/views/details/components/summary/summaryModalContent.tsx
@@ -121,10 +121,10 @@ const mapStateToProps = createMapStateToProps<SummaryModalContentOwnProps, Summa
       group_by: {
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.
       },
-      cost_type: costType,
     };
     const queryString = getQuery({
       ...newQuery,
+      cost_type: costType,
       currency,
     });
 

--- a/src/routes/views/details/gcpBreakdown/gcpBreakdown.tsx
+++ b/src/routes/views/details/gcpBreakdown/gcpBreakdown.tsx
@@ -79,9 +79,11 @@ const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, GcpBreakdown
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
-    currency,
   };
-  const queryString = getQuery(newQuery);
+  const queryString = getQuery({
+    ...newQuery,
+    currency,
+  });
 
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);

--- a/src/routes/views/details/gcpBreakdown/gcpBreakdown.tsx
+++ b/src/routes/views/details/gcpBreakdown/gcpBreakdown.tsx
@@ -23,7 +23,7 @@ import { createMapStateToProps } from 'store/common';
 import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import { CostOverview } from './costOverview';
 import { HistoricalData } from './historicalData';

--- a/src/routes/views/details/gcpDetails/gcpDetails.tsx
+++ b/src/routes/views/details/gcpDetails/gcpDetails.tsx
@@ -37,7 +37,7 @@ import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedGcpReportItems';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import { DetailsHeader } from './detailsHeader';
 import { DetailsTable } from './detailsTable';
@@ -388,9 +388,11 @@ const mapStateToProps = createMapStateToProps<GcpDetailsOwnProps, GcpDetailsStat
     exclude: queryFromRoute.exclude || baseQuery.exclude,
     group_by: queryFromRoute.group_by || baseQuery.group_by,
     order_by: queryFromRoute.order_by || baseQuery.order_by,
-    currency,
   };
-  const queryString = getQuery(query);
+  const queryString = getQuery({
+    ...query,
+    currency,
+  });
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);

--- a/src/routes/views/details/ibmBreakdown/ibmBreakdown.tsx
+++ b/src/routes/views/details/ibmBreakdown/ibmBreakdown.tsx
@@ -79,9 +79,11 @@ const mapStateToProps = createMapStateToProps<IbmBreakdownOwnProps, IbmBreakdown
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
-    currency,
   };
-  const queryString = getQuery(newQuery);
+  const queryString = getQuery({
+    ...newQuery,
+    currency,
+  });
 
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);

--- a/src/routes/views/details/ibmBreakdown/ibmBreakdown.tsx
+++ b/src/routes/views/details/ibmBreakdown/ibmBreakdown.tsx
@@ -23,7 +23,7 @@ import { createMapStateToProps } from 'store/common';
 import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import { CostOverview } from './costOverview';
 import { HistoricalData } from './historicalData';

--- a/src/routes/views/details/ibmDetails/ibmDetails.tsx
+++ b/src/routes/views/details/ibmDetails/ibmDetails.tsx
@@ -38,7 +38,7 @@ import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedIbmReportItems';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import { DetailsHeader } from './detailsHeader';
 import { DetailsTable } from './detailsTable';
@@ -389,9 +389,11 @@ const mapStateToProps = createMapStateToProps<IbmDetailsOwnProps, IbmDetailsStat
     exclude: queryFromRoute.exclude || baseQuery.exclude,
     group_by: queryFromRoute.group_by || baseQuery.group_by,
     order_by: queryFromRoute.order_by || baseQuery.order_by,
-    currency,
   };
-  const queryString = getQuery(query);
+  const queryString = getQuery({
+    ...query,
+    currency,
+  });
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);

--- a/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
+++ b/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
@@ -79,9 +79,11 @@ const mapStateToProps = createMapStateToProps<OciCostOwnProps, OciCostStateProps
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
-    currency,
   };
-  const queryString = getQuery(newQuery);
+  const queryString = getQuery({
+    ...newQuery,
+    currency,
+  });
 
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);

--- a/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
+++ b/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
@@ -23,7 +23,7 @@ import { createMapStateToProps } from 'store/common';
 import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import { CostOverview } from './costOverview';
 import { HistoricalData } from './historicalData';

--- a/src/routes/views/details/ociDetails/ociDetails.tsx
+++ b/src/routes/views/details/ociDetails/ociDetails.tsx
@@ -37,7 +37,7 @@ import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedOciReportItems';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import { DetailsHeader } from './detailsHeader';
 import { DetailsTable } from './detailsTable';
@@ -389,9 +389,11 @@ const mapStateToProps = createMapStateToProps<OciDetailsOwnProps, OciDetailsStat
     exclude: queryFromRoute.exclude || baseQuery.exclude,
     group_by: queryFromRoute.group_by || baseQuery.group_by,
     order_by: queryFromRoute.order_by || baseQuery.order_by,
-    currency,
   };
-  const queryString = getQuery(query);
+  const queryString = getQuery({
+    ...query,
+    currency,
+  });
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);

--- a/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -22,7 +22,7 @@ import { createMapStateToProps } from 'store/common';
 import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import { CostOverview } from './costOverview';
 import { HistoricalData } from './historicalData';
@@ -75,9 +75,11 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
-    currency,
   };
-  const queryString = getQuery(newQuery);
+  const queryString = getQuery({
+    ...newQuery,
+    currency,
+  });
 
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);

--- a/src/routes/views/details/ocpDetails/ocpDetails.tsx
+++ b/src/routes/views/details/ocpDetails/ocpDetails.tsx
@@ -40,7 +40,7 @@ import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedOcpReportItems';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import { DetailsHeader } from './detailsHeader';
 import { DetailsTable, DetailsTableColumnIds } from './detailsTable';
@@ -447,9 +447,11 @@ const mapStateToProps = createMapStateToProps<OcpDetailsOwnProps, OcpDetailsStat
     exclude: queryFromRoute.exclude || baseQuery.exclude,
     group_by: queryFromRoute.group_by || baseQuery.group_by,
     order_by: queryFromRoute.order_by || baseQuery.order_by,
-    currency,
   };
-  const queryString = getQuery(query);
+  const queryString = getQuery({
+    ...query,
+    currency,
+  });
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
   const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);

--- a/src/routes/views/explorer/explorer.tsx
+++ b/src/routes/views/explorer/explorer.tsx
@@ -386,7 +386,6 @@ class Explorer extends React.Component<ExplorerProps> {
           filter_by: query ? query.filter_by : undefined,
           group_by: query ? query.group_by : undefined,
           order_by: query ? query.order_by : undefined,
-          cost_type: query ? query.cost_type : undefined,
           dateRange, // Preserve date range
         })
       );
@@ -567,10 +566,10 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
     order_by: queryFromRoute.order_by,
     perspective,
     dateRange,
-    cost_type: costType,
   };
   const queryString = getQuery({
     ...query,
+    cost_type: costType,
     currency,
     perspective: undefined,
     dateRange: undefined,

--- a/src/routes/views/explorer/explorer.tsx
+++ b/src/routes/views/explorer/explorer.tsx
@@ -45,7 +45,7 @@ import type { ComputedReportItem } from 'utils/computedReport/getComputedReportI
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import type { CostTypes } from 'utils/costType';
 import { getCostType } from 'utils/costType';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 import {
   isAwsAvailable,
   isAzureAvailable,
@@ -293,11 +293,11 @@ class Explorer extends React.Component<ExplorerProps> {
     }
   };
 
-  public handleExportModalClose = (isOpen: boolean) => {
+  private handleExportModalClose = (isOpen: boolean) => {
     this.setState({ isExportModalOpen: isOpen });
   };
 
-  public handleExportModalOpen = () => {
+  private handleExportModalOpen = () => {
     this.setState({ isExportModalOpen: true });
   };
 
@@ -307,7 +307,7 @@ class Explorer extends React.Component<ExplorerProps> {
     let groupByKey = groupBy;
     let value = '*';
 
-    // Check for for org units
+    // Check for org units
     const index = groupBy.indexOf(orgUnitIdKey);
     if (index !== -1) {
       groupByKey = orgUnitIdKey.substring(0, orgUnitIdKey.length);
@@ -378,8 +378,7 @@ class Explorer extends React.Component<ExplorerProps> {
   };
 
   private updateReport = () => {
-    const { costType, currency, dateRange, fetchReport, history, location, perspective, query, queryString } =
-      this.props;
+    const { dateRange, fetchReport, history, location, perspective, query, queryString } = this.props;
     if (!location.search) {
       history.replace(
         getRouteForQuery(history, {
@@ -387,9 +386,8 @@ class Explorer extends React.Component<ExplorerProps> {
           filter_by: query ? query.filter_by : undefined,
           group_by: query ? query.group_by : undefined,
           order_by: query ? query.order_by : undefined,
+          cost_type: query ? query.cost_type : undefined,
           dateRange, // Preserve date range
-          cost_type: costType,
-          currency,
         })
       );
     } else if (perspective) {
@@ -555,6 +553,9 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
   const costType = perspective === PerspectiveType.aws ? getCostType() : undefined;
   const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
 
+  // eslint-disable-next-line no-console
+  console.log('Explorer getCurrency', currency);
+
   const query = {
     filter: {
       ...baseQuery.filter,
@@ -567,10 +568,10 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
     perspective,
     dateRange,
     cost_type: costType,
-    currency,
   };
   const queryString = getQuery({
     ...query,
+    currency,
     perspective: undefined,
     dateRange: undefined,
     end_date,

--- a/src/routes/views/explorer/explorerChart.tsx
+++ b/src/routes/views/explorer/explorerChart.tsx
@@ -276,10 +276,10 @@ const mapStateToProps = createMapStateToProps<ExplorerChartOwnProps, ExplorerCha
       perspective,
       dateRange,
       cost_type: costType,
-      currency,
     };
     const queryString = getQuery({
       ...query,
+      currency,
       perspective: undefined,
       dateRange: undefined,
       start_date,

--- a/src/routes/views/explorer/explorerChart.tsx
+++ b/src/routes/views/explorer/explorerChart.tsx
@@ -275,10 +275,10 @@ const mapStateToProps = createMapStateToProps<ExplorerChartOwnProps, ExplorerCha
       group_by: groupBy,
       perspective,
       dateRange,
-      cost_type: costType,
     };
     const queryString = getQuery({
       ...query,
+      cost_type: costType,
       currency,
       perspective: undefined,
       dateRange: undefined,

--- a/src/routes/views/explorer/explorerHeader.tsx
+++ b/src/routes/views/explorer/explorerHeader.tsx
@@ -358,10 +358,10 @@ const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHe
       order_by: queryFromRoute.order_by,
       perspective,
       dateRange,
-      cost_type: costType,
     };
     const queryString = getQuery({
       ...query,
+      cost_type: costType,
       currency,
       perspective: undefined,
       dateRange: undefined,

--- a/src/routes/views/explorer/explorerHeader.tsx
+++ b/src/routes/views/explorer/explorerHeader.tsx
@@ -359,10 +359,10 @@ const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHe
       perspective,
       dateRange,
       cost_type: costType,
-      currency,
     };
     const queryString = getQuery({
       ...query,
+      currency,
       perspective: undefined,
       dateRange: undefined,
       start_date,

--- a/src/routes/views/overview/awsDashboard/awsDashboardWidget.tsx
+++ b/src/routes/views/overview/awsDashboard/awsDashboardWidget.tsx
@@ -9,7 +9,7 @@ import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedAwsReportItemsParams } from 'utils/computedReport/getComputedAwsReportItems';
 import { getCostType } from 'utils/costType';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 interface AwsDashboardWidgetDispatchProps {
   fetchForecasts: typeof awsDashboardActions.fetchWidgetForecasts;

--- a/src/routes/views/overview/awsOcpDashboard/awsOcpDashboardWidget.tsx
+++ b/src/routes/views/overview/awsOcpDashboard/awsOcpDashboardWidget.tsx
@@ -8,7 +8,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedAwsReportItemsParams } from 'utils/computedReport/getComputedAwsReportItems';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 interface AwsOcpDashboardWidgetDispatchProps {
   fetchForecasts: typeof awsOcpDashboardActions.fetchWidgetForecasts;

--- a/src/routes/views/overview/azureDashboard/azureDashboardWidget.tsx
+++ b/src/routes/views/overview/azureDashboard/azureDashboardWidget.tsx
@@ -8,7 +8,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedAzureReportItemsParams } from 'utils/computedReport/getComputedAzureReportItems';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 interface AzureDashboardWidgetDispatchProps {
   fetchForecasts: typeof azureDashboardActions.fetchWidgetForecasts;

--- a/src/routes/views/overview/azureOcpDashboard/azureOcpDashboardWidget.tsx
+++ b/src/routes/views/overview/azureOcpDashboard/azureOcpDashboardWidget.tsx
@@ -12,7 +12,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedAzureReportItemsParams } from 'utils/computedReport/getComputedAzureReportItems';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 interface AzureOcpDashboardWidgetDispatchProps {
   fetchForecasts: typeof azureOcpDashboardActions.fetchWidgetForecasts;

--- a/src/routes/views/overview/gcpDashboard/gcpDashboardWidget.tsx
+++ b/src/routes/views/overview/gcpDashboard/gcpDashboardWidget.tsx
@@ -8,7 +8,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedGcpReportItemsParams } from 'utils/computedReport/getComputedGcpReportItems';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 interface GcpDashboardWidgetDispatchProps {
   fetchForecasts: typeof gcpDashboardActions.fetchWidgetForecasts;

--- a/src/routes/views/overview/gcpOcpDashboard/gcpOcpDashboardWidget.tsx
+++ b/src/routes/views/overview/gcpOcpDashboard/gcpOcpDashboardWidget.tsx
@@ -8,7 +8,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedGcpReportItemsParams } from 'utils/computedReport/getComputedGcpReportItems';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 interface GcpOcpDashboardWidgetDispatchProps {
   fetchForecasts: typeof gcpOcpDashboardActions.fetchWidgetForecasts;

--- a/src/routes/views/overview/ibmDashboard/ibmDashboardWidget.tsx
+++ b/src/routes/views/overview/ibmDashboard/ibmDashboardWidget.tsx
@@ -8,7 +8,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedIbmReportItemsParams } from 'utils/computedReport/getComputedIbmReportItems';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 interface IbmDashboardWidgetDispatchProps {
   fetchForecasts: typeof ibmDashboardActions.fetchWidgetForecasts;

--- a/src/routes/views/overview/ociDashboard/ociDashboardWidget.tsx
+++ b/src/routes/views/overview/ociDashboard/ociDashboardWidget.tsx
@@ -8,7 +8,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedOciReportItemsParams } from 'utils/computedReport/getComputedOciReportItems';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 interface OciDashboardWidgetDispatchProps {
   fetchForecasts: typeof ociDashboardActions.fetchWidgetForecasts;

--- a/src/routes/views/overview/ocpCloudDashboard/ocpCloudDashboardWidget.tsx
+++ b/src/routes/views/overview/ocpCloudDashboard/ocpCloudDashboardWidget.tsx
@@ -12,7 +12,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedOcpCloudReportItemsParams } from 'utils/computedReport/getComputedOcpCloudReportItems';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 interface OcpCloudDashboardWidgetDispatchProps {
   fetchForecasts: typeof ocpCloudDashboardActions.fetchWidgetForecasts;

--- a/src/routes/views/overview/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/routes/views/overview/ocpDashboard/ocpDashboardWidget.tsx
@@ -8,7 +8,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedOcpReportItemsParams } from 'utils/computedReport/getComputedOcpReportItems';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import { chartStyles } from './ocpDashboardWidget.styles';
 

--- a/src/routes/views/overview/overview.tsx
+++ b/src/routes/views/overview/overview.tsx
@@ -57,8 +57,8 @@ import { providersQuery, providersSelectors } from 'store/providers';
 import { userAccessQuery, userAccessSelectors } from 'store/userAccess';
 import type { CostTypes } from 'utils/costType';
 import { getCostType } from 'utils/costType';
-import { getCurrency } from 'utils/currency';
 import { getSinceDateRangeString } from 'utils/dates';
+import { getCurrency } from 'utils/localStorage';
 import {
   hasAwsAccess,
   hasAzureAccess,
@@ -480,7 +480,6 @@ class OverviewBase extends React.Component<OverviewProps> {
 
     const newQuery = {
       ...JSON.parse(JSON.stringify(query)),
-      currency: value,
     };
     history.replace(this.getRouteForQuery(newQuery));
   };
@@ -698,9 +697,11 @@ const mapStateToProps = createMapStateToProps<OverviewOwnProps, OverviewStatePro
     tabKey,
     ...(perspective && { perspective }),
     ...(perspective === InfrastructurePerspective.aws && { cost_type: costType }),
-    currency,
   };
-  const queryString = getQuery(query);
+  const queryString = getQuery({
+    ...query,
+    currency,
+  });
 
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);

--- a/src/routes/views/overview/overview.tsx
+++ b/src/routes/views/overview/overview.tsx
@@ -465,17 +465,16 @@ class OverviewBase extends React.Component<OverviewProps> {
     }
   };
 
-  private handleCostTypeSelected = (value: string) => {
+  private handleCostTypeSelected = () => {
     const { history, query } = this.props;
 
     const newQuery = {
       ...JSON.parse(JSON.stringify(query)),
-      cost_type: value,
     };
     history.replace(this.getRouteForQuery(newQuery));
   };
 
-  private handleCurrencySelected = (value: string) => {
+  private handleCurrencySelected = () => {
     const { history, query } = this.props;
 
     const newQuery = {
@@ -696,10 +695,10 @@ const mapStateToProps = createMapStateToProps<OverviewOwnProps, OverviewStatePro
   const query = {
     tabKey,
     ...(perspective && { perspective }),
-    ...(perspective === InfrastructurePerspective.aws && { cost_type: costType }),
   };
   const queryString = getQuery({
     ...query,
+    ...(perspective === InfrastructurePerspective.aws && { cost_type: costType }),
     currency,
   });
 

--- a/src/routes/views/utils/history.ts
+++ b/src/routes/views/utils/history.ts
@@ -23,10 +23,8 @@ export const handleCurrencySelected = (history, query: Query, value: string, res
 };
 
 export const handleCostTypeSelected = (history, query: Query, value: string, reset: boolean = false) => {
-  // Need param to restore cost type upon page refresh
   const newQuery = {
     ...JSON.parse(JSON.stringify(query)),
-    cost_type: value,
   };
   history.replace(getRouteForQuery(history, newQuery, reset)); // Don't reset pagination
 };

--- a/src/routes/views/utils/history.ts
+++ b/src/routes/views/utils/history.ts
@@ -18,7 +18,6 @@ export const getRouteForQuery = (history, query: Query, reset: boolean = false) 
 export const handleCurrencySelected = (history, query: Query, value: string, reset: boolean = false) => {
   const newQuery = {
     ...JSON.parse(JSON.stringify(query)),
-    currency: value,
   };
   history.replace(getRouteForQuery(history, newQuery, reset));
 };

--- a/src/store/accountSettings/accountSettingsReducer.ts
+++ b/src/store/accountSettings/accountSettingsReducer.ts
@@ -5,6 +5,7 @@ import { resetState } from 'store/ui/uiActions';
 import type { ActionType } from 'typesafe-actions';
 import { getType } from 'typesafe-actions';
 import {
+  getAccountCurrency,
   invalidateSession,
   isCostTypeAvailable,
   isCurrencyAvailable,
@@ -87,7 +88,16 @@ function initCurrency(value: string) {
   // Clear local storage value if current session is not valid
   invalidateSession();
 
+  // Reset UI's currency selection if default currency has changed.
+  if (value !== getAccountCurrency()) {
+    // Todo: After the settings page is moved to the Cost Management UI, we can clear the cached currency there.
+    // That way, resetting the currency for the UI should only affect the user who changed the default.
+    invalidateSession(true);
+  }
+
   if (!isCurrencyAvailable()) {
+    // eslint-disable-next-line no-console
+    console.log('setCurrency', value);
     setCurrency(value);
   }
   setAccountCurrency(value);

--- a/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
@@ -1,6 +1,6 @@
 import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import {
   awsDashboardDefaultFilters,

--- a/src/store/dashboard/awsOcpDashboard/awsOcpDashboardSelectors.ts
+++ b/src/store/dashboard/awsOcpDashboard/awsOcpDashboardSelectors.ts
@@ -1,6 +1,6 @@
 import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import {
   awsOcpDashboardDefaultFilters,

--- a/src/store/dashboard/azureDashboard/azureDashboardSelectors.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardSelectors.ts
@@ -1,6 +1,6 @@
 import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import {
   azureDashboardDefaultFilters,

--- a/src/store/dashboard/azureOcpDashboard/azureOcpDashboardSelectors.ts
+++ b/src/store/dashboard/azureOcpDashboard/azureOcpDashboardSelectors.ts
@@ -1,6 +1,6 @@
 import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import {
   azureOcpDashboardDefaultFilters,

--- a/src/store/dashboard/gcpDashboard/gcpDashboardSelectors.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardSelectors.ts
@@ -1,6 +1,6 @@
 import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import {
   gcpDashboardDefaultFilters,

--- a/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardSelectors.ts
+++ b/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardSelectors.ts
@@ -1,6 +1,6 @@
 import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import {
   gcpOcpDashboardDefaultFilters,

--- a/src/store/dashboard/ibmDashboard/ibmDashboardSelectors.ts
+++ b/src/store/dashboard/ibmDashboard/ibmDashboardSelectors.ts
@@ -1,6 +1,6 @@
 import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import {
   getQueryForWidget,

--- a/src/store/dashboard/ociDashboard/ociDashboardSelectors.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboardSelectors.ts
@@ -1,6 +1,6 @@
 import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import {
   getQueryForWidget,

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardSelectors.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardSelectors.ts
@@ -1,6 +1,6 @@
 import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import {
   getQueryForWidget,

--- a/src/store/dashboard/ocpDashboard/ocpDashboardSelectors.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardSelectors.ts
@@ -1,6 +1,6 @@
 import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
-import { getCurrency } from 'utils/currency';
+import { getCurrency } from 'utils/localStorage';
 
 import {
   getQueryForWidget,

--- a/src/utils/costType.ts
+++ b/src/utils/costType.ts
@@ -1,5 +1,3 @@
-import type { Query } from 'api/queries/query';
-import { parseQuery } from 'api/queries/query';
 import { getCostType as getCostTypeFromLocaleStorage } from 'utils/localStorage';
 
 // eslint-disable-next-line no-shadow
@@ -11,11 +9,6 @@ export const enum CostTypes {
 
 // Returns cost type
 export const getCostType = () => {
-  const query = parseQuery<Query>(location.search);
-
-  if (query.cost_type) {
-    return query.cost_type;
-  }
   switch (getCostTypeFromLocaleStorage()) {
     case 'blended_cost':
       return CostTypes.blended;

--- a/src/utils/currency.ts
+++ b/src/utils/currency.ts
@@ -1,9 +1,0 @@
-import type { Query } from 'api/queries/query';
-import { parseQuery } from 'api/queries/query';
-import { getCurrency as getCurrencyFromLocaleStorage } from 'utils/localStorage';
-
-// Returns cost type
-export const getCurrency = () => {
-  const query = parseQuery<Query>(location.search);
-  return query.currency ? query.currency : getCurrencyFromLocaleStorage();
-};

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -29,8 +29,8 @@ export const getSessionToken = () => {
 };
 
 // Invalidates session if not valid and restores query param values
-export const invalidateSession = () => {
-  if (!isSessionValid()) {
+export const invalidateSession = (force = false) => {
+  if (!isSessionValid() || force) {
     deleteSessionToken();
 
     // Delete cost type

--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,5 +1,3 @@
-import type { Query } from 'api/queries/query';
-import { parseQuery } from 'api/queries/query';
 import { getTokenCookie } from 'utils/cookie';
 
 const accountCurrencyID = 'cost_management_account_currency';
@@ -73,15 +71,6 @@ export const isCostTypeAvailable = () => {
   return costType && costType !== null;
 };
 
-// Restore cost type from query param if available
-export const restoreCostType = () => {
-  const queryFromRoute = parseQuery<Query>(location.search);
-
-  if (queryFromRoute.cost_type) {
-    setCostType(queryFromRoute.cost_type);
-  }
-};
-
 // Set cost type
 export const setCostType = (value: string) => {
   localStorage.setItem(costTypeID, value);
@@ -118,15 +107,6 @@ export const getCurrency = () => {
 export const isCurrencyAvailable = () => {
   const currency = localStorage.getItem(currencyID);
   return currency && currency !== null;
-};
-
-// Restore currency from query param if available
-export const restoreCurrency = () => {
-  const queryFromRoute = parseQuery<Query>(location.search);
-
-  if (queryFromRoute.currency) {
-    setCurrency(queryFromRoute.currency);
-  }
 };
 
 // Set account currency


### PR DESCRIPTION
This change resets the currency selection when the default currency is updated via settings page. This removes two query params from the browser URL; `currency` and `cost_type`. Using the existing properties stored via local storage only, so we don't override the default.

FYI, there is an edge case where a user sets the default currency after visiting a Cost Management page. Then, the user navigates back to the UI, but our currency dropdown remains unchanged. In this scenario, UI's currency selection had already been cached for the session. The user won't see the dropdown match the default currency until they login again.

https://issues.redhat.com/browse/COST-3207