### PR TITLE
Breakdown page doesn't show all "platform" clusters

### DIFF
--- a/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
@@ -111,6 +111,8 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
       providersQueryString
     );
 
+    const title = queryFromRoute[breakdownTitleKey] ? queryFromRoute[breakdownTitleKey] : groupByValue;
+
     return {
       costOverviewComponent: (
         <CostOverview
@@ -119,6 +121,7 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
           groupBy={groupBy}
           query={queryFromRoute}
           report={report}
+          title={title}
         />
       ),
       costType,
@@ -142,7 +145,7 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, AwsBreakdown
       reportQueryString,
       showCostType: true,
       tagReportPathsType: TagPathsType.aws,
-      title: queryFromRoute[breakdownTitleKey] ? queryFromRoute[breakdownTitleKey] : groupByValue,
+      title,
     };
   }
 );

--- a/src/routes/views/details/awsBreakdown/costOverview.tsx
+++ b/src/routes/views/details/awsBreakdown/costOverview.tsx
@@ -1,5 +1,3 @@
-import type { WrappedComponentProps } from 'react-intl';
-import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { CostOverviewBase } from 'routes/views/details/components/costOverview';
 import { awsCostOverviewSelectors } from 'store/breakdown/costOverview/awsCostOverview';
@@ -9,16 +7,19 @@ interface CostOverviewStateProps {
   widgets: number[];
 }
 
-type CostOverviewOwnProps = WrappedComponentProps;
+interface CostOverviewOwnProps {
+  title?: string;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<CostOverviewOwnProps, CostOverviewStateProps>((state, props) => {
   return {
     selectWidgets: awsCostOverviewSelectors.selectWidgets(state),
     widgets: awsCostOverviewSelectors.selectCurrentWidgets(state),
+    title: props.title,
   };
 });
 
-const CostOverview = injectIntl(connect(mapStateToProps, {})(CostOverviewBase));
+const CostOverview = connect(mapStateToProps, {})(CostOverviewBase);
 
 export { CostOverview };

--- a/src/routes/views/details/awsBreakdown/historicalData.tsx
+++ b/src/routes/views/details/awsBreakdown/historicalData.tsx
@@ -1,5 +1,3 @@
-import type { WrappedComponentProps } from 'react-intl';
-import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { HistoricalDataBase } from 'routes/views/details/components/historicalData';
 import { awsHistoricalDataSelectors } from 'store/breakdown/historicalData/awsHistoricalData';
@@ -9,7 +7,9 @@ interface HistoricalDataStateProps {
   widgets: number[];
 }
 
-type HistoricalDataOwnProps = WrappedComponentProps;
+interface HistoricalDataOwnProps {
+  // TBD...
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, HistoricalDataStateProps>((state, props) => {
@@ -19,6 +19,6 @@ const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, Historical
   };
 });
 
-const HistoricalData = injectIntl(connect(mapStateToProps, {})(HistoricalDataBase));
+const HistoricalData = connect(mapStateToProps, {})(HistoricalDataBase);
 
 export { HistoricalData };

--- a/src/routes/views/details/azureBreakdown/costOverview.tsx
+++ b/src/routes/views/details/azureBreakdown/costOverview.tsx
@@ -1,5 +1,3 @@
-import type { WrappedComponentProps } from 'react-intl';
-import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { CostOverviewBase } from 'routes/views/details/components/costOverview';
 import { azureCostOverviewSelectors } from 'store/breakdown/costOverview/azureCostOverview';
@@ -9,7 +7,9 @@ interface CostOverviewStateProps {
   widgets: number[];
 }
 
-type CostOverviewOwnProps = WrappedComponentProps;
+interface CostOverviewOwnProps {
+  // TBD...
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<CostOverviewOwnProps, CostOverviewStateProps>((state, props) => {
@@ -19,6 +19,6 @@ const mapStateToProps = createMapStateToProps<CostOverviewOwnProps, CostOverview
   };
 });
 
-const CostOverview = injectIntl(connect(mapStateToProps, {})(CostOverviewBase));
+const CostOverview = connect(mapStateToProps, {})(CostOverviewBase);
 
 export { CostOverview };

--- a/src/routes/views/details/azureBreakdown/historicalData.tsx
+++ b/src/routes/views/details/azureBreakdown/historicalData.tsx
@@ -1,5 +1,3 @@
-import type { WrappedComponentProps } from 'react-intl';
-import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { HistoricalDataBase } from 'routes/views/details/components/historicalData';
 import { azureHistoricalDataSelectors } from 'store/breakdown/historicalData/azureHistoricalData';
@@ -9,7 +7,9 @@ interface HistoricalDataStateProps {
   widgets: number[];
 }
 
-type HistoricalDataOwnProps = WrappedComponentProps;
+interface HistoricalDataOwnProps {
+  // TBD...
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, HistoricalDataStateProps>((state, props) => {
@@ -19,6 +19,6 @@ const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, Historical
   };
 });
 
-const HistoricalData = injectIntl(connect(mapStateToProps, {})(HistoricalDataBase));
+const HistoricalData = connect(mapStateToProps, {})(HistoricalDataBase);
 
 export { HistoricalData };

--- a/src/routes/views/details/components/breakdown/breakdownHeader.tsx
+++ b/src/routes/views/details/components/breakdown/breakdownHeader.tsx
@@ -75,8 +75,8 @@ class BreakdownHeader extends React.Component<BreakdownHeaderProps> {
       newQuery.filter.account = undefined;
       newQuery.filter.category = undefined;
       newQuery[breakdownDescKey] = undefined;
-      newQuery[orgUnitIdKey] = undefined;
       newQuery[breakdownTitleKey] = undefined;
+      newQuery[orgUnitIdKey] = undefined;
     }
     return `${detailsURL}?${getQueryRoute(newQuery)}`;
   };

--- a/src/routes/views/details/components/cluster/clusterContent.tsx
+++ b/src/routes/views/details/components/cluster/clusterContent.tsx
@@ -1,22 +1,21 @@
 import React from 'react';
 import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
-import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 
 interface ClusterContentOwnProps {
-  item: ComputedReportItem;
+  clusters: string[];
 }
 
 type ClusterContentProps = ClusterContentOwnProps & WrappedComponentProps;
 
 class ClusterContentBase extends React.Component<ClusterContentProps> {
   public render() {
-    const { item } = this.props;
+    const { clusters = [] } = this.props;
 
-    if (!item.clusters) {
+    if (clusters.length === 0) {
       return null;
     }
-    return item.clusters.map((cluster, index) => <div key={`cluster-${index}`}>{cluster}</div>);
+    return clusters.map((cluster, index) => <div key={`cluster-${index}`}>{cluster}</div>);
   }
 }
 

--- a/src/routes/views/details/components/cluster/clusterModal.tsx
+++ b/src/routes/views/details/components/cluster/clusterModal.tsx
@@ -5,16 +5,16 @@ import messages from 'locales/messages';
 import React from 'react';
 import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
-import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 
 import { ClusterContent } from './clusterContent';
 import { styles } from './clusterModal.styles';
 
 interface ClusterModalOwnProps {
+  clusters: string[];
   groupBy: string;
   isOpen: boolean;
-  item: ComputedReportItem;
   onClose(isOpen: boolean);
+  title?: string;
 }
 
 type ClusterModalProps = ClusterModalOwnProps & WrappedComponentProps;
@@ -26,8 +26,8 @@ class ClusterModalBase extends React.Component<ClusterModalProps> {
   }
 
   public shouldComponentUpdate(nextProps: ClusterModalProps) {
-    const { isOpen, item } = this.props;
-    return nextProps.item !== item || nextProps.isOpen !== isOpen;
+    const { clusters, isOpen } = this.props;
+    return nextProps.clusters !== clusters || nextProps.isOpen !== isOpen;
   }
 
   private handleClose = () => {
@@ -35,7 +35,7 @@ class ClusterModalBase extends React.Component<ClusterModalProps> {
   };
 
   public render() {
-    const { groupBy, intl, isOpen, item } = this.props;
+    const { clusters, groupBy, intl, isOpen, title } = this.props;
 
     return (
       <Modal
@@ -45,11 +45,11 @@ class ClusterModalBase extends React.Component<ClusterModalProps> {
         onClose={this.handleClose}
         title={intl.formatMessage(messages.detailsClustersModalTitle, {
           groupBy,
-          name: item.label,
+          name: title,
         })}
         width={'50%'}
       >
-        <ClusterContent item={item} />
+        <ClusterContent clusters={clusters} />
       </Modal>
     );
   }

--- a/src/routes/views/details/components/costOverview/costOverviewBase.tsx
+++ b/src/routes/views/details/components/costOverview/costOverviewBase.tsx
@@ -37,6 +37,7 @@ interface CostOverviewOwnProps {
 
 interface CostOverviewStateProps {
   selectWidgets?: () => void;
+  title?: string;
   widgets: number[];
 }
 
@@ -47,7 +48,7 @@ const PLACEHOLDER = 'placeholder';
 class CostOverviewsBase extends React.Component<CostOverviewProps> {
   // Returns cluster chart
   private getClusterChart = (widget: CostOverviewWidget) => {
-    const { groupBy, intl, isPlatformCosts, report } = this.props;
+    const { groupBy, intl, report, title } = this.props;
 
     let showWidget = false;
     for (const groupById of widget.cluster.showWidgetOnGroupBy) {
@@ -65,7 +66,7 @@ class CostOverviewsBase extends React.Component<CostOverviewProps> {
             </Title>
           </CardTitle>
           <CardBody>
-            <Cluster groupBy={widget.cluster.reportGroupBy} isPlatformCosts={isPlatformCosts} report={report} />
+            <Cluster groupBy={widget.cluster.reportGroupBy} report={report} title={title} />
           </CardBody>
         </Card>
       );

--- a/src/routes/views/details/gcpBreakdown/costOverview.tsx
+++ b/src/routes/views/details/gcpBreakdown/costOverview.tsx
@@ -1,5 +1,3 @@
-import type { WrappedComponentProps } from 'react-intl';
-import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { CostOverviewBase } from 'routes/views/details/components/costOverview';
 import { gcpCostOverviewSelectors } from 'store/breakdown/costOverview/gcpCostOverview';
@@ -9,7 +7,9 @@ interface CostOverviewStateProps {
   widgets: number[];
 }
 
-type CostOverviewOwnProps = WrappedComponentProps;
+interface CostOverviewOwnProps {
+  // TBD...
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<CostOverviewOwnProps, CostOverviewStateProps>((state, props) => {
@@ -19,6 +19,6 @@ const mapStateToProps = createMapStateToProps<CostOverviewOwnProps, CostOverview
   };
 });
 
-const CostOverview = injectIntl(connect(mapStateToProps, {})(CostOverviewBase));
+const CostOverview = connect(mapStateToProps, {})(CostOverviewBase);
 
 export { CostOverview };

--- a/src/routes/views/details/gcpBreakdown/historicalData.tsx
+++ b/src/routes/views/details/gcpBreakdown/historicalData.tsx
@@ -1,5 +1,3 @@
-import type { WrappedComponentProps } from 'react-intl';
-import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { HistoricalDataBase } from 'routes/views/details/components/historicalData';
 import { gcpHistoricalDataSelectors } from 'store/breakdown/historicalData/gcpHistoricalData';
@@ -9,7 +7,9 @@ interface HistoricalDataStateProps {
   widgets: number[];
 }
 
-type HistoricalDataOwnProps = WrappedComponentProps;
+interface HistoricalDataOwnProps {
+  // TBD...
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, HistoricalDataStateProps>((state, props) => {
@@ -19,6 +19,6 @@ const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, Historical
   };
 });
 
-const HistoricalData = injectIntl(connect(mapStateToProps, {})(HistoricalDataBase));
+const HistoricalData = connect(mapStateToProps, {})(HistoricalDataBase);
 
 export { HistoricalData };

--- a/src/routes/views/details/ibmBreakdown/costOverview.tsx
+++ b/src/routes/views/details/ibmBreakdown/costOverview.tsx
@@ -1,5 +1,3 @@
-import type { WrappedComponentProps } from 'react-intl';
-import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { CostOverviewBase } from 'routes/views/details/components/costOverview';
 import { ibmCostOverviewSelectors } from 'store/breakdown/costOverview/ibmCostOverview';
@@ -9,7 +7,9 @@ interface CostOverviewStateProps {
   widgets: number[];
 }
 
-type CostOverviewOwnProps = WrappedComponentProps;
+interface CostOverviewOwnProps {
+  // TBD...
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<CostOverviewOwnProps, CostOverviewStateProps>((state, props) => {
@@ -19,6 +19,6 @@ const mapStateToProps = createMapStateToProps<CostOverviewOwnProps, CostOverview
   };
 });
 
-const CostOverview = injectIntl(connect(mapStateToProps, {})(CostOverviewBase));
+const CostOverview = connect(mapStateToProps, {})(CostOverviewBase);
 
 export { CostOverview };

--- a/src/routes/views/details/ibmBreakdown/historicalData.tsx
+++ b/src/routes/views/details/ibmBreakdown/historicalData.tsx
@@ -1,5 +1,3 @@
-import type { WrappedComponentProps } from 'react-intl';
-import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { HistoricalDataBase } from 'routes/views/details/components/historicalData';
 import { ibmHistoricalDataSelectors } from 'store/breakdown/historicalData/ibmHistoricalData';
@@ -9,7 +7,9 @@ interface HistoricalDataStateProps {
   widgets: number[];
 }
 
-type HistoricalDataOwnProps = WrappedComponentProps;
+interface HistoricalDataOwnProps {
+  // TBD...
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, HistoricalDataStateProps>((state, props) => {
@@ -19,6 +19,6 @@ const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, Historical
   };
 });
 
-const HistoricalData = injectIntl(connect(mapStateToProps, {})(HistoricalDataBase));
+const HistoricalData = connect(mapStateToProps, {})(HistoricalDataBase);
 
 export { HistoricalData };

--- a/src/routes/views/details/ociBreakdown/costOverview.tsx
+++ b/src/routes/views/details/ociBreakdown/costOverview.tsx
@@ -1,5 +1,3 @@
-import type { WrappedComponentProps } from 'react-intl';
-import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { CostOverviewBase } from 'routes/views/details/components/costOverview';
 import { ociCostOverviewSelectors } from 'store/breakdown/costOverview/ociCostOverview';
@@ -9,7 +7,9 @@ interface CostOverviewStateProps {
   widgets: number[];
 }
 
-type CostOverviewOwnProps = WrappedComponentProps;
+interface CostOverviewOwnProps {
+  // TBD...
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<CostOverviewOwnProps, CostOverviewStateProps>((state, props) => {
@@ -19,6 +19,6 @@ const mapStateToProps = createMapStateToProps<CostOverviewOwnProps, CostOverview
   };
 });
 
-const CostOverview = injectIntl(connect(mapStateToProps, {})(CostOverviewBase));
+const CostOverview = connect(mapStateToProps, {})(CostOverviewBase);
 
 export { CostOverview };

--- a/src/routes/views/details/ociBreakdown/historicalData.tsx
+++ b/src/routes/views/details/ociBreakdown/historicalData.tsx
@@ -1,5 +1,3 @@
-import type { WrappedComponentProps } from 'react-intl';
-import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { HistoricalDataBase } from 'routes/views/details/components/historicalData';
 import { ociHistoricalDataSelectors } from 'store/breakdown/historicalData/ociHistoricalData';
@@ -9,7 +7,9 @@ interface HistoricalDataStateProps {
   widgets: number[];
 }
 
-type HistoricalDataOwnProps = WrappedComponentProps;
+interface HistoricalDataOwnProps {
+  // TBD...
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, HistoricalDataStateProps>((state, props) => {
@@ -19,6 +19,6 @@ const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, Historical
   };
 });
 
-const HistoricalData = injectIntl(connect(mapStateToProps, {})(HistoricalDataBase));
+const HistoricalData = connect(mapStateToProps, {})(HistoricalDataBase);
 
 export { HistoricalData };

--- a/src/routes/views/details/ocpBreakdown/costOverview.tsx
+++ b/src/routes/views/details/ocpBreakdown/costOverview.tsx
@@ -1,5 +1,3 @@
-import type { WrappedComponentProps } from 'react-intl';
-import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { CostOverviewBase } from 'routes/views/details/components/costOverview';
 import { ocpCostOverviewSelectors } from 'store/breakdown/costOverview/ocpCostOverview';
@@ -9,16 +7,19 @@ interface CostOverviewStateProps {
   widgets: number[];
 }
 
-type CostOverviewOwnProps = WrappedComponentProps;
+interface CostOverviewOwnProps {
+  title?: string;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<CostOverviewOwnProps, CostOverviewStateProps>((state, props) => {
   return {
     selectWidgets: ocpCostOverviewSelectors.selectWidgets(state),
     widgets: ocpCostOverviewSelectors.selectCurrentWidgets(state),
+    title: props.title,
   };
 });
 
-const CostOverview = injectIntl(connect(mapStateToProps, {})(CostOverviewBase));
+const CostOverview = connect(mapStateToProps, {})(CostOverviewBase);
 
 export { CostOverview };

--- a/src/routes/views/details/ocpBreakdown/historicalData.tsx
+++ b/src/routes/views/details/ocpBreakdown/historicalData.tsx
@@ -1,5 +1,3 @@
-import type { WrappedComponentProps } from 'react-intl';
-import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { HistoricalDataBase } from 'routes/views/details/components/historicalData';
 import { ocpHistoricalDataSelectors } from 'store/breakdown/historicalData/ocpHistoricalData';
@@ -9,7 +7,9 @@ interface HistoricalDataStateProps {
   widgets: number[];
 }
 
-type HistoricalDataOwnProps = WrappedComponentProps;
+interface HistoricalDataOwnProps {
+  // TBD...
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, HistoricalDataStateProps>((state, props) => {
@@ -19,6 +19,6 @@ const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, Historical
   };
 });
 
-const HistoricalData = injectIntl(connect(mapStateToProps, {})(HistoricalDataBase));
+const HistoricalData = connect(mapStateToProps, {})(HistoricalDataBase);
 
 export { HistoricalData };

--- a/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -104,6 +104,8 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
       providersQueryString
     );
 
+    const title = queryFromRoute[breakdownTitleKey] ? queryFromRoute[breakdownTitleKey] : groupByValue;
+
     return {
       costOverviewComponent: (
         <CostOverview
@@ -111,6 +113,7 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
           groupBy={groupBy}
           isPlatformCosts={isPlatformCosts(queryFromRoute)}
           report={report}
+          title={title}
         />
       ),
       currency,
@@ -131,7 +134,7 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, OcpBreakdown
       reportPathsType,
       reportQueryString,
       tagReportPathsType: TagPathsType.ocp,
-      title: queryFromRoute[breakdownTitleKey] ? queryFromRoute[breakdownTitleKey] : groupByValue,
+      title,
     };
   }
 );

--- a/src/routes/views/details/rhelBreakdown/costOverview.tsx
+++ b/src/routes/views/details/rhelBreakdown/costOverview.tsx
@@ -1,5 +1,3 @@
-import type { WrappedComponentProps } from 'react-intl';
-import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { CostOverviewBase } from 'routes/views/details/components/costOverview';
 import { rhelCostOverviewSelectors } from 'store/breakdown/costOverview/rhelCostOverview';
@@ -9,16 +7,19 @@ interface CostOverviewStateProps {
   widgets: number[];
 }
 
-type CostOverviewOwnProps = WrappedComponentProps;
+interface CostOverviewOwnProps {
+  title?: string;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<CostOverviewOwnProps, CostOverviewStateProps>((state, props) => {
   return {
     selectWidgets: rhelCostOverviewSelectors.selectWidgets(state),
     widgets: rhelCostOverviewSelectors.selectCurrentWidgets(state),
+    title: props.title,
   };
 });
 
-const CostOverview = injectIntl(connect(mapStateToProps, {})(CostOverviewBase));
+const CostOverview = connect(mapStateToProps, {})(CostOverviewBase);
 
 export { CostOverview };

--- a/src/routes/views/details/rhelBreakdown/historicalData.tsx
+++ b/src/routes/views/details/rhelBreakdown/historicalData.tsx
@@ -1,5 +1,3 @@
-import type { WrappedComponentProps } from 'react-intl';
-import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { HistoricalDataBase } from 'routes/views/details/components/historicalData';
 import { rhelHistoricalDataSelectors } from 'store/breakdown/historicalData/rhelHistoricalData';
@@ -9,7 +7,9 @@ interface HistoricalDataStateProps {
   widgets: number[];
 }
 
-type HistoricalDataOwnProps = WrappedComponentProps;
+interface HistoricalDataOwnProps {
+  // TBD...
+}
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, HistoricalDataStateProps>((state, props) => {
@@ -19,6 +19,6 @@ const mapStateToProps = createMapStateToProps<HistoricalDataOwnProps, Historical
   };
 });
 
-const HistoricalData = injectIntl(connect(mapStateToProps, {})(HistoricalDataBase));
+const HistoricalData = connect(mapStateToProps, {})(HistoricalDataBase);
 
 export { HistoricalData };

--- a/src/routes/views/details/rhelBreakdown/rhelBreakdown.tsx
+++ b/src/routes/views/details/rhelBreakdown/rhelBreakdown.tsx
@@ -104,6 +104,8 @@ const mapStateToProps = createMapStateToProps<RhelBreakdownOwnProps, RhelBreakdo
       providersQueryString
     );
 
+    const title = queryFromRoute[breakdownTitleKey] ? queryFromRoute[breakdownTitleKey] : groupByValue;
+
     return {
       costOverviewComponent: (
         <CostOverview
@@ -111,6 +113,7 @@ const mapStateToProps = createMapStateToProps<RhelBreakdownOwnProps, RhelBreakdo
           groupBy={groupBy}
           isPlatformCosts={isPlatformCosts(queryFromRoute)}
           report={report}
+          title={title}
         />
       ),
       currency,
@@ -131,7 +134,7 @@ const mapStateToProps = createMapStateToProps<RhelBreakdownOwnProps, RhelBreakdo
       reportPathsType,
       reportQueryString,
       tagReportPathsType: TagPathsType.rhel,
-      title: queryFromRoute[breakdownTitleKey] ? queryFromRoute[breakdownTitleKey] : groupByValue,
+      title,
     };
   }
 );


### PR DESCRIPTION
This ensures the clusters card (shown in the breakdown page) shows all clusters for the "platform" feature.