### PR TITLE
Wizard should remain on "Price list" table after deleting rates

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -10328,6 +10328,12 @@
         "value": "https://status.redhat.com"
       }
     ],
+    "remove": [
+      {
+        "type": 0,
+        "value": "Remove"
+      }
+    ],
     "requests": [
       {
         "type": 0,

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -446,6 +446,7 @@
   "rbacErrorDescription": "There was a problem receiving user permissions. Refreshing this page may fix it. If it does not, please contact your admin.",
   "rbacErrorTitle": "Failed to get RBAC information",
   "redHatStatusUrl": "https://status.redhat.com",
+  "remove": "Remove",
   "requests": "Requests",
   "rhel": "RHEL",
   "rhelCpuUsageAndRequests": "CPU usage and requests",

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -2753,6 +2753,11 @@ export default defineMessages({
     description: 'Red Hat status url for cloud services',
     id: 'redHatStatusUrl',
   },
+  remove: {
+    defaultMessage: 'Remove',
+    description: 'Remove',
+    id: 'remove',
+  },
   requests: {
     defaultMessage: 'Requests',
     description: 'Requests',

--- a/src/routes/costModels/createCostModelWizard/priceList.tsx
+++ b/src/routes/costModels/createCostModelWizard/priceList.tsx
@@ -25,8 +25,7 @@ const PriceList = () => {
           const items = [...tiers.slice(0, index), ...tiers.slice(index + 1)];
           submitTiers(items);
           if (items.length === 0) {
-            setState('form');
-            goToAddPL(false);
+            goToAddPL(true);
           }
         }}
         addRateAction={() => {

--- a/src/routes/costModels/createCostModelWizard/priceListTable.tsx
+++ b/src/routes/costModels/createCostModelWizard/priceListTable.tsx
@@ -246,7 +246,7 @@ class PriceListTable extends React.Component<Props, State> {
                           <RateTable
                             actions={[
                               {
-                                title: 'Remove',
+                                title: intl.formatMessage(messages.remove),
                                 onClick: (_evt, _rowId, rowData) => {
                                   deleteRateAction(rowData.data.index + from);
                                 },


### PR DESCRIPTION
The cost models wizard throws users into the "Create rate" dialog, in the "Price list" step, after deleting all rates. That is, when there is a single rate remaining.

It's confusing because users are blocked from navigating to the next wizard step, until they click "Cancel". With this change, the user would remain on the "Price list" table.

https://issues.redhat.com/browse/COST-3218

![chrome-capture-2022-11-9](https://user-images.githubusercontent.com/17481322/206823984-5fe18fea-0881-400e-b5ef-9c2e272339d2.gif)
