### PR TITLE
Insights Chrome session token

### DIFF
--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -1,5 +1,3 @@
-import { getTokenCookie } from 'utils/cookie';
-
 const accountCurrencyID = 'cost_management_account_currency';
 const costTypeID = 'cost_management_cost_type';
 const currencyID = 'cost_management_currency';
@@ -7,8 +5,9 @@ const inactiveSourcesID = 'cost_management_inactive_sources';
 const sessionTokenID = 'cost_management_session';
 
 // Returns a subset of the token cookie
-export const getPartialTokenCookie = () => {
-  const token = getTokenCookie();
+export const getPartialToken = async () => {
+  const insights = (window as any).insights;
+  const token = await insights.chrome.auth.getToken();
   return token.substring(token.length - 40, token.length);
 };
 
@@ -41,13 +40,15 @@ export const invalidateSession = (force = false) => {
 };
 
 // Returns true if session is valid
-export const isSessionValid = () => {
-  return getSessionToken() === getPartialTokenCookie();
+export const isSessionValid = async () => {
+  const partialToken = await getPartialToken();
+  return getSessionToken() === partialToken;
 };
 
 // Save partial session token
-export const saveSessionToken = () => {
-  localStorage.setItem(sessionTokenID, getPartialTokenCookie());
+export const saveSessionToken = async () => {
+  const partialToken = await getPartialToken();
+  localStorage.setItem(sessionTokenID, partialToken);
 };
 
 /**

--- a/test/testEnv.ts
+++ b/test/testEnv.ts
@@ -6,10 +6,11 @@ export interface Global {
   insights: any;
 }
 
-declare var global: Global;
+declare let global: Global;
 
 global.insights = {
   chrome: {
+    auth: { getToken: () => '' },
     identifyApp: jest.fn(),
     init: jest.fn(),
     isBeta: jest.fn(),


### PR DESCRIPTION
The Insights Chrome no longer appears to add the `cs_jwt` session token to local storage. As a result, the UI cannot properly clear local storage properties upon a new session. The local session is used to store user choices for currency, AWS cost type, and inactive sources alerts.

Instead of referencing the `cs_jwt` property in local storage, we can use `insights.chrome.auth.getToken()` instead.

https://issues.redhat.com/browse/COST-3500