### PR TITLE
Add "top costliest platform costs" card

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -11312,6 +11312,14 @@
               }
             ]
           },
+          "platform": {
+            "value": [
+              {
+                "type": 0,
+                "value": "Top 3 costliest platform costs related projects"
+              }
+            ]
+          },
           "product_service": {
             "value": [
               {

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -27,7 +27,7 @@
   "breakdownCostChartTooltip": "{name}: {value}",
   "breakdownCostOverviewTitle": "Cost overview",
   "breakdownHistoricalDataTitle": "Historical data",
-  "breakdownSummaryTitle": "{value, select, account {Cost by accounts} cluster {Cost by clusters} gcp_project {Cost by GCP projects} node {Cost by Node} org_unit_id {Cost by organizational units} payer_tenant_id {Cost by accounts} product_service {Cost by services} project {Cost by projects} region {Cost by regions} resource_location {Cost by regions} service {Cost by services} service_name {Cost by services} subscription_guid {Cost by accounts} tag {Cost by tags} other {}}",
+  "breakdownSummaryTitle": "{value, select, account {Cost by accounts} cluster {Cost by clusters} gcp_project {Cost by GCP projects} node {Cost by Node} org_unit_id {Cost by organizational units} payer_tenant_id {Cost by accounts} platform {Top 3 costliest platform costs related projects} product_service {Cost by services} project {Cost by projects} region {Cost by regions} resource_location {Cost by regions} service {Cost by services} service_name {Cost by services} subscription_guid {Cost by accounts} tag {Cost by tags} other {}}",
   "breakdownTitle": "{value}",
   "breakdownTotalCostDate": "{value} total cost ({dateRange})",
   "calculationType": "Calculation type",

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -165,6 +165,7 @@ export default defineMessages({
       'node {Cost by Node} ' +
       'org_unit_id {Cost by organizational units} ' +
       'payer_tenant_id {Cost by accounts} ' +
+      'platform {Top 3 costliest platform costs related projects} ' +
       'product_service {Cost by services} ' +
       'project {Cost by projects} ' +
       'region {Cost by regions} ' +

--- a/src/routes/views/details/components/costOverview/costOverviewBase.tsx
+++ b/src/routes/views/details/components/costOverview/costOverviewBase.tsx
@@ -153,7 +153,7 @@ class CostOverviewsBase extends React.Component<CostOverviewProps> {
 
   // Returns summary card widget
   private getSummaryCard = (widget: CostOverviewWidget) => {
-    const { costType, currency, groupBy, query } = this.props;
+    const { category, costType, currency, groupBy, query } = this.props;
 
     let showWidget = false;
     for (const groupById of widget.reportSummary.showWidgetOnGroupBy) {
@@ -166,9 +166,19 @@ class CostOverviewsBase extends React.Component<CostOverviewProps> {
         break;
       }
     }
+    if (!showWidget) {
+      for (const categoryId of widget.reportSummary.showWidgetOnCategory) {
+        if (categoryId === category) {
+          showWidget = true;
+          break;
+        }
+      }
+    }
     if (showWidget) {
       return (
         <SummaryCard
+          category={category}
+          categoryGroupBy={widget.reportSummary.categoryGroupBy}
           costType={costType}
           currency={currency}
           reportGroupBy={widget.reportSummary.reportGroupBy}

--- a/src/routes/views/details/components/summary/summaryCard.tsx
+++ b/src/routes/views/details/components/summary/summaryCard.tsx
@@ -30,6 +30,8 @@ import { skeletonWidth } from 'utils/skeleton';
 import { styles } from './summaryCard.styles';
 
 interface SummaryOwnProps {
+  category?: string;
+  categoryGroupBy?: string[];
   costType?: string;
   currency?: string;
   reportGroupBy?: string;
@@ -161,13 +163,13 @@ class SummaryBase extends React.Component<SummaryProps> {
   };
 
   public render() {
-    const { reportGroupBy, reportFetchStatus, intl } = this.props;
+    const { category, reportGroupBy, reportFetchStatus, intl } = this.props;
 
     return (
       <Card style={styles.card}>
         <CardTitle>
           <Title headingLevel="h2" size={TitleSizes.lg}>
-            {intl.formatMessage(messages.breakdownSummaryTitle, { value: reportGroupBy })}
+            {intl.formatMessage(messages.breakdownSummaryTitle, { value: category ? category : reportGroupBy })}
           </Title>
         </CardTitle>
         <CardBody>
@@ -189,7 +191,7 @@ class SummaryBase extends React.Component<SummaryProps> {
 }
 
 const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps>(
-  (state, { costType, currency, reportGroupBy, reportPathsType, reportType }) => {
+  (state, { categoryGroupBy, costType, currency, reportGroupBy, reportPathsType, reportType }) => {
     const queryFromRoute = parseQuery<Query>(location.search);
     const groupByOrgValue = getGroupByOrgValue(queryFromRoute);
     const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(queryFromRoute);
@@ -221,6 +223,11 @@ const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps
 
     const reportQueryString = getQuery({
       ...query,
+      ...(categoryGroupBy && {
+        group_by: {
+          project: categoryGroupBy,
+        },
+      }),
       cost_type: costType,
       currency,
     });

--- a/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -74,7 +74,7 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
     group_by: {
       ...(groupBy && { [groupBy]: groupByValue }),
     },
-    category: queryFromRoute.category,
+    category: queryFromRoute.category, // Needed to restore details page state
   };
 
   const reportQueryString = getQuery({

--- a/src/store/breakdown/costOverview/common/costOverviewCommon.ts
+++ b/src/store/breakdown/costOverview/common/costOverviewCommon.ts
@@ -21,7 +21,9 @@ export interface CostOverviewWidget {
     showCapacityOnGroupBy?: string[]; // Show capacity when group_by is matched
   };
   reportSummary?: {
+    categoryGroupBy?: string[];
     reportGroupBy: string; // Report group_by
+    showWidgetOnCategory?: string[];
     showWidgetOnGroupBy?: string[]; // Show widget when group_by is matched
     usePlaceholder?: boolean; // Use placeholder to keep card placement when widget is not shown
   };

--- a/src/store/breakdown/costOverview/ocpCostOverview/ocpCostOverviewWidgets.ts
+++ b/src/store/breakdown/costOverview/ocpCostOverview/ocpCostOverviewWidgets.ts
@@ -50,7 +50,9 @@ export const memoryUsageWidget: OcpCostOverviewWidget = {
 export const projectSummaryWidget: OcpCostOverviewWidget = {
   id: getId(),
   reportSummary: {
+    categoryGroupBy: ['kube-', 'openshift-'],
     reportGroupBy: 'project',
+    showWidgetOnCategory: ['platform'],
     showWidgetOnGroupBy: ['cluster'],
     usePlaceholder: true,
   },

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -72,7 +72,7 @@ export function getComputedReportItems<R extends Report, T extends ReportItem>({
   );
 }
 
-// For multiple group_by's ('kube-' and 'openshift-' for platform costs), all clusters are listed in the breakdown page
+// For multiple group_by's (platform costs; 'kube-' and 'openshift-'), all clusters are listed in the breakdown page
 function getClusters(val, item?: any) {
   const clusters = val.clusters ? val.clusters : [];
   if (item && item.clusters) {

--- a/src/utils/computedReport/getComputedReportItems.ts
+++ b/src/utils/computedReport/getComputedReportItems.ts
@@ -77,7 +77,7 @@ function getClusters(val, item?: any) {
   const clusters = val.clusters ? val.clusters : [];
   if (item && item.clusters) {
     item.clusters.forEach(cluster => {
-      if (!clusters.contains(cluster)) {
+      if (!clusters.includes(cluster)) {
         clusters.push(cluster);
       }
     });


### PR DESCRIPTION
As part of the OpenShift "platform costs" feature, this adds a "Top costliest platform costs" card for the OCP details breakdown page.

https://issues.redhat.com/browse/COST-2775

![Screen Shot 2022-11-21 at 1 36 27 PM](https://user-images.githubusercontent.com/17481322/203133610-f2807541-b9b1-4b2c-b71e-05cf96e79a6c.png)
