### PR TITLE
COST-3374: Update details breakdown query to use ID over label

### DIFF
--- a/src/routes/views/utils/paths.ts
+++ b/src/routes/views/utils/paths.ts
@@ -25,7 +25,7 @@ export const getBreakdownPath = ({
     ...(description && description !== label && { [breakdownDescKey]: description }),
     ...(isPlatformCosts && { [breakdownTitleKey]: label }),
     group_by: {
-      [groupBy]: isPlatformCosts ? '*' : label,
+      [groupBy]: isPlatformCosts ? '*' : description,
     },
   };
   if (isPlatformCosts) {


### PR DESCRIPTION
* When RBAC is enabled the query fails as the user isn't given access permissions via user-friendly name
* It was decided to avoid doing a lookup that adds the alias or source name to forego and potential privilege escalation

Related to:
https://issues.redhat.com/browse/COST-3374