### PR TITLE
Cleanup query string names

### DIFF
--- a/src/components/exports/exportsContent.tsx
+++ b/src/components/exports/exportsContent.tsx
@@ -27,6 +27,7 @@ interface ExportsContentStateProps {
   report: Report;
   reportError: AxiosError;
   reportFetchStatus: FetchStatus;
+  reportQueryString: string;
 }
 
 interface ExportsContentDispatchProps {
@@ -212,10 +213,15 @@ const mapStateToProps = createMapStateToProps<ExportsContentOwnProps, ExportsCon
   const reportType = ReportType.cost;
   const reportPathsType = ReportPathsType.ocp;
 
-  const queryString = getQuery(query);
-  // const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+  const reportQueryString = getQuery(query);
+  // const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
+  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);
+  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+    state,
+    reportPathsType,
+    reportType,
+    reportQueryString
+  );
 
   // Todo: For testing
   const report = {
@@ -273,6 +279,7 @@ const mapStateToProps = createMapStateToProps<ExportsContentOwnProps, ExportsCon
     report,
     reportError,
     reportFetchStatus,
+    reportQueryString,
   };
 });
 

--- a/src/routes/views/components/export/exportModal.tsx
+++ b/src/routes/views/components/export/exportModal.tsx
@@ -22,7 +22,6 @@ import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
-import { exportActions } from 'store/export';
 import { featureFlagsSelectors } from 'store/featureFlags';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 
@@ -36,8 +35,8 @@ export interface ExportModalOwnProps {
   isOpen: boolean;
   items?: ComputedReportItem[];
   onClose(isOpen: boolean);
-  queryString?: string;
   reportPathsType: ReportPathsType;
+  reportQueryString: string;
   resolution?: 'daily' | 'monthly'; // Default resolution
   showAggregateType?: boolean; // Monthly resolution filters are not valid with date range
   showFormatType?: boolean; // Format type; CVS / JSON
@@ -48,10 +47,6 @@ interface ExportModalStateProps {
   isExportsFeatureEnabled?: boolean;
 }
 
-interface ExportModalDispatchProps {
-  exportReport?: typeof exportActions.exportReport;
-}
-
 interface ExportModalState {
   error?: AxiosError;
   formatType: 'csv' | 'json';
@@ -60,7 +55,7 @@ interface ExportModalState {
   resolution: string;
 }
 
-type ExportModalProps = ExportModalOwnProps & ExportModalDispatchProps & ExportModalStateProps & WrappedComponentProps;
+type ExportModalProps = ExportModalOwnProps & ExportModalStateProps & WrappedComponentProps;
 
 const formatTypeOptions: {
   label: MessageDescriptor;
@@ -148,8 +143,8 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
       isAllItems,
       isExportsFeatureEnabled,
       items,
-      queryString,
       reportPathsType,
+      reportQueryString,
       showAggregateType = true,
       showFormatType = true,
       showTimeScope = true,
@@ -209,8 +204,8 @@ export class ExportModalBase extends React.Component<ExportModalProps, ExportMod
             onClose={this.handleClose}
             onError={this.handleError}
             name={defaultName}
-            queryString={queryString}
             reportPathsType={reportPathsType}
+            reportQueryString={reportQueryString}
             resolution={resolution}
           />,
           <Button ouiaId="cancel-btn" key="cancel" onClick={this.handleClose} variant={ButtonVariant.link}>
@@ -335,11 +330,7 @@ const mapStateToProps = createMapStateToProps<ExportModalOwnProps, unknown>(stat
   };
 });
 
-const mapDispatchToProps: ExportModalDispatchProps = {
-  exportReport: exportActions.exportReport,
-};
-
-const ExportModalConnect = connect(mapStateToProps, mapDispatchToProps)(ExportModalBase);
+const ExportModalConnect = connect(mapStateToProps, undefined)(ExportModalBase);
 const ExportModal = injectIntl(ExportModalConnect);
 
 export default ExportModal;

--- a/src/routes/views/components/export/exportSubmit.tsx
+++ b/src/routes/views/components/export/exportSubmit.tsx
@@ -117,14 +117,14 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
     });
   };
 
-  private handleFetchReport = () => {
-    const { fetchExport, isExportsFeatureEnabled, reportPathsType, reportQueryString } = this.props;
+  private handleFetchExport = () => {
+    const { exportQueryString, fetchExport, isExportsFeatureEnabled, reportPathsType } = this.props;
 
-    fetchExport(reportPathsType, reportType, reportQueryString, isExportsFeatureEnabled);
+    fetchExport(reportPathsType, reportType, exportQueryString, isExportsFeatureEnabled);
 
     this.setState(
       {
-        fetchReportClicked: true,
+        fetchExportClicked: true,
       },
       () => {
         this.getExport();
@@ -140,7 +140,7 @@ export class ExportSubmitBase extends React.Component<ExportSubmitProps> {
         ouiaId="submit-btn"
         isDisabled={disabled || exportFetchStatus === FetchStatus.inProgress}
         key="confirm"
-        onClick={this.handleFetchReport}
+        onClick={this.handleFetchExport}
         variant={ButtonVariant.primary}
       >
         {intl.formatMessage(messages.exportGenerate)}
@@ -235,7 +235,7 @@ const mapStateToProps = createMapStateToProps<ExportSubmitOwnProps, ExportSubmit
     state,
     reportPathsType,
     reportType,
-    reportQueryString
+    exportQueryString
   );
 
   return {

--- a/src/routes/views/components/resourceTypeahead/resourceInput.tsx
+++ b/src/routes/views/components/resourceTypeahead/resourceInput.tsx
@@ -39,6 +39,7 @@ interface ResourceInputOwnProps {
 
 interface ResourceInputStateProps {
   resourceFetchStatus?: FetchStatus;
+  resourceQueryString?: string;
 }
 
 interface ResourceInputState {
@@ -79,19 +80,15 @@ class ResourceInputBase extends React.Component<ResourceInputProps> {
   }
 
   public componentDidUpdate(prevProps: ResourceInputProps) {
-    const { fetchResource, resourceFetchStatus, resourcePathsType, resourceType, search } = this.props;
+    const { fetchResource, resourceFetchStatus, resourcePathsType, resourceType, resourceQueryString, search } =
+      this.props;
 
     if (search && prevProps.search !== search && resourceFetchStatus !== FetchStatus.inProgress) {
       clearTimeout(this.searchTimeout);
 
-      const query: Query = {
-        search,
-      };
-      const queryString = getQuery(query);
-
       // Delay was 750ms, but reduced -- https://issues.redhat.com/browse/COST-1742
       this.searchTimeout = setTimeout(() => {
-        fetchResource(resourcePathsType, resourceType, queryString);
+        fetchResource(resourcePathsType, resourceType, resourceQueryString);
       }, 625);
     }
   }
@@ -291,19 +288,20 @@ const mapStateToProps = createMapStateToProps<ResourceInputOwnProps, ResourceInp
     const query: Query = {
       search,
     };
-    const queryString = getQuery(query);
 
-    const resource = resourceSelectors.selectResource(state, resourcePathsType, resourceType, queryString);
+    const resourceQueryString = getQuery(query);
+    const resource = resourceSelectors.selectResource(state, resourcePathsType, resourceType, resourceQueryString);
     const resourceFetchStatus = resourceSelectors.selectResourceFetchStatus(
       state,
       resourcePathsType,
       resourceType,
-      queryString
+      resourceQueryString
     );
 
     return {
       resource,
       resourceFetchStatus,
+      resourceQueryString,
     };
   }
 );

--- a/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
@@ -39,12 +39,12 @@ interface AwsBreakdownStateProps {
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
   query: Query;
-  queryString: string;
   report: Report;
   reportError: AxiosError;
   reportFetchStatus: FetchStatus;
   reportType: ReportType;
   reportPathsType: ReportPathsType;
+  reportQueryString: string;
 }
 
 interface BreakdownDispatchProps {
@@ -83,15 +83,20 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
       ...(groupBy && { [groupBy]: groupByValue }),
     },
   };
-  const queryString = getQuery({
+
+  const reportQueryString = getQuery({
     ...newQuery,
     cost_type: costType,
     currency,
   });
-
-  const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+  const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
+  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);
+  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+    state,
+    reportPathsType,
+    reportType,
+    reportQueryString
+  );
 
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);
@@ -119,12 +124,12 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
     providersFetchStatus,
     providerType: ProviderType.aws,
     query,
-    queryString,
     report,
     reportError,
     reportFetchStatus,
     reportType,
     reportPathsType,
+    reportQueryString,
     showCostType: true,
     tagReportPathsType: TagPathsType.aws,
     title: query[breakdownTitleKey] ? query[breakdownTitleKey] : groupByValue,

--- a/src/routes/views/details/awsDetails/awsDetails.tsx
+++ b/src/routes/views/details/awsDetails/awsDetails.tsx
@@ -56,10 +56,10 @@ interface AwsDetailsStateProps {
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
   query: AwsQuery;
-  queryString: string;
   report: AwsReport;
   reportError: AxiosError;
   reportFetchStatus: FetchStatus;
+  reportQueryString: string;
 }
 
 interface AwsDetailsDispatchProps {
@@ -123,10 +123,10 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
   }
 
   public componentDidUpdate(prevProps: AwsDetailsProps, prevState: AwsDetailsState) {
-    const { location, report, reportError, queryString } = this.props;
+    const { location, report, reportError, reportQueryString } = this.props;
     const { selectedItems } = this.state;
 
-    const newQuery = prevProps.queryString !== queryString;
+    const newQuery = prevProps.reportQueryString !== reportQueryString;
     const noReport = !report && !reportError;
     const noLocation = !location.search;
     const newItems = prevState.selectedItems !== selectedItems;
@@ -151,7 +151,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
   };
 
   private getExportModal = (computedItems: ComputedReportItem[]) => {
-    const { query, queryString, report } = this.props;
+    const { query, report, reportQueryString } = this.props;
     const { isAllSelected, isExportModalOpen, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
@@ -173,8 +173,8 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
         isOpen={isExportModalOpen}
         items={items}
         onClose={this.handleExportModalClose}
-        queryString={queryString}
         reportPathsType={reportPathsType}
+        reportQueryString={reportQueryString}
       />
     );
   };
@@ -214,7 +214,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
   };
 
   private getTable = () => {
-    const { history, query, queryString, report, reportFetchStatus } = this.props;
+    const { history, query, report, reportFetchStatus, reportQueryString } = this.props;
     const { isAllSelected, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
@@ -230,8 +230,8 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
         isLoading={reportFetchStatus === FetchStatus.inProgress}
         onSelected={this.handleSelected}
         onSort={(sortType, isSortAscending) => handleSort(history, query, sortType, isSortAscending)}
-        queryString={queryString}
         report={report}
+        reportQueryString={reportQueryString}
         selectedItems={selectedItems}
       />
     );
@@ -329,7 +329,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
   };
 
   private updateReport = () => {
-    const { query, location, fetchReport, history, queryString } = this.props;
+    const { query, location, fetchReport, history, reportQueryString } = this.props;
     if (!location.search) {
       history.replace(
         getRouteForQuery(history, {
@@ -340,7 +340,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
         })
       );
     } else {
-      fetchReport(reportPathsType, reportType, queryString);
+      fetchReport(reportPathsType, reportType, reportQueryString);
     }
   };
 
@@ -424,14 +424,19 @@ const mapStateToProps = createMapStateToProps<AwsDetailsOwnProps, AwsDetailsStat
     group_by: queryFromRoute.group_by || baseQuery.group_by,
     order_by: queryFromRoute.order_by || baseQuery.order_by,
   };
-  const queryString = getQuery({
+  const reportQueryString = getQuery({
     ...query,
     cost_type: costType,
     currency,
   });
-  const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+  const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
+  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);
+  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+    state,
+    reportPathsType,
+    reportType,
+    reportQueryString
+  );
 
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);
@@ -449,10 +454,10 @@ const mapStateToProps = createMapStateToProps<AwsDetailsOwnProps, AwsDetailsStat
     providersError,
     providersFetchStatus,
     query,
-    queryString,
     report,
     reportError,
     reportFetchStatus,
+    reportQueryString,
 
     // Testing...
     //

--- a/src/routes/views/details/awsDetails/detailsHeader.tsx
+++ b/src/routes/views/details/awsDetails/detailsHeader.tsx
@@ -2,8 +2,6 @@ import { Title, TitleSizes } from '@patternfly/react-core';
 import { OrgPathsType } from 'api/orgs/org';
 import type { Providers } from 'api/providers';
 import { ProviderType } from 'api/providers';
-import type { AwsQuery } from 'api/queries/awsQuery';
-import { getQuery } from 'api/queries/awsQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import type { AwsReport } from 'api/reports/awsReports';
 import { TagPathsType } from 'api/tags/tag';
@@ -46,19 +44,10 @@ interface DetailsHeaderStateProps {
   providers: Providers;
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
-  queryString?: string;
+  providersQueryString?: string;
 }
 
 type DetailsHeaderProps = DetailsHeaderOwnProps & DetailsHeaderStateProps & WrappedComponentProps;
-
-const baseQuery: AwsQuery = {
-  delta: 'cost',
-  filter: {
-    time_scope_units: 'month',
-    time_scope_value: -1,
-    resolution: 'monthly',
-  },
-};
 
 const groupByOptions: {
   label: string;
@@ -147,8 +136,6 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHeaderStateProps>((state, props) => {
-  const queryString = getQuery(baseQuery);
-
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);
   const providersError = providersSelectors.selectProvidersError(state, ProviderType.all, providersQueryString);
@@ -164,7 +151,7 @@ const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHead
     providers: filterProviders(providers, ProviderType.aws),
     providersError,
     providersFetchStatus,
-    queryString,
+    providersQueryString,
   };
 });
 

--- a/src/routes/views/details/awsDetails/detailsTable.tsx
+++ b/src/routes/views/details/awsDetails/detailsTable.tsx
@@ -26,8 +26,8 @@ interface DetailsTableOwnProps {
   isLoading?: boolean;
   onSelected(items: ComputedReportItem[], isSelected: boolean);
   onSort(value: string, isSortAscending: boolean);
-  queryString: string;
   report: AwsReport;
+  reportQueryString: string;
   selectedItems?: ComputedReportItem[];
 }
 
@@ -61,8 +61,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   }
 
   private initDatum = () => {
-    const { groupBy, groupByOrg, groupByTagKey, isAllSelected, queryString, report, selectedItems, intl } = this.props;
-    if (!queryString || !report) {
+    const { groupBy, groupByOrg, groupByTagKey, isAllSelected, report, selectedItems, intl } = this.props;
+    if (!report) {
       return;
     }
 
@@ -176,15 +176,15 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private getActions = (item: ComputedReportItem, index: number, disabled: boolean = false) => {
-    const { groupBy, queryString } = this.props;
+    const { groupBy, reportQueryString } = this.props;
 
     return (
       <Actions
         groupBy={groupBy}
         isDisabled={disabled}
         item={item}
-        queryString={queryString}
         reportPathsType={reportPathsType}
+        reportQueryString={reportQueryString}
       />
     );
   };

--- a/src/routes/views/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/routes/views/details/azureBreakdown/azureBreakdown.tsx
@@ -39,12 +39,12 @@ interface AzureCostStateProps {
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
   query: Query;
-  queryString: string;
   report: Report;
   reportError: AxiosError;
   reportFetchStatus: FetchStatus;
   reportType: ReportType;
   reportPathsType: ReportPathsType;
+  reportQueryString: string;
 }
 
 interface AzureCostDispatchProps {
@@ -80,14 +80,19 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateP
       ...(groupBy && { [groupBy]: groupByValue }),
     },
   };
-  const queryString = getQuery({
+
+  const reportQueryString = getQuery({
     ...newQuery,
     currency,
   });
-
-  const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+  const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
+  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);
+  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+    state,
+    reportPathsType,
+    reportType,
+    reportQueryString
+  );
 
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);
@@ -112,12 +117,12 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, AzureCostStateP
     providersFetchStatus,
     providerType: ProviderType.azure,
     query,
-    queryString,
     report,
     reportError,
     reportFetchStatus,
     reportType,
     reportPathsType,
+    reportQueryString,
     tagReportPathsType: TagPathsType.azure,
     title: groupByValue,
   };

--- a/src/routes/views/details/azureDetails/azureDetails.tsx
+++ b/src/routes/views/details/azureDetails/azureDetails.tsx
@@ -50,10 +50,10 @@ interface AzureDetailsStateProps {
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
   query: AzureQuery;
-  queryString: string;
   report: AzureReport;
   reportError: AxiosError;
   reportFetchStatus: FetchStatus;
+  reportQueryString: string;
 }
 
 interface AzureDetailsDispatchProps {
@@ -117,10 +117,10 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
   }
 
   public componentDidUpdate(prevProps: AzureDetailsProps, prevState: AzureDetailsState) {
-    const { location, report, reportError, queryString } = this.props;
+    const { location, report, reportError, reportQueryString } = this.props;
     const { selectedItems } = this.state;
 
-    const newQuery = prevProps.queryString !== queryString;
+    const newQuery = prevProps.reportQueryString !== reportQueryString;
     const noReport = !report && !reportError;
     const noLocation = !location.search;
     const newItems = prevState.selectedItems !== selectedItems;
@@ -143,7 +143,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
   };
 
   private getExportModal = (computedItems: ComputedReportItem[]) => {
-    const { query, queryString, report } = this.props;
+    const { query, report, reportQueryString } = this.props;
     const { isAllSelected, isExportModalOpen, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
@@ -165,8 +165,8 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
         isOpen={isExportModalOpen}
         items={items}
         onClose={this.handleExportModalClose}
-        queryString={queryString}
         reportPathsType={reportPathsType}
+        reportQueryString={reportQueryString}
       />
     );
   };
@@ -206,7 +206,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
   };
 
   private getTable = () => {
-    const { history, query, queryString, report, reportFetchStatus } = this.props;
+    const { history, query, report, reportFetchStatus, reportQueryString } = this.props;
     const { isAllSelected, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
@@ -220,8 +220,8 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
         isLoading={reportFetchStatus === FetchStatus.inProgress}
         onSelected={this.handleSelected}
         onSort={(sortType, isSortAscending) => handleSort(history, query, sortType, isSortAscending)}
-        queryString={queryString}
         report={report}
+        reportQueryString={reportQueryString}
         selectedItems={selectedItems}
       />
     );
@@ -309,7 +309,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
   };
 
   private updateReport = () => {
-    const { fetchReport, history, location, query, queryString } = this.props;
+    const { fetchReport, history, location, query, reportQueryString } = this.props;
     if (!location.search) {
       history.replace(
         getRouteForQuery(history, {
@@ -320,7 +320,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
         })
       );
     } else {
-      fetchReport(reportPathsType, reportType, queryString);
+      fetchReport(reportPathsType, reportType, reportQueryString);
     }
   };
 
@@ -391,13 +391,18 @@ const mapStateToProps = createMapStateToProps<AzureDetailsOwnProps, AzureDetails
     group_by: queryFromRoute.group_by || baseQuery.group_by,
     order_by: queryFromRoute.order_by || baseQuery.order_by,
   };
-  const queryString = getQuery({
+  const reportQueryString = getQuery({
     ...query,
     currency,
   });
-  const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+  const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
+  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);
+  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+    state,
+    reportPathsType,
+    reportType,
+    reportQueryString
+  );
 
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);
@@ -414,10 +419,10 @@ const mapStateToProps = createMapStateToProps<AzureDetailsOwnProps, AzureDetails
     providersError,
     providersFetchStatus,
     query,
-    queryString,
     report,
     reportError,
     reportFetchStatus,
+    reportQueryString,
 
     // Testing...
     //

--- a/src/routes/views/details/azureDetails/detailsHeader.tsx
+++ b/src/routes/views/details/azureDetails/detailsHeader.tsx
@@ -1,8 +1,6 @@
 import { Title, TitleSizes } from '@patternfly/react-core';
 import type { Providers } from 'api/providers';
 import { ProviderType } from 'api/providers';
-import type { AzureQuery } from 'api/queries/azureQuery';
-import { getQuery } from 'api/queries/azureQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import type { AzureReport } from 'api/reports/azureReports';
 import { TagPathsType } from 'api/tags/tag';
@@ -41,19 +39,10 @@ interface DetailsHeaderStateProps {
   providers: Providers;
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
-  queryString?: string;
+  providersQueryString?: string;
 }
 
 type DetailsHeaderProps = DetailsHeaderOwnProps & DetailsHeaderStateProps & WrappedComponentProps;
-
-const baseQuery: AzureQuery = {
-  delta: 'cost',
-  filter: {
-    time_scope_units: 'month',
-    time_scope_value: -1,
-    resolution: 'monthly',
-  },
-};
 
 const groupByOptions: {
   label: string;
@@ -127,8 +116,6 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHeaderStateProps>((state, props) => {
-  const queryString = getQuery(baseQuery);
-
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);
   const providersError = providersSelectors.selectProvidersError(state, ProviderType.all, providersQueryString);
@@ -144,7 +131,7 @@ const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHead
     providers: filterProviders(providers, ProviderType.azure),
     providersError,
     providersFetchStatus,
-    queryString,
+    providersQueryString,
   };
 });
 

--- a/src/routes/views/details/azureDetails/detailsTable.tsx
+++ b/src/routes/views/details/azureDetails/detailsTable.tsx
@@ -25,8 +25,8 @@ interface DetailsTableOwnProps {
   isLoading?: boolean;
   onSelected(items: ComputedReportItem[], isSelected: boolean);
   onSort(value: string, isSortAscending: boolean);
-  queryString: string;
   report: AzureReport;
+  reportQueryString: string;
   selectedItems?: ComputedReportItem[];
 }
 
@@ -60,8 +60,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   }
 
   private initDatum = () => {
-    const { groupBy, groupByTagKey, isAllSelected, queryString, report, selectedItems, intl } = this.props;
-    if (!queryString || !report) {
+    const { groupBy, groupByTagKey, isAllSelected, report, selectedItems, intl } = this.props;
+    if (!report) {
       return;
     }
 
@@ -170,9 +170,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private getActions = (item: ComputedReportItem) => {
-    const { groupBy, queryString } = this.props;
+    const { groupBy, reportQueryString } = this.props;
 
-    return <Actions groupBy={groupBy} item={item} queryString={queryString} reportPathsType={reportPathsType} />;
+    return (
+      <Actions groupBy={groupBy} item={item} reportPathsType={reportPathsType} reportQueryString={reportQueryString} />
+    );
   };
 
   private getMonthOverMonthCost = (item: ComputedReportItem, index: number) => {

--- a/src/routes/views/details/azureDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/azureDetails/detailsToolbar.tsx
@@ -30,13 +30,13 @@ interface DetailsToolbarOwnProps {
   onFilterRemoved(filter: Filter);
   pagination?: React.ReactNode;
   query?: AzureQuery;
-  queryString?: string;
   selectedItems?: ComputedReportItem[];
 }
 
 interface DetailsToolbarStateProps {
   tagReport?: AzureTag;
   tagReportFetchStatus?: FetchStatus;
+  tagQueryString?: string;
 }
 
 interface DetailsToolbarDispatchProps {
@@ -60,7 +60,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   public state: DetailsToolbarState = { ...this.defaultState };
 
   public componentDidMount() {
-    const { fetchTag, queryString, tagReportFetchStatus } = this.props;
+    const { fetchTag, tagReportFetchStatus, tagQueryString } = this.props;
 
     this.setState(
       {
@@ -68,14 +68,14 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       },
       () => {
         if (tagReportFetchStatus !== FetchStatus.inProgress) {
-          fetchTag(tagReportPathsType, tagReportType, queryString);
+          fetchTag(tagReportPathsType, tagReportType, tagQueryString);
         }
       }
     );
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps) {
-    const { fetchTag, query, queryString, tagReport, tagReportFetchStatus } = this.props;
+    const { fetchTag, query, tagReport, tagReportFetchStatus, tagQueryString } = this.props;
 
     if (!isEqual(tagReport, prevProps.tagReport)) {
       this.setState(
@@ -84,13 +84,13 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         },
         () => {
           if (tagReportFetchStatus !== FetchStatus.inProgress) {
-            fetchTag(tagReportPathsType, tagReportType, queryString);
+            fetchTag(tagReportPathsType, tagReportType, tagQueryString);
           }
         }
       );
     } else if (query && !isEqual(query, prevProps.query)) {
       if (tagReportFetchStatus !== FetchStatus.inProgress) {
-        fetchTag(tagReportPathsType, tagReportType, queryString);
+        fetchTag(tagReportPathsType, tagReportType, tagQueryString);
       }
     }
   }
@@ -164,7 +164,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
   // Note: Omitting key_only would help to share a single, cached request -- the toolbar requires key values
   // However, for better server-side performance, we chose to use key_only here.
-  const queryString = getQuery({
+  const tagQueryString = getQuery({
     filter: {
       resolution: 'monthly',
       time_scope_units: 'month',
@@ -173,12 +173,17 @@ const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToo
     key_only: true,
     limit: 1000,
   });
-  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
-  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);
+  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, tagQueryString);
+  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(
+    state,
+    tagReportPathsType,
+    tagReportType,
+    tagQueryString
+  );
   return {
-    queryString,
     tagReportFetchStatus,
     tagReport,
+    tagQueryString,
   };
 });
 

--- a/src/routes/views/details/components/actions/actions.tsx
+++ b/src/routes/views/details/components/actions/actions.tsx
@@ -19,8 +19,8 @@ interface DetailsActionsOwnProps extends WrappedComponentProps, RouteComponentPr
   isDisabled?: boolean;
   item: ComputedReportItem;
   providerType?: ProviderType;
-  queryString: string;
   reportPathsType: ReportPathsType;
+  reportQueryString: string;
   showPriceListOption?: boolean;
 }
 
@@ -55,7 +55,7 @@ class DetailsActionsBase extends React.Component<DetailsActionsProps> {
   }
 
   private getExportModal = () => {
-    const { groupBy, item, queryString, reportPathsType } = this.props;
+    const { groupBy, item, reportPathsType, reportQueryString } = this.props;
     const { isExportModalOpen } = this.state;
 
     return (
@@ -65,8 +65,8 @@ class DetailsActionsBase extends React.Component<DetailsActionsProps> {
         isOpen={isExportModalOpen}
         items={[item]}
         onClose={this.handleExportModalClose}
-        queryString={queryString}
         reportPathsType={reportPathsType}
+        reportQueryString={reportQueryString}
       />
     );
   };

--- a/src/routes/views/details/components/breakdown/breakdownBase.tsx
+++ b/src/routes/views/details/components/breakdown/breakdownBase.tsx
@@ -53,12 +53,12 @@ interface BreakdownStateProps {
   providersFetchStatus?: FetchStatus;
   providerType?: ProviderType;
   query: Query;
-  queryString: string;
   report: Report;
   reportError: AxiosError;
   reportFetchStatus: FetchStatus;
   reportPathsType: ReportPathsType;
   reportType: ReportType;
+  reportQueryString: string;
   showCostType?: boolean;
   tagReportPathsType?: TagPathsType;
   title?: string;
@@ -92,9 +92,9 @@ class BreakdownBase extends React.Component<BreakdownProps> {
   }
 
   public componentDidUpdate(prevProps: BreakdownProps) {
-    const { location, report, reportError, queryString } = this.props;
+    const { location, report, reportError, reportQueryString } = this.props;
 
-    const newQuery = prevProps.queryString !== queryString;
+    const newQuery = prevProps.reportQueryString !== reportQueryString;
     const noReport = !report && !reportError;
     const noLocation = !location.search;
 
@@ -192,9 +192,9 @@ class BreakdownBase extends React.Component<BreakdownProps> {
   };
 
   private updateReport = () => {
-    const { location, fetchReport, queryString, reportPathsType, reportType } = this.props;
+    const { location, fetchReport, reportPathsType, reportType, reportQueryString } = this.props;
     if (location.search) {
-      fetchReport(reportPathsType, reportType, queryString);
+      fetchReport(reportPathsType, reportType, reportQueryString);
     }
   };
 

--- a/src/routes/views/details/components/summary/summaryCard.tsx
+++ b/src/routes/views/details/components/summary/summaryCard.tsx
@@ -41,9 +41,9 @@ interface SummaryStateProps {
   groupBy: string;
   groupByValue: string | number;
   query?: Query;
-  queryString?: string;
   report?: OcpReport;
   reportFetchStatus?: FetchStatus;
+  reportQueryString?: string;
 }
 
 interface SummaryState {
@@ -62,14 +62,18 @@ class SummaryBase extends React.Component<SummaryProps> {
   };
 
   public componentDidMount() {
-    const { fetchReport, queryString, reportPathsType, reportType } = this.props;
-    fetchReport(reportPathsType, reportType, queryString);
+    const { fetchReport, reportPathsType, reportType, reportQueryString } = this.props;
+    fetchReport(reportPathsType, reportType, reportQueryString);
   }
 
   public componentDidUpdate(prevProps: SummaryProps) {
-    const { costType, currency, fetchReport, queryString, reportPathsType, reportType } = this.props;
-    if (prevProps.queryString !== queryString || prevProps.costType !== costType || prevProps.currency !== currency) {
-      fetchReport(reportPathsType, reportType, queryString);
+    const { costType, currency, fetchReport, reportPathsType, reportType, reportQueryString } = this.props;
+    if (
+      prevProps.reportQueryString !== reportQueryString ||
+      prevProps.costType !== costType ||
+      prevProps.currency !== currency
+    ) {
+      fetchReport(reportPathsType, reportType, reportQueryString);
     }
   }
 
@@ -212,23 +216,29 @@ const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.
       },
     };
-    const queryString = getQuery({
+
+    const reportQueryString = getQuery({
       ...newQuery,
       cost_type: costType,
       currency,
     });
+    const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
+    const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+      state,
+      reportPathsType,
+      reportType,
+      reportQueryString
+    );
 
-    const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-    const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
     return {
       groupBy,
       groupByValue,
       query,
-      queryString,
       report,
       reportFetchStatus,
       reportPathsType,
       reportType,
+      reportQueryString,
     };
   }
 );

--- a/src/routes/views/details/components/summary/summaryModalContent.tsx
+++ b/src/routes/views/details/components/summary/summaryModalContent.tsx
@@ -25,9 +25,9 @@ interface SummaryModalContentOwnProps {
 }
 
 interface SummaryModalContentStateProps {
-  queryString?: string;
   report?: Report;
   reportFetchStatus?: FetchStatus;
+  reportQueryString?: string;
 }
 
 interface SummaryModalContentDispatchProps {
@@ -47,14 +47,14 @@ class SummaryModalContentBase extends React.Component<SummaryModalContentProps> 
   }
 
   public componentDidMount() {
-    const { fetchReport, queryString, reportPathsType } = this.props;
-    fetchReport(reportPathsType, reportType, queryString);
+    const { fetchReport, reportPathsType, reportQueryString } = this.props;
+    fetchReport(reportPathsType, reportType, reportQueryString);
   }
 
   public componentDidUpdate(prevProps: SummaryModalContentProps) {
-    const { fetchReport, queryString, reportPathsType } = this.props;
-    if (prevProps.queryString !== queryString) {
-      fetchReport(reportPathsType, reportType, queryString);
+    const { fetchReport, reportPathsType, reportQueryString } = this.props;
+    if (prevProps.reportQueryString !== reportQueryString) {
+      fetchReport(reportPathsType, reportType, reportQueryString);
     }
   }
 
@@ -122,18 +122,24 @@ const mapStateToProps = createMapStateToProps<SummaryModalContentOwnProps, Summa
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by specific account, project, etc.
       },
     };
-    const queryString = getQuery({
+
+    const reportQueryString = getQuery({
       ...newQuery,
       cost_type: costType,
       currency,
     });
+    const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
+    const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+      state,
+      reportPathsType,
+      reportType,
+      reportQueryString
+    );
 
-    const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-    const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
     return {
-      queryString,
       report,
       reportFetchStatus,
+      reportQueryString,
     };
   }
 );

--- a/src/routes/views/details/components/tag/tagLink.tsx
+++ b/src/routes/views/details/components/tag/tagLink.tsx
@@ -28,9 +28,9 @@ interface TagLinkStateProps {
   groupBy: string;
   groupByValue: string | number;
   query?: Query;
-  queryString?: string;
   tagReport?: Tag;
   tagReportFetchStatus?: FetchStatus;
+  tagQueryString?: string;
 }
 
 interface TagLinkDispatchProps {
@@ -54,14 +54,14 @@ class TagLinkBase extends React.Component<TagLinkProps> {
   }
 
   public componentDidMount() {
-    const { fetchTag, queryString, tagReportPathsType } = this.props;
-    fetchTag(tagReportPathsType, tagReportType, queryString);
+    const { fetchTag, tagReportPathsType, tagQueryString } = this.props;
+    fetchTag(tagReportPathsType, tagReportType, tagQueryString);
   }
 
   public componentDidUpdate(prevProps: TagLinkProps) {
-    const { fetchTag, queryString, tagReportPathsType } = this.props;
-    if (prevProps.queryString !== queryString) {
-      fetchTag(tagReportPathsType, tagReportType, queryString);
+    const { fetchTag, tagReportPathsType, tagQueryString } = this.props;
+    if (prevProps.tagQueryString !== tagQueryString) {
+      fetchTag(tagReportPathsType, tagReportType, tagQueryString);
     }
   }
 
@@ -132,18 +132,22 @@ const mapStateToProps = createMapStateToProps<TagLinkOwnProps, TagLinkStateProps
       ...(groupBy && groupBy.indexOf(tagPrefix) === -1 && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
     },
   };
-  const queryString = getQuery(newQuery);
-
-  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
-  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);
+  const tagQueryString = getQuery(newQuery);
+  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, tagQueryString);
+  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(
+    state,
+    tagReportPathsType,
+    tagReportType,
+    tagQueryString
+  );
 
   return {
     groupBy,
     groupByValue,
     query,
-    queryString,
     tagReport,
     tagReportFetchStatus,
+    tagQueryString,
   };
 });
 

--- a/src/routes/views/details/components/tag/tagModal.tsx
+++ b/src/routes/views/details/components/tag/tagModal.tsx
@@ -25,9 +25,9 @@ interface TagModalStateProps {
   groupBy: string;
   groupByValue: string | number;
   query?: Query;
-  queryString?: string;
   tagReport?: Tag;
   tagReportFetchStatus?: FetchStatus;
+  tagQueryString?: string;
 }
 
 interface TagModalDispatchProps {
@@ -45,14 +45,14 @@ class TagModalBase extends React.Component<TagModalProps> {
   }
 
   public componentDidMount() {
-    const { fetchTag, queryString, tagReportPathsType } = this.props;
-    fetchTag(tagReportPathsType, tagReportType, queryString);
+    const { fetchTag, tagReportPathsType, tagQueryString } = this.props;
+    fetchTag(tagReportPathsType, tagReportType, tagQueryString);
   }
 
   public componentDidUpdate(prevProps: TagModalProps) {
-    const { fetchTag, queryString, tagReportPathsType } = this.props;
-    if (prevProps.queryString !== queryString) {
-      fetchTag(tagReportPathsType, tagReportType, queryString);
+    const { fetchTag, tagReportPathsType, tagQueryString } = this.props;
+    if (prevProps.tagQueryString !== tagQueryString) {
+      fetchTag(tagReportPathsType, tagReportType, tagQueryString);
     }
   }
 
@@ -125,18 +125,23 @@ const mapStateToProps = createMapStateToProps<TagModalOwnProps, TagModalStatePro
       ...(groupBy && groupBy.indexOf(tagPrefix) === -1 && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
     },
   };
-  const queryString = getQuery(newQuery);
 
-  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
-  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);
+  const tagQueryString = getQuery(newQuery);
+  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, tagQueryString);
+  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(
+    state,
+    tagReportPathsType,
+    tagReportType,
+    tagQueryString
+  );
 
   return {
     groupBy,
     groupByValue,
     query,
-    queryString,
     tagReport,
     tagReportFetchStatus,
+    tagQueryString,
   };
 });
 

--- a/src/routes/views/details/components/usageChart/usageChart.tsx
+++ b/src/routes/views/details/components/usageChart/usageChart.tsx
@@ -39,7 +39,7 @@ interface UsageChartStateProps {
   groupBy?: string;
   report?: Report;
   reportFetchStatus?: FetchStatus;
-  queryString?: string;
+  reportQueryString?: string;
 }
 
 interface UsageChartDispatchProps {
@@ -60,16 +60,16 @@ class UsageChartBase extends React.Component<UsageChartProps> {
   };
 
   public componentDidMount() {
-    const { fetchReport, queryString, reportPathsType, reportType } = this.props;
-    fetchReport(reportPathsType, reportType, queryString);
+    const { fetchReport, reportPathsType, reportType, reportQueryString } = this.props;
+    fetchReport(reportPathsType, reportType, reportQueryString);
 
     this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
   }
 
   public componentDidUpdate(prevProps: UsageChartProps) {
-    const { fetchReport, queryString, reportPathsType, reportType } = this.props;
-    if (prevProps.queryString !== this.props.queryString) {
-      fetchReport(reportPathsType, reportType, queryString);
+    const { fetchReport, reportPathsType, reportType, reportQueryString } = this.props;
+    if (prevProps.reportQueryString !== this.props.reportQueryString) {
+      fetchReport(reportPathsType, reportType, reportQueryString);
     }
   }
 
@@ -393,16 +393,21 @@ const mapStateToProps = createMapStateToProps<UsageChartOwnProps, UsageChartStat
         ...(groupBy && { [groupBy]: groupByValue }),
       },
     };
-    const queryString = getQuery(newQuery);
 
-    const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-    const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+    const reportQueryString = getQuery(newQuery);
+    const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
+    const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+      state,
+      reportPathsType,
+      reportType,
+      reportQueryString
+    );
 
     return {
       groupBy,
       report,
       reportFetchStatus,
-      queryString,
+      reportQueryString,
     };
   }
 );

--- a/src/routes/views/details/gcpBreakdown/gcpBreakdown.tsx
+++ b/src/routes/views/details/gcpBreakdown/gcpBreakdown.tsx
@@ -39,12 +39,12 @@ interface GcpBreakdownStateProps {
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
   query: Query;
-  queryString: string;
   report: Report;
   reportError: AxiosError;
   reportFetchStatus: FetchStatus;
   reportType: ReportType;
   reportPathsType: ReportPathsType;
+  reportQueryString: string;
 }
 
 interface BreakdownDispatchProps {
@@ -80,14 +80,19 @@ const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, GcpBreakdown
       ...(groupBy && { [groupBy]: groupByValue }),
     },
   };
-  const queryString = getQuery({
+
+  const reportQueryString = getQuery({
     ...newQuery,
     currency,
   });
-
-  const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+  const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
+  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);
+  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+    state,
+    reportPathsType,
+    reportType,
+    reportQueryString
+  );
 
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);
@@ -112,12 +117,12 @@ const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, GcpBreakdown
     providersFetchStatus,
     providerType: ProviderType.gcp,
     query,
-    queryString,
     report,
     reportError,
     reportFetchStatus,
     reportType,
     reportPathsType,
+    reportQueryString,
     tagReportPathsType: TagPathsType.gcp,
     title: query[breakdownTitleKey] ? query[breakdownTitleKey] : groupByValue,
   };

--- a/src/routes/views/details/gcpDetails/detailsHeader.tsx
+++ b/src/routes/views/details/gcpDetails/detailsHeader.tsx
@@ -1,8 +1,6 @@
 import { Title, TitleSizes } from '@patternfly/react-core';
 import type { Providers } from 'api/providers';
 import { ProviderType } from 'api/providers';
-import type { GcpQuery } from 'api/queries/gcpQuery';
-import { getQuery } from 'api/queries/gcpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import type { GcpReport } from 'api/reports/gcpReports';
 import { TagPathsType } from 'api/tags/tag';
@@ -41,19 +39,10 @@ interface DetailsHeaderStateProps {
   providers: Providers;
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
-  queryString?: string;
+  providersQueryString?: string;
 }
 
 type DetailsHeaderProps = DetailsHeaderOwnProps & DetailsHeaderStateProps & WrappedComponentProps;
-
-const baseQuery: GcpQuery = {
-  delta: 'cost',
-  filter: {
-    time_scope_units: 'month',
-    time_scope_value: -1,
-    resolution: 'monthly',
-  },
-};
 
 const groupByOptions: {
   label: string;
@@ -128,8 +117,6 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHeaderStateProps>((state, props) => {
-  const queryString = getQuery(baseQuery);
-
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);
   const providersError = providersSelectors.selectProvidersError(state, ProviderType.all, providersQueryString);
@@ -145,7 +132,7 @@ const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHead
     providers: filterProviders(providers, ProviderType.gcp),
     providersError,
     providersFetchStatus,
-    queryString,
+    providersQueryString,
   };
 });
 

--- a/src/routes/views/details/gcpDetails/detailsTable.tsx
+++ b/src/routes/views/details/gcpDetails/detailsTable.tsx
@@ -25,8 +25,8 @@ interface DetailsTableOwnProps {
   isLoading?: boolean;
   onSelected(items: ComputedReportItem[], isSelected: boolean);
   onSort(value: string, isSortAscending: boolean);
-  queryString: string;
   report: GcpReport;
+  reportQueryString: string;
   selectedItems?: ComputedReportItem[];
 }
 
@@ -60,8 +60,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   }
 
   private initDatum = () => {
-    const { groupBy, groupByTagKey, isAllSelected, queryString, report, selectedItems, intl } = this.props;
-    if (!queryString || !report) {
+    const { groupBy, groupByTagKey, isAllSelected, report, selectedItems, intl } = this.props;
+    if (!report) {
       return;
     }
 
@@ -170,9 +170,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private getActions = (item: ComputedReportItem) => {
-    const { groupBy, queryString } = this.props;
+    const { groupBy, reportQueryString } = this.props;
 
-    return <Actions groupBy={groupBy} item={item} queryString={queryString} reportPathsType={reportPathsType} />;
+    return (
+      <Actions groupBy={groupBy} item={item} reportPathsType={reportPathsType} reportQueryString={reportQueryString} />
+    );
   };
 
   private getMonthOverMonthCost = (item: ComputedReportItem, index: number) => {

--- a/src/routes/views/details/gcpDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/gcpDetails/detailsToolbar.tsx
@@ -31,13 +31,13 @@ interface DetailsToolbarOwnProps {
   onFilterRemoved(filter: Filter);
   pagination?: React.ReactNode;
   query?: GcpQuery;
-  queryString?: string;
   selectedItems?: ComputedReportItem[];
 }
 
 interface DetailsToolbarStateProps {
   tagReport?: Tag;
   tagReportFetchStatus?: FetchStatus;
+  tagQueryString?: string;
 }
 
 interface DetailsToolbarDispatchProps {
@@ -61,7 +61,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   public state: DetailsToolbarState = { ...this.defaultState };
 
   public componentDidMount() {
-    const { fetchTag, queryString, tagReportFetchStatus } = this.props;
+    const { fetchTag, tagReportFetchStatus, tagQueryString } = this.props;
 
     this.setState(
       {
@@ -69,14 +69,14 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       },
       () => {
         if (tagReportFetchStatus !== FetchStatus.inProgress) {
-          fetchTag(tagReportPathsType, tagReportType, queryString);
+          fetchTag(tagReportPathsType, tagReportType, tagQueryString);
         }
       }
     );
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps) {
-    const { fetchTag, query, queryString, tagReport, tagReportFetchStatus } = this.props;
+    const { fetchTag, query, tagReport, tagReportFetchStatus, tagQueryString } = this.props;
 
     if (!isEqual(tagReport, prevProps.tagReport)) {
       this.setState(
@@ -85,13 +85,13 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         },
         () => {
           if (tagReportFetchStatus !== FetchStatus.inProgress) {
-            fetchTag(tagReportPathsType, tagReportType, queryString);
+            fetchTag(tagReportPathsType, tagReportType, tagQueryString);
           }
         }
       );
     } else if (query && !isEqual(query, prevProps.query)) {
       if (tagReportFetchStatus !== FetchStatus.inProgress) {
-        fetchTag(tagReportPathsType, tagReportType, queryString);
+        fetchTag(tagReportPathsType, tagReportType, tagQueryString);
       }
     }
   }
@@ -162,7 +162,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
   // Note: Omitting key_only would help to share a single, cached request -- the toolbar requires key values
   // However, for better server-side performance, we chose to use key_only here.
-  const queryString = getQuery({
+  const tagQueryString = getQuery({
     filter: {
       resolution: 'monthly',
       time_scope_units: 'month',
@@ -172,12 +172,17 @@ const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToo
     limit: 1000,
   });
 
-  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
-  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);
+  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, tagQueryString);
+  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(
+    state,
+    tagReportPathsType,
+    tagReportType,
+    tagQueryString
+  );
   return {
-    queryString,
     tagReport,
     tagReportFetchStatus,
+    tagQueryString,
   };
 });
 

--- a/src/routes/views/details/gcpDetails/gcpDetails.tsx
+++ b/src/routes/views/details/gcpDetails/gcpDetails.tsx
@@ -50,10 +50,10 @@ interface GcpDetailsStateProps {
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
   query: GcpQuery;
-  queryString: string;
   report: GcpReport;
   reportError: AxiosError;
   reportFetchStatus: FetchStatus;
+  reportQueryString: string;
 }
 
 interface GcpDetailsDispatchProps {
@@ -117,10 +117,10 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
   }
 
   public componentDidUpdate(prevProps: GcpDetailsProps, prevState: GcpDetailsState) {
-    const { location, report, reportError, queryString } = this.props;
+    const { location, report, reportError, reportQueryString } = this.props;
     const { selectedItems } = this.state;
 
-    const newQuery = prevProps.queryString !== queryString;
+    const newQuery = prevProps.reportQueryString !== reportQueryString;
     const noReport = !report && !reportError;
     const noLocation = !location.search;
     const newItems = prevState.selectedItems !== selectedItems;
@@ -143,7 +143,7 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
   };
 
   private getExportModal = (computedItems: ComputedReportItem[]) => {
-    const { query, queryString, report } = this.props;
+    const { query, report, reportQueryString } = this.props;
     const { isAllSelected, isExportModalOpen, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
@@ -165,8 +165,8 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
         isOpen={isExportModalOpen}
         items={items}
         onClose={this.handleExportModalClose}
-        queryString={queryString}
         reportPathsType={reportPathsType}
+        reportQueryString={reportQueryString}
       />
     );
   };
@@ -206,7 +206,7 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
   };
 
   private getTable = () => {
-    const { history, query, queryString, report, reportFetchStatus } = this.props;
+    const { history, query, report, reportFetchStatus, reportQueryString } = this.props;
     const { isAllSelected, selectedItems } = this.state;
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByTagKey = getGroupByTagKey(query);
@@ -219,8 +219,8 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
         isLoading={reportFetchStatus === FetchStatus.inProgress}
         onSelected={this.handleSelected}
         onSort={(sortType, isSortAscending) => handleSort(history, query, sortType, isSortAscending)}
-        queryString={queryString}
         report={report}
+        reportQueryString={reportQueryString}
         selectedItems={selectedItems}
       />
     );
@@ -308,7 +308,7 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
   };
 
   private updateReport = () => {
-    const { fetchReport, history, location, query, queryString } = this.props;
+    const { fetchReport, history, location, query, reportQueryString } = this.props;
     if (!location.search) {
       history.replace(
         getRouteForQuery(history, {
@@ -319,7 +319,7 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
         })
       );
     } else {
-      fetchReport(reportPathsType, reportType, queryString);
+      fetchReport(reportPathsType, reportType, reportQueryString);
     }
   };
 
@@ -390,13 +390,18 @@ const mapStateToProps = createMapStateToProps<GcpDetailsOwnProps, GcpDetailsStat
     group_by: queryFromRoute.group_by || baseQuery.group_by,
     order_by: queryFromRoute.order_by || baseQuery.order_by,
   };
-  const queryString = getQuery({
+  const reportQueryString = getQuery({
     ...query,
     currency,
   });
-  const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+  const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
+  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);
+  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+    state,
+    reportPathsType,
+    reportType,
+    reportQueryString
+  );
 
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);
@@ -413,10 +418,10 @@ const mapStateToProps = createMapStateToProps<GcpDetailsOwnProps, GcpDetailsStat
     providersError,
     providersFetchStatus,
     query,
-    queryString,
     report,
     reportError,
     reportFetchStatus,
+    reportQueryString,
 
     // Testing...
     //

--- a/src/routes/views/details/ibmBreakdown/ibmBreakdown.tsx
+++ b/src/routes/views/details/ibmBreakdown/ibmBreakdown.tsx
@@ -39,12 +39,12 @@ interface IbmBreakdownStateProps {
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
   query: Query;
-  queryString: string;
   report: Report;
   reportError: AxiosError;
   reportFetchStatus: FetchStatus;
   reportType: ReportType;
   reportPathsType: ReportPathsType;
+  reportQueryString: string;
 }
 
 interface BreakdownDispatchProps {
@@ -80,14 +80,19 @@ const mapStateToProps = createMapStateToProps<IbmBreakdownOwnProps, IbmBreakdown
       ...(groupBy && { [groupBy]: groupByValue }),
     },
   };
-  const queryString = getQuery({
+
+  const reportQueryString = getQuery({
     ...newQuery,
     currency,
   });
-
-  const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+  const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
+  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);
+  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+    state,
+    reportPathsType,
+    reportType,
+    reportQueryString
+  );
 
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);
@@ -112,12 +117,12 @@ const mapStateToProps = createMapStateToProps<IbmBreakdownOwnProps, IbmBreakdown
     providersFetchStatus,
     providerType: ProviderType.ibm,
     query,
-    queryString,
     report,
     reportError,
     reportFetchStatus,
     reportType,
     reportPathsType,
+    reportQueryString,
     tagReportPathsType: TagPathsType.ibm,
     title: query[breakdownTitleKey] ? query[breakdownTitleKey] : groupByValue,
   };

--- a/src/routes/views/details/ibmDetails/detailsHeader.tsx
+++ b/src/routes/views/details/ibmDetails/detailsHeader.tsx
@@ -1,8 +1,6 @@
 import { Title, TitleSizes } from '@patternfly/react-core';
 import type { Providers } from 'api/providers';
 import { ProviderType } from 'api/providers';
-import type { IbmQuery } from 'api/queries/ibmQuery';
-import { getQuery } from 'api/queries/ibmQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import type { IbmReport } from 'api/reports/ibmReports';
 import { TagPathsType } from 'api/tags/tag';
@@ -41,19 +39,10 @@ interface DetailsHeaderStateProps {
   providers: Providers;
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
-  queryString?: string;
+  providersQueryString?: string;
 }
 
 type DetailsHeaderProps = DetailsHeaderOwnProps & DetailsHeaderStateProps & WrappedComponentProps;
-
-const baseQuery: IbmQuery = {
-  delta: 'cost',
-  filter: {
-    time_scope_units: 'month',
-    time_scope_value: -1,
-    resolution: 'monthly',
-  },
-};
 
 const groupByOptions: {
   label: string;
@@ -128,8 +117,6 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHeaderStateProps>((state, props) => {
-  const queryString = getQuery(baseQuery);
-
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);
   const providersError = providersSelectors.selectProvidersError(state, ProviderType.all, providersQueryString);
@@ -145,7 +132,7 @@ const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHead
     providers: filterProviders(providers, ProviderType.ibm),
     providersError,
     providersFetchStatus,
-    queryString,
+    providersQueryString,
   };
 });
 

--- a/src/routes/views/details/ibmDetails/detailsTable.tsx
+++ b/src/routes/views/details/ibmDetails/detailsTable.tsx
@@ -25,8 +25,8 @@ interface DetailsTableOwnProps {
   isLoading?: boolean;
   onSelected(items: ComputedReportItem[], isSelected: boolean);
   onSort(value: string, isSortAscending: boolean);
-  queryString: string;
   report: IbmReport;
+  reportQueryString: string;
   selectedItems?: ComputedReportItem[];
 }
 
@@ -60,8 +60,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   }
 
   private initDatum = () => {
-    const { groupBy, groupByTagKey, isAllSelected, queryString, report, selectedItems, intl } = this.props;
-    if (!queryString || !report) {
+    const { groupBy, groupByTagKey, isAllSelected, report, selectedItems, intl } = this.props;
+    if (!report) {
       return;
     }
 
@@ -170,9 +170,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private getActions = (item: ComputedReportItem) => {
-    const { groupBy, queryString } = this.props;
+    const { groupBy, reportQueryString } = this.props;
 
-    return <Actions groupBy={groupBy} item={item} queryString={queryString} reportPathsType={reportPathsType} />;
+    return (
+      <Actions groupBy={groupBy} item={item} reportPathsType={reportPathsType} reportQueryString={reportQueryString} />
+    );
   };
 
   private getMonthOverMonthCost = (item: ComputedReportItem, index: number) => {

--- a/src/routes/views/details/ibmDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/ibmDetails/detailsToolbar.tsx
@@ -31,13 +31,13 @@ interface DetailsToolbarOwnProps {
   onFilterRemoved(filter: Filter);
   pagination?: React.ReactNode;
   query?: IbmQuery;
-  queryString?: string;
   selectedItems?: ComputedReportItem[];
 }
 
 interface DetailsToolbarStateProps {
   tagReport?: Tag;
   tagReportFetchStatus?: FetchStatus;
+  tagQueryString?: string;
 }
 
 interface DetailsToolbarDispatchProps {
@@ -61,7 +61,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   public state: DetailsToolbarState = { ...this.defaultState };
 
   public componentDidMount() {
-    const { fetchTag, queryString, tagReportFetchStatus } = this.props;
+    const { fetchTag, tagReportFetchStatus, tagQueryString } = this.props;
 
     this.setState(
       {
@@ -69,14 +69,14 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       },
       () => {
         if (tagReportFetchStatus !== FetchStatus.inProgress) {
-          fetchTag(tagReportPathsType, tagReportType, queryString);
+          fetchTag(tagReportPathsType, tagReportType, tagQueryString);
         }
       }
     );
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps) {
-    const { fetchTag, query, queryString, tagReport, tagReportFetchStatus } = this.props;
+    const { fetchTag, query, tagReport, tagReportFetchStatus, tagQueryString } = this.props;
 
     if (!isEqual(tagReport, prevProps.tagReport)) {
       this.setState(
@@ -85,12 +85,12 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         },
         () => {
           if (tagReportFetchStatus !== FetchStatus.inProgress) {
-            fetchTag(tagReportPathsType, tagReportType, queryString);
+            fetchTag(tagReportPathsType, tagReportType, tagQueryString);
           }
         }
       );
     } else if (query && !isEqual(query, prevProps.query) && tagReportFetchStatus !== FetchStatus.inProgress) {
-      fetchTag(tagReportPathsType, tagReportType, queryString);
+      fetchTag(tagReportPathsType, tagReportType, tagQueryString);
     }
   }
 
@@ -160,7 +160,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
   // Note: Omitting key_only would help to share a single, cached request -- the toolbar requires key values
   // However, for better server-side performance, we chose to use key_only here.
-  const queryString = getQuery({
+  const tagQueryString = getQuery({
     filter: {
       resolution: 'monthly',
       time_scope_units: 'month',
@@ -170,12 +170,17 @@ const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToo
     limit: 1000,
   });
 
-  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
-  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);
+  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, tagQueryString);
+  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(
+    state,
+    tagReportPathsType,
+    tagReportType,
+    tagQueryString
+  );
   return {
-    queryString,
     tagReport,
     tagReportFetchStatus,
+    tagQueryString,
   };
 });
 

--- a/src/routes/views/details/ibmDetails/ibmDetails.tsx
+++ b/src/routes/views/details/ibmDetails/ibmDetails.tsx
@@ -51,10 +51,10 @@ interface IbmDetailsStateProps {
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
   query: IbmQuery;
-  queryString: string;
   report: IbmReport;
   reportError: AxiosError;
   reportFetchStatus: FetchStatus;
+  reportQueryString: string;
 }
 
 interface IbmDetailsDispatchProps {
@@ -118,10 +118,10 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
   }
 
   public componentDidUpdate(prevProps: IbmDetailsProps, prevState: IbmDetailsState) {
-    const { location, report, reportError, queryString } = this.props;
+    const { location, report, reportError, reportQueryString } = this.props;
     const { selectedItems } = this.state;
 
-    const newQuery = prevProps.queryString !== queryString;
+    const newQuery = prevProps.reportQueryString !== reportQueryString;
     const noReport = !report && !reportError;
     const noLocation = !location.search;
     const newItems = prevState.selectedItems !== selectedItems;
@@ -144,7 +144,7 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
   };
 
   private getExportModal = (computedItems: ComputedReportItem[]) => {
-    const { query, queryString, report } = this.props;
+    const { query, report, reportQueryString } = this.props;
     const { isAllSelected, isExportModalOpen, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
@@ -166,8 +166,8 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
         isOpen={isExportModalOpen}
         items={items}
         onClose={this.handleExportModalClose}
-        queryString={queryString}
         reportPathsType={reportPathsType}
+        reportQueryString={reportQueryString}
       />
     );
   };
@@ -207,7 +207,7 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
   };
 
   private getTable = () => {
-    const { history, query, queryString, report, reportFetchStatus } = this.props;
+    const { history, query, report, reportFetchStatus, reportQueryString } = this.props;
     const { isAllSelected, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
@@ -221,8 +221,8 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
         isLoading={reportFetchStatus === FetchStatus.inProgress}
         onSelected={this.handleSelected}
         onSort={(sortType, isSortAscending) => handleSort(history, query, sortType, isSortAscending)}
-        queryString={queryString}
         report={report}
+        reportQueryString={reportQueryString}
         selectedItems={selectedItems}
       />
     );
@@ -310,7 +310,7 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
   };
 
   private updateReport = () => {
-    const { fetchReport, history, location, query, queryString } = this.props;
+    const { fetchReport, history, location, query, reportQueryString } = this.props;
     if (!location.search) {
       history.replace(
         getRouteForQuery(history, {
@@ -321,7 +321,7 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
         })
       );
     } else {
-      fetchReport(reportPathsType, reportType, queryString);
+      fetchReport(reportPathsType, reportType, reportQueryString);
     }
   };
 
@@ -392,13 +392,18 @@ const mapStateToProps = createMapStateToProps<IbmDetailsOwnProps, IbmDetailsStat
     group_by: queryFromRoute.group_by || baseQuery.group_by,
     order_by: queryFromRoute.order_by || baseQuery.order_by,
   };
-  const queryString = getQuery({
+  const reportQueryString = getQuery({
     ...query,
     currency,
   });
-  const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+  const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
+  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);
+  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+    state,
+    reportPathsType,
+    reportType,
+    reportQueryString
+  );
 
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);
@@ -415,10 +420,10 @@ const mapStateToProps = createMapStateToProps<IbmDetailsOwnProps, IbmDetailsStat
     providersError,
     providersFetchStatus,
     query,
-    queryString,
     report,
     reportError,
     reportFetchStatus,
+    reportQueryString,
 
     // Testing...
     //

--- a/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
+++ b/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
@@ -39,12 +39,12 @@ interface OciCostStateProps {
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
   query: Query;
-  queryString: string;
   report: Report;
   reportError: AxiosError;
   reportFetchStatus: FetchStatus;
   reportType: ReportType;
   reportPathsType: ReportPathsType;
+  reportQueryString: string;
 }
 
 interface OciCostDispatchProps {
@@ -80,14 +80,19 @@ const mapStateToProps = createMapStateToProps<OciCostOwnProps, OciCostStateProps
       ...(groupBy && { [groupBy]: groupByValue }),
     },
   };
-  const queryString = getQuery({
+
+  const reportQueryString = getQuery({
     ...newQuery,
     currency,
   });
-
-  const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+  const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
+  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);
+  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+    state,
+    reportPathsType,
+    reportType,
+    reportQueryString
+  );
 
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);
@@ -112,12 +117,12 @@ const mapStateToProps = createMapStateToProps<OciCostOwnProps, OciCostStateProps
     providersFetchStatus,
     providerType: ProviderType.oci,
     query,
-    queryString,
     report,
     reportError,
     reportFetchStatus,
     reportType,
     reportPathsType,
+    reportQueryString,
     tagReportPathsType: TagPathsType.oci,
     title: groupByValue,
   };

--- a/src/routes/views/details/ociDetails/detailsHeader.tsx
+++ b/src/routes/views/details/ociDetails/detailsHeader.tsx
@@ -1,8 +1,6 @@
 import { Title, TitleSizes } from '@patternfly/react-core';
 import type { Providers } from 'api/providers';
 import { ProviderType } from 'api/providers';
-import type { OciQuery } from 'api/queries/ociQuery';
-import { getQuery } from 'api/queries/ociQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import type { OciReport } from 'api/reports/ociReports';
 import { TagPathsType } from 'api/tags/tag';
@@ -41,19 +39,10 @@ interface DetailsHeaderStateProps {
   providers: Providers;
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
-  queryString?: string;
+  providersQueryString?: string;
 }
 
 type DetailsHeaderProps = DetailsHeaderOwnProps & DetailsHeaderStateProps & WrappedComponentProps;
-
-const baseQuery: OciQuery = {
-  delta: 'cost',
-  filter: {
-    time_scope_units: 'month',
-    time_scope_value: -1,
-    resolution: 'monthly',
-  },
-};
 
 const groupByOptions: {
   label: string;
@@ -127,8 +116,6 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHeaderStateProps>((state, props) => {
-  const queryString = getQuery(baseQuery);
-
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);
   const providersError = providersSelectors.selectProvidersError(state, ProviderType.all, providersQueryString);
@@ -144,7 +131,7 @@ const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHead
     providers: filterProviders(providers, ProviderType.oci),
     providersError,
     providersFetchStatus,
-    queryString,
+    providersQueryString,
   };
 });
 

--- a/src/routes/views/details/ociDetails/detailsTable.tsx
+++ b/src/routes/views/details/ociDetails/detailsTable.tsx
@@ -25,8 +25,8 @@ interface DetailsTableOwnProps {
   isLoading?: boolean;
   onSelected(items: ComputedReportItem[], isSelected: boolean);
   onSort(value: string, isSortAscending: boolean);
-  queryString: string;
   report: OciReport;
+  reportQueryString: string;
   selectedItems?: ComputedReportItem[];
 }
 
@@ -170,9 +170,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private getActions = (item: ComputedReportItem) => {
-    const { groupBy, queryString } = this.props;
+    const { groupBy, reportQueryString } = this.props;
 
-    return <Actions groupBy={groupBy} item={item} queryString={queryString} reportPathsType={reportPathsType} />;
+    return (
+      <Actions groupBy={groupBy} item={item} reportPathsType={reportPathsType} reportQueryString={reportQueryString} />
+    );
   };
 
   private getMonthOverMonthCost = (item: ComputedReportItem, index: number) => {

--- a/src/routes/views/details/ociDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/ociDetails/detailsToolbar.tsx
@@ -30,13 +30,13 @@ interface DetailsToolbarOwnProps {
   onFilterRemoved(filter: Filter);
   pagination?: React.ReactNode;
   query?: OciQuery;
-  queryString?: string;
   selectedItems?: ComputedReportItem[];
 }
 
 interface DetailsToolbarStateProps {
   tagReport?: OciTag;
   tagReportFetchStatus?: FetchStatus;
+  tagQueryString?: string;
 }
 
 interface DetailsToolbarDispatchProps {
@@ -60,7 +60,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   public state: DetailsToolbarState = { ...this.defaultState };
 
   public componentDidMount() {
-    const { fetchTag, queryString, tagReportFetchStatus } = this.props;
+    const { fetchTag, tagReportFetchStatus, tagQueryString } = this.props;
 
     this.setState(
       {
@@ -68,14 +68,14 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       },
       () => {
         if (tagReportFetchStatus !== FetchStatus.inProgress) {
-          fetchTag(tagReportPathsType, tagReportType, queryString);
+          fetchTag(tagReportPathsType, tagReportType, tagQueryString);
         }
       }
     );
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps) {
-    const { fetchTag, query, queryString, tagReport, tagReportFetchStatus } = this.props;
+    const { fetchTag, query, tagReport, tagReportFetchStatus, tagQueryString } = this.props;
 
     if (!isEqual(tagReport, prevProps.tagReport)) {
       this.setState(
@@ -84,13 +84,13 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         },
         () => {
           if (tagReportFetchStatus !== FetchStatus.inProgress) {
-            fetchTag(tagReportPathsType, tagReportType, queryString);
+            fetchTag(tagReportPathsType, tagReportType, tagQueryString);
           }
         }
       );
     } else if (query && !isEqual(query, prevProps.query)) {
       if (tagReportFetchStatus !== FetchStatus.inProgress) {
-        fetchTag(tagReportPathsType, tagReportType, queryString);
+        fetchTag(tagReportPathsType, tagReportType, tagQueryString);
       }
     }
   }
@@ -167,7 +167,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
   // Note: Omitting key_only would help to share a single, cached request -- the toolbar requires key values
   // However, for better server-side performance, we chose to use key_only here.
-  const queryString = getQuery({
+  const tagQueryString = getQuery({
     filter: {
       resolution: 'monthly',
       time_scope_units: 'month',
@@ -176,12 +176,17 @@ const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToo
     key_only: true,
     limit: 1000,
   });
-  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
-  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);
+  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, tagQueryString);
+  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(
+    state,
+    tagReportPathsType,
+    tagReportType,
+    tagQueryString
+  );
   return {
-    queryString,
     tagReportFetchStatus,
     tagReport,
+    tagQueryString,
   };
 });
 

--- a/src/routes/views/details/ociDetails/ociDetails.tsx
+++ b/src/routes/views/details/ociDetails/ociDetails.tsx
@@ -50,10 +50,10 @@ interface OciDetailsStateProps {
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
   query: OciQuery;
-  queryString: string;
   report: OciReport;
   reportError: AxiosError;
   reportFetchStatus: FetchStatus;
+  reportQueryString: string;
 }
 
 interface OciDetailsDispatchProps {
@@ -117,10 +117,10 @@ class OciDetails extends React.Component<OciDetailsProps> {
   }
 
   public componentDidUpdate(prevProps: OciDetailsProps, prevState: OciDetailsState) {
-    const { location, report, reportError, queryString } = this.props;
+    const { location, report, reportError, reportQueryString } = this.props;
     const { selectedItems } = this.state;
 
-    const newQuery = prevProps.queryString !== queryString;
+    const newQuery = prevProps.reportQueryString !== reportQueryString;
     const noReport = !report && !reportError;
     const noLocation = !location.search;
     const newItems = prevState.selectedItems !== selectedItems;
@@ -143,7 +143,7 @@ class OciDetails extends React.Component<OciDetailsProps> {
   };
 
   private getExportModal = (computedItems: ComputedReportItem[]) => {
-    const { query, queryString, report } = this.props;
+    const { query, report, reportQueryString } = this.props;
     const { isAllSelected, isExportModalOpen, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
@@ -165,8 +165,8 @@ class OciDetails extends React.Component<OciDetailsProps> {
         isOpen={isExportModalOpen}
         items={items}
         onClose={this.handleExportModalClose}
-        queryString={queryString}
         reportPathsType={reportPathsType}
+        reportQueryString={reportQueryString}
       />
     );
   };
@@ -206,7 +206,7 @@ class OciDetails extends React.Component<OciDetailsProps> {
   };
 
   private getTable = () => {
-    const { history, query, queryString, report, reportFetchStatus } = this.props;
+    const { history, query, report, reportFetchStatus, reportQueryString } = this.props;
     const { isAllSelected, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
@@ -220,8 +220,8 @@ class OciDetails extends React.Component<OciDetailsProps> {
         isLoading={reportFetchStatus === FetchStatus.inProgress}
         onSelected={this.handleSelected}
         onSort={(sortType, isSortAscending) => handleSort(history, query, sortType, isSortAscending)}
-        queryString={queryString}
         report={report}
+        reportQueryString={reportQueryString}
         selectedItems={selectedItems}
       />
     );
@@ -309,7 +309,7 @@ class OciDetails extends React.Component<OciDetailsProps> {
   };
 
   private updateReport = () => {
-    const { fetchReport, history, location, query, queryString } = this.props;
+    const { fetchReport, history, location, query, reportQueryString } = this.props;
     if (!location.search) {
       history.replace(
         getRouteForQuery(history, {
@@ -320,7 +320,7 @@ class OciDetails extends React.Component<OciDetailsProps> {
         })
       );
     } else {
-      fetchReport(reportPathsType, reportType, queryString);
+      fetchReport(reportPathsType, reportType, reportQueryString);
     }
   };
 
@@ -391,13 +391,18 @@ const mapStateToProps = createMapStateToProps<OciDetailsOwnProps, OciDetailsStat
     group_by: queryFromRoute.group_by || baseQuery.group_by,
     order_by: queryFromRoute.order_by || baseQuery.order_by,
   };
-  const queryString = getQuery({
+  const reportQueryString = getQuery({
     ...query,
     currency,
   });
-  const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+  const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
+  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);
+  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+    state,
+    reportPathsType,
+    reportType,
+    reportQueryString
+  );
 
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);
@@ -414,10 +419,10 @@ const mapStateToProps = createMapStateToProps<OciDetailsOwnProps, OciDetailsStat
     providersError,
     providersFetchStatus,
     query,
-    queryString,
     report,
     reportError,
     reportFetchStatus,
+    reportQueryString,
 
     // Testing...
     //

--- a/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -35,12 +35,12 @@ interface OcpBreakdownStateProps {
   detailsURL: string;
   HistoricalData?: React.ReactNode;
   query: Query;
-  queryString: string;
   report: Report;
   reportError: AxiosError;
   reportFetchStatus: FetchStatus;
   reportType: ReportType;
   reportPathsType: ReportPathsType;
+  reportQueryString: string;
 }
 
 interface BreakdownDispatchProps {
@@ -76,14 +76,19 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
       ...(groupBy && { [groupBy]: groupByValue }),
     },
   };
-  const queryString = getQuery({
+
+  const reportQueryString = getQuery({
     ...newQuery,
     currency,
   });
-
-  const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+  const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
+  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);
+  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+    state,
+    reportPathsType,
+    reportType,
+    reportQueryString
+  );
 
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);
@@ -106,12 +111,12 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
     providersFetchStatus,
     providerType: ProviderType.ocp,
     query,
-    queryString,
     report,
     reportError,
     reportFetchStatus,
     reportType,
     reportPathsType,
+    reportQueryString,
     tagReportPathsType: TagPathsType.ocp,
     title: groupByValue,
   };

--- a/src/routes/views/details/ocpDetails/detailsHeader.tsx
+++ b/src/routes/views/details/ocpDetails/detailsHeader.tsx
@@ -1,8 +1,6 @@
 import { Title, TitleSizes, Tooltip } from '@patternfly/react-core';
 import type { Providers } from 'api/providers';
 import { ProviderType } from 'api/providers';
-import type { OcpQuery } from 'api/queries/ocpQuery';
-import { getQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import type { OcpReport } from 'api/reports/ocpReports';
 import { TagPathsType } from 'api/tags/tag';
@@ -42,21 +40,12 @@ interface DetailsHeaderStateProps {
   providers: Providers;
   providersError: AxiosError;
   providersFetchStatus: FetchStatus;
-  queryString: string;
+  providersQueryString: string;
 }
 
 interface DetailsHeaderState {}
 
 type DetailsHeaderProps = DetailsHeaderOwnProps & DetailsHeaderStateProps & WrappedComponentProps;
-
-const baseQuery: OcpQuery = {
-  delta: 'cost',
-  filter: {
-    time_scope_units: 'month',
-    time_scope_value: -1,
-    resolution: 'monthly',
-  },
-};
 
 const groupByOptions: {
   label: string;
@@ -157,8 +146,6 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHeaderStateProps>((state, props) => {
-  const queryString = getQuery(baseQuery);
-
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);
   const providersError = providersSelectors.selectProvidersError(state, ProviderType.all, providersQueryString);
@@ -174,7 +161,7 @@ const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHead
     providers: filterProviders(providers, ProviderType.ocp),
     providersError,
     providersFetchStatus,
-    queryString,
+    providersQueryString,
   };
 });
 

--- a/src/routes/views/details/ocpDetails/detailsTable.tsx
+++ b/src/routes/views/details/ocpDetails/detailsTable.tsx
@@ -28,8 +28,8 @@ interface DetailsTableOwnProps {
   isLoading?: boolean;
   onSelected(items: ComputedReportItem[], isSelected: boolean);
   onSort(value: string, isSortAscending: boolean);
-  queryString: string;
   report: OcpReport;
+  reportQueryString: string;
   selectedItems?: ComputedReportItem[];
 }
 
@@ -73,9 +73,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   }
 
   private initDatum = () => {
-    const { groupBy, groupByTagKey, hiddenColumns, isAllSelected, queryString, report, selectedItems, intl } =
-      this.props;
-    if (!queryString || !report) {
+    const { groupBy, groupByTagKey, hiddenColumns, isAllSelected, report, selectedItems, intl } = this.props;
+    if (!report) {
       return;
     }
 
@@ -248,15 +247,15 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   };
 
   private getActions = (item: ComputedReportItem) => {
-    const { groupBy, queryString } = this.props;
+    const { groupBy, reportQueryString } = this.props;
 
     return (
       <Actions
         groupBy={groupBy}
         item={item}
         providerType={ProviderType.ocp}
-        queryString={queryString}
         reportPathsType={reportPathsType}
+        reportQueryString={reportQueryString}
         showPriceListOption={groupBy === 'cluster'}
       />
     );

--- a/src/routes/views/details/ocpDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/ocpDetails/detailsToolbar.tsx
@@ -31,13 +31,13 @@ interface DetailsToolbarOwnProps {
   onPlatformCostsChanged(checked: boolean);
   pagination?: React.ReactNode;
   query?: OcpQuery;
-  queryString?: string;
   selectedItems?: ComputedReportItem[];
 }
 
 interface DetailsToolbarStateProps {
   tagReport?: OcpTag;
   tagReportFetchStatus?: FetchStatus;
+  tagQueryString?: string;
 }
 
 interface DetailsToolbarDispatchProps {
@@ -61,7 +61,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
   public state: DetailsToolbarState = { ...this.defaultState };
 
   public componentDidMount() {
-    const { fetchTag, queryString, tagReportFetchStatus } = this.props;
+    const { fetchTag, tagReportFetchStatus, tagQueryString } = this.props;
 
     this.setState(
       {
@@ -69,14 +69,14 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       },
       () => {
         if (tagReportFetchStatus !== FetchStatus.inProgress) {
-          fetchTag(tagReportPathsType, tagReportType, queryString);
+          fetchTag(tagReportPathsType, tagReportType, tagQueryString);
         }
       }
     );
   }
 
   public componentDidUpdate(prevProps: DetailsToolbarProps) {
-    const { fetchTag, query, queryString, tagReport, tagReportFetchStatus } = this.props;
+    const { fetchTag, query, tagReport, tagReportFetchStatus, tagQueryString } = this.props;
     if (!isEqual(tagReport, prevProps.tagReport)) {
       this.setState(
         {
@@ -84,12 +84,12 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         },
         () => {
           if (tagReportFetchStatus !== FetchStatus.inProgress) {
-            fetchTag(tagReportPathsType, tagReportType, queryString);
+            fetchTag(tagReportPathsType, tagReportType, tagQueryString);
           }
         }
       );
     } else if (query && !isEqual(query, prevProps.query) && tagReportFetchStatus !== FetchStatus.inProgress) {
-      fetchTag(tagReportPathsType, tagReportType, queryString);
+      fetchTag(tagReportPathsType, tagReportType, tagQueryString);
     }
   }
 
@@ -165,7 +165,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
 const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToolbarStateProps>((state, props) => {
   // Note: Omitting key_only would help to share a single, cached request -- the toolbar requires key values
   // However, for better server-side performance, we chose to use key_only here.
-  const queryString = getQuery({
+  const tagQueryString = getQuery({
     filter: {
       resolution: 'monthly',
       time_scope_units: 'month',
@@ -174,12 +174,17 @@ const mapStateToProps = createMapStateToProps<DetailsToolbarOwnProps, DetailsToo
     key_only: true,
     limit: 1000,
   });
-  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, queryString);
-  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagReportPathsType, tagReportType, queryString);
+  const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, tagQueryString);
+  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(
+    state,
+    tagReportPathsType,
+    tagReportType,
+    tagQueryString
+  );
   return {
-    queryString,
     tagReport,
     tagReportFetchStatus,
+    tagQueryString,
   };
 });
 

--- a/src/routes/views/details/ocpDetails/ocpDetails.tsx
+++ b/src/routes/views/details/ocpDetails/ocpDetails.tsx
@@ -52,10 +52,10 @@ interface OcpDetailsStateProps {
   providers: Providers;
   providersFetchStatus: FetchStatus;
   query: OcpQuery;
-  queryString: string;
   report: OcpReport;
   reportError: AxiosError;
   reportFetchStatus: FetchStatus;
+  reportQueryString: string;
 }
 
 interface OcpDetailsDispatchProps {
@@ -143,10 +143,10 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
   }
 
   public componentDidUpdate(prevProps: OcpDetailsProps, prevState: OcpDetailsState) {
-    const { location, report, reportError, queryString } = this.props;
+    const { location, report, reportError, reportQueryString } = this.props;
     const { selectedItems } = this.state;
 
-    const newQuery = prevProps.queryString !== queryString;
+    const newQuery = prevProps.reportQueryString !== reportQueryString;
     const noReport = !report && !reportError;
     const noLocation = !location.search;
     const newItems = prevState.selectedItems !== selectedItems;
@@ -187,7 +187,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
   };
 
   private getExportModal = (computedItems: ComputedReportItem[]) => {
-    const { query, queryString, report } = this.props;
+    const { query, report, reportQueryString } = this.props;
     const { isAllSelected, isExportModalOpen, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
@@ -209,8 +209,8 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
         isOpen={isExportModalOpen}
         items={items}
         onClose={this.handleExportModalClose}
-        queryString={queryString}
         reportPathsType={reportPathsType}
+        reportQueryString={reportQueryString}
       />
     );
   };
@@ -250,7 +250,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
   };
 
   private getTable = () => {
-    const { history, query, queryString, report, reportFetchStatus } = this.props;
+    const { history, query, report, reportFetchStatus, reportQueryString } = this.props;
     const { hiddenColumns, isAllSelected, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
@@ -265,8 +265,8 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
         isLoading={reportFetchStatus === FetchStatus.inProgress}
         onSelected={this.handleSelected}
         onSort={(sortType, isSortAscending) => handleSort(history, query, sortType, isSortAscending)}
-        queryString={queryString}
         report={report}
+        reportQueryString={reportQueryString}
         selectedItems={selectedItems}
       />
     );
@@ -380,7 +380,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
   };
 
   private updateReport = () => {
-    const { fetchReport, history, location, query, queryString } = this.props;
+    const { fetchReport, history, location, query, reportQueryString } = this.props;
     if (!location.search) {
       history.replace(
         getRouteForQuery(history, {
@@ -391,7 +391,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
         })
       );
     } else {
-      fetchReport(reportPathsType, reportType, queryString);
+      fetchReport(reportPathsType, reportType, reportQueryString);
     }
   };
 
@@ -464,13 +464,18 @@ const mapStateToProps = createMapStateToProps<OcpDetailsOwnProps, OcpDetailsStat
     order_by: queryFromRoute.order_by || baseQuery.order_by,
     category: queryFromRoute.category,
   };
-  const queryString = getQuery({
+  const reportQueryString = getQuery({
     ...query,
     currency,
   });
-  const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
-  const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+  const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
+  const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);
+  const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+    state,
+    reportPathsType,
+    reportType,
+    reportQueryString
+  );
 
   const providersQueryString = getProvidersQuery(providersQuery);
   const providers = providersSelectors.selectProviders(state, ProviderType.all, providersQueryString);
@@ -485,10 +490,10 @@ const mapStateToProps = createMapStateToProps<OcpDetailsOwnProps, OcpDetailsStat
     providers: filterProviders(providers, ProviderType.ocp),
     providersFetchStatus,
     query,
-    queryString,
     report,
     reportError,
     reportFetchStatus,
+    reportQueryString,
   };
 });
 

--- a/src/routes/views/explorer/explorer.tsx
+++ b/src/routes/views/explorer/explorer.tsx
@@ -191,8 +191,8 @@ class Explorer extends React.Component<ExplorerProps> {
         isOpen={isExportModalOpen}
         items={items}
         onClose={this.handleExportModalClose}
-        queryString={reportQueryString}
         reportPathsType={getReportPathsType(perspective)}
+        reportQueryString={reportQueryString}
         resolution="daily"
         showTimeScope={false}
       />

--- a/src/routes/views/explorer/explorerChart.tsx
+++ b/src/routes/views/explorer/explorerChart.tsx
@@ -46,10 +46,10 @@ interface ExplorerChartStateProps {
   end_date?: string;
   perspective: PerspectiveType;
   query: Query;
-  queryString: string;
   report: Report;
   reportError: AxiosError;
   reportFetchStatus: FetchStatus;
+  reportQueryString: string;
   start_date?: string;
 }
 
@@ -76,9 +76,9 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
   }
 
   public componentDidUpdate(prevProps: ExplorerChartProps) {
-    const { report, reportError, queryString } = this.props;
+    const { report, reportError, reportQueryString } = this.props;
 
-    const newQuery = prevProps.queryString !== queryString;
+    const newQuery = prevProps.reportQueryString !== reportQueryString;
     const noReport = !report && !reportError;
 
     if (newQuery || noReport) {
@@ -116,13 +116,13 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps> {
   };
 
   private fetchReport = () => {
-    const { fetchReport, perspective, queryString } = this.props;
+    const { fetchReport, perspective, reportQueryString } = this.props;
 
     if (perspective) {
       const reportPathsType = getReportPathsType(perspective);
       const reportType = getReportType(perspective);
 
-      fetchReport(reportPathsType, reportType, queryString);
+      fetchReport(reportPathsType, reportType, reportQueryString);
     }
   };
 
@@ -277,23 +277,28 @@ const mapStateToProps = createMapStateToProps<ExplorerChartOwnProps, ExplorerCha
       start_date,
       end_date,
     };
-    const queryString = getQuery(query);
 
     const reportPathsType = getReportPathsType(perspective);
     const reportType = getReportType(perspective);
 
-    const report = reportSelectors.selectReport(state, reportPathsType, reportType, queryString);
-    const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, queryString);
-    const reportFetchStatus = reportSelectors.selectReportFetchStatus(state, reportPathsType, reportType, queryString);
+    const reportQueryString = getQuery(query);
+    const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
+    const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);
+    const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+      state,
+      reportPathsType,
+      reportType,
+      reportQueryString
+    );
 
     return {
       end_date,
       perspective,
       query,
-      queryString,
       report,
       reportError,
       reportFetchStatus,
+      reportQueryString,
       start_date,
     };
   }

--- a/src/routes/views/explorer/explorerHeader.tsx
+++ b/src/routes/views/explorer/explorerHeader.tsx
@@ -321,7 +321,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps> {
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHeaderStateProps>(
-  (state, { costType, currency, perspective }) => {
+  (state, { perspective }) => {
     const queryFromRoute = parseQuery<Query>(location.search);
     const dateRangeType = getDateRangeTypeDefault(queryFromRoute);
     const { end_date, start_date } = getDateRangeFromQuery(queryFromRoute);

--- a/src/routes/views/explorer/explorerHeader.tsx
+++ b/src/routes/views/explorer/explorerHeader.tsx
@@ -3,7 +3,7 @@ import type { Providers } from 'api/providers';
 import { ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import type { Query } from 'api/queries/query';
-import { getQuery, parseQuery } from 'api/queries/query';
+import { parseQuery } from 'api/queries/query';
 import { getUserAccessQuery } from 'api/queries/userAccessQuery';
 import type { UserAccess } from 'api/userAccess';
 import { UserAccessType } from 'api/userAccess';
@@ -86,7 +86,6 @@ interface ExplorerHeaderStateProps {
   providersFetchStatus: FetchStatus;
   providersQueryString: string;
   query: Query;
-  queryString: string;
   userAccess: UserAccess;
   userAccessError: AxiosError;
   userAccessFetchStatus: FetchStatus;
@@ -367,17 +366,6 @@ const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHe
         start_date,
       }),
     };
-    const queryString = getQuery({
-      ...query,
-      cost_type: costType,
-      currency,
-      ...(dateRangeType !== DateRangeType.custom && {
-        end_date,
-        start_date,
-      }),
-      perspective: undefined,
-      dateRangeType: undefined,
-    });
 
     return {
       awsProviders: filterProviders(providers, ProviderType.aws),
@@ -396,7 +384,6 @@ const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHe
       providersFetchStatus,
       providersQueryString,
       query,
-      queryString,
       userAccess,
       userAccessError,
       userAccessFetchStatus,

--- a/src/store/accountSettings/accountSettingsActions.ts
+++ b/src/store/accountSettings/accountSettingsActions.ts
@@ -3,10 +3,10 @@ import { fetchAccountSettings as apiGetAccountSettings } from 'api/accountSettin
 import type { AxiosError } from 'axios';
 import { createAction } from 'typesafe-actions';
 
-import { getReportId } from './accountSettingsCommon';
+import { getFetchId } from './accountSettingsCommon';
 
 interface AccountSettingsActionMeta {
-  reportId: string;
+  fetchId: string;
 }
 
 export const fetchAccountSettingsRequest = createAction('accountSettings/fetch/request')<AccountSettingsActionMeta>();
@@ -22,7 +22,7 @@ export const fetchAccountSettingsFailure = createAction('accountSettings/fetch/f
 export function fetchAccountSettings() {
   return dispatch => {
     const meta: AccountSettingsActionMeta = {
-      reportId: getReportId(),
+      fetchId: getFetchId(),
     };
 
     dispatch(fetchAccountSettingsRequest(meta));

--- a/src/store/accountSettings/accountSettingsCommon.ts
+++ b/src/store/accountSettings/accountSettingsCommon.ts
@@ -1,6 +1,6 @@
 export const stateKey = 'accountSettings';
 export const accountSettingsKey = 'accountSettings';
 
-export function getReportId() {
+export function getFetchId() {
   return `accountSettings`;
 }

--- a/src/store/accountSettings/accountSettingsReducer.ts
+++ b/src/store/accountSettings/accountSettingsReducer.ts
@@ -48,7 +48,7 @@ export function accountSettingsReducer(state = defaultState, action: AccountSett
     case getType(fetchAccountSettingsRequest):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.payload.reportId, FetchStatus.inProgress),
+        fetchStatus: new Map(state.fetchStatus).set(action.payload.fetchId, FetchStatus.inProgress),
       };
     case getType(fetchAccountSettingsSuccess):
       initCostType(action.payload.data.cost_type);
@@ -56,17 +56,17 @@ export function accountSettingsReducer(state = defaultState, action: AccountSett
 
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.reportId, FetchStatus.complete),
-        byId: new Map(state.byId).set(action.meta.reportId, {
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        byId: new Map(state.byId).set(action.meta.fetchId, {
           ...action.payload,
         }),
-        errors: new Map(state.errors).set(action.meta.reportId, null),
+        errors: new Map(state.errors).set(action.meta.fetchId, null),
       };
     case getType(fetchAccountSettingsFailure):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.reportId, FetchStatus.complete),
-        errors: new Map(state.errors).set(action.meta.reportId, action.payload),
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        errors: new Map(state.errors).set(action.meta.fetchId, action.payload),
       };
     default:
       return state;

--- a/src/store/accountSettings/accountSettingsSelectors.ts
+++ b/src/store/accountSettings/accountSettingsSelectors.ts
@@ -1,15 +1,15 @@
 import type { RootState } from 'store/rootReducer';
 
-import { getReportId, stateKey } from './accountSettingsCommon';
+import { getFetchId, stateKey } from './accountSettingsCommon';
 
 export const selectAccountSettingsState = (state: RootState) => state[stateKey];
 
 // Fetch account settings
 
-export const selectAccountSettings = (state: RootState) => selectAccountSettingsState(state).byId.get(getReportId());
+export const selectAccountSettings = (state: RootState) => selectAccountSettingsState(state).byId.get(getFetchId());
 
 export const selectAccountSettingsFetchStatus = (state: RootState) =>
-  selectAccountSettingsState(state).fetchStatus.get(getReportId());
+  selectAccountSettingsState(state).fetchStatus.get(getFetchId());
 
 export const selectAccountSettingsError = (state: RootState) =>
-  selectAccountSettingsState(state).errors.get(getReportId());
+  selectAccountSettingsState(state).errors.get(getFetchId());

--- a/src/store/costModels/actions.ts
+++ b/src/store/costModels/actions.ts
@@ -44,11 +44,11 @@ export const {
   AxiosError
 >();
 
-export const fetchCostModels = (query: string = ''): any => {
+export const fetchCostModels = (queryString: string = ''): any => {
   return (dispatch: Dispatch) => {
     dispatch(fetchCostModelsRequest());
 
-    return apiGetCostModels(query)
+    return apiGetCostModels(queryString)
       .then(res => {
         dispatch(fetchCostModelsSuccess(res));
       })

--- a/src/store/export/export.test.ts
+++ b/src/store/export/export.test.ts
@@ -26,14 +26,14 @@ const mockExport: Export = {
   },
 } as any;
 
-const query = 'query';
 const reportType = ReportType.cost;
 const reportPathsType = ReportPathsType.aws;
+const reportQueryString = 'reportQueryString';
 
 runExportMock.mockResolvedValue({ data: mockExport });
 global.Date.now = jest.fn(() => 12345);
 
-jest.spyOn(actions, 'exportReport');
+jest.spyOn(actions, 'fetchExport');
 jest.spyOn(selectors, 'selectExportFetchStatus');
 
 test('default state', () => {
@@ -43,47 +43,47 @@ test('default state', () => {
 
 test('fetch export success', async () => {
   const store = createExportsStore();
-  store.dispatch(actions.exportReport(reportPathsType, reportType, query));
+  store.dispatch(actions.fetchExport(reportPathsType, reportType, reportQueryString));
   expect(runExportMock).toBeCalled();
-  expect(selectors.selectExportFetchStatus(store.getState(), reportPathsType, reportType, query)).toBe(
+  expect(selectors.selectExportFetchStatus(store.getState(), reportPathsType, reportType, reportQueryString)).toBe(
     FetchStatus.inProgress
   );
   await waitFor(() => expect(selectors.selectExportFetchStatus).toHaveBeenCalled());
   const finishedState = store.getState();
-  expect(selectors.selectExportFetchStatus(finishedState, reportPathsType, reportType, query)).toBe(
+  expect(selectors.selectExportFetchStatus(finishedState, reportPathsType, reportType, reportQueryString)).toBe(
     FetchStatus.complete
   );
-  expect(selectors.selectExportError(finishedState, reportPathsType, reportType, query)).toBe(null);
+  expect(selectors.selectExportError(finishedState, reportPathsType, reportType, reportQueryString)).toBe(null);
 });
 
 test('fetch export failure', async () => {
   const store = createExportsStore();
   const error = Symbol('export error');
   runExportMock.mockRejectedValueOnce(error);
-  store.dispatch(actions.exportReport(reportPathsType, reportType, query));
+  store.dispatch(actions.fetchExport(reportPathsType, reportType, reportQueryString));
   expect(runExport).toBeCalled();
-  expect(selectors.selectExportFetchStatus(store.getState(), reportPathsType, reportType, query)).toBe(
+  expect(selectors.selectExportFetchStatus(store.getState(), reportPathsType, reportType, reportQueryString)).toBe(
     FetchStatus.inProgress
   );
   await waitFor(() => expect(selectors.selectExportFetchStatus).toHaveBeenCalled());
   const finishedState = store.getState();
-  expect(selectors.selectExportFetchStatus(finishedState, reportPathsType, reportType, query)).toBe(
+  expect(selectors.selectExportFetchStatus(finishedState, reportPathsType, reportType, reportQueryString)).toBe(
     FetchStatus.complete
   );
-  expect(selectors.selectExportError(finishedState, reportPathsType, reportType, query)).toBe(error);
+  expect(selectors.selectExportError(finishedState, reportPathsType, reportType, reportQueryString)).toBe(error);
 });
 
 test('does not export if the request is in progress', () => {
   const store = createExportsStore();
-  store.dispatch(actions.exportReport(reportPathsType, reportType, query));
-  store.dispatch(actions.exportReport(reportPathsType, reportType, query));
+  store.dispatch(actions.fetchExport(reportPathsType, reportType, reportQueryString));
+  store.dispatch(actions.fetchExport(reportPathsType, reportType, reportQueryString));
   expect(runExport).toHaveBeenCalledTimes(1);
 });
 
 test('export is not re-exported if it has not expired', async () => {
   const store = createExportsStore();
-  store.dispatch(actions.exportReport(reportPathsType, reportType, query));
-  await waitFor(() => expect(actions.exportReport).toHaveBeenCalled());
-  store.dispatch(actions.exportReport(reportPathsType, reportType, query));
+  store.dispatch(actions.fetchExport(reportPathsType, reportType, reportQueryString));
+  await waitFor(() => expect(actions.fetchExport).toHaveBeenCalled());
+  store.dispatch(actions.fetchExport(reportPathsType, reportType, reportQueryString));
   expect(runExport).toHaveBeenCalledTimes(1);
 });

--- a/src/store/export/exportActions.tsx
+++ b/src/store/export/exportActions.tsx
@@ -18,7 +18,7 @@ import { createAction } from 'typesafe-actions';
 const expirationMS = 30 * 60 * 1000; // 30 minutes
 
 interface ExportActionMeta {
-  reportId: string;
+  exportId: string;
 }
 
 export const fetchExportRequest = createAction('report/request')<ExportActionMeta>();
@@ -27,7 +27,7 @@ export const fetchExportFailure = createAction('report/failure')<AxiosError, Exp
 
 const exportSuccessID = 'cost_management_export_success';
 
-export function exportReport(
+export function fetchExport(
   reportPathsType: ReportPathsType,
   reportType: ReportType,
   query: string,
@@ -39,7 +39,7 @@ export function exportReport(
     }
 
     const meta: ExportActionMeta = {
-      reportId: getExportId(reportPathsType, reportType, query),
+      exportId: getExportId(reportPathsType, reportType, query),
     };
 
     dispatch(fetchExportRequest(meta));

--- a/src/store/export/exportCommon.ts
+++ b/src/store/export/exportCommon.ts
@@ -2,6 +2,6 @@ import type { ReportPathsType, ReportType } from 'api/reports/report';
 
 export const exportStateKey = 'export';
 
-export function getExportId(reportPathsType: ReportPathsType, reportType: ReportType, query: string) {
-  return `${reportPathsType}-${reportType}--${query}`;
+export function getFetchId(reportPathsType: ReportPathsType, reportType: ReportType, reportQueryString: string) {
+  return `${reportPathsType}-${reportType}--${reportQueryString}`;
 }

--- a/src/store/export/exportReducer.ts
+++ b/src/store/export/exportReducer.ts
@@ -36,25 +36,25 @@ export function exportReducer(state = defaultState, action: ExportAction): Expor
     case getType(fetchExportRequest):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.payload.reportId, FetchStatus.inProgress),
+        fetchStatus: new Map(state.fetchStatus).set(action.payload.exportId, FetchStatus.inProgress),
       };
 
     case getType(fetchExportSuccess):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.reportId, FetchStatus.complete),
-        byId: new Map(state.byId).set(action.meta.reportId, {
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.exportId, FetchStatus.complete),
+        byId: new Map(state.byId).set(action.meta.exportId, {
           data: action.payload as any,
           timeRequested: Date.now(),
         }),
-        errors: new Map(state.errors).set(action.meta.reportId, null),
+        errors: new Map(state.errors).set(action.meta.exportId, null),
       };
 
     case getType(fetchExportFailure):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.reportId, FetchStatus.complete),
-        errors: new Map(state.errors).set(action.meta.reportId, action.payload),
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.exportId, FetchStatus.complete),
+        errors: new Map(state.errors).set(action.meta.exportId, action.payload),
       };
     default:
       return state;

--- a/src/store/export/exportReducer.ts
+++ b/src/store/export/exportReducer.ts
@@ -36,25 +36,25 @@ export function exportReducer(state = defaultState, action: ExportAction): Expor
     case getType(fetchExportRequest):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.payload.exportId, FetchStatus.inProgress),
+        fetchStatus: new Map(state.fetchStatus).set(action.payload.fetchId, FetchStatus.inProgress),
       };
 
     case getType(fetchExportSuccess):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.exportId, FetchStatus.complete),
-        byId: new Map(state.byId).set(action.meta.exportId, {
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        byId: new Map(state.byId).set(action.meta.fetchId, {
           data: action.payload as any,
           timeRequested: Date.now(),
         }),
-        errors: new Map(state.errors).set(action.meta.exportId, null),
+        errors: new Map(state.errors).set(action.meta.fetchId, null),
       };
 
     case getType(fetchExportFailure):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.exportId, FetchStatus.complete),
-        errors: new Map(state.errors).set(action.meta.exportId, action.payload),
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        errors: new Map(state.errors).set(action.meta.fetchId, action.payload),
       };
     default:
       return state;

--- a/src/store/export/exportSelectors.ts
+++ b/src/store/export/exportSelectors.ts
@@ -1,7 +1,7 @@
 import type { ReportPathsType, ReportType } from 'api/reports/report';
 import type { RootState } from 'store/rootReducer';
 
-import { exportStateKey, getExportId } from './exportCommon';
+import { exportStateKey, getFetchId } from './exportCommon';
 
 export const selectExportState = (state: RootState) => state[exportStateKey];
 
@@ -9,19 +9,19 @@ export const selectExport = (
   state: RootState,
   reportPathsType: ReportPathsType,
   reportType: ReportType,
-  query: string
-) => selectExportState(state).byId.get(getExportId(reportPathsType, reportType, query));
+  reportQueryString: string
+) => selectExportState(state).byId.get(getFetchId(reportPathsType, reportType, reportQueryString));
 
 export const selectExportFetchStatus = (
   state: RootState,
   reportPathsType: ReportPathsType,
   reportType: ReportType,
-  query: string
-) => selectExportState(state).fetchStatus.get(getExportId(reportPathsType, reportType, query));
+  reportQueryString: string
+) => selectExportState(state).fetchStatus.get(getFetchId(reportPathsType, reportType, reportQueryString));
 
 export const selectExportError = (
   state: RootState,
   reportPathsType: ReportPathsType,
   reportType: ReportType,
-  query: string
-) => selectExportState(state).errors.get(getExportId(reportPathsType, reportType, query));
+  reportQueryString: string
+) => selectExportState(state).errors.get(getFetchId(reportPathsType, reportType, reportQueryString));

--- a/src/store/forecasts/forecast.test.ts
+++ b/src/store/forecasts/forecast.test.ts
@@ -26,9 +26,9 @@ const mockForecast: Forecast = {
   },
 } as any;
 
-const query = 'query';
 const forecastType = ForecastType.cost;
 const forecastPathsType = ForecastPathsType.aws;
+const reportQueryString = 'reportQueryString';
 
 runForecastMock.mockResolvedValue({ data: mockForecast });
 global.Date.now = jest.fn(() => 12345);
@@ -43,47 +43,47 @@ test('default state', () => {
 
 test('fetch forecast success', async () => {
   const store = createForecastsStore();
-  store.dispatch(actions.fetchForecast(forecastPathsType, forecastType, query));
+  store.dispatch(actions.fetchForecast(forecastPathsType, forecastType, reportQueryString));
   expect(runForecastMock).toBeCalled();
-  expect(selectors.selectForecastFetchStatus(store.getState(), forecastPathsType, forecastType, query)).toBe(
-    FetchStatus.inProgress
-  );
+  expect(
+    selectors.selectForecastFetchStatus(store.getState(), forecastPathsType, forecastType, reportQueryString)
+  ).toBe(FetchStatus.inProgress);
   await waitFor(() => expect(selectors.selectForecastFetchStatus).toHaveBeenCalled());
   const finishedState = store.getState();
-  expect(selectors.selectForecastFetchStatus(finishedState, forecastPathsType, forecastType, query)).toBe(
+  expect(selectors.selectForecastFetchStatus(finishedState, forecastPathsType, forecastType, reportQueryString)).toBe(
     FetchStatus.complete
   );
-  expect(selectors.selectForecastError(finishedState, forecastPathsType, forecastType, query)).toBe(null);
+  expect(selectors.selectForecastError(finishedState, forecastPathsType, forecastType, reportQueryString)).toBe(null);
 });
 
 test('fetch forecast failure', async () => {
   const store = createForecastsStore();
   const error = Symbol('forecast error');
   runForecastMock.mockRejectedValueOnce(error);
-  store.dispatch(actions.fetchForecast(forecastPathsType, forecastType, query));
+  store.dispatch(actions.fetchForecast(forecastPathsType, forecastType, reportQueryString));
   expect(runForecast).toBeCalled();
-  expect(selectors.selectForecastFetchStatus(store.getState(), forecastPathsType, forecastType, query)).toBe(
-    FetchStatus.inProgress
-  );
+  expect(
+    selectors.selectForecastFetchStatus(store.getState(), forecastPathsType, forecastType, reportQueryString)
+  ).toBe(FetchStatus.inProgress);
   await waitFor(() => expect(selectors.selectForecastFetchStatus).toHaveBeenCalled());
   const finishedState = store.getState();
-  expect(selectors.selectForecastFetchStatus(finishedState, forecastPathsType, forecastType, query)).toBe(
+  expect(selectors.selectForecastFetchStatus(finishedState, forecastPathsType, forecastType, reportQueryString)).toBe(
     FetchStatus.complete
   );
-  expect(selectors.selectForecastError(finishedState, forecastPathsType, forecastType, query)).toBe(error);
+  expect(selectors.selectForecastError(finishedState, forecastPathsType, forecastType, reportQueryString)).toBe(error);
 });
 
 test('does not fetch forecast if the request is in progress', () => {
   const store = createForecastsStore();
-  store.dispatch(actions.fetchForecast(forecastPathsType, forecastType, query));
-  store.dispatch(actions.fetchForecast(forecastPathsType, forecastType, query));
+  store.dispatch(actions.fetchForecast(forecastPathsType, forecastType, reportQueryString));
+  store.dispatch(actions.fetchForecast(forecastPathsType, forecastType, reportQueryString));
   expect(runForecast).toHaveBeenCalledTimes(1);
 });
 
 test('forecast is not refetched if it has not expired', async () => {
   const store = createForecastsStore();
-  store.dispatch(actions.fetchForecast(forecastPathsType, forecastType, query));
+  store.dispatch(actions.fetchForecast(forecastPathsType, forecastType, reportQueryString));
   await waitFor(() => expect(actions.fetchForecast).toHaveBeenCalled());
-  store.dispatch(actions.fetchForecast(forecastPathsType, forecastType, query));
+  store.dispatch(actions.fetchForecast(forecastPathsType, forecastType, reportQueryString));
   expect(runForecast).toHaveBeenCalledTimes(1);
 });

--- a/src/store/forecasts/forecastActions.ts
+++ b/src/store/forecasts/forecastActions.ts
@@ -7,13 +7,13 @@ import { FetchStatus } from 'store/common';
 import type { RootState } from 'store/rootReducer';
 import { createAction } from 'typesafe-actions';
 
-import { getForecastId } from './forecastCommon';
+import { getFetchId } from './forecastCommon';
 import { selectForecast, selectForecastFetchStatus } from './forecastSelectors';
 
 const expirationMS = 30 * 60 * 1000; // 30 minutes
 
 interface ForecastActionMeta {
-  forecastId: string;
+  fetchId: string;
 }
 
 export const fetchForecastRequest = createAction('forecast/request')<ForecastActionMeta>();
@@ -23,19 +23,19 @@ export const fetchForecastFailure = createAction('forecast/failure')<AxiosError,
 export function fetchForecast(
   forecastPathsType: ForecastPathsType,
   forecastType: ForecastType,
-  query: string
+  forecastQueryString: string
 ): ThunkAction<void, RootState, void, any> {
   return (dispatch, getState) => {
-    if (!isForecastExpired(getState(), forecastPathsType, forecastType, query)) {
+    if (!isForecastExpired(getState(), forecastPathsType, forecastType, forecastQueryString)) {
       return;
     }
 
     const meta: ForecastActionMeta = {
-      forecastId: getForecastId(forecastPathsType, forecastType, query),
+      fetchId: getFetchId(forecastPathsType, forecastType, forecastQueryString),
     };
 
     dispatch(fetchForecastRequest(meta));
-    runForecast(forecastPathsType, forecastType, query)
+    runForecast(forecastPathsType, forecastType, forecastQueryString)
       .then(res => {
         dispatch(fetchForecastSuccess(res.data, meta));
       })
@@ -49,10 +49,10 @@ function isForecastExpired(
   state: RootState,
   forecastPathsType: ForecastPathsType,
   forecastType: ForecastType,
-  query: string
+  forecastQueryString: string
 ) {
-  const forecast = selectForecast(state, forecastPathsType, forecastType, query);
-  const fetchStatus = selectForecastFetchStatus(state, forecastPathsType, forecastType, query);
+  const forecast = selectForecast(state, forecastPathsType, forecastType, forecastQueryString);
+  const fetchStatus = selectForecastFetchStatus(state, forecastPathsType, forecastType, forecastQueryString);
   if (fetchStatus === FetchStatus.inProgress) {
     return false;
   }

--- a/src/store/forecasts/forecastCommon.ts
+++ b/src/store/forecasts/forecastCommon.ts
@@ -2,6 +2,10 @@ import type { ForecastPathsType, ForecastType } from 'api/forecasts/forecast';
 
 export const forecastStateKey = 'forecast';
 
-export function getForecastId(forecastPathsType: ForecastPathsType, forecastType: ForecastType, query: string) {
-  return `${forecastPathsType}--${forecastType}--${query}`;
+export function getFetchId(
+  forecastPathsType: ForecastPathsType,
+  forecastType: ForecastType,
+  forecastQueryString: string
+) {
+  return `${forecastPathsType}--${forecastType}--${forecastQueryString}`;
 }

--- a/src/store/forecasts/forecastReducer.ts
+++ b/src/store/forecasts/forecastReducer.ts
@@ -36,25 +36,25 @@ export function forecastReducer(state = defaultState, action: ForecastAction): F
     case getType(fetchForecastRequest):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.payload.forecastId, FetchStatus.inProgress),
+        fetchStatus: new Map(state.fetchStatus).set(action.payload.fetchId, FetchStatus.inProgress),
       };
 
     case getType(fetchForecastSuccess):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.forecastId, FetchStatus.complete),
-        byId: new Map(state.byId).set(action.meta.forecastId, {
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        byId: new Map(state.byId).set(action.meta.fetchId, {
           ...action.payload,
           timeRequested: Date.now(),
         }),
-        errors: new Map(state.errors).set(action.meta.forecastId, null),
+        errors: new Map(state.errors).set(action.meta.fetchId, null),
       };
 
     case getType(fetchForecastFailure):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.forecastId, FetchStatus.complete),
-        errors: new Map(state.errors).set(action.meta.forecastId, action.payload),
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        errors: new Map(state.errors).set(action.meta.fetchId, action.payload),
       };
     default:
       return state;

--- a/src/store/forecasts/forecastSelectors.ts
+++ b/src/store/forecasts/forecastSelectors.ts
@@ -1,7 +1,7 @@
 import type { ForecastPathsType, ForecastType } from 'api/forecasts/forecast';
 import type { RootState } from 'store/rootReducer';
 
-import { forecastStateKey, getForecastId } from './forecastCommon';
+import { forecastStateKey, getFetchId } from './forecastCommon';
 
 export const selectForecastState = (state: RootState) => state[forecastStateKey];
 
@@ -9,19 +9,19 @@ export const selectForecast = (
   state: RootState,
   forecastPathsType: ForecastPathsType,
   forecastType: ForecastType,
-  query: string
-) => selectForecastState(state).byId.get(getForecastId(forecastPathsType, forecastType, query));
+  forecastQueryString: string
+) => selectForecastState(state).byId.get(getFetchId(forecastPathsType, forecastType, forecastQueryString));
 
 export const selectForecastFetchStatus = (
   state: RootState,
   forecastPathsType: ForecastPathsType,
   forecastType: ForecastType,
-  query: string
-) => selectForecastState(state).fetchStatus.get(getForecastId(forecastPathsType, forecastType, query));
+  forecastQueryString: string
+) => selectForecastState(state).fetchStatus.get(getFetchId(forecastPathsType, forecastType, forecastQueryString));
 
 export const selectForecastError = (
   state: RootState,
   forecastPathsType: ForecastPathsType,
   forecastType: ForecastType,
-  query: string
-) => selectForecastState(state).errors.get(getForecastId(forecastPathsType, forecastType, query));
+  forecastQueryString: string
+) => selectForecastState(state).errors.get(getFetchId(forecastPathsType, forecastType, forecastQueryString));

--- a/src/store/orgs/org.test.ts
+++ b/src/store/orgs/org.test.ts
@@ -26,9 +26,9 @@ const mockOrgReport: Org = {
   },
 } as any;
 
-const query = 'query';
 const orgReportType = OrgType.org;
 const orgReportPathsType = OrgPathsType.aws;
+const orgQueryString = 'orgQueryString';
 
 runOrgMock.mockResolvedValue({ data: mockOrgReport });
 global.Date.now = jest.fn(() => 12345);
@@ -43,47 +43,47 @@ test('default state', () => {
 
 test('fetch org report success', async () => {
   const store = createOrgsStore();
-  store.dispatch(actions.fetchOrg(orgReportPathsType, orgReportType, query));
+  store.dispatch(actions.fetchOrg(orgReportPathsType, orgReportType, orgQueryString));
   expect(runOrgMock).toBeCalled();
-  expect(selectors.selectOrgFetchStatus(store.getState(), orgReportPathsType, orgReportType, query)).toBe(
+  expect(selectors.selectOrgFetchStatus(store.getState(), orgReportPathsType, orgReportType, orgQueryString)).toBe(
     FetchStatus.inProgress
   );
   await waitFor(() => expect(selectors.selectOrgFetchStatus).toHaveBeenCalled());
   const finishedState = store.getState();
-  expect(selectors.selectOrgFetchStatus(finishedState, orgReportPathsType, orgReportType, query)).toBe(
+  expect(selectors.selectOrgFetchStatus(finishedState, orgReportPathsType, orgReportType, orgQueryString)).toBe(
     FetchStatus.complete
   );
-  expect(selectors.selectOrgError(finishedState, orgReportPathsType, orgReportType, query)).toBe(null);
+  expect(selectors.selectOrgError(finishedState, orgReportPathsType, orgReportType, orgQueryString)).toBe(null);
 });
 
 test('fetch org report failure', async () => {
   const store = createOrgsStore();
   const error = Symbol('org error');
   runOrgMock.mockRejectedValueOnce(error);
-  store.dispatch(actions.fetchOrg(orgReportPathsType, orgReportType, query));
+  store.dispatch(actions.fetchOrg(orgReportPathsType, orgReportType, orgQueryString));
   expect(runOrg).toBeCalled();
-  expect(selectors.selectOrgFetchStatus(store.getState(), orgReportPathsType, orgReportType, query)).toBe(
+  expect(selectors.selectOrgFetchStatus(store.getState(), orgReportPathsType, orgReportType, orgQueryString)).toBe(
     FetchStatus.inProgress
   );
   await waitFor(() => expect(selectors.selectOrgFetchStatus).toHaveBeenCalled());
   const finishedState = store.getState();
-  expect(selectors.selectOrgFetchStatus(finishedState, orgReportPathsType, orgReportType, query)).toBe(
+  expect(selectors.selectOrgFetchStatus(finishedState, orgReportPathsType, orgReportType, orgQueryString)).toBe(
     FetchStatus.complete
   );
-  expect(selectors.selectOrgError(finishedState, orgReportPathsType, orgReportType, query)).toBe(error);
+  expect(selectors.selectOrgError(finishedState, orgReportPathsType, orgReportType, orgQueryString)).toBe(error);
 });
 
 test('does not fetch org report if the request is in progress', () => {
   const store = createOrgsStore();
-  store.dispatch(actions.fetchOrg(orgReportPathsType, orgReportType, query));
-  store.dispatch(actions.fetchOrg(orgReportPathsType, orgReportType, query));
+  store.dispatch(actions.fetchOrg(orgReportPathsType, orgReportType, orgQueryString));
+  store.dispatch(actions.fetchOrg(orgReportPathsType, orgReportType, orgQueryString));
   expect(runOrg).toHaveBeenCalledTimes(1);
 });
 
 test('org report is not refetched if it has not expired', async () => {
   const store = createOrgsStore();
-  store.dispatch(actions.fetchOrg(orgReportPathsType, orgReportType, query));
+  store.dispatch(actions.fetchOrg(orgReportPathsType, orgReportType, orgQueryString));
   await waitFor(() => expect(actions.fetchOrg).toHaveBeenCalled());
-  store.dispatch(actions.fetchOrg(orgReportPathsType, orgReportType, query));
+  store.dispatch(actions.fetchOrg(orgReportPathsType, orgReportType, orgQueryString));
   expect(runOrg).toHaveBeenCalledTimes(1);
 });

--- a/src/store/orgs/orgActions.ts
+++ b/src/store/orgs/orgActions.ts
@@ -7,13 +7,13 @@ import { FetchStatus } from 'store/common';
 import type { RootState } from 'store/rootReducer';
 import { createAction } from 'typesafe-actions';
 
-import { getOrgId } from './orgCommon';
+import { getFetchId } from './orgCommon';
 import { selectOrg, selectOrgFetchStatus } from './orgSelectors';
 
 const expirationMS = 30 * 60 * 1000; // 30 minutes
 
 interface OrgActionMeta {
-  orgId: string;
+  fetchId: string;
 }
 
 export const fetchOrgRequest = createAction('org/request')<OrgActionMeta>();
@@ -23,19 +23,19 @@ export const fetchOrgFailure = createAction('org/failure')<AxiosError, OrgAction
 export function fetchOrg(
   orgPathsType: OrgPathsType,
   orgType: OrgType,
-  query: string
+  orgQueryString: string
 ): ThunkAction<void, RootState, void, any> {
   return (dispatch, getState) => {
-    if (!isOrgExpired(getState(), orgPathsType, orgType, query)) {
+    if (!isOrgExpired(getState(), orgPathsType, orgType, orgQueryString)) {
       return;
     }
 
     const meta: OrgActionMeta = {
-      orgId: getOrgId(orgPathsType, orgType, query),
+      fetchId: getFetchId(orgPathsType, orgType, orgQueryString),
     };
 
     dispatch(fetchOrgRequest(meta));
-    runOrg(orgPathsType, orgType, query)
+    runOrg(orgPathsType, orgType, orgQueryString)
       .then(res => {
         // See https://github.com/project-koku/koku-ui/pull/580
         // const repsonseData = dropCurrentMonthData(res, query);
@@ -47,9 +47,9 @@ export function fetchOrg(
   };
 }
 
-function isOrgExpired(state: RootState, orgPathsType: OrgPathsType, orgType: OrgType, query: string) {
-  const orgReport = selectOrg(state, orgPathsType, orgType, query);
-  const fetchStatus = selectOrgFetchStatus(state, orgPathsType, orgType, query);
+function isOrgExpired(state: RootState, orgPathsType: OrgPathsType, orgType: OrgType, orgQueryString: string) {
+  const orgReport = selectOrg(state, orgPathsType, orgType, orgQueryString);
+  const fetchStatus = selectOrgFetchStatus(state, orgPathsType, orgType, orgQueryString);
   if (fetchStatus === FetchStatus.inProgress) {
     return false;
   }

--- a/src/store/orgs/orgCommon.ts
+++ b/src/store/orgs/orgCommon.ts
@@ -2,6 +2,6 @@ import type { OrgPathsType, OrgType } from 'api/orgs/org';
 
 export const orgStateKey = 'org';
 
-export function getOrgId(orgPathsType: OrgPathsType, orgType: OrgType, query: string) {
-  return `${orgPathsType}--${orgType}--${query}`;
+export function getFetchId(orgPathsType: OrgPathsType, orgType: OrgType, orgQueryString: string) {
+  return `${orgPathsType}--${orgType}--${orgQueryString}`;
 }

--- a/src/store/orgs/orgReducer.ts
+++ b/src/store/orgs/orgReducer.ts
@@ -36,25 +36,25 @@ export function orgReducer(state = defaultState, action: OrgAction): OrgState {
     case getType(fetchOrgRequest):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.payload.orgId, FetchStatus.inProgress),
+        fetchStatus: new Map(state.fetchStatus).set(action.payload.fetchId, FetchStatus.inProgress),
       };
 
     case getType(fetchOrgSuccess):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.orgId, FetchStatus.complete),
-        byId: new Map(state.byId).set(action.meta.orgId, {
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        byId: new Map(state.byId).set(action.meta.fetchId, {
           ...action.payload,
           timeRequested: Date.now(),
         }),
-        errors: new Map(state.errors).set(action.meta.orgId, null),
+        errors: new Map(state.errors).set(action.meta.fetchId, null),
       };
 
     case getType(fetchOrgFailure):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.orgId, FetchStatus.complete),
-        errors: new Map(state.errors).set(action.meta.orgId, action.payload),
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        errors: new Map(state.errors).set(action.meta.fetchId, action.payload),
       };
     default:
       return state;

--- a/src/store/orgs/orgSelectors.ts
+++ b/src/store/orgs/orgSelectors.ts
@@ -1,15 +1,23 @@
 import type { OrgPathsType, OrgType } from 'api/orgs/org';
 import type { RootState } from 'store/rootReducer';
 
-import { getOrgId, orgStateKey } from './orgCommon';
+import { getFetchId, orgStateKey } from './orgCommon';
 
 export const selectOrgState = (state: RootState) => state[orgStateKey];
 
-export const selectOrg = (state: RootState, orgPathsType: OrgPathsType, orgType: OrgType, query: string) =>
-  selectOrgState(state).byId.get(getOrgId(orgPathsType, orgType, query));
+export const selectOrg = (state: RootState, orgPathsType: OrgPathsType, orgType: OrgType, orgQueryString: string) =>
+  selectOrgState(state).byId.get(getFetchId(orgPathsType, orgType, orgQueryString));
 
-export const selectOrgFetchStatus = (state: RootState, orgPathsType: OrgPathsType, orgType: OrgType, query: string) =>
-  selectOrgState(state).fetchStatus.get(getOrgId(orgPathsType, orgType, query));
+export const selectOrgFetchStatus = (
+  state: RootState,
+  orgPathsType: OrgPathsType,
+  orgType: OrgType,
+  orgQueryString: string
+) => selectOrgState(state).fetchStatus.get(getFetchId(orgPathsType, orgType, orgQueryString));
 
-export const selectOrgError = (state: RootState, orgPathsType: OrgPathsType, orgType: OrgType, query: string) =>
-  selectOrgState(state).errors.get(getOrgId(orgPathsType, orgType, query));
+export const selectOrgError = (
+  state: RootState,
+  orgPathsType: OrgPathsType,
+  orgType: OrgType,
+  orgQueryString: string
+) => selectOrgState(state).errors.get(getFetchId(orgPathsType, orgType, orgQueryString));

--- a/src/store/providers/providersActions.ts
+++ b/src/store/providers/providersActions.ts
@@ -4,25 +4,25 @@ import { fetchProviders as apiGetProviders } from 'api/providers';
 import type { AxiosError } from 'axios';
 import { createAction } from 'typesafe-actions';
 
-import { getReportId } from './providersCommon';
+import { getFetchId } from './providersCommon';
 
 interface ProvidersActionMeta {
-  reportId: string;
+  fetchId: string;
 }
 
 export const fetchProvidersRequest = createAction('providers/fetch/request')<ProvidersActionMeta>();
 export const fetchProvidersSuccess = createAction('providers/fetch/success')<Providers, ProvidersActionMeta>();
 export const fetchProvidersFailure = createAction('providers/fetch/failure')<AxiosError, ProvidersActionMeta>();
 
-export function fetchProviders(reportType: ProviderType, query: string) {
+export function fetchProviders(reportType: ProviderType, reportQueryString: string) {
   return dispatch => {
     const meta: ProvidersActionMeta = {
-      reportId: getReportId(reportType, query),
+      fetchId: getFetchId(reportType, reportQueryString),
     };
 
     dispatch(fetchProvidersRequest(meta));
 
-    return apiGetProviders(query)
+    return apiGetProviders(reportQueryString)
       .then(res => {
         dispatch(fetchProvidersSuccess(res.data, meta));
       })

--- a/src/store/providers/providersCommon.ts
+++ b/src/store/providers/providersCommon.ts
@@ -39,6 +39,6 @@ export const providersQuery: ProvidersQuery = {
   limit: 1000,
 };
 
-export function getReportId(type: ProviderType, query: string) {
-  return `${type}--${query}`;
+export function getFetchId(type: ProviderType, provideQueryString: string) {
+  return `${type}--${provideQueryString}`;
 }

--- a/src/store/providers/providersReducer.ts
+++ b/src/store/providers/providersReducer.ts
@@ -32,22 +32,22 @@ export function providersReducer(state = defaultState, action: ProvidersAction):
     case getType(fetchProvidersRequest):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.payload.reportId, FetchStatus.inProgress),
+        fetchStatus: new Map(state.fetchStatus).set(action.payload.fetchId, FetchStatus.inProgress),
       };
     case getType(fetchProvidersSuccess):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.reportId, FetchStatus.complete),
-        byId: new Map(state.byId).set(action.meta.reportId, {
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        byId: new Map(state.byId).set(action.meta.fetchId, {
           ...action.payload,
         }),
-        errors: new Map(state.errors).set(action.meta.reportId, null),
+        errors: new Map(state.errors).set(action.meta.fetchId, null),
       };
     case getType(fetchProvidersFailure):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.reportId, FetchStatus.complete),
-        errors: new Map(state.errors).set(action.meta.reportId, action.payload),
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        errors: new Map(state.errors).set(action.meta.fetchId, action.payload),
       };
     default:
       return state;

--- a/src/store/providers/providersSelectors.ts
+++ b/src/store/providers/providersSelectors.ts
@@ -1,7 +1,7 @@
 import type { ProviderType } from 'api/providers';
 import type { RootState } from 'store/rootReducer';
 
-import { addProviderKey, getReportId, stateKey } from './providersCommon';
+import { addProviderKey, getFetchId, stateKey } from './providersCommon';
 
 export const selectProvidersState = (state: RootState) => state[stateKey];
 
@@ -14,11 +14,11 @@ export const selectAddProviderError = (state: RootState) => selectProvidersState
 
 // Fetch providers
 
-export const selectProviders = (state: RootState, providerType: ProviderType, query: string) =>
-  selectProvidersState(state).byId.get(getReportId(providerType, query));
+export const selectProviders = (state: RootState, providerType: ProviderType, provideQueryString: string) =>
+  selectProvidersState(state).byId.get(getFetchId(providerType, provideQueryString));
 
-export const selectProvidersFetchStatus = (state: RootState, providerType: ProviderType, query: string) =>
-  selectProvidersState(state).fetchStatus.get(getReportId(providerType, query));
+export const selectProvidersFetchStatus = (state: RootState, providerType: ProviderType, provideQueryString: string) =>
+  selectProvidersState(state).fetchStatus.get(getFetchId(providerType, provideQueryString));
 
-export const selectProvidersError = (state: RootState, providerType: ProviderType, query: string) =>
-  selectProvidersState(state).errors.get(getReportId(providerType, query));
+export const selectProvidersError = (state: RootState, providerType: ProviderType, provideQueryString: string) =>
+  selectProvidersState(state).errors.get(getFetchId(providerType, provideQueryString));

--- a/src/store/reports/report.test.ts
+++ b/src/store/reports/report.test.ts
@@ -26,9 +26,9 @@ const mockReport: Report = {
   },
 } as any;
 
-const query = 'query';
 const reportType = ReportType.cost;
 const reportPathsType = ReportPathsType.aws;
+const reportQueryString = 'reportQueryString';
 
 runReportMock.mockResolvedValue({ data: mockReport });
 global.Date.now = jest.fn(() => 12345);
@@ -43,47 +43,47 @@ test('default state', () => {
 
 test('fetch report success', async () => {
   const store = createReportsStore();
-  store.dispatch(actions.fetchReport(reportPathsType, reportType, query));
+  store.dispatch(actions.fetchReport(reportPathsType, reportType, reportQueryString));
   expect(runReportMock).toBeCalled();
-  expect(selectors.selectReportFetchStatus(store.getState(), reportPathsType, reportType, query)).toBe(
+  expect(selectors.selectReportFetchStatus(store.getState(), reportPathsType, reportType, reportQueryString)).toBe(
     FetchStatus.inProgress
   );
   await waitFor(() => expect(selectors.selectReportFetchStatus).toHaveBeenCalled());
   const finishedState = store.getState();
-  expect(selectors.selectReportFetchStatus(finishedState, reportPathsType, reportType, query)).toBe(
+  expect(selectors.selectReportFetchStatus(finishedState, reportPathsType, reportType, reportQueryString)).toBe(
     FetchStatus.complete
   );
-  expect(selectors.selectReportError(finishedState, reportPathsType, reportType, query)).toBe(null);
+  expect(selectors.selectReportError(finishedState, reportPathsType, reportType, reportQueryString)).toBe(null);
 });
 
 test('fetch report failure', async () => {
   const store = createReportsStore();
   const error = Symbol('report error');
   runReportMock.mockRejectedValueOnce(error);
-  store.dispatch(actions.fetchReport(reportPathsType, reportType, query));
+  store.dispatch(actions.fetchReport(reportPathsType, reportType, reportQueryString));
   expect(runReport).toBeCalled();
-  expect(selectors.selectReportFetchStatus(store.getState(), reportPathsType, reportType, query)).toBe(
+  expect(selectors.selectReportFetchStatus(store.getState(), reportPathsType, reportType, reportQueryString)).toBe(
     FetchStatus.inProgress
   );
   await waitFor(() => expect(selectors.selectReportFetchStatus).toHaveBeenCalled());
   const finishedState = store.getState();
-  expect(selectors.selectReportFetchStatus(finishedState, reportPathsType, reportType, query)).toBe(
+  expect(selectors.selectReportFetchStatus(finishedState, reportPathsType, reportType, reportQueryString)).toBe(
     FetchStatus.complete
   );
-  expect(selectors.selectReportError(finishedState, reportPathsType, reportType, query)).toBe(error);
+  expect(selectors.selectReportError(finishedState, reportPathsType, reportType, reportQueryString)).toBe(error);
 });
 
 test('does not fetch report if the request is in progress', () => {
   const store = createReportsStore();
-  store.dispatch(actions.fetchReport(reportPathsType, reportType, query));
-  store.dispatch(actions.fetchReport(reportPathsType, reportType, query));
+  store.dispatch(actions.fetchReport(reportPathsType, reportType, reportQueryString));
+  store.dispatch(actions.fetchReport(reportPathsType, reportType, reportQueryString));
   expect(runReport).toHaveBeenCalledTimes(1);
 });
 
 test('report is not refetched if it has not expired', async () => {
   const store = createReportsStore();
-  store.dispatch(actions.fetchReport(reportPathsType, reportType, query));
+  store.dispatch(actions.fetchReport(reportPathsType, reportType, reportQueryString));
   await waitFor(() => expect(actions.fetchReport).toHaveBeenCalled());
-  store.dispatch(actions.fetchReport(reportPathsType, reportType, query));
+  store.dispatch(actions.fetchReport(reportPathsType, reportType, reportQueryString));
   expect(runReport).toHaveBeenCalledTimes(1);
 });

--- a/src/store/reports/reportCommon.ts
+++ b/src/store/reports/reportCommon.ts
@@ -1,6 +1,6 @@
 import type { ReportPathsType, ReportType } from 'api/reports/report';
 export const reportStateKey = 'report';
 
-export function getReportId(reportPathsType: ReportPathsType, reportType: ReportType, query: string) {
-  return `${reportPathsType}--${reportType}--${query}`;
+export function getFetchId(reportPathsType: ReportPathsType, reportType: ReportType, reportQueryString: string) {
+  return `${reportPathsType}--${reportType}--${reportQueryString}`;
 }

--- a/src/store/reports/reportReducer.ts
+++ b/src/store/reports/reportReducer.ts
@@ -36,25 +36,25 @@ export function reportReducer(state = defaultState, action: ReportAction): Repor
     case getType(fetchReportRequest):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.payload.reportId, FetchStatus.inProgress),
+        fetchStatus: new Map(state.fetchStatus).set(action.payload.fetchId, FetchStatus.inProgress),
       };
 
     case getType(fetchReportSuccess):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.reportId, FetchStatus.complete),
-        byId: new Map(state.byId).set(action.meta.reportId, {
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        byId: new Map(state.byId).set(action.meta.fetchId, {
           ...action.payload,
           timeRequested: Date.now(),
         }),
-        errors: new Map(state.errors).set(action.meta.reportId, null),
+        errors: new Map(state.errors).set(action.meta.fetchId, null),
       };
 
     case getType(fetchReportFailure):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.reportId, FetchStatus.complete),
-        errors: new Map(state.errors).set(action.meta.reportId, action.payload),
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        errors: new Map(state.errors).set(action.meta.fetchId, action.payload),
       };
     default:
       return state;

--- a/src/store/reports/reportSelectors.ts
+++ b/src/store/reports/reportSelectors.ts
@@ -1,7 +1,7 @@
 import type { ReportPathsType, ReportType } from 'api/reports/report';
 import type { RootState } from 'store/rootReducer';
 
-import { getReportId, reportStateKey } from './reportCommon';
+import { getFetchId, reportStateKey } from './reportCommon';
 
 export const selectReportState = (state: RootState) => state[reportStateKey];
 
@@ -9,19 +9,19 @@ export const selectReport = (
   state: RootState,
   reportPathsType: ReportPathsType,
   reportType: ReportType,
-  query: string
-) => selectReportState(state).byId.get(getReportId(reportPathsType, reportType, query));
+  reportQueryString: string
+) => selectReportState(state).byId.get(getFetchId(reportPathsType, reportType, reportQueryString));
 
 export const selectReportFetchStatus = (
   state: RootState,
   reportPathsType: ReportPathsType,
   reportType: ReportType,
-  query: string
-) => selectReportState(state).fetchStatus.get(getReportId(reportPathsType, reportType, query));
+  reportQueryString: string
+) => selectReportState(state).fetchStatus.get(getFetchId(reportPathsType, reportType, reportQueryString));
 
 export const selectReportError = (
   state: RootState,
   reportPathsType: ReportPathsType,
   reportType: ReportType,
-  query: string
-) => selectReportState(state).errors.get(getReportId(reportPathsType, reportType, query));
+  reportQueryString: string
+) => selectReportState(state).errors.get(getFetchId(reportPathsType, reportType, reportQueryString));

--- a/src/store/resources/resource.test.ts
+++ b/src/store/resources/resource.test.ts
@@ -26,9 +26,9 @@ const mockResource: Resource = {
   },
 } as any;
 
-const query = 'query';
 const resourceType = ResourceType.account;
 const resourcePathsType = ResourcePathsType.aws;
+const resourceQueryString = 'resourceQueryString';
 
 runResourceMock.mockResolvedValue({ data: mockResource });
 global.Date.now = jest.fn(() => 12345);
@@ -43,47 +43,49 @@ test('default state', () => {
 
 test('fetch resource success', async () => {
   const store = createResourcesStore();
-  store.dispatch(actions.fetchResource(resourcePathsType, resourceType, query));
+  store.dispatch(actions.fetchResource(resourcePathsType, resourceType, resourceQueryString));
   expect(runResourceMock).toBeCalled();
-  expect(selectors.selectResourceFetchStatus(store.getState(), resourcePathsType, resourceType, query)).toBe(
-    FetchStatus.inProgress
-  );
+  expect(
+    selectors.selectResourceFetchStatus(store.getState(), resourcePathsType, resourceType, resourceQueryString)
+  ).toBe(FetchStatus.inProgress);
   await waitFor(() => expect(selectors.selectResourceFetchStatus).toHaveBeenCalled());
   const finishedState = store.getState();
-  expect(selectors.selectResourceFetchStatus(finishedState, resourcePathsType, resourceType, query)).toBe(
+  expect(selectors.selectResourceFetchStatus(finishedState, resourcePathsType, resourceType, resourceQueryString)).toBe(
     FetchStatus.complete
   );
-  expect(selectors.selectResourceError(finishedState, resourcePathsType, resourceType, query)).toBe(null);
+  expect(selectors.selectResourceError(finishedState, resourcePathsType, resourceType, resourceQueryString)).toBe(null);
 });
 
 test('fetch resource failure', async () => {
   const store = createResourcesStore();
   const error = Symbol('resource error');
   runResourceMock.mockRejectedValueOnce(error);
-  store.dispatch(actions.fetchResource(resourcePathsType, resourceType, query));
+  store.dispatch(actions.fetchResource(resourcePathsType, resourceType, resourceQueryString));
   expect(runResource).toBeCalled();
-  expect(selectors.selectResourceFetchStatus(store.getState(), resourcePathsType, resourceType, query)).toBe(
-    FetchStatus.inProgress
-  );
+  expect(
+    selectors.selectResourceFetchStatus(store.getState(), resourcePathsType, resourceType, resourceQueryString)
+  ).toBe(FetchStatus.inProgress);
   await waitFor(() => expect(selectors.selectResourceFetchStatus).toHaveBeenCalled());
   const finishedState = store.getState();
-  expect(selectors.selectResourceFetchStatus(finishedState, resourcePathsType, resourceType, query)).toBe(
+  expect(selectors.selectResourceFetchStatus(finishedState, resourcePathsType, resourceType, resourceQueryString)).toBe(
     FetchStatus.complete
   );
-  expect(selectors.selectResourceError(finishedState, resourcePathsType, resourceType, query)).toBe(error);
+  expect(selectors.selectResourceError(finishedState, resourcePathsType, resourceType, resourceQueryString)).toBe(
+    error
+  );
 });
 
 test('does not fetch resource if the request is in progress', () => {
   const store = createResourcesStore();
-  store.dispatch(actions.fetchResource(resourcePathsType, resourceType, query));
-  store.dispatch(actions.fetchResource(resourcePathsType, resourceType, query));
+  store.dispatch(actions.fetchResource(resourcePathsType, resourceType, resourceQueryString));
+  store.dispatch(actions.fetchResource(resourcePathsType, resourceType, resourceQueryString));
   expect(runResource).toHaveBeenCalledTimes(1);
 });
 
 test('resource is not refetched if it has not expired', async () => {
   const store = createResourcesStore();
-  store.dispatch(actions.fetchResource(resourcePathsType, resourceType, query));
+  store.dispatch(actions.fetchResource(resourcePathsType, resourceType, resourceQueryString));
   await waitFor(() => expect(actions.fetchResource).toHaveBeenCalled());
-  store.dispatch(actions.fetchResource(resourcePathsType, resourceType, query));
+  store.dispatch(actions.fetchResource(resourcePathsType, resourceType, resourceQueryString));
   expect(runResource).toHaveBeenCalledTimes(1);
 });

--- a/src/store/resources/resourceCommon.ts
+++ b/src/store/resources/resourceCommon.ts
@@ -2,6 +2,10 @@ import type { ResourcePathsType, ResourceType } from 'api/resources/resource';
 
 export const resourceStateKey = 'resource';
 
-export function getResourceId(resourcePathsType: ResourcePathsType, resourceType: ResourceType, query: string) {
-  return `${resourcePathsType}--${resourceType}--${query}`;
+export function getFetchId(
+  resourcePathsType: ResourcePathsType,
+  resourceType: ResourceType,
+  resourceQueryString: string
+) {
+  return `${resourcePathsType}--${resourceType}--${resourceQueryString}`;
 }

--- a/src/store/resources/resourceReducer.ts
+++ b/src/store/resources/resourceReducer.ts
@@ -36,25 +36,25 @@ export function resourceReducer(state = defaultState, action: ResourceAction): R
     case getType(fetchResourceRequest):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.payload.resourceId, FetchStatus.inProgress),
+        fetchStatus: new Map(state.fetchStatus).set(action.payload.fetchId, FetchStatus.inProgress),
       };
 
     case getType(fetchResourceSuccess):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.resourceId, FetchStatus.complete),
-        byId: new Map(state.byId).set(action.meta.resourceId, {
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        byId: new Map(state.byId).set(action.meta.fetchId, {
           ...action.payload,
           timeRequested: Date.now(),
         }),
-        errors: new Map(state.errors).set(action.meta.resourceId, null),
+        errors: new Map(state.errors).set(action.meta.fetchId, null),
       };
 
     case getType(fetchResourceFailure):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.resourceId, FetchStatus.complete),
-        errors: new Map(state.errors).set(action.meta.resourceId, action.payload),
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        errors: new Map(state.errors).set(action.meta.fetchId, action.payload),
       };
     default:
       return state;

--- a/src/store/resources/resourceSelectors.ts
+++ b/src/store/resources/resourceSelectors.ts
@@ -1,7 +1,7 @@
 import type { ResourcePathsType, ResourceType } from 'api/resources/resource';
 import type { RootState } from 'store/rootReducer';
 
-import { getResourceId, resourceStateKey } from './resourceCommon';
+import { getFetchId, resourceStateKey } from './resourceCommon';
 
 export const selectResourceState = (state: RootState) => state[resourceStateKey];
 
@@ -9,19 +9,19 @@ export const selectResource = (
   state: RootState,
   resourcePathsType: ResourcePathsType,
   resourceType: ResourceType,
-  query: string
-) => selectResourceState(state).byId.get(getResourceId(resourcePathsType, resourceType, query));
+  resourceQueryString: string
+) => selectResourceState(state).byId.get(getFetchId(resourcePathsType, resourceType, resourceQueryString));
 
 export const selectResourceFetchStatus = (
   state: RootState,
   resourcePathsType: ResourcePathsType,
   resourceType: ResourceType,
-  query: string
-) => selectResourceState(state).fetchStatus.get(getResourceId(resourcePathsType, resourceType, query));
+  resourceQueryString: string
+) => selectResourceState(state).fetchStatus.get(getFetchId(resourcePathsType, resourceType, resourceQueryString));
 
 export const selectResourceError = (
   state: RootState,
   resourcePathsType: ResourcePathsType,
   resourceType: ResourceType,
-  query: string
-) => selectResourceState(state).errors.get(getResourceId(resourcePathsType, resourceType, query));
+  resourceQueryString: string
+) => selectResourceState(state).errors.get(getFetchId(resourcePathsType, resourceType, resourceQueryString));

--- a/src/store/sourceSettings/actions.ts
+++ b/src/store/sourceSettings/actions.ts
@@ -22,11 +22,11 @@ export const {
   AxiosError
 >();
 
-export const fetchSources = (query: string = '') => {
+export const fetchSources = (sourcesQueryString: string = '') => {
   return (dispatch: Dispatch) => {
     dispatch(fetchSourcesRequest());
 
-    return apiGetSources(query)
+    return apiGetSources(sourcesQueryString)
       .then(res => {
         dispatch(fetchSourcesSuccess(res));
       })

--- a/src/store/tags/tag.test.ts
+++ b/src/store/tags/tag.test.ts
@@ -26,9 +26,9 @@ const mockTagReport: Tag = {
   },
 } as any;
 
-const query = 'query';
 const tagReportType = TagType.tag;
 const tagReportPathsType = TagPathsType.aws;
+const tagQueryString = 'tagQueryString';
 
 runTagMock.mockResolvedValue({ data: mockTagReport });
 global.Date.now = jest.fn(() => 12345);
@@ -43,47 +43,47 @@ test('default state', () => {
 
 test('fetch tag report success', async () => {
   const store = createTagsStore();
-  store.dispatch(actions.fetchTag(tagReportPathsType, tagReportType, query));
+  store.dispatch(actions.fetchTag(tagReportPathsType, tagReportType, tagQueryString));
   expect(runTagMock).toBeCalled();
-  expect(selectors.selectTagFetchStatus(store.getState(), tagReportPathsType, tagReportType, query)).toBe(
+  expect(selectors.selectTagFetchStatus(store.getState(), tagReportPathsType, tagReportType, tagQueryString)).toBe(
     FetchStatus.inProgress
   );
   await waitFor(() => expect(selectors.selectTagFetchStatus).toHaveBeenCalled());
   const finishedState = store.getState();
-  expect(selectors.selectTagFetchStatus(finishedState, tagReportPathsType, tagReportType, query)).toBe(
+  expect(selectors.selectTagFetchStatus(finishedState, tagReportPathsType, tagReportType, tagQueryString)).toBe(
     FetchStatus.complete
   );
-  expect(selectors.selectTagError(finishedState, tagReportPathsType, tagReportType, query)).toBe(null);
+  expect(selectors.selectTagError(finishedState, tagReportPathsType, tagReportType, tagQueryString)).toBe(null);
 });
 
 test('fetch tag report failure', async () => {
   const store = createTagsStore();
   const error = Symbol('tag error');
   runTagMock.mockRejectedValueOnce(error);
-  store.dispatch(actions.fetchTag(tagReportPathsType, tagReportType, query));
+  store.dispatch(actions.fetchTag(tagReportPathsType, tagReportType, tagQueryString));
   expect(runTag).toBeCalled();
-  expect(selectors.selectTagFetchStatus(store.getState(), tagReportPathsType, tagReportType, query)).toBe(
+  expect(selectors.selectTagFetchStatus(store.getState(), tagReportPathsType, tagReportType, tagQueryString)).toBe(
     FetchStatus.inProgress
   );
   await waitFor(() => expect(selectors.selectTagFetchStatus).toHaveBeenCalled());
   const finishedState = store.getState();
-  expect(selectors.selectTagFetchStatus(finishedState, tagReportPathsType, tagReportType, query)).toBe(
+  expect(selectors.selectTagFetchStatus(finishedState, tagReportPathsType, tagReportType, tagQueryString)).toBe(
     FetchStatus.complete
   );
-  expect(selectors.selectTagError(finishedState, tagReportPathsType, tagReportType, query)).toBe(error);
+  expect(selectors.selectTagError(finishedState, tagReportPathsType, tagReportType, tagQueryString)).toBe(error);
 });
 
 test('does not fetch tag report if the request is in progress', () => {
   const store = createTagsStore();
-  store.dispatch(actions.fetchTag(tagReportPathsType, tagReportType, query));
-  store.dispatch(actions.fetchTag(tagReportPathsType, tagReportType, query));
+  store.dispatch(actions.fetchTag(tagReportPathsType, tagReportType, tagQueryString));
+  store.dispatch(actions.fetchTag(tagReportPathsType, tagReportType, tagQueryString));
   expect(runTag).toHaveBeenCalledTimes(1);
 });
 
 test('tag report is not refetched if it has not expired', async () => {
   const store = createTagsStore();
-  store.dispatch(actions.fetchTag(tagReportPathsType, tagReportType, query));
+  store.dispatch(actions.fetchTag(tagReportPathsType, tagReportType, tagQueryString));
   await waitFor(() => expect(actions.fetchTag).toHaveBeenCalled());
-  store.dispatch(actions.fetchTag(tagReportPathsType, tagReportType, query));
+  store.dispatch(actions.fetchTag(tagReportPathsType, tagReportType, tagQueryString));
   expect(runTag).toHaveBeenCalledTimes(1);
 });

--- a/src/store/tags/tagActions.ts
+++ b/src/store/tags/tagActions.ts
@@ -7,13 +7,13 @@ import { FetchStatus } from 'store/common';
 import type { RootState } from 'store/rootReducer';
 import { createAction } from 'typesafe-actions';
 
-import { getTagId } from './tagCommon';
+import { getFetchId } from './tagCommon';
 import { selectTag, selectTagFetchStatus } from './tagSelectors';
 
 const expirationMS = 30 * 60 * 1000; // 30 minutes
 
 interface TagActionMeta {
-  tagId: string;
+  fetchId: string;
 }
 
 export const fetchTagRequest = createAction('tag/request')<TagActionMeta>();
@@ -23,19 +23,19 @@ export const fetchTagFailure = createAction('tag/failure')<AxiosError, TagAction
 export function fetchTag(
   tagPathsType: TagPathsType,
   tagType: TagType,
-  query: string
+  tagQueryString: string
 ): ThunkAction<void, RootState, void, any> {
   return (dispatch, getState) => {
-    if (!isTagExpired(getState(), tagPathsType, tagType, query)) {
+    if (!isTagExpired(getState(), tagPathsType, tagType, tagQueryString)) {
       return;
     }
 
     const meta: TagActionMeta = {
-      tagId: getTagId(tagPathsType, tagType, query),
+      fetchId: getFetchId(tagPathsType, tagType, tagQueryString),
     };
 
     dispatch(fetchTagRequest(meta));
-    runTag(tagPathsType, tagType, query)
+    runTag(tagPathsType, tagType, tagQueryString)
       .then(res => {
         // See https://github.com/project-koku/koku-ui/pull/580
         // const repsonseData = dropCurrentMonthData(res, query);
@@ -47,9 +47,9 @@ export function fetchTag(
   };
 }
 
-function isTagExpired(state: RootState, tagPathsType: TagPathsType, tagType: TagType, query: string) {
-  const tagReport = selectTag(state, tagPathsType, tagType, query);
-  const fetchStatus = selectTagFetchStatus(state, tagPathsType, tagType, query);
+function isTagExpired(state: RootState, tagPathsType: TagPathsType, tagType: TagType, tagQueryString: string) {
+  const tagReport = selectTag(state, tagPathsType, tagType, tagQueryString);
+  const fetchStatus = selectTagFetchStatus(state, tagPathsType, tagType, tagQueryString);
   if (fetchStatus === FetchStatus.inProgress) {
     return false;
   }

--- a/src/store/tags/tagCommon.ts
+++ b/src/store/tags/tagCommon.ts
@@ -2,6 +2,6 @@ import type { TagPathsType, TagType } from 'api/tags/tag';
 
 export const tagStateKey = 'tag';
 
-export function getTagId(tagPathsType: TagPathsType, tagType: TagType, query: string) {
-  return `${tagPathsType}--${tagType}--${query}`;
+export function getFetchId(tagPathsType: TagPathsType, tagType: TagType, tagQueryString: string) {
+  return `${tagPathsType}--${tagType}--${tagQueryString}`;
 }

--- a/src/store/tags/tagReducer.ts
+++ b/src/store/tags/tagReducer.ts
@@ -36,25 +36,25 @@ export function tagReducer(state = defaultState, action: TagAction): TagState {
     case getType(fetchTagRequest):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.payload.tagId, FetchStatus.inProgress),
+        fetchStatus: new Map(state.fetchStatus).set(action.payload.fetchId, FetchStatus.inProgress),
       };
 
     case getType(fetchTagSuccess):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.tagId, FetchStatus.complete),
-        byId: new Map(state.byId).set(action.meta.tagId, {
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        byId: new Map(state.byId).set(action.meta.fetchId, {
           ...action.payload,
           timeRequested: Date.now(),
         }),
-        errors: new Map(state.errors).set(action.meta.tagId, null),
+        errors: new Map(state.errors).set(action.meta.fetchId, null),
       };
 
     case getType(fetchTagFailure):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.tagId, FetchStatus.complete),
-        errors: new Map(state.errors).set(action.meta.tagId, action.payload),
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        errors: new Map(state.errors).set(action.meta.fetchId, action.payload),
       };
     default:
       return state;

--- a/src/store/tags/tagSelectors.ts
+++ b/src/store/tags/tagSelectors.ts
@@ -1,15 +1,23 @@
 import type { TagPathsType, TagType } from 'api/tags/tag';
 import type { RootState } from 'store/rootReducer';
 
-import { getTagId, tagStateKey } from './tagCommon';
+import { getFetchId, tagStateKey } from './tagCommon';
 
 export const selectTagState = (state: RootState) => state[tagStateKey];
 
-export const selectTag = (state: RootState, tagPathsType: TagPathsType, tagType: TagType, query: string) =>
-  selectTagState(state).byId.get(getTagId(tagPathsType, tagType, query));
+export const selectTag = (state: RootState, tagPathsType: TagPathsType, tagType: TagType, tagQueryString: string) =>
+  selectTagState(state).byId.get(getFetchId(tagPathsType, tagType, tagQueryString));
 
-export const selectTagFetchStatus = (state: RootState, tagPathsType: TagPathsType, tagType: TagType, query: string) =>
-  selectTagState(state).fetchStatus.get(getTagId(tagPathsType, tagType, query));
+export const selectTagFetchStatus = (
+  state: RootState,
+  tagPathsType: TagPathsType,
+  tagType: TagType,
+  tagQueryString: string
+) => selectTagState(state).fetchStatus.get(getFetchId(tagPathsType, tagType, tagQueryString));
 
-export const selectTagError = (state: RootState, tagPathsType: TagPathsType, tagType: TagType, query: string) =>
-  selectTagState(state).errors.get(getTagId(tagPathsType, tagType, query));
+export const selectTagError = (
+  state: RootState,
+  tagPathsType: TagPathsType,
+  tagType: TagType,
+  tagQueryString: string
+) => selectTagState(state).errors.get(getFetchId(tagPathsType, tagType, tagQueryString));

--- a/src/store/userAccess/userAccessActions.ts
+++ b/src/store/userAccess/userAccessActions.ts
@@ -4,25 +4,25 @@ import { fetchUserAccess as apiGetUserAccess } from 'api/userAccess';
 import type { AxiosError } from 'axios';
 import { createAction } from 'typesafe-actions';
 
-import { getReportId } from './userAccessCommon';
+import { getFetchId } from './userAccessCommon';
 
 interface UserAccessActionMeta {
-  reportId: string;
+  fetchId: string;
 }
 
 export const fetchUserAccessRequest = createAction('userAccess/fetch/request')<UserAccessActionMeta>();
 export const fetchUserAccessSuccess = createAction('userAccess/fetch/success')<UserAccess, UserAccessActionMeta>();
 export const fetchUserAccessFailure = createAction('userAccess/fetch/failure')<AxiosError, UserAccessActionMeta>();
 
-export function fetchUserAccess(reportType: UserAccessType, query: string) {
+export function fetchUserAccess(userAccessType: UserAccessType, userAccessQueryString: string) {
   return dispatch => {
     const meta: UserAccessActionMeta = {
-      reportId: getReportId(reportType, query),
+      fetchId: getFetchId(userAccessType, userAccessQueryString),
     };
 
     dispatch(fetchUserAccessRequest(meta));
 
-    return apiGetUserAccess(query)
+    return apiGetUserAccess(userAccessQueryString)
       .then(res => {
         dispatch(fetchUserAccessSuccess(res.data, meta));
       })

--- a/src/store/userAccess/userAccessCommon.ts
+++ b/src/store/userAccess/userAccessCommon.ts
@@ -2,7 +2,6 @@ import type { UserAccessQuery } from 'api/queries/userAccessQuery';
 import type { UserAccessType } from 'api/userAccess';
 
 export const stateKey = 'userAccess';
-export const userAccessKey = 'user-access';
 
 export const awsUserAccessQuery: UserAccessQuery = {
   type: 'AWS',
@@ -32,6 +31,6 @@ export const ibmUserAccessQuery: UserAccessQuery = {
 // Omitting the type param returns all user access
 export const userAccessQuery: UserAccessQuery = {};
 
-export function getReportId(type: UserAccessType, query: string) {
-  return `${type}--${query}`;
+export function getFetchId(userAccessType: UserAccessType, userAccessQueryString: string) {
+  return `${userAccessType}--${userAccessQueryString}`;
 }

--- a/src/store/userAccess/userAccessReducer.ts
+++ b/src/store/userAccess/userAccessReducer.ts
@@ -32,22 +32,22 @@ export function userAccessReducer(state = defaultState, action: UserAccessAction
     case getType(fetchUserAccessRequest):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.payload.reportId, FetchStatus.inProgress),
+        fetchStatus: new Map(state.fetchStatus).set(action.payload.fetchId, FetchStatus.inProgress),
       };
     case getType(fetchUserAccessSuccess):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.reportId, FetchStatus.complete),
-        byId: new Map(state.byId).set(action.meta.reportId, {
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        byId: new Map(state.byId).set(action.meta.fetchId, {
           ...action.payload,
         }),
-        errors: new Map(state.errors).set(action.meta.reportId, null),
+        errors: new Map(state.errors).set(action.meta.fetchId, null),
       };
     case getType(fetchUserAccessFailure):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.reportId, FetchStatus.complete),
-        errors: new Map(state.errors).set(action.meta.reportId, action.payload),
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        errors: new Map(state.errors).set(action.meta.fetchId, action.payload),
       };
     default:
       return state;

--- a/src/store/userAccess/userAccessSelectors.ts
+++ b/src/store/userAccess/userAccessSelectors.ts
@@ -1,17 +1,23 @@
 import type { UserAccessType } from 'api/userAccess';
 import type { RootState } from 'store/rootReducer';
 
-import { getReportId, stateKey } from './userAccessCommon';
+import { getFetchId, stateKey } from './userAccessCommon';
 
 export const selectUserAccessState = (state: RootState) => state[stateKey];
 
 // Fetch userAccess
 
-export const selectUserAccess = (state: RootState, providerType: UserAccessType, query: string) =>
-  selectUserAccessState(state).byId.get(getReportId(providerType, query));
+export const selectUserAccess = (state: RootState, providerType: UserAccessType, providerQueryString: string) =>
+  selectUserAccessState(state).byId.get(getFetchId(providerType, providerQueryString));
 
-export const selectUserAccessFetchStatus = (state: RootState, providerType: UserAccessType, query: string) =>
-  selectUserAccessState(state).fetchStatus.get(getReportId(providerType, query));
+export const selectUserAccessFetchStatus = (
+  state: RootState,
+  userAccessType: UserAccessType,
+  userAccessQueryString: string
+) => selectUserAccessState(state).fetchStatus.get(getFetchId(userAccessType, userAccessQueryString));
 
-export const selectUserAccessError = (state: RootState, providerType: UserAccessType, query: string) =>
-  selectUserAccessState(state).errors.get(getReportId(providerType, query));
+export const selectUserAccessError = (
+  state: RootState,
+  userAccessType: UserAccessType,
+  userAccessQueryString: string
+) => selectUserAccessState(state).errors.get(getFetchId(userAccessType, userAccessQueryString));


### PR DESCRIPTION
Renamed query and queryString as reportQueryString, tagQueryString, etc.
Renamed getReportId, getExportId, etc. as getFetchId