### PR TITLE
Added cost distribution flag

### DIFF
--- a/src/components/featureFlags/featureFlags.tsx
+++ b/src/components/featureFlags/featureFlags.tsx
@@ -14,6 +14,7 @@ type FeatureFlagsProps = FeatureFlagsOwnProps & RouteComponentProps<void>;
 // eslint-disable-next-line no-shadow
 export const enum FeatureToggle {
   currency = 'cost-management.ui.currency', // Currency support https://issues.redhat.com/browse/COST-1277
+  distribution = 'cost-management.ui.cost-distribution', // Cost distribution https://issues.redhat.com/browse/COST-3249
   excludes = 'cost-management.ui.negative-filtering', // Contains filter https://issues.redhat.com/browse/COST-2773
   exports = 'cost-management.ui.exports', // Async exports https://issues.redhat.com/browse/COST-2223
   ibm = 'cost-management.ui.ibm', // IBM https://issues.redhat.com/browse/COST-935
@@ -58,6 +59,7 @@ const FeatureFlagsBase: React.FC<FeatureFlagsProps> = ({ children = null }) => {
         dispatch(
           featureFlagsActions.setFeatureFlags({
             isCurrencyFeatureEnabled: client.isEnabled(FeatureToggle.currency),
+            isDistributionFeatureEnabled: client.isEnabled(FeatureToggle.distribution),
             isExcludesFeatureEnabled: client.isEnabled(FeatureToggle.excludes),
             isExportsFeatureEnabled: client.isEnabled(FeatureToggle.exports),
             isIbmFeatureEnabled: client.isEnabled(FeatureToggle.ibm),

--- a/src/store/featureFlags/__snapshots__/featureFlags.test.ts.snap
+++ b/src/store/featureFlags/__snapshots__/featureFlags.test.ts.snap
@@ -4,6 +4,7 @@ exports[`default state 1`] = `
 {
   "hasFeatureFlags": false,
   "isCurrencyFeatureEnabled": false,
+  "isDistributionFeatureEnabled": false,
   "isExcludesFeatureEnabled": false,
   "isExportsFeatureEnabled": false,
   "isIbmFeatureEnabled": false,

--- a/src/store/featureFlags/featureFlags.test.ts
+++ b/src/store/featureFlags/featureFlags.test.ts
@@ -20,6 +20,12 @@ test('currency feature is enabled', async () => {
   expect(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(store.getState())).toBe(true);
 });
 
+test('distribution feature is enabled', async () => {
+  const store = createUIStore();
+  store.dispatch(actions.setFeatureFlags({ isDistributionFeatureEnabled: true }));
+  expect(featureFlagsSelectors.selectIsDistributionFeatureEnabled(store.getState())).toBe(true);
+});
+
 test('excludes feature is enabled', async () => {
   const store = createUIStore();
   store.dispatch(actions.setFeatureFlags({ isExcludesFeatureEnabled: true }));

--- a/src/store/featureFlags/featureFlagsActions.ts
+++ b/src/store/featureFlags/featureFlagsActions.ts
@@ -2,6 +2,7 @@ import { createAction } from 'typesafe-actions';
 
 export interface FeatureFlagsActionMeta {
   isCurrencyFeatureEnabled?: boolean;
+  isDistributionFeatureEnabled?: boolean;
   isExcludesFeatureEnabled?: boolean;
   isExportsFeatureEnabled?: boolean;
   isIbmFeatureEnabled?: boolean;

--- a/src/store/featureFlags/featureFlagsReducer.ts
+++ b/src/store/featureFlags/featureFlagsReducer.ts
@@ -9,6 +9,7 @@ export type FeatureFlagsAction = ActionType<typeof setFeatureFlags | typeof rese
 export type FeatureFlagsState = Readonly<{
   hasFeatureFlags: boolean;
   isCurrencyFeatureEnabled: boolean;
+  isDistributionFeatureEnabled: boolean;
   isExcludesFeatureEnabled: boolean;
   isExportsFeatureEnabled: boolean;
   isIbmFeatureEnabled: boolean;
@@ -18,6 +19,7 @@ export type FeatureFlagsState = Readonly<{
 export const defaultState: FeatureFlagsState = {
   hasFeatureFlags: false,
   isCurrencyFeatureEnabled: false,
+  isDistributionFeatureEnabled: false,
   isExcludesFeatureEnabled: false,
   isExportsFeatureEnabled: false,
   isIbmFeatureEnabled: false,
@@ -33,6 +35,7 @@ export function featureFlagsReducer(state = defaultState, action: FeatureFlagsAc
         ...state,
         hasFeatureFlags: true,
         isCurrencyFeatureEnabled: action.payload.isCurrencyFeatureEnabled,
+        isDistributionFeatureEnabled: action.payload.isDistributionFeatureEnabled,
         isExcludesFeatureEnabled: action.payload.isExcludesFeatureEnabled,
         isExportsFeatureEnabled: action.payload.isExportsFeatureEnabled,
         isIbmFeatureEnabled: action.payload.isIbmFeatureEnabled,

--- a/src/store/featureFlags/featureFlagsSelectors.ts
+++ b/src/store/featureFlags/featureFlagsSelectors.ts
@@ -8,6 +8,8 @@ export const selectHasFeatureFlags = (state: RootState) => selectFeatureFlagsSta
 
 export const selectIsCurrencyFeatureEnabled = (state: RootState) =>
   selectFeatureFlagsState(state)?.isCurrencyFeatureEnabled;
+export const selectIsDistributionFeatureEnabled = (state: RootState) =>
+  selectFeatureFlagsState(state)?.isDistributionFeatureEnabled;
 export const selectIsExcludesFeatureEnabled = (state: RootState) =>
   selectFeatureFlagsState(state).isExcludesFeatureEnabled;
 export const selectIsExportsFeatureEnabled = (state: RootState) =>


### PR DESCRIPTION
Added cost distribution flag. This will allow new features to be tested in stage with the cost-demo user.

Example:
```
import { featureFlagsSelectors } from 'store/featureFlags';
...
const isDistributionFeatureEnabled = featureFlagsSelectors.selectIsDistributionFeatureEnabled(state);
```

https://issues.redhat.com/browse/COST-3145