### PR TITLE
Missing tag link for OCI breakdown

### DIFF
--- a/src/routes/views/details/components/breakdown/breakdownHeader.tsx
+++ b/src/routes/views/details/components/breakdown/breakdownHeader.tsx
@@ -117,8 +117,9 @@ class BreakdownHeader extends React.Component<BreakdownHeaderProps> {
     const showTags =
       filterByAccount ||
       groupBy === 'account' ||
-      groupBy === 'project' ||
       groupBy === 'gcp_project' ||
+      groupBy === 'payer_tenant_id' ||
+      groupBy === 'project' ||
       groupBy === 'subscription_guid';
 
     // i18n groupBy key


### PR DESCRIPTION
The tag link is missing from the OCI breakdown page.

https://issues.redhat.com/browse/COST-3498