### PR TITLE
Match new labels in details table

### DIFF
--- a/src/api/queries/query.ts
+++ b/src/api/queries/query.ts
@@ -2,17 +2,17 @@ import { parse, stringify } from 'qs';
 
 export const logicalOrPrefix = 'or:'; // logical OR prefix for group_by
 export const logicalAndPrefix = 'and:'; // logical AND prefix for group_by
+export const noPrefix = 'no-'; // no-project, no-region, no-<tag>
 export const tagPrefix = 'tag:'; // Tag prefix for group_by
 
 export const breakdownDescKey = 'breakdown_desc'; // Used to display a description in the breakdown header
-export const breakdownGroupByKey = 'breakdown_group_by'; // Used to display a breadcrumb in the breakdown header
 export const breakdownTitleKey = 'breakdown_title'; // Used to display a title in the breakdown header
 export const orgUnitIdKey = 'org_unit_id'; // Org unit ID for group_by
 export const orgUnitNameKey = 'org_unit_name'; // Org unit name for group_by
-export const platformCategory = 'platform'; // Used to display platform costs
+export const platformCategoryKey = 'platform'; // Used to display platform costs
 export const tagKey = 'tag'; // Tag key for group_by
-export const unallocatedPlatformCapacity = 'Platform Unallocated Capacity'; // Unallocated platform costs
-export const unallocatedWorkersCapacity = 'Workers Unallocated Capacity'; // Unallocated workers costs
+export const unallocatedPlatformCapacityKey = 'platform unallocated'; // Unallocated platform costs
+export const unallocatedWorkersCapacityKey = 'workers unallocated'; // Unallocated workers costs
 
 export interface Filters {
   category?: string;

--- a/src/routes/views/details/awsDetails/awsDetails.tsx
+++ b/src/routes/views/details/awsDetails/awsDetails.tsx
@@ -6,7 +6,7 @@ import { ProviderType } from 'api/providers';
 import type { AwsQuery } from 'api/queries/awsQuery';
 import { getQuery, parseQuery } from 'api/queries/awsQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { orgUnitIdKey, tagPrefix } from 'api/queries/query';
+import { noPrefix, orgUnitIdKey, tagPrefix } from 'api/queries/query';
 import type { AwsReport } from 'api/reports/awsReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import type { AxiosError } from 'axios';
@@ -162,7 +162,12 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     // Omit items labeled 'no-project'
     const items = [];
     selectedItems.map(item => {
-      if (!(item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`)) {
+      if (
+        !(
+          item.label?.toLowerCase() === `${noPrefix}${groupById}` ||
+          item.label?.toLowerCase() === `${noPrefix}${groupByTagKey}`
+        )
+      ) {
         items.push(item);
       }
     });

--- a/src/routes/views/details/awsDetails/detailsTable.tsx
+++ b/src/routes/views/details/awsDetails/detailsTable.tsx
@@ -1,5 +1,6 @@
 import 'routes/views/details/components/dataTable/dataTable.scss';
 
+import { noPrefix } from 'api/queries/query';
 import type { AwsReport } from 'api/reports/awsReports';
 import { ReportPathsType } from 'api/reports/report';
 import messages from 'locales/messages';
@@ -125,7 +126,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       const cost = this.getTotalCost(item, index);
       const monthOverMonth = this.getMonthOverMonthCost(item, index);
       const label = item && item.label && item.label !== null ? item.label : '';
-      const isDisabled = label === `no-${groupBy}` || label === `no-${groupByTagKey}`;
+      const isDisabled =
+        label?.toLowerCase() === `${noPrefix}${groupBy}` || label?.toLowerCase() === `${noPrefix}${groupByTagKey}`;
       const desc = item.id && item.id !== item.label ? <div style={styles.infoDescription}>{item.id}</div> : null;
       const actions = this.getActions(item, isDisabled);
 

--- a/src/routes/views/details/azureDetails/azureDetails.tsx
+++ b/src/routes/views/details/azureDetails/azureDetails.tsx
@@ -4,7 +4,7 @@ import { ProviderType } from 'api/providers';
 import type { AzureQuery } from 'api/queries/azureQuery';
 import { getQuery, parseQuery } from 'api/queries/azureQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { tagPrefix } from 'api/queries/query';
+import { noPrefix, tagPrefix } from 'api/queries/query';
 import type { AzureReport } from 'api/reports/azureReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import type { AxiosError } from 'axios';
@@ -154,7 +154,12 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     // Omit items labeled 'no-project'
     const items = [];
     selectedItems.map(item => {
-      if (!(item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`)) {
+      if (
+        !(
+          item.label?.toLowerCase() === `${noPrefix}${groupById}` ||
+          item.label?.toLowerCase() === `${noPrefix}${groupByTagKey}`
+        )
+      ) {
         items.push(item);
       }
     });

--- a/src/routes/views/details/azureDetails/detailsTable.tsx
+++ b/src/routes/views/details/azureDetails/detailsTable.tsx
@@ -1,5 +1,6 @@
 import 'routes/views/details/components/dataTable/dataTable.scss';
 
+import { noPrefix } from 'api/queries/query';
 import type { AzureReport } from 'api/reports/azureReports';
 import { ReportPathsType } from 'api/reports/report';
 import messages from 'locales/messages';
@@ -121,7 +122,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       const cost = this.getTotalCost(item, index);
       const label = item && item.label !== null ? item.label : '';
       const monthOverMonth = this.getMonthOverMonthCost(item, index);
-      const isDisabled = label === `no-${groupBy}` || label === `no-${groupByTagKey}`;
+      const isDisabled =
+        label?.toLowerCase() === `${noPrefix}${groupBy}` || label?.toLowerCase() === `${noPrefix}${groupByTagKey}`;
       const desc = item.id && item.id !== item.label ? <div style={styles.infoDescription}>{item.id}</div> : null;
       const actions = this.getActions(item, isDisabled);
 

--- a/src/routes/views/details/components/cluster/cluster.tsx
+++ b/src/routes/views/details/components/cluster/cluster.tsx
@@ -1,4 +1,4 @@
-import { platformCategory } from 'api/queries/query';
+import { platformCategoryKey } from 'api/queries/query';
 import type { Report } from 'api/reports/report';
 import messages from 'locales/messages';
 import React from 'react';
@@ -64,7 +64,7 @@ class ClusterBase extends React.Component<ClusterProps> {
       return null;
     }
     if (isPlatformCosts) {
-      item.label = platformCategory;
+      item.label = platformCategoryKey;
     }
 
     for (const cluster of item.clusters) {

--- a/src/routes/views/details/components/costOverview/costOverviewBase.tsx
+++ b/src/routes/views/details/components/costOverview/costOverviewBase.tsx
@@ -12,7 +12,7 @@ import {
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
 import type { Query } from 'api/queries/query';
-import { orgUnitIdKey, platformCategory, tagPrefix } from 'api/queries/query';
+import { orgUnitIdKey, platformCategoryKey, tagPrefix } from 'api/queries/query';
 import type { Report } from 'api/reports/report';
 import messages from 'locales/messages';
 import React from 'react';
@@ -172,7 +172,7 @@ class CostOverviewsBase extends React.Component<CostOverviewProps> {
     }
     if (!showWidget && widget.reportSummary.showWidgetOnCategory) {
       for (const categoryId of widget.reportSummary.showWidgetOnCategory) {
-        if (isPlatformCosts && categoryId === platformCategory) {
+        if (isPlatformCosts && categoryId === platformCategoryKey) {
           showWidget = true;
           break;
         }

--- a/src/routes/views/details/components/summary/summaryCard.tsx
+++ b/src/routes/views/details/components/summary/summaryCard.tsx
@@ -11,7 +11,7 @@ import {
   TitleSizes,
 } from '@patternfly/react-core';
 import type { Query } from 'api/queries/query';
-import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, platformCategory } from 'api/queries/query';
+import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, platformCategoryKey } from 'api/queries/query';
 import type { OcpReport } from 'api/reports/ocpReports';
 import type { ReportPathsType, ReportType } from 'api/reports/report';
 import messages from 'locales/messages';
@@ -140,7 +140,7 @@ class SummaryBase extends React.Component<SummaryProps> {
             costType={costType}
             currency={currency}
             groupBy={groupBy}
-            groupByValue={isPlatformCosts ? platformCategory : groupByValue}
+            groupByValue={isPlatformCosts ? platformCategoryKey : groupByValue}
             isOpen={isBulletChartModalOpen}
             onClose={this.handleBulletChartModalClose}
             query={query}
@@ -171,7 +171,7 @@ class SummaryBase extends React.Component<SummaryProps> {
         <CardTitle>
           <Title headingLevel="h2" size={TitleSizes.lg}>
             {intl.formatMessage(messages.breakdownSummaryTitle, {
-              value: isPlatformCosts ? platformCategory : reportGroupBy,
+              value: isPlatformCosts ? platformCategoryKey : reportGroupBy,
             })}
           </Title>
         </CardTitle>

--- a/src/routes/views/details/components/tag/tagModal.tsx
+++ b/src/routes/views/details/components/tag/tagModal.tsx
@@ -1,6 +1,13 @@
 import { Modal } from '@patternfly/react-core';
 import type { Query } from 'api/queries/query';
-import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, platformCategory, tagPrefix } from 'api/queries/query';
+import {
+  getQuery,
+  logicalAndPrefix,
+  orgUnitIdKey,
+  parseQuery,
+  platformCategoryKey,
+  tagPrefix,
+} from 'api/queries/query';
 import type { Tag, TagPathsType } from 'api/tags/tag';
 import { TagType } from 'api/tags/tag';
 import messages from 'locales/messages';
@@ -98,7 +105,7 @@ class TagModalBase extends React.Component<TagModalProps> {
       >
         <TagContent
           groupBy={groupBy}
-          groupByValue={this.props.isPlatformCosts ? platformCategory : groupByValue}
+          groupByValue={this.props.isPlatformCosts ? platformCategoryKey : groupByValue}
           tagReport={tagReport}
         />
       </Modal>

--- a/src/routes/views/details/gcpDetails/detailsTable.tsx
+++ b/src/routes/views/details/gcpDetails/detailsTable.tsx
@@ -1,5 +1,6 @@
 import 'routes/views/details/components/dataTable/dataTable.scss';
 
+import { noPrefix } from 'api/queries/query';
 import type { GcpReport } from 'api/reports/gcpReports';
 import { ReportPathsType } from 'api/reports/report';
 import messages from 'locales/messages';
@@ -121,7 +122,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       const cost = this.getTotalCost(item, index);
       const label = item && item.label !== null ? item.label : '';
       const monthOverMonth = this.getMonthOverMonthCost(item, index);
-      const isDisabled = label === `no-${groupBy}` || label === `no-${groupByTagKey}`;
+      const isDisabled =
+        label?.toLowerCase() === `${noPrefix}${groupBy}` || label?.toLowerCase() === `${noPrefix}${groupByTagKey}`;
       const desc = item.id && item.id !== item.label ? <div style={styles.infoDescription}>{item.id}</div> : null;
       const actions = this.getActions(item, isDisabled);
 

--- a/src/routes/views/details/gcpDetails/gcpDetails.tsx
+++ b/src/routes/views/details/gcpDetails/gcpDetails.tsx
@@ -4,7 +4,7 @@ import { ProviderType } from 'api/providers';
 import type { GcpQuery } from 'api/queries/gcpQuery';
 import { getQuery, parseQuery } from 'api/queries/gcpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { tagPrefix } from 'api/queries/query';
+import { noPrefix, tagPrefix } from 'api/queries/query';
 import type { GcpReport } from 'api/reports/gcpReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import type { AxiosError } from 'axios';
@@ -154,7 +154,12 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
     // Omit items labeled 'no-project'
     const items = [];
     selectedItems.map(item => {
-      if (!(item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`)) {
+      if (
+        !(
+          item.label?.toLowerCase() === `${noPrefix}${groupById}` ||
+          item.label?.toLowerCase() === `${noPrefix}${groupByTagKey}`
+        )
+      ) {
         items.push(item);
       }
     });

--- a/src/routes/views/details/ibmDetails/detailsTable.tsx
+++ b/src/routes/views/details/ibmDetails/detailsTable.tsx
@@ -1,5 +1,6 @@
 import 'routes/views/details/components/dataTable/dataTable.scss';
 
+import { noPrefix } from 'api/queries/query';
 import type { IbmReport } from 'api/reports/ibmReports';
 import { ReportPathsType } from 'api/reports/report';
 import messages from 'locales/messages';
@@ -121,7 +122,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       const cost = this.getTotalCost(item, index);
       const label = item && item.label !== null ? item.label : '';
       const monthOverMonth = this.getMonthOverMonthCost(item, index);
-      const isDisabled = label === `no-${groupBy}` || label === `no-${groupByTagKey}`;
+      const isDisabled =
+        label?.toLowerCase() === `${noPrefix}${groupBy}` || label?.toLowerCase() === `${noPrefix}${groupByTagKey}`;
       const desc = item.id && item.id !== item.label ? <div style={styles.infoDescription}>{item.id}</div> : null;
       const actions = this.getActions(item, isDisabled);
 

--- a/src/routes/views/details/ibmDetails/ibmDetails.tsx
+++ b/src/routes/views/details/ibmDetails/ibmDetails.tsx
@@ -4,7 +4,7 @@ import { ProviderType } from 'api/providers';
 import type { IbmQuery } from 'api/queries/ibmQuery';
 import { getQuery, parseQuery } from 'api/queries/ibmQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { tagPrefix } from 'api/queries/query';
+import { noPrefix, tagPrefix } from 'api/queries/query';
 import type { IbmReport } from 'api/reports/ibmReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import type { AxiosError } from 'axios';
@@ -155,7 +155,12 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
     // Omit items labeled 'no-project'
     const items = [];
     selectedItems.map(item => {
-      if (!(item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`)) {
+      if (
+        !(
+          item.label?.toLowerCase() === `${noPrefix}${groupById}` ||
+          item.label?.toLowerCase() === `${noPrefix}${groupByTagKey}`
+        )
+      ) {
         items.push(item);
       }
     });

--- a/src/routes/views/details/ociDetails/detailsTable.tsx
+++ b/src/routes/views/details/ociDetails/detailsTable.tsx
@@ -1,5 +1,6 @@
 import 'routes/views/details/components/dataTable/dataTable.scss';
 
+import { noPrefix } from 'api/queries/query';
 import type { OciReport } from 'api/reports/ociReports';
 import { ReportPathsType } from 'api/reports/report';
 import messages from 'locales/messages';
@@ -121,7 +122,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       const cost = this.getTotalCost(item, index);
       const label = item && item.label !== null ? item.label : '';
       const monthOverMonth = this.getMonthOverMonthCost(item, index);
-      const isDisabled = label === `no-${groupBy}` || label === `no-${groupByTagKey}`;
+      const isDisabled =
+        label?.toLowerCase() === `${noPrefix}${groupBy}` || label?.toLowerCase() === `${noPrefix}${groupByTagKey}`;
       const desc = item.id && item.id !== item.label ? <div style={styles.infoDescription}>{item.id}</div> : null;
       const actions = this.getActions(item, isDisabled);
 

--- a/src/routes/views/details/ociDetails/ociDetails.tsx
+++ b/src/routes/views/details/ociDetails/ociDetails.tsx
@@ -4,7 +4,7 @@ import { ProviderType } from 'api/providers';
 import type { OciQuery } from 'api/queries/ociQuery';
 import { getQuery, parseQuery } from 'api/queries/ociQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { tagPrefix } from 'api/queries/query';
+import { noPrefix, tagPrefix } from 'api/queries/query';
 import type { OciReport } from 'api/reports/ociReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import type { AxiosError } from 'axios';
@@ -154,7 +154,12 @@ class OciDetails extends React.Component<OciDetailsProps> {
     // Omit items labeled 'no-project'
     const items = [];
     selectedItems.map(item => {
-      if (!(item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`)) {
+      if (
+        !(
+          item.label?.toLowerCase() === `${noPrefix}${groupById}` ||
+          item.label?.toLowerCase() === `${noPrefix}${groupByTagKey}`
+        )
+      ) {
         items.push(item);
       }
     });

--- a/src/routes/views/details/ocpDetails/detailsTable.tsx
+++ b/src/routes/views/details/ocpDetails/detailsTable.tsx
@@ -2,7 +2,12 @@ import 'routes/views/details/components/dataTable/dataTable.scss';
 
 import { Label } from '@patternfly/react-core';
 import { ProviderType } from 'api/providers';
-import { platformCategory, unallocatedPlatformCapacity, unallocatedWorkersCapacity } from 'api/queries/query';
+import {
+  noPrefix,
+  platformCategoryKey,
+  unallocatedPlatformCapacityKey,
+  unallocatedWorkersCapacityKey,
+} from 'api/queries/query';
 import type { OcpReport } from 'api/reports/ocpReports';
 import { ReportPathsType } from 'api/reports/report';
 import messages from 'locales/messages';
@@ -179,11 +184,15 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       const monthOverMonth = this.getMonthOverMonthCost(item, index);
       const supplementaryCost = this.getSupplementaryCost(item, index);
       const InfrastructureCost = this.getInfrastructureCost(item, index);
-      const isPlatformCosts = item.classification === 'category' && item.label === platformCategory;
+      const isPlatformCosts = item.classification === 'category' && item.label === platformCategoryKey;
       const isUnallocatedCosts =
-        item.label === unallocatedPlatformCapacity || item.label === unallocatedWorkersCapacity;
+        item.label?.toLowerCase() === unallocatedPlatformCapacityKey ||
+        item.label?.toLowerCase() === unallocatedWorkersCapacityKey;
       const desc = item.id && item.id !== item.label ? <div style={styles.infoDescription}>{item.id}</div> : null;
-      const isDisabled = label === `no-${groupBy}` || label === `no-${groupByTagKey}` || isUnallocatedCosts;
+      const isDisabled =
+        label?.toLowerCase() === `${noPrefix}${groupBy}` ||
+        label?.toLowerCase() === `${noPrefix}${groupByTagKey}` ||
+        isUnallocatedCosts;
       const actions = this.getActions(item, isDisabled);
 
       const name = isDisabled ? (

--- a/src/routes/views/details/ocpDetails/ocpDetails.tsx
+++ b/src/routes/views/details/ocpDetails/ocpDetails.tsx
@@ -4,7 +4,7 @@ import { ProviderType } from 'api/providers';
 import type { OcpQuery } from 'api/queries/ocpQuery';
 import { getQuery, parseQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { tagPrefix } from 'api/queries/query';
+import { noPrefix, tagPrefix } from 'api/queries/query';
 import type { OcpReport } from 'api/reports/ocpReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import type { AxiosError } from 'axios';
@@ -198,7 +198,12 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     // Omit items labeled 'no-project'
     const items = [];
     selectedItems.map(item => {
-      if (!(item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`)) {
+      if (
+        !(
+          item.label?.toLowerCase() === `${noPrefix}${groupById}` ||
+          item.label?.toLowerCase() === `${noPrefix}${groupByTagKey}`
+        )
+      ) {
         items.push(item);
       }
     });

--- a/src/routes/views/details/rhelDetails/detailsTable.tsx
+++ b/src/routes/views/details/rhelDetails/detailsTable.tsx
@@ -2,7 +2,12 @@ import 'routes/views/details/components/dataTable/dataTable.scss';
 
 import { Label } from '@patternfly/react-core';
 import { ProviderType } from 'api/providers';
-import { platformCategory, unallocatedPlatformCapacity, unallocatedWorkersCapacity } from 'api/queries/query';
+import {
+  noPrefix,
+  platformCategoryKey,
+  unallocatedPlatformCapacityKey,
+  unallocatedWorkersCapacityKey,
+} from 'api/queries/query';
 import { ReportPathsType } from 'api/reports/report';
 import type { RhelReport } from 'api/reports/rhelReports';
 import messages from 'locales/messages';
@@ -179,11 +184,15 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       const monthOverMonth = this.getMonthOverMonthCost(item, index);
       const supplementaryCost = this.getSupplementaryCost(item, index);
       const InfrastructureCost = this.getInfrastructureCost(item, index);
-      const isPlatformCosts = item.classification === 'category' && item.label === platformCategory;
+      const isPlatformCosts = item.classification === 'category' && item.label === platformCategoryKey;
       const isUnallocatedCosts =
-        item.label === unallocatedPlatformCapacity || item.label === unallocatedWorkersCapacity;
+        item.label?.toLowerCase() === unallocatedPlatformCapacityKey ||
+        item.label?.toLowerCase() === unallocatedWorkersCapacityKey;
       const desc = item.id && item.id !== item.label ? <div style={styles.infoDescription}>{item.id}</div> : null;
-      const isDisabled = label === `no-${groupBy}` || label === `no-${groupByTagKey}` || isUnallocatedCosts;
+      const isDisabled =
+        label?.toLowerCase() === `${noPrefix}${groupBy}` ||
+        label?.toLowerCase() === `${noPrefix}${groupByTagKey}` ||
+        isUnallocatedCosts;
       const actions = this.getActions(item, isDisabled);
 
       const name = isDisabled ? (

--- a/src/routes/views/details/rhelDetails/rhelDetails.tsx
+++ b/src/routes/views/details/rhelDetails/rhelDetails.tsx
@@ -4,7 +4,7 @@ import { ProviderType } from 'api/providers';
 import type { OcpQuery } from 'api/queries/ocpQuery';
 import { getQuery, parseQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { tagPrefix } from 'api/queries/query';
+import { noPrefix, tagPrefix } from 'api/queries/query';
 import type { OcpReport } from 'api/reports/ocpReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import type { AxiosError } from 'axios';
@@ -198,7 +198,12 @@ class RhelDetails extends React.Component<OcpDetailsProps> {
     // Omit items labeled 'no-project'
     const items = [];
     selectedItems.map(item => {
-      if (!(item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`)) {
+      if (
+        !(
+          item.label?.toLowerCase() === `${noPrefix}${groupById}` ||
+          item.label?.toLowerCase() === `${noPrefix}${groupByTagKey}`
+        )
+      ) {
         items.push(item);
       }
     });

--- a/src/routes/views/explorer/explorer.tsx
+++ b/src/routes/views/explorer/explorer.tsx
@@ -3,7 +3,7 @@ import type { Providers } from 'api/providers';
 import { ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import type { Query } from 'api/queries/query';
-import { getQuery, parseQuery } from 'api/queries/query';
+import { getQuery, noPrefix, parseQuery } from 'api/queries/query';
 import { orgUnitIdKey, tagPrefix } from 'api/queries/query';
 import { getUserAccessQuery } from 'api/queries/userAccessQuery';
 import type { Report } from 'api/reports/report';
@@ -183,7 +183,12 @@ class Explorer extends React.Component<ExplorerProps> {
     // Omit items labeled 'no-project'
     const items = [];
     selectedItems.map(item => {
-      if (!(item.label === `no-${groupById}` || item.label === `no-${groupByTagKey}`)) {
+      if (
+        !(
+          item.label?.toLowerCase() === `${noPrefix}${groupById}` ||
+          item.label?.toLowerCase() === `${noPrefix}${groupByTagKey}`
+        )
+      ) {
         items.push(item);
       }
     });

--- a/src/routes/views/explorer/explorerTable.tsx
+++ b/src/routes/views/explorer/explorerTable.tsx
@@ -14,7 +14,7 @@ import {
   Tr,
 } from '@patternfly/react-table';
 import type { Query } from 'api/queries/query';
-import { parseQuery } from 'api/queries/query';
+import { noPrefix, parseQuery } from 'api/queries/query';
 import type { Report } from 'api/reports/report';
 import { format } from 'date-fns';
 import messages from 'locales/messages';
@@ -235,7 +235,9 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps> {
 
       rows.push({
         cells,
-        selectionDisabled: selectItem.label === `no-${groupBy}` || selectItem.label === `no-${groupByTagKey}`,
+        selectionDisabled:
+          selectItem.label?.toLowerCase() === `${noPrefix}${groupBy}` ||
+          selectItem.label?.toLowerCase() === `${noPrefix}${groupByTagKey}`,
         item: selectItem,
         selected: isAllSelected || (selectedItems && selectedItems.find(val => val.id === selectItem.id) !== undefined),
       });

--- a/src/routes/views/utils/paths.ts
+++ b/src/routes/views/utils/paths.ts
@@ -1,5 +1,5 @@
 import type { Query } from 'api/queries/query';
-import { getQueryRoute, platformCategory } from 'api/queries/query';
+import { getQueryRoute, platformCategoryKey } from 'api/queries/query';
 import { breakdownDescKey, breakdownTitleKey, orgUnitIdKey } from 'api/queries/query';
 import { parseQuery } from 'api/queries/query';
 import type { RouteComponentProps } from 'utils/router';
@@ -32,7 +32,7 @@ export const getBreakdownPath = ({
     if (!newQuery.filter) {
       newQuery.filter = {};
     }
-    newQuery.filter.category = platformCategory;
+    newQuery.filter.category = platformCategoryKey;
   }
   return `${basePath}?${getQueryRoute(newQuery)}`;
 };
@@ -83,5 +83,5 @@ export const getOrgBreakdownPath = ({
 };
 
 export const isPlatformCosts = (queryFromRoute: Query) => {
-  return queryFromRoute && queryFromRoute.filter && queryFromRoute.filter.category === platformCategory;
+  return queryFromRoute && queryFromRoute.filter && queryFromRoute.filter.category === platformCategoryKey;
 };


### PR DESCRIPTION
The cost APIs are renaming a few labels in which are displayed the details table. The UI must be updated to match the strings below.

- no-\<something> =>  No-\<something>
- Platform Unallocated Capacity => Platform unallocated
- Workers Unallocated Capacity => Workers unallocated

https://issues.redhat.com/browse/COST-3335