### PR TITLE
Filtering of cost models by source type doesn't work

### DIFF
--- a/src/routes/costModels/costModelsDetails/utils/filters.tsx
+++ b/src/routes/costModels/costModelsDetails/utils/filters.tsx
@@ -275,6 +275,7 @@ const sourceTypeFilterMergeProps = (
     filterType,
     intl,
     query,
+    router,
   };
 };
 


### PR DESCRIPTION
Fixes a missing router property

https://issues.redhat.com/browse/COST-3340