### PR TITLE
Export should include AWS cost type

### DIFF
--- a/src/routes/views/components/export/exportModal.tsx
+++ b/src/routes/views/components/export/exportModal.tsx
@@ -22,6 +22,7 @@ import React from 'react';
 import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
+import type { PerspectiveType } from 'routes/views/explorer/explorerUtils';
 import { createMapStateToProps } from 'store/common';
 import { exportActions } from 'store/export';
 import { featureFlagsSelectors } from 'store/featureFlags';
@@ -37,6 +38,7 @@ export interface ExportModalOwnProps {
   isOpen: boolean;
   items?: ComputedReportItem[];
   onClose(isOpen: boolean);
+  perspective?: PerspectiveType;
   query?: Query;
   queryString?: string;
   reportPathsType: ReportPathsType;
@@ -150,6 +152,7 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
       isAllItems,
       isExportsFeatureEnabled,
       items,
+      perspective,
       query,
       reportPathsType,
       showAggregateType = true,
@@ -210,6 +213,7 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
             timeScope={showTimeScope ? timeScope : undefined}
             onClose={this.handleClose}
             onError={this.handleError}
+            perspective={perspective}
             name={defaultName}
             query={query}
             reportPathsType={reportPathsType}

--- a/src/routes/views/details/awsDetails/awsDetails.tsx
+++ b/src/routes/views/details/awsDetails/awsDetails.tsx
@@ -21,6 +21,7 @@ import { NoData } from 'routes/state/noData';
 import { NoProviders } from 'routes/state/noProviders';
 import { NotAvailable } from 'routes/state/notAvailable';
 import { ExportModal } from 'routes/views/components/export';
+import { PerspectiveType } from 'routes/views/explorer/explorerUtils';
 import { getGroupByTagKey } from 'routes/views/utils/groupBy';
 import {
   getRouteForQuery,
@@ -44,7 +45,6 @@ import type { CostTypes } from 'utils/costType';
 import { getCostType } from 'utils/costType';
 import { getCurrency } from 'utils/localStorage';
 
-import { PerspectiveType } from '../../explorer/explorerUtils';
 import { styles } from './awsDetails.styles';
 import { DetailsHeader } from './detailsHeader';
 import { DetailsTable } from './detailsTable';

--- a/src/routes/views/details/awsDetails/awsDetails.tsx
+++ b/src/routes/views/details/awsDetails/awsDetails.tsx
@@ -44,6 +44,7 @@ import type { CostTypes } from 'utils/costType';
 import { getCostType } from 'utils/costType';
 import { getCurrency } from 'utils/localStorage';
 
+import { PerspectiveType } from '../../explorer/explorerUtils';
 import { styles } from './awsDetails.styles';
 import { DetailsHeader } from './detailsHeader';
 import { DetailsTable } from './detailsTable';
@@ -172,6 +173,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isOpen={isExportModalOpen}
         items={items}
+        perspective={PerspectiveType.aws}
         onClose={this.handleExportModalClose}
         query={query}
         reportPathsType={reportPathsType}
@@ -289,7 +291,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     let groupByKey = groupBy;
     let value = '*';
 
-    // Check for for org units
+    // Check for org units
     const index = groupBy.indexOf(orgUnitIdKey);
     if (index !== -1) {
       groupByKey = orgUnitIdKey.substring(0, orgUnitIdKey.length);

--- a/src/routes/views/explorer/explorer.tsx
+++ b/src/routes/views/explorer/explorer.tsx
@@ -191,6 +191,7 @@ class Explorer extends React.Component<ExplorerProps> {
         isOpen={isExportModalOpen}
         items={items}
         onClose={this.handleExportModalClose}
+        perspective={perspective}
         query={query}
         reportPathsType={getReportPathsType(perspective)}
         resolution="daily"


### PR DESCRIPTION
The export feature should include AWS cost type when generating API requests for the AWS details page and Cost Explorer

https://issues.redhat.com/browse/COST-3278