### PR TITLE
Add cost_type for all AWS and "AWS on OCP" overview cards

### DIFF
--- a/src/store/dashboard/awsDashboard/awsDashboardCommon.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardCommon.ts
@@ -21,7 +21,7 @@ export const enum AwsDashboardTab {
 }
 
 export interface AwsDashboardWidget extends DashboardWidget<AwsDashboardTab> {
-  savingsPlan?: boolean;
+  // TBD...
 }
 
 export function getGroupByForTab(widget: AwsDashboardWidget): AwsQuery['group_by'] {

--- a/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
@@ -31,8 +31,8 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
   const props = {
+    cost_type: getCostType(),
     ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
-    ...(widget.savingsPlan && { cost_type: getCostType() }),
   };
 
   return {

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -64,7 +64,6 @@ export const costSummaryWidget: AwsDashboardWidget = {
     showHorizontal: true,
     viewAllPath: paths.awsDetails,
   },
-  savingsPlan: true,
   tabsFilter: {
     limit: 3,
   },
@@ -93,7 +92,6 @@ export const databaseWidget: AwsDashboardWidget = {
   filter: {
     service: 'AmazonRDS,AmazonDynamoDB,AmazonElastiCache,AmazonNeptune,AmazonRedshift,AmazonDocumentDB',
   },
-  savingsPlan: true,
   tabsFilter: {
     service: 'AmazonRDS,AmazonDynamoDB,AmazonElastiCache,AmazonNeptune,AmazonRedshift,AmazonDocumentDB',
   },
@@ -120,7 +118,6 @@ export const networkWidget: AwsDashboardWidget = {
   filter: {
     service: 'AmazonVPC,AmazonCloudFront,AmazonRoute53,AmazonAPIGateway',
   },
-  savingsPlan: true,
   tabsFilter: {
     service: 'AmazonVPC,AmazonCloudFront,AmazonRoute53,AmazonAPIGateway',
   },

--- a/src/store/dashboard/awsOcpDashboard/awsOcpDashboardCommon.ts
+++ b/src/store/dashboard/awsOcpDashboard/awsOcpDashboardCommon.ts
@@ -21,7 +21,7 @@ export const enum AwsOcpDashboardTab {
 }
 
 export interface AwsOcpDashboardWidget extends DashboardWidget<AwsOcpDashboardTab> {
-  savingsPlan?: boolean;
+  // TBD...
 }
 
 export function getGroupByForTab(widget: AwsOcpDashboardWidget): AwsQuery['group_by'] {

--- a/src/store/dashboard/awsOcpDashboard/awsOcpDashboardSelectors.ts
+++ b/src/store/dashboard/awsOcpDashboard/awsOcpDashboardSelectors.ts
@@ -31,9 +31,8 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
   const props = {
+    ...(featureFlagsSelectors.selectIsCostTypeFeatureEnabled(state) && { cost_type: getCostType() }),
     ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
-    ...(featureFlagsSelectors.selectIsCostTypeFeatureEnabled(state) &&
-      widget.savingsPlan && { cost_type: getCostType() }),
   };
 
   return {

--- a/src/store/dashboard/awsOcpDashboard/awsOcpDashboardWidgets.ts
+++ b/src/store/dashboard/awsOcpDashboard/awsOcpDashboardWidgets.ts
@@ -62,7 +62,6 @@ export const costSummaryWidget: AwsOcpDashboardWidget = {
     costKey: messages.cost,
     showHorizontal: true,
   },
-  savingsPlan: true,
   tabsFilter: {
     limit: 3,
   },
@@ -91,7 +90,6 @@ export const databaseWidget: AwsOcpDashboardWidget = {
   filter: {
     service: awsDashboardWidgets.databaseWidget.filter.service,
   },
-  savingsPlan: true,
   tabsFilter: {
     service: awsDashboardWidgets.databaseWidget.tabsFilter.service,
   },
@@ -118,7 +116,6 @@ export const networkWidget: AwsOcpDashboardWidget = {
   filter: {
     service: awsDashboardWidgets.networkWidget.filter.service,
   },
-  savingsPlan: true,
   tabsFilter: {
     service: awsDashboardWidgets.networkWidget.tabsFilter.service,
   },


### PR DESCRIPTION
Add cost_type for all AWS and "AWS on OCP" overview cards. This change adds the cost_type param for compute and storage APIs.

https://issues.redhat.com/browse/COST-3122