### PR TITLE
Details breakdown title and description are same

### DIFF
--- a/src/routes/views/details/azureDetails/detailsTable.tsx
+++ b/src/routes/views/details/azureDetails/detailsTable.tsx
@@ -132,11 +132,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         <Link
           to={getBreakdownPath({
             basePath: paths.azureDetailsBreakdown,
-            label: label.toString(),
             description: item.id,
             groupBy,
             id: item.id,
             router,
+            title: label.toString(),
           })}
         >
           {label}

--- a/src/routes/views/details/gcpDetails/detailsTable.tsx
+++ b/src/routes/views/details/gcpDetails/detailsTable.tsx
@@ -132,11 +132,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         <Link
           to={getBreakdownPath({
             basePath: paths.gcpDetailsBreakdown,
-            label: label.toString(),
             description: item.id,
             groupBy,
             id: item.id,
             router,
+            title: label.toString(),
           })}
         >
           {label}

--- a/src/routes/views/details/ibmDetails/detailsTable.tsx
+++ b/src/routes/views/details/ibmDetails/detailsTable.tsx
@@ -132,11 +132,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         <Link
           to={getBreakdownPath({
             basePath: paths.ibmDetailsBreakdown,
-            label: label.toString(),
             description: item.id,
             groupBy,
             id: item.id,
             router,
+            title: label.toString(),
           })}
         >
           {label}

--- a/src/routes/views/details/ociDetails/detailsTable.tsx
+++ b/src/routes/views/details/ociDetails/detailsTable.tsx
@@ -132,11 +132,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         <Link
           to={getBreakdownPath({
             basePath: paths.ociDetailsBreakdown,
-            label: label.toString(),
             description: item.id,
             groupBy,
             id: item.id,
             router,
+            title: label.toString(),
           })}
         >
           {label}

--- a/src/routes/views/details/ocpDetails/detailsTable.tsx
+++ b/src/routes/views/details/ocpDetails/detailsTable.tsx
@@ -192,12 +192,12 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         <Link
           to={getBreakdownPath({
             basePath: paths.ocpDetailsBreakdown,
-            label: label.toString(),
             description: item.id,
             id: item.id,
             isPlatformCosts,
             groupBy,
             router,
+            title: label.toString(),
           })}
         >
           {label}

--- a/src/routes/views/details/rhelDetails/detailsTable.tsx
+++ b/src/routes/views/details/rhelDetails/detailsTable.tsx
@@ -189,11 +189,11 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
         <Link
           to={getBreakdownPath({
             basePath: paths.rhelDetailsBreakdown,
-            label: label.toString(),
             description: item.id,
             groupBy,
             id: item.id,
             router,
+            title: label.toString(),
           })}
         >
           {label}

--- a/src/routes/views/utils/paths.ts
+++ b/src/routes/views/utils/paths.ts
@@ -10,22 +10,22 @@ export const getBreakdownPath = ({
   groupBy,
   id,
   isPlatformCosts,
-  label,
   router,
+  title,
 }: {
   basePath: string;
   description: string; // Used to display a description in the breakdown header
   groupBy: string | number;
   id: string | number; // group_by[account]=<id> param in the breakdown page
   isPlatformCosts?: boolean;
-  label: string;
   router: RouteComponentProps;
+  title: string | number; // Used to display a title in the breakdown header
 }) => {
   const queryFromRoute = parseQuery<Query>(router.location.search);
   const newQuery = {
     ...queryFromRoute,
-    ...(description && description !== label && { [breakdownDescKey]: description }),
-    ...(isPlatformCosts && { [breakdownTitleKey]: label }),
+    ...(description && description !== title && { [breakdownDescKey]: description }),
+    ...(title && { [breakdownTitleKey]: title }),
     group_by: {
       [groupBy]: isPlatformCosts ? '*' : id, // Use ID here -- see https://github.com/project-koku/koku-ui/pull/2821
     },


### PR DESCRIPTION
This update ensures the details breakdown page title and description are unique.

https://issues.redhat.com/browse/COST-3380

OCP Clusters
![Screen Shot 2023-01-11 at 12 51 18 PM](https://user-images.githubusercontent.com/17481322/211889261-bb3ddc72-47ff-4f3f-a905-05cc8f952976.png)
