### PR TITLE
Migrate cost explorer page to use PatternFly composable table

### DIFF
--- a/src/routes/views/details/components/dataTable/dataTable.tsx
+++ b/src/routes/views/details/components/dataTable/dataTable.tsx
@@ -52,7 +52,7 @@ class DataTable extends React.Component<DataTableProps> {
     const { columns, query } = this.props;
 
     const orderBy = columns[index].orderBy;
-    const direction = query.order_by[orderBy];
+    const direction = query && query.order_by && query.order_by[orderBy];
 
     return direction
       ? {
@@ -144,6 +144,7 @@ class DataTable extends React.Component<DataTableProps> {
                       <Td
                         dataLabel={columns[cellIndex].name}
                         key={`cell-${cellIndex}-${rowIndex}`}
+                        modifier="nowrap"
                         select={{
                           disable: row.selectionDisabled, // Disable select for "no-project"
                           isSelected: row.selected,
@@ -155,6 +156,7 @@ class DataTable extends React.Component<DataTableProps> {
                       <Td
                         dataLabel={columns[cellIndex].name}
                         key={`cell-${rowIndex}-${cellIndex}`}
+                        modifier="nowrap"
                         isActionCell={cellIndex === row.cells.length - 1}
                       >
                         {item.value}

--- a/src/routes/views/explorer/explorerTable.styles.ts
+++ b/src/routes/views/explorer/explorerTable.styles.ts
@@ -24,8 +24,4 @@ export const styles = {
     color: global_disabled_color_100.value,
     fontSize: global_FontSize_xs.value,
   },
-  tableContainer: {
-    position: 'relative',
-    overflowX: 'auto',
-  },
 } as { [className: string]: React.CSSProperties };


### PR DESCRIPTION
- Migrate cost explorer page to use PatternFly composable table
- Add "nowrap" style to details tables

https://issues.redhat.com/browse/COST-3231

**Explorer table:**
![Screen Shot 2022-11-07 at 11 20 39 PM](https://user-images.githubusercontent.com/17481322/200474925-6ad98b73-1cc4-459c-8853-3518fdb653f8.png)
