### PR TITLE
Use PatternFly's getCustomTheme function

### DIFF
--- a/src/routes/views/components/charts/chartTheme/theme-utils.ts
+++ b/src/routes/views/components/charts/chartTheme/theme-utils.ts
@@ -1,8 +1,8 @@
-import { ChartThemeColor, mergeTheme } from '@patternfly/react-charts';
+import { ChartThemeColor, getCustomTheme } from '@patternfly/react-charts';
 
 import { default as ChartTheme } from './theme-koku';
 
 // Applies theme color and variant to base theme
-const getTheme = () => mergeTheme(ChartThemeColor.default, ChartTheme);
+const getTheme = () => getCustomTheme(ChartThemeColor.default, null, ChartTheme);
 
 export default getTheme;


### PR DESCRIPTION
Charts should use PatternFly's getCustomTheme function instead of mergeTheme. The mergeTheme function will be removed for the upcoming v5 breaking change release.

https://issues.redhat.com/browse/COST-3496