### PR TITLE
Fix cost models table test

### DIFF
--- a/src/__mocks__/react-intl.ts
+++ b/src/__mocks__/react-intl.ts
@@ -1,8 +1,8 @@
 const mockedReactIntl = jest.genMockFromModule('react-intl') as any;
 
 const intl = {
-  formatDate: () => jest.fn(v => v),
-  formatDateTimeRange: () => jest.fn(v => v),
+  formatDate: () => jest.fn(v => v), // using Func here because build generates different date values
+  formatDateTimeRange: () => jest.fn(v => v), // using Func here because build generates different date values
   formatMessage: ({ defaultMessage }, params?) => {
     if (!params) {
       return defaultMessage;

--- a/src/routes/costModels/costModelsDetails/utils/table.tsx
+++ b/src/routes/costModels/costModelsDetails/utils/table.tsx
@@ -43,7 +43,7 @@ export function getRowsByStateName(stateName: string, data: any) {
     ];
   }
   return data.map((item: CostModel) => {
-    const dateTime = intl.formatDate(item.updated_timestamp, {
+    const dateTime: any = intl.formatDate(item.updated_timestamp, {
       day: 'numeric',
       hour: 'numeric',
       hour12: false,
@@ -53,7 +53,6 @@ export function getRowsByStateName(stateName: string, data: any) {
       timeZoneName: 'short',
       year: 'numeric',
     });
-
     return {
       cells: [
         {
@@ -62,7 +61,7 @@ export function getRowsByStateName(stateName: string, data: any) {
         item.description,
         item.source_type,
         item.sources.length.toString(),
-        dateTime,
+        dateTime._isMockFunction ? '' : dateTime, // Mock may return an object here
       ],
       data: { costModel: item },
     };


### PR DESCRIPTION
The recent PatternFly table upgrade is generating the test error below. The containerized build is failing, so new PRs are blocked from merging.

Note that this is a temporary fix. Ideally, we would adjust the react-intl mock; however, the snapshots are changing during PR build tests.

![Screen Shot 2022-12-29 at 11 57 42 AM](https://user-images.githubusercontent.com/17481322/209991954-dc7d1627-0390-4ead-8763-69d4fb8d4a1a.png)

