### PR TITLE
OCP cluster breakdown card layout

### DIFF
--- a/src/routes/views/details/components/costOverview/costOverviewBase.tsx
+++ b/src/routes/views/details/components/costOverview/costOverviewBase.tsx
@@ -69,6 +69,8 @@ class CostOverviewsBase extends React.Component<CostOverviewProps> {
           </CardBody>
         </Card>
       );
+    } else {
+      return PLACEHOLDER;
     }
     return null;
   };


### PR DESCRIPTION
Ensure cpu, memory, and volume cards appear on right side of page for OCP cluster breakdown.

![Screen Shot 2022-11-21 at 7 09 34 PM](https://user-images.githubusercontent.com/17481322/203183389-0ede0caf-9e34-47d0-805c-211dd40999df.png)
