### PR TITLE
Use new project classifications

### DIFF
--- a/src/api/queries/query.ts
+++ b/src/api/queries/query.ts
@@ -1,18 +1,5 @@
 import { parse, stringify } from 'qs';
-
-export const logicalOrPrefix = 'or:'; // logical OR prefix for group_by
-export const logicalAndPrefix = 'and:'; // logical AND prefix for group_by
-export const noPrefix = 'No-'; // no-project, no-region, no-<tag>
-export const tagPrefix = 'tag:'; // Tag prefix for group_by
-
-export const breakdownDescKey = 'breakdown_desc'; // Used to display a description in the breakdown header
-export const breakdownTitleKey = 'breakdown_title'; // Used to display a title in the breakdown header
-export const orgUnitIdKey = 'org_unit_id'; // Org unit ID for group_by
-export const orgUnitNameKey = 'org_unit_name'; // Org unit name for group_by
-export const platformCategoryKey = 'Platform'; // Used to display platform costs
-export const tagKey = 'tag'; // Tag key for group_by
-export const unallocatedPlatformCapacityKey = 'Platform unallocated'; // Unallocated platform costs
-export const unallocatedWorkerCapacityKey = 'Worker unallocated'; // Unallocated workers costs
+import { logicalAndPrefix, logicalOrPrefix } from 'utils/props';
 
 export interface Filters {
   category?: string;

--- a/src/routes/views/components/dataToolbar/dataToolbar.tsx
+++ b/src/routes/views/components/dataToolbar/dataToolbar.tsx
@@ -27,7 +27,6 @@ import { FilterIcon } from '@patternfly/react-icons/dist/esm/icons/filter-icon';
 import { SearchIcon } from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import type { Org } from 'api/orgs/org';
 import type { Query } from 'api/queries/query';
-import { orgUnitIdKey, orgUnitNameKey, platformCategoryKey, tagKey, tagPrefix } from 'api/queries/query';
 import type { ResourcePathsType, ResourceType } from 'api/resources/resource';
 import { isResourceTypeValid } from 'api/resources/resourceUtils';
 import type { Tag } from 'api/tags/tag';
@@ -45,6 +44,7 @@ import { createMapStateToProps } from 'store/common';
 import { featureFlagsSelectors } from 'store/featureFlags';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { isEqual } from 'utils/equal';
+import { orgUnitIdKey, orgUnitNameKey, platformCategoryKey, tagKey, tagPrefix } from 'utils/props';
 
 import { DataKebab } from './dataKebab';
 import { styles } from './dataToolbar.styles';

--- a/src/routes/views/components/dataToolbar/tagValue.tsx
+++ b/src/routes/views/components/dataToolbar/tagValue.tsx
@@ -10,7 +10,7 @@ import {
 } from '@patternfly/react-core';
 import { SearchIcon } from '@patternfly/react-icons/dist/esm/icons/search-icon';
 import type { Query } from 'api/queries/query';
-import { getQuery, orgUnitIdKey, parseQuery } from 'api/queries/query';
+import { getQuery, parseQuery } from 'api/queries/query';
 import type { Tag, TagPathsType } from 'api/tags/tag';
 import { TagType } from 'api/tags/tag';
 import { intl } from 'components/i18n';
@@ -22,6 +22,7 @@ import { connect } from 'react-redux';
 import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'routes/views/utils/groupBy';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
+import { orgUnitIdKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/components/export/exportModal.tsx
+++ b/src/routes/views/components/export/exportModal.tsx
@@ -11,7 +11,6 @@ import {
   Radio,
   TextInput,
 } from '@patternfly/react-core';
-import { tagPrefix } from 'api/queries/query';
 import type { ReportPathsType } from 'api/reports/report';
 import type { AxiosError } from 'axios';
 import { format } from 'date-fns';
@@ -24,6 +23,7 @@ import { connect } from 'react-redux';
 import { createMapStateToProps } from 'store/common';
 import { featureFlagsSelectors } from 'store/featureFlags';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
+import { tagPrefix } from 'utils/props';
 
 import { styles } from './exportModal.styles';
 import { ExportSubmit } from './exportSubmit';

--- a/src/routes/views/components/export/exportSubmit.tsx
+++ b/src/routes/views/components/export/exportSubmit.tsx
@@ -2,7 +2,7 @@ import { Button, ButtonVariant } from '@patternfly/react-core';
 import type { Export } from 'api/export/export';
 import type { Query } from 'api/queries/query';
 import { parseQuery } from 'api/queries/query';
-import { getQuery, orgUnitIdKey, tagPrefix } from 'api/queries/query';
+import { getQuery } from 'api/queries/query';
 import type { ReportPathsType } from 'api/reports/report';
 import { ReportType } from 'api/reports/report';
 import type { AxiosError } from 'axios';
@@ -19,6 +19,7 @@ import { exportActions, exportSelectors } from 'store/export';
 import { featureFlagsSelectors } from 'store/featureFlags';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { getToday } from 'utils/dates';
+import { orgUnitIdKey, tagPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/components/groupBy/groupBy.tsx
+++ b/src/routes/views/components/groupBy/groupBy.tsx
@@ -3,7 +3,7 @@ import { Select, SelectOption, SelectVariant, Title } from '@patternfly/react-co
 import type { Org, OrgPathsType } from 'api/orgs/org';
 import { OrgType } from 'api/orgs/org';
 import type { Query } from 'api/queries/query';
-import { getQuery, orgUnitIdKey, parseQuery, tagKey, tagPrefix } from 'api/queries/query';
+import { getQuery, parseQuery } from 'api/queries/query';
 import type { Tag, TagPathsType } from 'api/tags/tag';
 import { TagType } from 'api/tags/tag';
 import messages from 'locales/messages';
@@ -16,6 +16,7 @@ import { getDateRangeFromQuery } from 'routes/views/utils/dateRange';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { orgActions, orgSelectors } from 'store/orgs';
 import { tagActions, tagSelectors } from 'store/tags';
+import { orgUnitIdKey, tagKey, tagPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/components/groupBy/groupByOrg.tsx
+++ b/src/routes/views/components/groupBy/groupByOrg.tsx
@@ -2,11 +2,12 @@ import type { SelectOptionObject } from '@patternfly/react-core';
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import type { Org } from 'api/orgs/org';
 import type { Query } from 'api/queries/query';
-import { orgUnitIdKey, orgUnitNameKey, parseQuery } from 'api/queries/query';
+import { parseQuery } from 'api/queries/query';
 import messages from 'locales/messages';
 import React from 'react';
 import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
+import { orgUnitIdKey, orgUnitNameKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/components/groupBy/groupByTag.tsx
+++ b/src/routes/views/components/groupBy/groupByTag.tsx
@@ -1,12 +1,13 @@
 import { Select, SelectOption, SelectVariant } from '@patternfly/react-core';
 import type { Query } from 'api/queries/query';
-import { parseQuery, tagPrefix } from 'api/queries/query';
+import { parseQuery } from 'api/queries/query';
 import type { Tag } from 'api/tags/tag';
 import messages from 'locales/messages';
 import { uniq, uniqBy } from 'lodash';
 import React from 'react';
 import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
+import { tagPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
@@ -3,7 +3,6 @@ import { ProviderType } from 'api/providers';
 import { getQuery, parseQuery } from 'api/queries/awsQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import type { Query } from 'api/queries/query';
-import { breakdownDescKey, breakdownTitleKey, logicalAndPrefix, orgUnitIdKey } from 'api/queries/query';
 import type { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { TagPathsType } from 'api/tags/tag';
@@ -24,6 +23,7 @@ import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCostType } from 'utils/costType';
 import { getCurrency } from 'utils/localStorage';
+import { breakdownDescKey, breakdownTitleKey, logicalAndPrefix, orgUnitIdKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/awsDetails/awsDetails.tsx
+++ b/src/routes/views/details/awsDetails/awsDetails.tsx
@@ -6,7 +6,6 @@ import { ProviderType } from 'api/providers';
 import type { AwsQuery } from 'api/queries/awsQuery';
 import { getQuery, parseQuery } from 'api/queries/awsQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { noPrefix, orgUnitIdKey, tagPrefix } from 'api/queries/query';
 import type { AwsReport } from 'api/reports/awsReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import type { AxiosError } from 'axios';
@@ -42,6 +41,7 @@ import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputed
 import type { CostTypes } from 'utils/costType';
 import { getCostType } from 'utils/costType';
 import { getCurrency } from 'utils/localStorage';
+import { noPrefix, orgUnitIdKey, tagPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/awsDetails/detailsTable.tsx
+++ b/src/routes/views/details/awsDetails/detailsTable.tsx
@@ -1,6 +1,5 @@
 import 'routes/views/details/components/dataTable/dataTable.scss';
 
-import { noPrefix } from 'api/queries/query';
 import type { AwsReport } from 'api/reports/awsReports';
 import { ReportPathsType } from 'api/reports/report';
 import messages from 'locales/messages';
@@ -18,6 +17,7 @@ import type { ComputedReportItem } from 'utils/computedReport/getComputedReportI
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dates';
 import { formatCurrency, formatPercentage } from 'utils/format';
+import { noPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/awsDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/awsDetails/detailsToolbar.tsx
@@ -2,7 +2,7 @@ import type { ToolbarChipGroup } from '@patternfly/react-core';
 import type { Org } from 'api/orgs/org';
 import { OrgPathsType, OrgType } from 'api/orgs/org';
 import type { AwsQuery } from 'api/queries/awsQuery';
-import { getQuery, orgUnitIdKey, tagKey } from 'api/queries/query';
+import { getQuery } from 'api/queries/query';
 import { ResourcePathsType } from 'api/resources/resource';
 import type { Tag } from 'api/tags/tag';
 import { TagPathsType, TagType } from 'api/tags/tag';
@@ -18,6 +18,7 @@ import { orgActions, orgSelectors } from 'store/orgs';
 import { tagActions, tagSelectors } from 'store/tags';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { isEqual } from 'utils/equal';
+import { orgUnitIdKey, tagKey } from 'utils/props';
 
 interface DetailsToolbarOwnProps {
   isAllSelected?: boolean;

--- a/src/routes/views/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/routes/views/details/azureBreakdown/azureBreakdown.tsx
@@ -3,7 +3,6 @@ import { ProviderType } from 'api/providers';
 import { getQuery, parseQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import type { Query } from 'api/queries/query';
-import { breakdownDescKey } from 'api/queries/query';
 import type { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { TagPathsType } from 'api/tags/tag';
@@ -23,6 +22,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCurrency } from 'utils/localStorage';
+import { breakdownDescKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/azureDetails/azureDetails.tsx
+++ b/src/routes/views/details/azureDetails/azureDetails.tsx
@@ -4,7 +4,6 @@ import { ProviderType } from 'api/providers';
 import type { AzureQuery } from 'api/queries/azureQuery';
 import { getQuery, parseQuery } from 'api/queries/azureQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { noPrefix, tagPrefix } from 'api/queries/query';
 import type { AzureReport } from 'api/reports/azureReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import type { AxiosError } from 'axios';
@@ -37,6 +36,7 @@ import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedAzureReportI
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getCurrency } from 'utils/localStorage';
+import { noPrefix, tagPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/azureDetails/detailsTable.tsx
+++ b/src/routes/views/details/azureDetails/detailsTable.tsx
@@ -1,6 +1,5 @@
 import 'routes/views/details/components/dataTable/dataTable.scss';
 
-import { noPrefix } from 'api/queries/query';
 import type { AzureReport } from 'api/reports/azureReports';
 import { ReportPathsType } from 'api/reports/report';
 import messages from 'locales/messages';
@@ -18,6 +17,7 @@ import type { ComputedReportItem } from 'utils/computedReport/getComputedReportI
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dates';
 import { formatCurrency, formatPercentage } from 'utils/format';
+import { noPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/azureDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/azureDetails/detailsToolbar.tsx
@@ -1,7 +1,6 @@
 import type { ToolbarChipGroup } from '@patternfly/react-core';
 import type { AzureQuery } from 'api/queries/azureQuery';
 import { getQuery } from 'api/queries/azureQuery';
-import { tagKey } from 'api/queries/query';
 import { ResourcePathsType } from 'api/resources/resource';
 import type { AzureTag } from 'api/tags/azureTags';
 import { TagPathsType, TagType } from 'api/tags/tag';
@@ -16,6 +15,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { isEqual } from 'utils/equal';
+import { tagKey } from 'utils/props';
 
 interface DetailsToolbarOwnProps {
   isAllSelected?: boolean;

--- a/src/routes/views/details/components/actions/actions.tsx
+++ b/src/routes/views/details/components/actions/actions.tsx
@@ -1,6 +1,5 @@
 import { Dropdown, DropdownItem, KebabToggle } from '@patternfly/react-core';
 import type { ProviderType } from 'api/providers';
-import { tagPrefix } from 'api/queries/query';
 import type { ReportPathsType } from 'api/reports/report';
 import messages from 'locales/messages';
 import React from 'react';
@@ -11,6 +10,7 @@ import { ExportModal } from 'routes/views/components/export';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions } from 'store/costModels';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
+import { tagPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/components/breakdown/breakdownHeader.tsx
+++ b/src/routes/views/details/components/breakdown/breakdownHeader.tsx
@@ -3,7 +3,7 @@ import './breakdownHeader.scss';
 import { Title, TitleSizes } from '@patternfly/react-core';
 import { AngleLeftIcon } from '@patternfly/react-icons/dist/esm/icons/angle-left-icon';
 import type { Query } from 'api/queries/query';
-import { breakdownDescKey, breakdownTitleKey, getQueryRoute, orgUnitIdKey } from 'api/queries/query';
+import { getQueryRoute } from 'api/queries/query';
 import type { Report } from 'api/reports/report';
 import type { TagPathsType } from 'api/tags/tag';
 import messages from 'locales/messages';
@@ -21,6 +21,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import type { CostTypes } from 'utils/costType';
 import { getTotalCostDateRangeString } from 'utils/dates';
 import { formatCurrency } from 'utils/format';
+import { breakdownDescKey, breakdownTitleKey, orgUnitIdKey } from 'utils/props';
 
 import { styles } from './breakdownHeader.styles';
 

--- a/src/routes/views/details/components/cluster/cluster.tsx
+++ b/src/routes/views/details/components/cluster/cluster.tsx
@@ -1,10 +1,10 @@
-import { platformCategoryKey } from 'api/queries/query';
 import type { Report } from 'api/reports/report';
 import messages from 'locales/messages';
 import React from 'react';
 import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
 import { getComputedReportItems } from 'utils/computedReport/getComputedReportItems';
+import { platformCategoryKey } from 'utils/props';
 
 import { styles } from './cluster.styles';
 import { ClusterModal } from './clusterModal';

--- a/src/routes/views/details/components/costOverview/costOverviewBase.tsx
+++ b/src/routes/views/details/components/costOverview/costOverviewBase.tsx
@@ -12,7 +12,6 @@ import {
 } from '@patternfly/react-core';
 import { OutlinedQuestionCircleIcon } from '@patternfly/react-icons/dist/esm/icons/outlined-question-circle-icon';
 import type { Query } from 'api/queries/query';
-import { orgUnitIdKey, platformCategoryKey, tagPrefix } from 'api/queries/query';
 import type { Report } from 'api/reports/report';
 import messages from 'locales/messages';
 import React from 'react';
@@ -25,6 +24,7 @@ import { UsageChart } from 'routes/views/details/components/usageChart';
 import { styles } from 'routes/views/details/ocpDetails/detailsHeader.styles';
 import type { CostOverviewWidget } from 'store/breakdown/costOverview/common/costOverviewCommon';
 import { CostOverviewWidgetType } from 'store/breakdown/costOverview/common/costOverviewCommon';
+import { orgUnitIdKey, platformCategoryKey, tagPrefix } from 'utils/props';
 
 interface CostOverviewOwnProps {
   costType?: string;

--- a/src/routes/views/details/components/historicalData/historicalDataTrendChart.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataTrendChart.tsx
@@ -1,6 +1,6 @@
 import { Skeleton } from '@patternfly/react-core';
 import type { Query } from 'api/queries/query';
-import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery } from 'api/queries/query';
+import { getQuery, parseQuery } from 'api/queries/query';
 import type { Report, ReportPathsType } from 'api/reports/report';
 import { ReportType } from 'api/reports/report';
 import messages from 'locales/messages';
@@ -14,6 +14,7 @@ import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'routes/views/
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
 import { formatUnits, unitsLookupKey } from 'utils/format';
+import { logicalAndPrefix, orgUnitIdKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 import { skeletonWidth } from 'utils/skeleton';

--- a/src/routes/views/details/components/historicalData/historicalDataUsageChart.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataUsageChart.tsx
@@ -1,6 +1,6 @@
 import { Skeleton } from '@patternfly/react-core';
 import type { Query } from 'api/queries/query';
-import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery } from 'api/queries/query';
+import { getQuery, parseQuery } from 'api/queries/query';
 import type { Report, ReportPathsType } from 'api/reports/report';
 import { ReportType } from 'api/reports/report';
 import messages from 'locales/messages';
@@ -14,6 +14,7 @@ import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'routes/views/
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
 import { formatUnits, unitsLookupKey } from 'utils/format';
+import { logicalAndPrefix, orgUnitIdKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 import { skeletonWidth } from 'utils/skeleton';

--- a/src/routes/views/details/components/summary/summaryCard.tsx
+++ b/src/routes/views/details/components/summary/summaryCard.tsx
@@ -11,7 +11,7 @@ import {
   TitleSizes,
 } from '@patternfly/react-core';
 import type { Query } from 'api/queries/query';
-import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, platformCategoryKey } from 'api/queries/query';
+import { getQuery, parseQuery } from 'api/queries/query';
 import type { OcpReport } from 'api/reports/ocpReports';
 import type { ReportPathsType, ReportType } from 'api/reports/report';
 import messages from 'locales/messages';
@@ -25,6 +25,7 @@ import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'routes/views/
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getComputedReportItems } from 'utils/computedReport/getComputedReportItems';
+import { logicalAndPrefix, orgUnitIdKey, platformCategoryKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 import { skeletonWidth } from 'utils/skeleton';

--- a/src/routes/views/details/components/summary/summaryModalContent.tsx
+++ b/src/routes/views/details/components/summary/summaryModalContent.tsx
@@ -1,6 +1,6 @@
 import { Title, TitleSizes } from '@patternfly/react-core';
 import type { Query } from 'api/queries/query';
-import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery } from 'api/queries/query';
+import { getQuery, parseQuery } from 'api/queries/query';
 import type { Report, ReportPathsType } from 'api/reports/report';
 import { ReportType } from 'api/reports/report';
 import messages from 'locales/messages';
@@ -14,6 +14,7 @@ import type { FetchStatus } from 'store/common';
 import { createMapStateToProps } from 'store/common';
 import { reportActions, reportSelectors } from 'store/reports';
 import { formatCurrency } from 'utils/format';
+import { logicalAndPrefix, orgUnitIdKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/components/tag/tagLink.tsx
+++ b/src/routes/views/details/components/tag/tagLink.tsx
@@ -1,6 +1,6 @@
 import { TagIcon } from '@patternfly/react-icons/dist/esm/icons/tag-icon';
 import type { Query } from 'api/queries/query';
-import { getQuery, logicalAndPrefix, orgUnitIdKey, parseQuery, tagPrefix } from 'api/queries/query';
+import { getQuery, parseQuery } from 'api/queries/query';
 import type { Tag, TagPathsType } from 'api/tags/tag';
 import { TagType } from 'api/tags/tag';
 import React from 'react';
@@ -11,6 +11,7 @@ import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'routes/views/
 import type { FetchStatus } from 'store/common';
 import { createMapStateToProps } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
+import { logicalAndPrefix, orgUnitIdKey, tagPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/components/tag/tagModal.tsx
+++ b/src/routes/views/details/components/tag/tagModal.tsx
@@ -1,13 +1,6 @@
 import { Modal } from '@patternfly/react-core';
 import type { Query } from 'api/queries/query';
-import {
-  getQuery,
-  logicalAndPrefix,
-  orgUnitIdKey,
-  parseQuery,
-  platformCategoryKey,
-  tagPrefix,
-} from 'api/queries/query';
+import { getQuery, parseQuery } from 'api/queries/query';
 import type { Tag, TagPathsType } from 'api/tags/tag';
 import { TagType } from 'api/tags/tag';
 import messages from 'locales/messages';
@@ -20,6 +13,7 @@ import { isPlatformCosts } from 'routes/views/utils/paths';
 import type { FetchStatus } from 'store/common';
 import { createMapStateToProps } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
+import { logicalAndPrefix, orgUnitIdKey, platformCategoryKey, tagPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/gcpBreakdown/gcpBreakdown.tsx
+++ b/src/routes/views/details/gcpBreakdown/gcpBreakdown.tsx
@@ -4,7 +4,6 @@ import type { GcpQuery } from 'api/queries/gcpQuery';
 import { getQuery, parseQuery } from 'api/queries/gcpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import type { Query } from 'api/queries/query';
-import { breakdownDescKey, breakdownTitleKey } from 'api/queries/query';
 import type { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { TagPathsType } from 'api/tags/tag';
@@ -24,6 +23,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCurrency } from 'utils/localStorage';
+import { breakdownDescKey, breakdownTitleKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/gcpDetails/detailsTable.tsx
+++ b/src/routes/views/details/gcpDetails/detailsTable.tsx
@@ -1,6 +1,5 @@
 import 'routes/views/details/components/dataTable/dataTable.scss';
 
-import { noPrefix } from 'api/queries/query';
 import type { GcpReport } from 'api/reports/gcpReports';
 import { ReportPathsType } from 'api/reports/report';
 import messages from 'locales/messages';
@@ -18,6 +17,7 @@ import type { ComputedReportItem } from 'utils/computedReport/getComputedReportI
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dates';
 import { formatCurrency, formatPercentage } from 'utils/format';
+import { noPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/gcpDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/gcpDetails/detailsToolbar.tsx
@@ -1,7 +1,6 @@
 import type { ToolbarChipGroup } from '@patternfly/react-core';
 import type { GcpQuery } from 'api/queries/gcpQuery';
 import { getQuery } from 'api/queries/gcpQuery';
-import { tagKey } from 'api/queries/query';
 import { ResourcePathsType } from 'api/resources/resource';
 import type { Tag } from 'api/tags/tag';
 import { TagPathsType, TagType } from 'api/tags/tag';
@@ -16,6 +15,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { isEqual } from 'utils/equal';
+import { tagKey } from 'utils/props';
 
 interface DetailsToolbarOwnProps {
   isAllSelected?: boolean;

--- a/src/routes/views/details/gcpDetails/gcpDetails.tsx
+++ b/src/routes/views/details/gcpDetails/gcpDetails.tsx
@@ -4,7 +4,6 @@ import { ProviderType } from 'api/providers';
 import type { GcpQuery } from 'api/queries/gcpQuery';
 import { getQuery, parseQuery } from 'api/queries/gcpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { noPrefix, tagPrefix } from 'api/queries/query';
 import type { GcpReport } from 'api/reports/gcpReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import type { AxiosError } from 'axios';
@@ -37,6 +36,7 @@ import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedGcpReportIte
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getCurrency } from 'utils/localStorage';
+import { noPrefix, tagPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/ibmBreakdown/ibmBreakdown.tsx
+++ b/src/routes/views/details/ibmBreakdown/ibmBreakdown.tsx
@@ -4,7 +4,6 @@ import type { IbmQuery } from 'api/queries/ibmQuery';
 import { getQuery, parseQuery } from 'api/queries/ibmQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import type { Query } from 'api/queries/query';
-import { breakdownDescKey, breakdownTitleKey } from 'api/queries/query';
 import type { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { TagPathsType } from 'api/tags/tag';
@@ -24,6 +23,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCurrency } from 'utils/localStorage';
+import { breakdownDescKey, breakdownTitleKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/ibmDetails/detailsTable.tsx
+++ b/src/routes/views/details/ibmDetails/detailsTable.tsx
@@ -1,6 +1,5 @@
 import 'routes/views/details/components/dataTable/dataTable.scss';
 
-import { noPrefix } from 'api/queries/query';
 import type { IbmReport } from 'api/reports/ibmReports';
 import { ReportPathsType } from 'api/reports/report';
 import messages from 'locales/messages';
@@ -18,6 +17,7 @@ import type { ComputedReportItem } from 'utils/computedReport/getComputedReportI
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dates';
 import { formatCurrency, formatPercentage } from 'utils/format';
+import { noPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/ibmDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/ibmDetails/detailsToolbar.tsx
@@ -1,7 +1,6 @@
 import type { ToolbarChipGroup } from '@patternfly/react-core';
 import type { IbmQuery } from 'api/queries/ibmQuery';
 import { getQuery } from 'api/queries/ibmQuery';
-import { tagKey } from 'api/queries/query';
 import { ResourcePathsType } from 'api/resources/resource';
 import type { Tag } from 'api/tags/tag';
 import { TagPathsType, TagType } from 'api/tags/tag';
@@ -16,6 +15,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { isEqual } from 'utils/equal';
+import { tagKey } from 'utils/props';
 
 interface DetailsToolbarOwnProps {
   isAllSelected?: boolean;

--- a/src/routes/views/details/ibmDetails/ibmDetails.tsx
+++ b/src/routes/views/details/ibmDetails/ibmDetails.tsx
@@ -4,7 +4,6 @@ import { ProviderType } from 'api/providers';
 import type { IbmQuery } from 'api/queries/ibmQuery';
 import { getQuery, parseQuery } from 'api/queries/ibmQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { noPrefix, tagPrefix } from 'api/queries/query';
 import type { IbmReport } from 'api/reports/ibmReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import type { AxiosError } from 'axios';
@@ -38,6 +37,7 @@ import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedIbmReportIte
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getCurrency } from 'utils/localStorage';
+import { noPrefix, tagPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
+++ b/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
@@ -4,7 +4,6 @@ import type { OcpQuery } from 'api/queries/ocpQuery';
 import { getQuery, parseQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import type { Query } from 'api/queries/query';
-import { breakdownDescKey } from 'api/queries/query';
 import type { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { TagPathsType } from 'api/tags/tag';
@@ -24,6 +23,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCurrency } from 'utils/localStorage';
+import { breakdownDescKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/ociDetails/detailsTable.tsx
+++ b/src/routes/views/details/ociDetails/detailsTable.tsx
@@ -1,6 +1,5 @@
 import 'routes/views/details/components/dataTable/dataTable.scss';
 
-import { noPrefix } from 'api/queries/query';
 import type { OciReport } from 'api/reports/ociReports';
 import { ReportPathsType } from 'api/reports/report';
 import messages from 'locales/messages';
@@ -18,6 +17,7 @@ import type { ComputedReportItem } from 'utils/computedReport/getComputedReportI
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dates';
 import { formatCurrency, formatPercentage } from 'utils/format';
+import { noPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/ociDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/ociDetails/detailsToolbar.tsx
@@ -1,7 +1,6 @@
 import type { ToolbarChipGroup } from '@patternfly/react-core';
 import type { OciQuery } from 'api/queries/ociQuery';
 import { getQuery } from 'api/queries/ociQuery';
-import { tagKey } from 'api/queries/query';
 import { ResourcePathsType } from 'api/resources/resource';
 import type { OciTag } from 'api/tags/ociTags';
 import { TagPathsType, TagType } from 'api/tags/tag';
@@ -16,6 +15,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { isEqual } from 'utils/equal';
+import { tagKey } from 'utils/props';
 
 interface DetailsToolbarOwnProps {
   isAllSelected?: boolean;

--- a/src/routes/views/details/ociDetails/ociDetails.tsx
+++ b/src/routes/views/details/ociDetails/ociDetails.tsx
@@ -4,7 +4,6 @@ import { ProviderType } from 'api/providers';
 import type { OciQuery } from 'api/queries/ociQuery';
 import { getQuery, parseQuery } from 'api/queries/ociQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { noPrefix, tagPrefix } from 'api/queries/query';
 import type { OciReport } from 'api/reports/ociReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import type { AxiosError } from 'axios';
@@ -37,6 +36,7 @@ import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedOciReportIte
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getCurrency } from 'utils/localStorage';
+import { noPrefix, tagPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -2,7 +2,6 @@ import { ProviderType } from 'api/providers';
 import { getQuery, parseQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import type { Query } from 'api/queries/query';
-import { breakdownDescKey, breakdownTitleKey } from 'api/queries/query';
 import type { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { TagPathsType } from 'api/tags/tag';
@@ -23,6 +22,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCurrency } from 'utils/localStorage';
+import { breakdownDescKey, breakdownTitleKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/ocpDetails/detailsTable.tsx
+++ b/src/routes/views/details/ocpDetails/detailsTable.tsx
@@ -2,12 +2,6 @@ import 'routes/views/details/components/dataTable/dataTable.scss';
 
 import { Label } from '@patternfly/react-core';
 import { ProviderType } from 'api/providers';
-import {
-  noPrefix,
-  platformCategoryKey,
-  unallocatedPlatformCapacityKey,
-  unallocatedWorkerCapacityKey,
-} from 'api/queries/query';
 import type { OcpReport } from 'api/reports/ocpReports';
 import { ReportPathsType } from 'api/reports/report';
 import messages from 'locales/messages';
@@ -25,6 +19,7 @@ import type { ComputedReportItem } from 'utils/computedReport/getComputedReportI
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dates';
 import { formatCurrency, formatPercentage } from 'utils/format';
+import { classificationDefault, classificationPlatform, classificationUnallocated, noPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 
@@ -184,9 +179,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       const monthOverMonth = this.getMonthOverMonthCost(item, index);
       const supplementaryCost = this.getSupplementaryCost(item, index);
       const InfrastructureCost = this.getInfrastructureCost(item, index);
-      const isPlatformCosts = item.classification === 'category' && item.label === platformCategoryKey;
-      const isUnallocatedCosts =
-        item.label === unallocatedPlatformCapacityKey || item.label === unallocatedWorkerCapacityKey;
+      const isPlatformCosts = item.classification === classificationPlatform;
+      const isUnallocatedCosts = item.classification === classificationUnallocated;
       const desc = item.id && item.id !== item.label ? <div style={styles.infoDescription}>{item.id}</div> : null;
       const isDisabled =
         label === `${noPrefix}${groupBy}` || label === `${noPrefix}${groupByTagKey}` || isUnallocatedCosts;
@@ -222,15 +216,16 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           },
           {
             hidden: !showDefaultProject,
-            value: item.default_project ? (
-              <div>
-                <Label variant="outline" color="green">
-                  {intl.formatMessage(messages.default)}
-                </Label>
-              </div>
-            ) : (
-              <div style={styles.defaultLabel} />
-            ),
+            value:
+              item.classification === classificationDefault ? (
+                <div>
+                  <Label variant="outline" color="green">
+                    {intl.formatMessage(messages.default)}
+                  </Label>
+                </div>
+              ) : (
+                <div style={styles.defaultLabel} />
+              ),
           },
           { value: <div>{monthOverMonth}</div>, id: DetailsTableColumnIds.monthOverMonth },
           { value: <div>{InfrastructureCost}</div>, id: DetailsTableColumnIds.infrastructure },

--- a/src/routes/views/details/ocpDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/ocpDetails/detailsToolbar.tsx
@@ -1,7 +1,6 @@
 import type { ToolbarChipGroup } from '@patternfly/react-core';
 import type { OcpQuery } from 'api/queries/ocpQuery';
 import { getQuery } from 'api/queries/ocpQuery';
-import { tagKey } from 'api/queries/query';
 import { ResourcePathsType } from 'api/resources/resource';
 import type { OcpTag } from 'api/tags/ocpTags';
 import { TagPathsType, TagType } from 'api/tags/tag';
@@ -16,6 +15,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { isEqual } from 'utils/equal';
+import { tagKey } from 'utils/props';
 
 interface DetailsToolbarOwnProps {
   isAllSelected?: boolean;

--- a/src/routes/views/details/ocpDetails/ocpDetails.tsx
+++ b/src/routes/views/details/ocpDetails/ocpDetails.tsx
@@ -4,7 +4,6 @@ import { ProviderType } from 'api/providers';
 import type { OcpQuery } from 'api/queries/ocpQuery';
 import { getQuery, parseQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { noPrefix, platformCategoryKey, tagPrefix } from 'api/queries/query';
 import type { OcpReport } from 'api/reports/ocpReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import type { AxiosError } from 'axios';
@@ -40,6 +39,7 @@ import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedOcpReportIte
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getCurrency } from 'utils/localStorage';
+import { noPrefix, platformCategoryKey, tagPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/rhelBreakdown/rhelBreakdown.tsx
+++ b/src/routes/views/details/rhelBreakdown/rhelBreakdown.tsx
@@ -1,7 +1,6 @@
 import { ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import type { Query } from 'api/queries/query';
-import { breakdownDescKey, breakdownTitleKey } from 'api/queries/query';
 import { getQuery, parseQuery } from 'api/queries/rhelQuery';
 import type { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
@@ -23,6 +22,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCurrency } from 'utils/localStorage';
+import { breakdownDescKey, breakdownTitleKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/rhelDetails/detailsTable.tsx
+++ b/src/routes/views/details/rhelDetails/detailsTable.tsx
@@ -2,7 +2,6 @@ import 'routes/views/details/components/dataTable/dataTable.scss';
 
 import { Label } from '@patternfly/react-core';
 import { ProviderType } from 'api/providers';
-import { noPrefix } from 'api/queries/query';
 import { ReportPathsType } from 'api/reports/report';
 import type { RhelReport } from 'api/reports/rhelReports';
 import messages from 'locales/messages';
@@ -20,6 +19,7 @@ import type { ComputedReportItem } from 'utils/computedReport/getComputedReportI
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dates';
 import { formatCurrency, formatPercentage } from 'utils/format';
+import { noPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/details/rhelDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/rhelDetails/detailsToolbar.tsx
@@ -1,7 +1,6 @@
 import type { ToolbarChipGroup } from '@patternfly/react-core';
 import type { OcpQuery } from 'api/queries/ocpQuery';
 import { getQuery } from 'api/queries/ocpQuery';
-import { tagKey } from 'api/queries/query';
 import { ResourcePathsType } from 'api/resources/resource';
 import type { OcpTag } from 'api/tags/ocpTags';
 import { TagPathsType, TagType } from 'api/tags/tag';
@@ -16,6 +15,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { isEqual } from 'utils/equal';
+import { tagKey } from 'utils/props';
 
 interface DetailsToolbarOwnProps {
   isAllSelected?: boolean;

--- a/src/routes/views/details/rhelDetails/rhelDetails.tsx
+++ b/src/routes/views/details/rhelDetails/rhelDetails.tsx
@@ -4,7 +4,6 @@ import { ProviderType } from 'api/providers';
 import type { OcpQuery } from 'api/queries/ocpQuery';
 import { getQuery, parseQuery } from 'api/queries/ocpQuery';
 import { getProvidersQuery } from 'api/queries/providersQuery';
-import { noPrefix, platformCategoryKey, tagPrefix } from 'api/queries/query';
 import type { OcpReport } from 'api/reports/ocpReports';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import type { AxiosError } from 'axios';
@@ -40,6 +39,7 @@ import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedOcpReportIte
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getCurrency } from 'utils/localStorage';
+import { noPrefix, platformCategoryKey, tagPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/explorer/explorer.tsx
+++ b/src/routes/views/explorer/explorer.tsx
@@ -3,8 +3,7 @@ import type { Providers } from 'api/providers';
 import { ProviderType } from 'api/providers';
 import { getProvidersQuery } from 'api/queries/providersQuery';
 import type { Query } from 'api/queries/query';
-import { getQuery, noPrefix, parseQuery } from 'api/queries/query';
-import { orgUnitIdKey, tagPrefix } from 'api/queries/query';
+import { getQuery, parseQuery } from 'api/queries/query';
 import { getUserAccessQuery } from 'api/queries/userAccessQuery';
 import type { Report } from 'api/reports/report';
 import type { UserAccess } from 'api/userAccess';
@@ -45,6 +44,7 @@ import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputed
 import type { CostTypes } from 'utils/costType';
 import { getCostType } from 'utils/costType';
 import { getCurrency } from 'utils/localStorage';
+import { noPrefix, orgUnitIdKey, tagPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 import {

--- a/src/routes/views/explorer/explorerFilter.tsx
+++ b/src/routes/views/explorer/explorerFilter.tsx
@@ -2,7 +2,7 @@ import type { ToolbarChipGroup } from '@patternfly/react-core';
 import type { Org, OrgPathsType } from 'api/orgs/org';
 import { OrgType } from 'api/orgs/org';
 import type { Query } from 'api/queries/query';
-import { getQuery, orgUnitIdKey, parseQuery, tagKey } from 'api/queries/query';
+import { getQuery, parseQuery } from 'api/queries/query';
 import type { ResourcePathsType } from 'api/resources/resource';
 import type { Tag, TagPathsType } from 'api/tags/tag';
 import { TagType } from 'api/tags/tag';
@@ -21,6 +21,7 @@ import { orgActions, orgSelectors } from 'store/orgs';
 import { tagActions, tagSelectors } from 'store/tags';
 import { formatStartEndDate } from 'utils/dates';
 import { isEqual } from 'utils/equal';
+import { orgUnitIdKey, tagKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/explorer/explorerTable.tsx
+++ b/src/routes/views/explorer/explorerTable.tsx
@@ -14,7 +14,7 @@ import {
   Tr,
 } from '@patternfly/react-table';
 import type { Query } from 'api/queries/query';
-import { noPrefix, parseQuery } from 'api/queries/query';
+import { parseQuery } from 'api/queries/query';
 import type { Report } from 'api/reports/report';
 import { format } from 'date-fns';
 import messages from 'locales/messages';
@@ -29,6 +29,7 @@ import { createMapStateToProps } from 'store/common';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { formatCurrency } from 'utils/format';
+import { noPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 

--- a/src/routes/views/utils/groupBy.ts
+++ b/src/routes/views/utils/groupBy.ts
@@ -1,5 +1,5 @@
 import type { Query } from 'api/queries/query';
-import { orgUnitIdKey, tagPrefix } from 'api/queries/query';
+import { orgUnitIdKey, tagPrefix } from 'utils/props';
 
 export const getGroupById = (query: Query) => {
   const groupBys = query && query.group_by ? Object.keys(query.group_by) : [];

--- a/src/routes/views/utils/paths.ts
+++ b/src/routes/views/utils/paths.ts
@@ -1,7 +1,7 @@
 import type { Query } from 'api/queries/query';
-import { getQueryRoute, platformCategoryKey } from 'api/queries/query';
-import { breakdownDescKey, breakdownTitleKey, orgUnitIdKey } from 'api/queries/query';
+import { getQueryRoute } from 'api/queries/query';
 import { parseQuery } from 'api/queries/query';
+import { breakdownDescKey, breakdownTitleKey, orgUnitIdKey, platformCategoryKey } from 'utils/props';
 import type { RouteComponentProps } from 'utils/router';
 
 export const getBreakdownPath = ({

--- a/src/store/breakdown/costOverview/awsCostOverview/awsCostOverviewWidgets.ts
+++ b/src/store/breakdown/costOverview/awsCostOverview/awsCostOverviewWidgets.ts
@@ -1,6 +1,6 @@
-import { tagPrefix } from 'api/queries/query';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { CostOverviewWidgetType } from 'store/breakdown/costOverview/common/costOverviewCommon';
+import { tagPrefix } from 'utils/props';
 
 import type { AwsCostOverviewWidget } from './awsCostOverviewCommon';
 

--- a/src/store/breakdown/costOverview/azureCostOverview/azureCostOverviewWidgets.ts
+++ b/src/store/breakdown/costOverview/azureCostOverview/azureCostOverviewWidgets.ts
@@ -1,7 +1,7 @@
-import { tagPrefix } from 'api/queries/query';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import type { AzureCostOverviewWidget } from 'store/breakdown/costOverview/azureCostOverview';
 import { CostOverviewWidgetType } from 'store/breakdown/costOverview/common/costOverviewCommon';
+import { tagPrefix } from 'utils/props';
 
 let currrentId = 0;
 const getId = () => currrentId++;

--- a/src/store/breakdown/costOverview/gcpCostOverview/gcpCostOverviewWidgets.ts
+++ b/src/store/breakdown/costOverview/gcpCostOverview/gcpCostOverviewWidgets.ts
@@ -1,6 +1,6 @@
-import { tagPrefix } from 'api/queries/query';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { CostOverviewWidgetType } from 'store/breakdown/costOverview/common/costOverviewCommon';
+import { tagPrefix } from 'utils/props';
 
 import type { GcpCostOverviewWidget } from './gcpCostOverviewCommon';
 

--- a/src/store/breakdown/costOverview/ibmCostOverview/ibmCostOverviewWidgets.ts
+++ b/src/store/breakdown/costOverview/ibmCostOverview/ibmCostOverviewWidgets.ts
@@ -1,6 +1,6 @@
-import { tagPrefix } from 'api/queries/query';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { CostOverviewWidgetType } from 'store/breakdown/costOverview/common/costOverviewCommon';
+import { tagPrefix } from 'utils/props';
 
 import type { IbmCostOverviewWidget } from './ibmCostOverviewCommon';
 

--- a/src/store/breakdown/costOverview/ociCostOverview/ociCostOverviewWidgets.ts
+++ b/src/store/breakdown/costOverview/ociCostOverview/ociCostOverviewWidgets.ts
@@ -1,7 +1,7 @@
-import { tagPrefix } from 'api/queries/query';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { CostOverviewWidgetType } from 'store/breakdown/costOverview/common/costOverviewCommon';
 import type { OciCostOverviewWidget } from 'store/breakdown/costOverview/ociCostOverview';
+import { tagPrefix } from 'utils/props';
 
 let currrentId = 0;
 const getId = () => currrentId++;

--- a/src/store/breakdown/costOverview/ocpCostOverview/ocpCostOverviewWidgets.ts
+++ b/src/store/breakdown/costOverview/ocpCostOverview/ocpCostOverviewWidgets.ts
@@ -1,6 +1,6 @@
-import { platformCategoryKey } from 'api/queries/query';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { CostOverviewWidgetType } from 'store/breakdown/costOverview/common/costOverviewCommon';
+import { platformCategoryKey } from 'utils/props';
 
 import type { OcpCostOverviewWidget } from './ocpCostOverviewCommon';
 

--- a/src/store/breakdown/costOverview/rhelCostOverview/rhelCostOverviewWidgets.ts
+++ b/src/store/breakdown/costOverview/rhelCostOverview/rhelCostOverviewWidgets.ts
@@ -1,6 +1,6 @@
-import { platformCategoryKey } from 'api/queries/query';
 import { ReportPathsType, ReportType } from 'api/reports/report';
 import { CostOverviewWidgetType } from 'store/breakdown/costOverview/common/costOverviewCommon';
+import { platformCategoryKey } from 'utils/props';
 
 import type { RhelCostOverviewWidget } from './rhelCostOverviewCommon';
 

--- a/src/utils/computedReport/getItemLabel.ts
+++ b/src/utils/computedReport/getItemLabel.ts
@@ -1,4 +1,4 @@
-import { tagPrefix } from 'api/queries/query';
+import { tagPrefix } from 'utils/props';
 
 export interface GetItemLabelParams {
   idKey: any;

--- a/src/utils/props.ts
+++ b/src/utils/props.ts
@@ -1,0 +1,15 @@
+export const logicalOrPrefix = 'or:'; // logical OR prefix for group_by
+export const logicalAndPrefix = 'and:'; // logical AND prefix for group_by
+export const noPrefix = 'No-'; // no-project, no-region, no-<tag>
+export const tagPrefix = 'tag:'; // Tag prefix for group_by
+
+export const breakdownDescKey = 'breakdown_desc'; // Used to display a description in the breakdown header
+export const breakdownTitleKey = 'breakdown_title'; // Used to display a title in the breakdown header
+export const orgUnitIdKey = 'org_unit_id'; // Org unit ID for group_by
+export const orgUnitNameKey = 'org_unit_name'; // Org unit name for group_by
+export const platformCategoryKey = 'Platform'; // Used to display platform costs
+export const tagKey = 'tag'; // Tag key for group_by
+
+export const classificationDefault = 'default'; // Classification default costs
+export const classificationPlatform = 'category_Platform'; // Classification platform costs
+export const classificationUnallocated = 'unallocated'; // Classification for unallocated platform and worker costs


### PR DESCRIPTION
This updates the UI to use the new classifications provided by the cost APIs, instead of parsing project labels.
Also moved commonly used properties to `utils/props.ts`.

Summary of classifications:

- default for the projects that are kube- or openshift-
- category_<category_name> for the categories, so category_Platform for the Platform category
- unallocated for the Platform unallocated and Worker unallocated projects
- project for anything that does not fit any of the above criteria

https://issues.redhat.com/browse/COST-3347