### PR TITLE
Wrap "Cost distribution" wizard step with Unleash

### DIFF
--- a/src/routes/costModels/createCostModelWizard/distribution.tsx
+++ b/src/routes/costModels/createCostModelWizard/distribution.tsx
@@ -3,14 +3,27 @@ import messages from 'locales/messages';
 import React from 'react';
 import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
+import { connect } from 'react-redux';
 import { Form } from 'routes/costModels/components/forms/form';
+import { createMapStateToProps } from 'store/common';
+import { featureFlagsSelectors } from 'store/featureFlags';
 
 import { CostModelContext } from './context';
 import { styles } from './wizard.styles';
 
-class Distribution extends React.Component<WrappedComponentProps> {
+interface DistributionOwnProps extends WrappedComponentProps {
+  // TBD...
+}
+
+interface DistributionStateProps {
+  isCostDistributionFeatureEnabled?: boolean;
+}
+
+type DistributionProps = DistributionOwnProps & DistributionStateProps;
+
+class DistributionBase extends React.Component<DistributionProps> {
   public render() {
-    const { intl } = this.props;
+    const { intl, isCostDistributionFeatureEnabled } = this.props;
 
     return (
       <CostModelContext.Consumer>
@@ -28,10 +41,12 @@ class Distribution extends React.Component<WrappedComponentProps> {
                 <Title headingLevel="h2" size="xl" style={styles.titleWithLearnMore}>
                   {intl.formatMessage(messages.costDistribution)}
                 </Title>
-                {/* TODO: show when we get the new doc urls */}
-                {/* <a href={intl.formatMessage(messages.docsCostModelsDistribution)} rel="noreferrer" target="_blank">
-                  {intl.formatMessage(messages.learnMore)}
-                </a> */}
+                {/* Todo: Update when we get the new doc urls */}
+                {isCostDistributionFeatureEnabled && (
+                  <a href={intl.formatMessage(messages.docsCostModelsDistribution)} rel="noreferrer" target="_blank">
+                    {intl.formatMessage(messages.learnMore)}
+                  </a>
+                )}
               </StackItem>
               <StackItem>
                 <Title headingLevel="h3" size="md">
@@ -65,8 +80,7 @@ class Distribution extends React.Component<WrappedComponentProps> {
                   </FormGroup>
                 </Form>
               </StackItem>
-              {/* TODO: unhide after api implemented */}
-              {false && (
+              {isCostDistributionFeatureEnabled && (
                 <>
                   <StackItem>
                     <Title headingLevel="h3" size="md">
@@ -146,4 +160,12 @@ class Distribution extends React.Component<WrappedComponentProps> {
   }
 }
 
-export default injectIntl(Distribution);
+const mapStateToProps = createMapStateToProps<undefined, DistributionStateProps>((state, props) => {
+  return {
+    isCostDistributionFeatureEnabled: featureFlagsSelectors.selectIsCostDistributionFeatureEnabled(state),
+  };
+});
+
+const Distribution = injectIntl(connect(mapStateToProps, {})(DistributionBase));
+
+export default Distribution;

--- a/src/routes/costModels/createCostModelWizard/markup.tsx
+++ b/src/routes/costModels/createCostModelWizard/markup.tsx
@@ -20,16 +20,29 @@ import messages from 'locales/messages';
 import React from 'react';
 import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
+import { connect } from 'react-redux';
 import { Form } from 'routes/costModels/components/forms/form';
 import { styles as costCalcStyles } from 'routes/costModels/costModel/costCalc.styles';
+import { createMapStateToProps } from 'store/common';
+import { featureFlagsSelectors } from 'store/featureFlags';
 import { countDecimals, isPercentageFormatValid } from 'utils/format';
 
 import { CostModelContext } from './context';
 import { styles } from './wizard.styles';
 
-class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
+interface MarkupWithDistributionOwnProps extends WrappedComponentProps {
+  // TBD...
+}
+
+interface MarkupWithDistributionStateProps {
+  isCostDistributionFeatureEnabled?: boolean;
+}
+
+type MarkupWithDistributionProps = MarkupWithDistributionOwnProps & MarkupWithDistributionStateProps;
+
+class MarkupWithDistributionBase extends React.Component<MarkupWithDistributionProps> {
   public render() {
-    const { intl } = this.props;
+    const { intl, isCostDistributionFeatureEnabled } = this.props;
 
     const handleOnKeyDown = event => {
       // Prevent 'enter', '+', and '-'
@@ -62,10 +75,12 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
                 <Title headingLevel="h2" size={TitleSizes.xl} style={styles.titleWithLearnMore}>
                   {intl.formatMessage(messages.costCalculationsOptional)}
                 </Title>
-                {/* TODO: show when we get the new doc urls */}
-                {/* <a href={intl.formatMessage(messages.docsCostModelsMarkup)} rel="noreferrer" target="_blank">
-                  {intl.formatMessage(messages.learnMore)}
-                </a> */}
+                {/* Todo: Update when we get the new doc urls */}
+                {isCostDistributionFeatureEnabled && (
+                  <a href={intl.formatMessage(messages.docsCostModelsMarkup)} rel="noreferrer" target="_blank">
+                    {intl.formatMessage(messages.learnMore)}
+                  </a>
+                )}
               </StackItem>
               <StackItem>
                 <Title headingLevel="h3" size="md">
@@ -156,4 +171,12 @@ class MarkupWithDistribution extends React.Component<WrappedComponentProps> {
   }
 }
 
-export default injectIntl(MarkupWithDistribution);
+const mapStateToProps = createMapStateToProps<undefined, MarkupWithDistributionStateProps>((state, props) => {
+  return {
+    isCostDistributionFeatureEnabled: featureFlagsSelectors.selectIsCostDistributionFeatureEnabled(state),
+  };
+});
+
+const MarkupWithDistribution = injectIntl(connect(mapStateToProps, {})(MarkupWithDistributionBase));
+
+export default MarkupWithDistribution;

--- a/src/routes/costModels/createCostModelWizard/review.tsx
+++ b/src/routes/costModels/createCostModelWizard/review.tsx
@@ -22,8 +22,11 @@ import messages from 'locales/messages';
 import React from 'react';
 import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
+import { connect } from 'react-redux';
 import { RateTable } from 'routes/costModels/components/rateTable';
 import { WarningIcon } from 'routes/costModels/components/warningIcon';
+import { createMapStateToProps } from 'store/common';
+import { featureFlagsSelectors } from 'store/featureFlags';
 
 import { CostModelContext } from './context';
 
@@ -50,7 +53,17 @@ const ReviewSuccessBase: React.FC<WrappedComponentProps> = ({ intl }) => (
 
 const ReviewSuccess = injectIntl(ReviewSuccessBase);
 
-const ReviewDetailsBase: React.FC<WrappedComponentProps> = ({ intl }) => (
+interface ReviewDetailsOwnProps extends WrappedComponentProps {
+  // TBD...
+}
+
+interface ReviewDetailsStateProps {
+  isCostDistributionFeatureEnabled?: boolean;
+}
+
+type ReviewDetailsProps = ReviewDetailsOwnProps & ReviewDetailsStateProps;
+
+const ReviewDetailsBase: React.FC<ReviewDetailsProps> = ({ intl, isCostDistributionFeatureEnabled }) => (
   <CostModelContext.Consumer>
     {({
       checked,
@@ -133,8 +146,8 @@ const ReviewDetailsBase: React.FC<WrappedComponentProps> = ({ intl }) => (
                       <TextListItem component={TextListItemVariants.dd}>
                         {intl.formatMessage(messages.distributionTypeDescription, { type: distribution })}
                       </TextListItem>
-                      {/* TODO: add back after backend done for distribute unallocated */}
-                      {false && (
+                      {/* Todo: add back after backend done for distribute unallocated */}
+                      {isCostDistributionFeatureEnabled && (
                         <>
                           <TextListItem component={TextListItemVariants.dd}>
                             {intl.formatMessage(messages.distributeCosts, {
@@ -171,7 +184,13 @@ const ReviewDetailsBase: React.FC<WrappedComponentProps> = ({ intl }) => (
   </CostModelContext.Consumer>
 );
 
-const ReviewDetails = injectIntl(ReviewDetailsBase);
+const mapStateToProps = createMapStateToProps<undefined, ReviewDetailsStateProps>((state, props) => {
+  return {
+    isCostDistributionFeatureEnabled: featureFlagsSelectors.selectIsCostDistributionFeatureEnabled(state),
+  };
+});
+
+const ReviewDetails = injectIntl(connect(mapStateToProps, {})(ReviewDetailsBase));
 
 const ReviewWithDistribution = () => {
   return (


### PR DESCRIPTION
The cost models wizard was updated to add a "Cost distribution" step via  https://issues.redhat.com/browse/COST-3145. However, the selections for "unallocated capacity" are commented out in the code.

This wraps the "Cost distribution" feature with this flag, so it can be available for testing.

https://issues.redhat.com/browse/COST-3319