### PR TITLE
Simplify platform costs feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "xstate": "^4.34.0"
   },
   "devDependencies": {
+    "@formatjs/cli": "^5.1.4",
     "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^1.2.6",
     "@redhat-cloud-services/frontend-components-config": "^4.6.34",
     "@testing-library/react": "^12.1.5",

--- a/src/api/queries/query.ts
+++ b/src/api/queries/query.ts
@@ -9,6 +9,7 @@ export const breakdownGroupByKey = 'breakdown_group_by'; // Used to display a br
 export const breakdownTitleKey = 'breakdown_title'; // Used to display a title in the breakdown header
 export const orgUnitIdKey = 'org_unit_id'; // Org unit ID for group_by
 export const orgUnitNameKey = 'org_unit_name'; // Org unit name for group_by
+export const platformCategory = 'platform'; // Used to display platform costs
 export const tagKey = 'tag'; // Tag key for group_by
 
 export interface Filters {
@@ -22,6 +23,7 @@ export interface Filters {
 }
 
 export interface Query {
+  breakdown_title?: string | number;
   category?: string;
   cost_type?: any;
   currency?: any;

--- a/src/routes/views/details/components/cluster/cluster.tsx
+++ b/src/routes/views/details/components/cluster/cluster.tsx
@@ -1,3 +1,4 @@
+import { platformCategory } from 'api/queries/query';
 import type { Report } from 'api/reports/report';
 import messages from 'locales/messages';
 import React from 'react';
@@ -9,8 +10,8 @@ import { styles } from './cluster.styles';
 import { ClusterModal } from './clusterModal';
 
 interface ClusterOwnProps {
-  category?: string;
   groupBy: string;
+  isPlatformCosts?: boolean;
   report: Report;
 }
 
@@ -45,7 +46,7 @@ class ClusterBase extends React.Component<ClusterProps> {
   };
 
   public render() {
-    const { category, groupBy, report, intl } = this.props;
+    const { groupBy, intl, isPlatformCosts, report } = this.props;
     const { isOpen, showAll } = this.state;
 
     let charCount = 0;
@@ -61,6 +62,9 @@ class ClusterBase extends React.Component<ClusterProps> {
     const item = computedItems && computedItems.length ? computedItems[0] : undefined;
     if (!item) {
       return null;
+    }
+    if (isPlatformCosts) {
+      item.label = platformCategory;
     }
 
     for (const cluster of item.clusters) {
@@ -92,7 +96,7 @@ class ClusterBase extends React.Component<ClusterProps> {
             {intl.formatMessage(messages.detailsMoreClusters, { value: allClusters.length - someClusters.length })}
           </a>
         )}
-        <ClusterModal category={category} groupBy={groupBy} isOpen={isOpen} item={item} onClose={this.handleClose} />
+        <ClusterModal groupBy={groupBy} isOpen={isOpen} item={item} onClose={this.handleClose} />
       </div>
     );
   }

--- a/src/routes/views/details/components/cluster/clusterModal.tsx
+++ b/src/routes/views/details/components/cluster/clusterModal.tsx
@@ -11,7 +11,6 @@ import { ClusterContent } from './clusterContent';
 import { styles } from './clusterModal.styles';
 
 interface ClusterModalOwnProps {
-  category?: string;
   groupBy: string;
   isOpen: boolean;
   item: ComputedReportItem;
@@ -36,7 +35,7 @@ class ClusterModalBase extends React.Component<ClusterModalProps> {
   };
 
   public render() {
-    const { category, groupBy, isOpen, item, intl } = this.props;
+    const { groupBy, intl, isOpen, item } = this.props;
 
     return (
       <Modal
@@ -46,7 +45,7 @@ class ClusterModalBase extends React.Component<ClusterModalProps> {
         onClose={this.handleClose}
         title={intl.formatMessage(messages.detailsClustersModalTitle, {
           groupBy,
-          name: category ? category : item.label,
+          name: item.label,
         })}
         width={'50%'}
       >

--- a/src/routes/views/details/components/costOverview/costOverviewBase.tsx
+++ b/src/routes/views/details/components/costOverview/costOverviewBase.tsx
@@ -12,7 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
 import type { Query } from 'api/queries/query';
-import { orgUnitIdKey, tagPrefix } from 'api/queries/query';
+import { orgUnitIdKey, platformCategory, tagPrefix } from 'api/queries/query';
 import type { Report } from 'api/reports/report';
 import messages from 'locales/messages';
 import React from 'react';
@@ -27,10 +27,10 @@ import type { CostOverviewWidget } from 'store/breakdown/costOverview/common/cos
 import { CostOverviewWidgetType } from 'store/breakdown/costOverview/common/costOverviewCommon';
 
 interface CostOverviewOwnProps {
-  category?: string;
   costType?: string;
   currency?: string;
   groupBy: string;
+  isPlatformCosts?: boolean;
   query?: Query;
   report: Report;
 }
@@ -47,7 +47,7 @@ const PLACEHOLDER = 'placeholder';
 class CostOverviewsBase extends React.Component<CostOverviewProps> {
   // Returns cluster chart
   private getClusterChart = (widget: CostOverviewWidget) => {
-    const { category, groupBy, report, intl } = this.props;
+    const { groupBy, intl, isPlatformCosts, report } = this.props;
 
     let showWidget = false;
     for (const groupById of widget.cluster.showWidgetOnGroupBy) {
@@ -65,7 +65,7 @@ class CostOverviewsBase extends React.Component<CostOverviewProps> {
             </Title>
           </CardTitle>
           <CardBody>
-            <Cluster category={category} groupBy={widget.cluster.reportGroupBy} report={report} />
+            <Cluster groupBy={widget.cluster.reportGroupBy} isPlatformCosts={isPlatformCosts} report={report} />
           </CardBody>
         </Card>
       );
@@ -155,7 +155,7 @@ class CostOverviewsBase extends React.Component<CostOverviewProps> {
 
   // Returns summary card widget
   private getSummaryCard = (widget: CostOverviewWidget) => {
-    const { category, costType, currency, groupBy, query } = this.props;
+    const { costType, currency, groupBy, isPlatformCosts, query } = this.props;
 
     let showWidget = false;
     if (widget.reportSummary.showWidgetOnGroupBy) {
@@ -172,7 +172,7 @@ class CostOverviewsBase extends React.Component<CostOverviewProps> {
     }
     if (!showWidget && widget.reportSummary.showWidgetOnCategory) {
       for (const categoryId of widget.reportSummary.showWidgetOnCategory) {
-        if (categoryId === category) {
+        if (isPlatformCosts && categoryId === platformCategory) {
           showWidget = true;
           break;
         }
@@ -181,9 +181,9 @@ class CostOverviewsBase extends React.Component<CostOverviewProps> {
     if (showWidget) {
       return (
         <SummaryCard
-          category={category}
           costType={costType}
           currency={currency}
+          isPlatformCosts={isPlatformCosts}
           reportGroupBy={widget.reportSummary.reportGroupBy}
           reportPathsType={widget.reportPathsType}
           reportType={widget.reportType}

--- a/src/routes/views/details/components/summary/summaryCard.tsx
+++ b/src/routes/views/details/components/summary/summaryCard.tsx
@@ -11,7 +11,7 @@ import {
   TitleSizes,
 } from '@patternfly/react-core';
 import type { Query } from 'api/queries/query';
-import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery } from 'api/queries/query';
+import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, platformCategory } from 'api/queries/query';
 import type { OcpReport } from 'api/reports/ocpReports';
 import type { ReportPathsType, ReportType } from 'api/reports/report';
 import messages from 'locales/messages';
@@ -30,9 +30,9 @@ import { skeletonWidth } from 'utils/skeleton';
 import { styles } from './summaryCard.styles';
 
 interface SummaryOwnProps {
-  category?: string;
   costType?: string;
   currency?: string;
+  isPlatformCosts?: boolean;
   reportGroupBy?: string;
   reportPathsType: ReportPathsType;
   reportType: ReportType;
@@ -109,7 +109,7 @@ class SummaryBase extends React.Component<SummaryProps> {
   };
 
   private getViewAll = () => {
-    const { costType, currency, groupBy, query, reportGroupBy, reportPathsType, intl } = this.props;
+    const { costType, currency, groupBy, intl, isPlatformCosts, query, reportGroupBy, reportPathsType } = this.props;
     const { isBulletChartModalOpen } = this.state;
 
     const computedItems = this.getItems();
@@ -138,7 +138,7 @@ class SummaryBase extends React.Component<SummaryProps> {
             costType={costType}
             currency={currency}
             groupBy={groupBy}
-            groupByValue={groupByValue}
+            groupByValue={isPlatformCosts ? platformCategory : groupByValue}
             isOpen={isBulletChartModalOpen}
             onClose={this.handleBulletChartModalClose}
             query={query}
@@ -162,13 +162,15 @@ class SummaryBase extends React.Component<SummaryProps> {
   };
 
   public render() {
-    const { category, reportGroupBy, reportFetchStatus, intl } = this.props;
+    const { intl, isPlatformCosts, reportGroupBy, reportFetchStatus } = this.props;
 
     return (
       <Card style={styles.card}>
         <CardTitle>
           <Title headingLevel="h2" size={TitleSizes.lg}>
-            {intl.formatMessage(messages.breakdownSummaryTitle, { value: category ? category : reportGroupBy })}
+            {intl.formatMessage(messages.breakdownSummaryTitle, {
+              value: isPlatformCosts ? platformCategory : reportGroupBy,
+            })}
           </Title>
         </CardTitle>
         <CardBody>

--- a/src/routes/views/details/components/tag/tagContent.tsx
+++ b/src/routes/views/details/components/tag/tagContent.tsx
@@ -9,7 +9,6 @@ import { connect } from 'react-redux';
 import { styles } from './tag.styles';
 
 interface TagContentOwnProps {
-  category?: string;
   groupBy: string;
   groupByValue: string | number;
   tagReport?: Tag;
@@ -47,7 +46,7 @@ class TagContentBase extends React.Component<TagContentProps> {
   };
 
   public render() {
-    const { category, groupBy, groupByValue, intl } = this.props;
+    const { groupBy, groupByValue, intl } = this.props;
     const dataListItems = this.getDataListItems();
 
     return (
@@ -58,7 +57,7 @@ class TagContentBase extends React.Component<TagContentProps> {
           </span>
         </div>
         <div style={styles.groupByHeading}>
-          <span>{category ? category : groupByValue}</span>
+          <span>{groupByValue}</span>
         </div>
         <DataList aria-label={intl.formatMessage(messages.tagNames)} isCompact>
           <DataListItem aria-labelledby="heading1">

--- a/src/routes/views/details/components/tag/tagModal.tsx
+++ b/src/routes/views/details/components/tag/tagModal.tsx
@@ -1,6 +1,6 @@
 import { Modal } from '@patternfly/react-core';
 import type { Query } from 'api/queries/query';
-import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, tagPrefix } from 'api/queries/query';
+import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, platformCategory, tagPrefix } from 'api/queries/query';
 import type { Tag, TagPathsType } from 'api/tags/tag';
 import { TagType } from 'api/tags/tag';
 import messages from 'locales/messages';
@@ -9,6 +9,7 @@ import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'routes/views/utils/groupBy';
+import { isPlatformCosts } from 'routes/views/utils/paths';
 import type { FetchStatus } from 'store/common';
 import { createMapStateToProps } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
@@ -22,9 +23,9 @@ interface TagModalOwnProps {
 }
 
 interface TagModalStateProps {
-  category?: string;
   groupBy: string;
   groupByValue: string | number;
+  isPlatformCosts?: boolean;
   query?: Query;
   tagReport?: Tag;
   tagReportFetchStatus?: FetchStatus;
@@ -81,7 +82,7 @@ class TagModalBase extends React.Component<TagModalProps> {
   };
 
   public render() {
-    const { category, groupBy, isOpen, query, tagReport, intl } = this.props;
+    const { groupBy, intl, isOpen, query, tagReport } = this.props;
 
     // Match page header description
     const groupByValue = query && query.filter && query.filter.account ? query.filter.account : this.props.groupByValue;
@@ -93,7 +94,11 @@ class TagModalBase extends React.Component<TagModalProps> {
         title={intl.formatMessage(messages.tagHeadingTitle, { value: this.getTagValueCount() })}
         width={'50%'}
       >
-        <TagContent category={category} groupBy={groupBy} groupByValue={groupByValue} tagReport={tagReport} />
+        <TagContent
+          groupBy={groupBy}
+          groupByValue={this.props.isPlatformCosts ? platformCategory : groupByValue}
+          tagReport={tagReport}
+        />
       </Modal>
     );
   }
@@ -139,9 +144,9 @@ const mapStateToProps = createMapStateToProps<TagModalOwnProps, TagModalStatePro
   );
 
   return {
-    category: queryFromRoute.category,
     groupBy,
     groupByValue,
+    isPlatformCosts: isPlatformCosts(queryFromRoute),
     query,
     tagReport,
     tagReportFetchStatus,

--- a/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -2,7 +2,7 @@ import { ProviderType } from 'api/providers';
 import { getQuery, parseQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import type { Query } from 'api/queries/query';
-import { breakdownDescKey } from 'api/queries/query';
+import { breakdownDescKey, breakdownTitleKey } from 'api/queries/query';
 import type { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { TagPathsType } from 'api/tags/tag';
@@ -15,6 +15,7 @@ import { connect } from 'react-redux';
 import { paths } from 'routes';
 import { BreakdownBase } from 'routes/views/details/components/breakdown';
 import { getGroupById, getGroupByValue } from 'routes/views/utils/groupBy';
+import { isPlatformCosts } from 'routes/views/utils/paths';
 import { filterProviders } from 'routes/views/utils/providers';
 import type { FetchStatus } from 'store/common';
 import { createMapStateToProps } from 'store/common';
@@ -100,7 +101,12 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
 
   return {
     costOverviewComponent: (
-      <CostOverview category={queryFromRoute.category} currency={currency} groupBy={groupBy} report={report} />
+      <CostOverview
+        currency={currency}
+        groupBy={groupBy}
+        isPlatformCosts={isPlatformCosts(queryFromRoute)}
+        report={report}
+      />
     ),
     currency,
     description: queryFromRoute[breakdownDescKey],
@@ -120,7 +126,7 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
     reportPathsType,
     reportQueryString,
     tagReportPathsType: TagPathsType.ocp,
-    title: queryFromRoute.category ? queryFromRoute.category : groupByValue,
+    title: queryFromRoute[breakdownTitleKey] ? queryFromRoute[breakdownTitleKey] : groupByValue,
   };
 });
 

--- a/src/routes/views/utils/paths.ts
+++ b/src/routes/views/utils/paths.ts
@@ -1,5 +1,5 @@
 import type { Query } from 'api/queries/query';
-import { getQueryRoute } from 'api/queries/query';
+import { getQueryRoute, platformCategory } from 'api/queries/query';
 import { breakdownDescKey, breakdownTitleKey, orgUnitIdKey } from 'api/queries/query';
 import { parseQuery } from 'api/queries/query';
 
@@ -20,6 +20,7 @@ export const getBreakdownPath = ({
   const newQuery = {
     ...queryFromRoute,
     ...(description && description !== label && { [breakdownDescKey]: description }),
+    ...(isPlatformCosts && { [breakdownTitleKey]: label }),
     group_by: {
       [groupBy]: label,
     },
@@ -73,4 +74,8 @@ export const getOrgBreakdownPath = ({
     };
   }
   return `${basePath}?${getQueryRoute(newQuery)}`;
+};
+
+export const isPlatformCosts = (queryFromRoute: Query) => {
+  return queryFromRoute.category === platformCategory && queryFromRoute.breakdown_title === platformCategory;
 };

--- a/src/routes/views/utils/paths.ts
+++ b/src/routes/views/utils/paths.ts
@@ -77,5 +77,13 @@ export const getOrgBreakdownPath = ({
 };
 
 export const isPlatformCosts = (queryFromRoute: Query) => {
-  return queryFromRoute.category === platformCategory && queryFromRoute.breakdown_title === platformCategory;
+  let result = false;
+
+  // Note that "kube-" and "openshift-" are provided only when users select the 'platform' project.
+  // The category below is mainly used to restore state for the previous page
+  if (Array.isArray(queryFromRoute.group_by.project)) {
+    result =
+      queryFromRoute.group_by.project.includes('kube-') && queryFromRoute.group_by.project.includes('openshift-');
+  }
+  return result && queryFromRoute.category === platformCategory;
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -350,6 +350,11 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@formatjs/cli@^5.1.4":
+  version "5.1.4"
+  resolved "https://registry.yarnpkg.com/@formatjs/cli/-/cli-5.1.4.tgz#c000350604f0c008aa31ac6af0c0f8e224a64017"
+  integrity sha512-N9EiLc16pBf7E90ZqiFiYeiNLr6BpU3YSsy70WBU/cIvLpXq1fYs6p9IZz/iYM92bIn7ix81I+42Q3tfqvMejA==
+
 "@formatjs/ecma402-abstract@1.14.0":
   version "1.14.0"
   resolved "https://registry.yarnpkg.com/@formatjs/ecma402-abstract/-/ecma402-abstract-1.14.0.tgz#2ee584d671e2776434da88b3e1ae4ed3053ad450"


### PR DESCRIPTION
Refactored breakdown page to simplify the platform costs feature. 

https://issues.redhat.com/browse/COST-3283

FYI, the "category" query param is only used to restore the details page. It doesn't indicate if the current project is a "platform" cost. For that, we must look at the group_by's provided to the breakdown page.

In the screenshots below, the "platform" project shows new features as expected. However, the "analitics" project should not display them.

**Example: "platform"**
![platform](https://user-images.githubusercontent.com/17481322/204874510-1d0dbe3f-8497-4d95-996a-b1d2d797975c.png)

**Example: "analitics"**
![analytics](https://user-images.githubusercontent.com/17481322/204874530-7cf91bfd-5445-4c2e-9498-4383277e2906.png)
