### PR TITLE
OCI cost explorer shows dates instead of accounts and services

### DIFF
--- a/src/api/reports/explorerReports.ts
+++ b/src/api/reports/explorerReports.ts
@@ -7,6 +7,8 @@ export interface ExplorerReportItem extends ReportItem {
   gcp_project?: string;
   node?: string;
   org_unit_id?: string;
+  payer_tenant_id?: string;
+  product_service?: string;
   project?: string;
   region?: string;
   resource_location?: string;

--- a/src/utils/computedReport/getComputedExplorerReportItems.ts
+++ b/src/utils/computedReport/getComputedExplorerReportItems.ts
@@ -22,6 +22,12 @@ export function getIdKeyForGroupBy(groupBy: Query['group_by'] = {}): ComputedExp
   if (groupBy.org_unit_id) {
     return 'org_unit_id';
   }
+  if (groupBy.payer_tenant_id) {
+    return 'payer_tenant_id';
+  }
+  if (groupBy.product_service) {
+    return 'product_service';
+  }
   if (groupBy.project) {
     return 'project';
   }


### PR DESCRIPTION
This fixes an issue where the Cost explorer shows dates for OCI instead of account and service names.

Note that we have to specifically look for `payer_tenant_id` and `product_service` in the API response; otherwise, the code defaults to the `date`.

https://issues.redhat.com/browse/COST-3262

![Screen Shot 2022-11-15 at 11 25 08 AM](https://user-images.githubusercontent.com/17481322/201972585-13838c1a-6386-4681-a937-46563d5c8ab6.png)
