### PR TITLE
Add cost type selector to "AWS filtered by OpenShift" perspective

### DIFF
--- a/src/routes/views/explorer/explorer.tsx
+++ b/src/routes/views/explorer/explorer.tsx
@@ -549,11 +549,12 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
     groupBy = { [getGroupByDefault(perspective)]: '*' };
   }
 
-  const costType = perspective === PerspectiveType.aws ? getCostType() : undefined;
+  const isCostTypeFeatureEnabled = featureFlagsSelectors.selectIsCostTypeFeatureEnabled(state);
+  const costType =
+    perspective === PerspectiveType.aws || (perspective === PerspectiveType.awsOcp && isCostTypeFeatureEnabled)
+      ? getCostType()
+      : undefined;
   const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
-
-  // eslint-disable-next-line no-console
-  console.log('Explorer getCurrency', currency);
 
   const query = {
     filter: {

--- a/src/routes/views/explorer/explorerHeader.tsx
+++ b/src/routes/views/explorer/explorerHeader.tsx
@@ -73,6 +73,7 @@ interface ExplorerHeaderStateProps {
   azureProviders?: Providers;
   gcpProviders?: Providers;
   ibmProviders?: Providers;
+  isCostTypeFeatureEnabled?: boolean;
   isCurrencyFeatureEnabled?: boolean;
   isExportsFeatureEnabled?: boolean;
   isIbmFeatureEnabled?: boolean;
@@ -244,6 +245,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
       currency,
       groupBy,
       intl,
+      isCostTypeFeatureEnabled,
       isCurrencyFeatureEnabled,
       isExportsFeatureEnabled,
       onCostTypeSelected,
@@ -296,7 +298,8 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
               tagReportPathsType={tagReportPathsType}
             />
           </div>
-          {perspective === PerspectiveType.aws && (
+          {(perspective === PerspectiveType.aws ||
+            (perspective === PerspectiveType.awsOcp && isCostTypeFeatureEnabled)) && (
             <div style={styles.costType}>
               <CostType costType={costType} onSelect={onCostTypeSelected} />
             </div>
@@ -374,6 +377,7 @@ const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHe
       azureProviders: filterProviders(providers, ProviderType.azure),
       gcpProviders: filterProviders(providers, ProviderType.gcp),
       ibmProviders: filterProviders(providers, ProviderType.ibm),
+      isCostTypeFeatureEnabled: featureFlagsSelectors.selectIsCostTypeFeatureEnabled(state),
       isCurrencyFeatureEnabled: featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state),
       isExportsFeatureEnabled: featureFlagsSelectors.selectIsExportsFeatureEnabled(state),
       isIbmFeatureEnabled: featureFlagsSelectors.selectIsIbmFeatureEnabled(state),

--- a/src/routes/views/overview/awsOcpDashboard/awsOcpDashboardWidget.tsx
+++ b/src/routes/views/overview/awsOcpDashboard/awsOcpDashboardWidget.tsx
@@ -10,6 +10,8 @@ import { reportSelectors } from 'store/reports';
 import type { ComputedAwsReportItemsParams } from 'utils/computedReport/getComputedAwsReportItems';
 import { getCurrency } from 'utils/localStorage';
 
+import { getCostType } from '../../../../utils/costType';
+
 interface AwsOcpDashboardWidgetDispatchProps {
   fetchForecasts: typeof awsOcpDashboardActions.fetchWidgetForecasts;
   fetchReports: typeof awsOcpDashboardActions.fetchWidgetReports;
@@ -34,6 +36,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     return {
       ...widget,
       ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+      ...(featureFlagsSelectors.selectIsCostTypeFeatureEnabled(state) && { costType: getCostType() }),
       getIdKeyForTab,
       currentQuery: queries.current,
       forecastQuery: queries.forecast,

--- a/src/routes/views/overview/awsOcpDashboard/awsOcpDashboardWidget.tsx
+++ b/src/routes/views/overview/awsOcpDashboard/awsOcpDashboardWidget.tsx
@@ -8,9 +8,8 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedAwsReportItemsParams } from 'utils/computedReport/getComputedAwsReportItems';
+import { getCostType } from 'utils/costType';
 import { getCurrency } from 'utils/localStorage';
-
-import { getCostType } from '../../../../utils/costType';
 
 interface AwsOcpDashboardWidgetDispatchProps {
   fetchForecasts: typeof awsOcpDashboardActions.fetchWidgetForecasts;

--- a/src/store/accountSettings/accountSettingsReducer.ts
+++ b/src/store/accountSettings/accountSettingsReducer.ts
@@ -96,8 +96,6 @@ function initCurrency(value: string) {
   }
 
   if (!isCurrencyAvailable()) {
-    // eslint-disable-next-line no-console
-    console.log('setCurrency', value);
     setCurrency(value);
   }
   setAccountCurrency(value);

--- a/src/store/dashboard/awsDashboard/__snapshots__/awsDashboard.test.ts.snap
+++ b/src/store/dashboard/awsDashboard/__snapshots__/awsDashboard.test.ts.snap
@@ -15,7 +15,7 @@ exports[`fetch widget reports 1`] = `
   [
     "aws",
     "cost",
-    "cost_type=unblended_cost&filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[service]=*",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[service]=*&cost_type=unblended_cost",
   ],
 ]
 `;

--- a/src/store/dashboard/awsDashboard/awsDashboardCommon.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardCommon.ts
@@ -1,7 +1,6 @@
 import type { AwsFilters, AwsQuery } from 'api/queries/awsQuery';
 import { getQuery } from 'api/queries/awsQuery';
 import type { DashboardWidget } from 'store/dashboard/common/dashboardCommon';
-import { getCostType } from 'utils/costType';
 
 export const awsDashboardStateKey = 'awsDashboard';
 export const awsDashboardDefaultFilters: AwsFilters = {
@@ -44,7 +43,6 @@ export function getGroupByForTab(widget: AwsDashboardWidget): AwsQuery['group_by
 export function getQueryForWidget(widget: AwsDashboardWidget, filter: AwsFilters = awsDashboardDefaultFilters, props?) {
   const query: AwsQuery = {
     filter,
-    ...(widget.savingsPlan && { cost_type: getCostType() }),
     ...(props ? props : {}),
   };
   return getQuery(query);
@@ -65,7 +63,6 @@ export function getQueryForWidgetTabs(
     newFilter.service = undefined;
   }
   const query: AwsQuery = {
-    ...(widget.savingsPlan && { cost_type: getCostType() }),
     filter: newFilter,
     group_by,
     ...(props ? props : {}),

--- a/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
@@ -1,5 +1,6 @@
 import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
+import { getCostType } from 'utils/costType';
 import { getCurrency } from 'utils/localStorage';
 
 import {
@@ -31,6 +32,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
   };
   const props = {
     ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+    ...(widget.savingsPlan && { cost_type: getCostType() }),
   };
 
   return {

--- a/src/store/dashboard/awsOcpDashboard/awsOcpDashboardCommon.ts
+++ b/src/store/dashboard/awsOcpDashboard/awsOcpDashboardCommon.ts
@@ -20,7 +20,9 @@ export const enum AwsOcpDashboardTab {
   regions = 'regions',
 }
 
-export interface AwsOcpDashboardWidget extends DashboardWidget<AwsOcpDashboardTab> {}
+export interface AwsOcpDashboardWidget extends DashboardWidget<AwsOcpDashboardTab> {
+  savingsPlan?: boolean;
+}
 
 export function getGroupByForTab(widget: AwsOcpDashboardWidget): AwsQuery['group_by'] {
   switch (widget.currentTab) {
@@ -38,7 +40,11 @@ export function getGroupByForTab(widget: AwsOcpDashboardWidget): AwsQuery['group
   }
 }
 
-export function getQueryForWidget(filter: AwsFilters = awsOcpDashboardDefaultFilters, props?) {
+export function getQueryForWidget(
+  widget: AwsOcpDashboardWidget,
+  filter: AwsFilters = awsOcpDashboardDefaultFilters,
+  props?
+) {
   const query: AwsQuery = {
     filter,
     ...(props ? props : {}),

--- a/src/store/dashboard/awsOcpDashboard/awsOcpDashboardSelectors.ts
+++ b/src/store/dashboard/awsOcpDashboard/awsOcpDashboardSelectors.ts
@@ -1,5 +1,6 @@
 import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
+import { getCostType } from 'utils/costType';
 import { getCurrency } from 'utils/localStorage';
 
 import {
@@ -31,18 +32,21 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
   };
   const props = {
     ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+    ...(featureFlagsSelectors.selectIsCostTypeFeatureEnabled(state) &&
+      widget.savingsPlan && { cost_type: getCostType() }),
   };
 
   return {
     previous: getQueryForWidget(
+      widget,
       {
         ...filter,
         time_scope_value: -2,
       },
       props
     ),
-    current: getQueryForWidget(filter, props),
-    forecast: getQueryForWidget({}, { limit: 31, ...props }),
+    current: getQueryForWidget(widget, filter, props),
+    forecast: getQueryForWidget(widget, {}, { limit: 31, ...props }),
     tabs: getQueryForWidgetTabs(
       widget,
       {

--- a/src/store/dashboard/awsOcpDashboard/awsOcpDashboardWidgets.ts
+++ b/src/store/dashboard/awsOcpDashboard/awsOcpDashboardWidgets.ts
@@ -62,6 +62,7 @@ export const costSummaryWidget: AwsOcpDashboardWidget = {
     costKey: messages.cost,
     showHorizontal: true,
   },
+  savingsPlan: true,
   tabsFilter: {
     limit: 3,
   },
@@ -90,6 +91,7 @@ export const databaseWidget: AwsOcpDashboardWidget = {
   filter: {
     service: awsDashboardWidgets.databaseWidget.filter.service,
   },
+  savingsPlan: true,
   tabsFilter: {
     service: awsDashboardWidgets.databaseWidget.tabsFilter.service,
   },
@@ -116,6 +118,7 @@ export const networkWidget: AwsOcpDashboardWidget = {
   filter: {
     service: awsDashboardWidgets.networkWidget.filter.service,
   },
+  savingsPlan: true,
   tabsFilter: {
     service: awsDashboardWidgets.networkWidget.tabsFilter.service,
   },


### PR DESCRIPTION
Add cost type selector to "AWS filtered by OpenShift" perspective in overview and cost explorer pages.

Note that this feature uses the Unleash cost-management.ui.cost-type toggle, which is currently disabled until API support is available.

https://issues.redhat.com/browse/COST-3122

![Screen Shot 2022-11-14 at 8 27 44 PM](https://user-images.githubusercontent.com/17481322/201804024-c009db7d-d6c4-432b-85a4-ac4272eb7ee1.png)
