### PR TITLE
Add platform costs support for breakdown page

### DIFF
--- a/src/routes/views/details/components/cluster/cluster.tsx
+++ b/src/routes/views/details/components/cluster/cluster.tsx
@@ -9,6 +9,7 @@ import { styles } from './cluster.styles';
 import { ClusterModal } from './clusterModal';
 
 interface ClusterOwnProps {
+  category?: string;
   groupBy: string;
   report: Report;
 }
@@ -44,7 +45,7 @@ class ClusterBase extends React.Component<ClusterProps> {
   };
 
   public render() {
-    const { groupBy, report, intl } = this.props;
+    const { category, groupBy, report, intl } = this.props;
     const { isOpen, showAll } = this.state;
 
     let charCount = 0;
@@ -91,7 +92,7 @@ class ClusterBase extends React.Component<ClusterProps> {
             {intl.formatMessage(messages.detailsMoreClusters, { value: allClusters.length - someClusters.length })}
           </a>
         )}
-        <ClusterModal groupBy={groupBy} isOpen={isOpen} item={item} onClose={this.handleClose} />
+        <ClusterModal category={category} groupBy={groupBy} isOpen={isOpen} item={item} onClose={this.handleClose} />
       </div>
     );
   }

--- a/src/routes/views/details/components/cluster/clusterModal.tsx
+++ b/src/routes/views/details/components/cluster/clusterModal.tsx
@@ -11,6 +11,7 @@ import { ClusterContent } from './clusterContent';
 import { styles } from './clusterModal.styles';
 
 interface ClusterModalOwnProps {
+  category?: string;
   groupBy: string;
   isOpen: boolean;
   item: ComputedReportItem;
@@ -35,7 +36,7 @@ class ClusterModalBase extends React.Component<ClusterModalProps> {
   };
 
   public render() {
-    const { groupBy, isOpen, item, intl } = this.props;
+    const { category, groupBy, isOpen, item, intl } = this.props;
 
     return (
       <Modal
@@ -43,7 +44,10 @@ class ClusterModalBase extends React.Component<ClusterModalProps> {
         style={styles.modal}
         isOpen={isOpen}
         onClose={this.handleClose}
-        title={intl.formatMessage(messages.detailsClustersModalTitle, { groupBy, name: item.label })}
+        title={intl.formatMessage(messages.detailsClustersModalTitle, {
+          groupBy,
+          name: category ? category : item.label,
+        })}
         width={'50%'}
       >
         <ClusterContent item={item} />

--- a/src/routes/views/details/components/costOverview/costOverviewBase.tsx
+++ b/src/routes/views/details/components/costOverview/costOverviewBase.tsx
@@ -27,6 +27,7 @@ import type { CostOverviewWidget } from 'store/breakdown/costOverview/common/cos
 import { CostOverviewWidgetType } from 'store/breakdown/costOverview/common/costOverviewCommon';
 
 interface CostOverviewOwnProps {
+  category?: string;
   costType?: string;
   currency?: string;
   groupBy: string;
@@ -46,7 +47,7 @@ const PLACEHOLDER = 'placeholder';
 class CostOverviewsBase extends React.Component<CostOverviewProps> {
   // Returns cluster chart
   private getClusterChart = (widget: CostOverviewWidget) => {
-    const { groupBy, report, intl } = this.props;
+    const { category, groupBy, report, intl } = this.props;
 
     let showWidget = false;
     for (const groupById of widget.cluster.showWidgetOnGroupBy) {
@@ -64,7 +65,7 @@ class CostOverviewsBase extends React.Component<CostOverviewProps> {
             </Title>
           </CardTitle>
           <CardBody>
-            <Cluster groupBy={widget.cluster.reportGroupBy} report={report} />
+            <Cluster category={category} groupBy={widget.cluster.reportGroupBy} report={report} />
           </CardBody>
         </Card>
       );

--- a/src/routes/views/details/components/historicalData/historicalDataCostChart.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataCostChart.tsx
@@ -171,6 +171,11 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
     };
     const currentQueryString = getQuery({
       ...currentQuery,
+      ...(queryFromRoute.category === 'platform' && {
+        group_by: {
+          project: ['kube-', 'openshift-'],
+        },
+      }),
       cost_type: costType,
       currency,
     });
@@ -184,6 +189,11 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
     };
     const previousQueryString = getQuery({
       ...previousQuery,
+      ...(queryFromRoute.category === 'platform' && {
+        group_by: {
+          project: ['kube-', 'openshift-'],
+        },
+      }),
       cost_type: costType,
       currency,
     });

--- a/src/routes/views/details/components/historicalData/historicalDataTrendChart.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataTrendChart.tsx
@@ -190,6 +190,11 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
     };
     const currentQueryString = getQuery({
       ...currentQuery,
+      ...(queryFromRoute.category === 'platform' && {
+        group_by: {
+          project: ['kube-', 'openshift-'],
+        },
+      }),
       cost_type: costType,
       currency,
     });
@@ -203,6 +208,11 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
     };
     const previousQueryString = getQuery({
       ...previousQuery,
+      ...(queryFromRoute.category === 'platform' && {
+        group_by: {
+          project: ['kube-', 'openshift-'],
+        },
+      }),
       cost_type: costType,
       currency,
     });

--- a/src/routes/views/details/components/historicalData/historicalDataUsageChart.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataUsageChart.tsx
@@ -149,6 +149,8 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
         ...(groupBy && !groupByOrgValue && { [groupBy]: groupByValue }),
       },
     };
+
+    // Current report
     const currentQuery: Query = {
       ...baseQuery,
       filter: {
@@ -157,18 +159,14 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
         time_scope_value: -1,
       },
     };
-    const currentQueryString = getQuery(currentQuery);
-    const previousQuery: Query = {
-      ...baseQuery,
-      filter: {
-        resolution: 'daily',
-        time_scope_units: 'month',
-        time_scope_value: -2,
-      },
-    };
-    const previousQueryString = getQuery(previousQuery);
-
-    // Current report
+    const currentQueryString = getQuery({
+      ...currentQuery,
+      ...(queryFromRoute.category === 'platform' && {
+        group_by: {
+          project: ['kube-', 'openshift-'],
+        },
+      }),
+    });
     const currentReport = reportSelectors.selectReport(state, reportPathsType, reportType, currentQueryString);
     const currentReportFetchStatus = reportSelectors.selectReportFetchStatus(
       state,
@@ -178,6 +176,22 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
     );
 
     // Previous report
+    const previousQuery: Query = {
+      ...baseQuery,
+      filter: {
+        resolution: 'daily',
+        time_scope_units: 'month',
+        time_scope_value: -2,
+      },
+    };
+    const previousQueryString = getQuery({
+      ...previousQuery,
+      ...(queryFromRoute.category === 'platform' && {
+        group_by: {
+          project: ['kube-', 'openshift-'],
+        },
+      }),
+    });
     const previousReport = reportSelectors.selectReport(state, reportPathsType, reportType, previousQueryString);
     const previousReportFetchStatus = reportSelectors.selectReportFetchStatus(
       state,

--- a/src/routes/views/details/components/usageChart/usageChart.tsx
+++ b/src/routes/views/details/components/usageChart/usageChart.tsx
@@ -375,7 +375,7 @@ const mapStateToProps = createMapStateToProps<UsageChartOwnProps, UsageChartStat
     const groupBy = getGroupById(queryFromRoute);
     const groupByValue = getGroupByValue(queryFromRoute);
 
-    const newQuery: Query = {
+    const query: Query = {
       filter: {
         time_scope_units: 'month',
         time_scope_value: -1,
@@ -394,7 +394,14 @@ const mapStateToProps = createMapStateToProps<UsageChartOwnProps, UsageChartStat
       },
     };
 
-    const reportQueryString = getQuery(newQuery);
+    const reportQueryString = getQuery({
+      ...query,
+      ...(queryFromRoute.category === 'platform' && {
+        group_by: {
+          project: ['kube-', 'openshift-'],
+        },
+      }),
+    });
     const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
     const reportFetchStatus = reportSelectors.selectReportFetchStatus(
       state,

--- a/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -74,10 +74,16 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
+    category: queryFromRoute.category,
   };
 
   const reportQueryString = getQuery({
     ...query,
+    ...(queryFromRoute.category === 'platform' && {
+      group_by: {
+        project: ['kube-', 'openshift-'],
+      },
+    }),
     currency,
   });
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
@@ -98,7 +104,9 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
   );
 
   return {
-    costOverviewComponent: <CostOverview currency={currency} groupBy={groupBy} report={report} />,
+    costOverviewComponent: (
+      <CostOverview category={queryFromRoute.category} currency={currency} groupBy={groupBy} report={report} />
+    ),
     currency,
     description: queryFromRoute[breakdownDescKey],
     detailsURL,

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -72,6 +72,27 @@ export function getComputedReportItems<R extends Report, T extends ReportItem>({
   );
 }
 
+// For multiple group_by's ('kube-' and 'openshift-' for platform costs), all clusters are listed in the breakdown page
+function getClusters(val, item?: any) {
+  const clusters = val.clusters ? val.clusters : [];
+  if (item && item.clusters) {
+    item.clusters.forEach(cluster => {
+      if (!clusters.contains(cluster)) {
+        clusters.push(cluster);
+      }
+    });
+  }
+  return clusters.sort((a, b) => {
+    if (a < b) {
+      return -1;
+    }
+    if (a > b) {
+      return 1;
+    }
+    return 0;
+  });
+}
+
 function getCostData(val, key, item?: any) {
   return {
     markup: {
@@ -153,7 +174,6 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
         const classification = val.classification;
         const cluster_alias = val.clusters && val.clusters.length > 0 ? val.clusters[0] : undefined;
         const cluster = cluster_alias || val.cluster;
-        const clusters = val.clusters ? val.clusters : [];
         const date = val.date;
         const default_project = val.default_project && val.default_project.toLowerCase() === 'true';
         const delta_percent = val.delta_percent ? val.delta_percent : 0;
@@ -187,7 +207,7 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
             ...getUsageData(val), // capacity, limit, request, & usage
             classification,
             cluster,
-            clusters,
+            clusters: getClusters(val),
             cost: getCostData(val, 'cost'),
             date,
             default_project,
@@ -218,7 +238,7 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
               ...getUsageData(val, item), // capacity, limit, request, & usage
               classification,
               cluster,
-              clusters,
+              clusters: getClusters(val, item),
               date,
               default_project,
               delta_percent,
@@ -236,7 +256,7 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
               ...getUsageData(val), // capacity, limit, request, & usage
               classification,
               cluster,
-              clusters,
+              clusters: getClusters(val),
               cost: getCostData(val, 'cost'),
               date,
               default_project,


### PR DESCRIPTION
Added platform costs support for breakdown page

Note that the cost-demo user does not have volumes for "platform costs", so the "Volume" chart shows zero values.

https://issues.redhat.com/browse/COST-3283

![Screen Shot 2022-11-21 at 12 26 14 PM](https://user-images.githubusercontent.com/17481322/203121398-6027ac22-b983-4e86-9aef-fc8dcf793cb2.png)
