### PR TITLE
Clear date picker's end date

### DIFF
--- a/src/routes/views/explorer/explorerDatePicker.tsx
+++ b/src/routes/views/explorer/explorerDatePicker.tsx
@@ -55,7 +55,7 @@ class ExplorerDatePickerBase extends React.Component<ExplorerDatePickerProps> {
     if (prevState.startDate !== startDate) {
       // Don't adjust unless an end date has already been selected
       if (endDate && !this.isEndDateValid(startDate, endDate)) {
-        this.setState({ endDate: this.getMaxEndDate() });
+        this.setState({ endDate: undefined });
       }
     }
   }

--- a/src/utils/dates.ts
+++ b/src/utils/dates.ts
@@ -14,12 +14,13 @@ export const formatStartEndDate = (startDate, endDate, isFormatted = true) => {
   };
 };
 
-export const getToday = (hrs: number = 0, min: number = 0, sec: number = 0) => {
+export const getToday = (hrs: number = 0, min: number = 0, sec: number = 0, ms: number = 0) => {
   const today = new Date();
 
   today.setHours(hrs);
   today.setMinutes(min);
   today.setSeconds(sec);
+  today.setMilliseconds(ms);
 
   return today;
 };


### PR DESCRIPTION
Clearing the date picker's end date per QE / UX feedback. If the end date becomes invalid, after choosing a new start date, we will clear the end date.

https://issues.redhat.com/browse/COST-3271

![chrome-capture-2022-10-28 (1)](https://user-images.githubusercontent.com/17481322/204335933-84262d42-4b30-4a5e-a815-1817986df100.gif)
