### PR TITLE
Refactor to use Insights' shared router

### DIFF
--- a/src/components/pageTitle/pageTitle.tsx
+++ b/src/components/pageTitle/pageTitle.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
 import { routes } from 'routes';
-import { usePathname } from 'utils/paths';
+import { formatPath, usePathname } from 'utils/paths';
 
 interface PageTitleOwnProps {
   children?: React.ReactNode;
@@ -15,9 +15,9 @@ const PageTitleBase: React.FC<PageTitleProps> = ({ children = null, intl }) => {
   const getPageTitle = () => {
     const pathname = usePathname();
     switch (pathname) {
-      case routes.explorer.pathname:
+      case formatPath(routes.explorer.path):
         return messages.pageTitleExplorer;
-      case routes.overview.pathname:
+      case formatPath(routes.overview.path):
         return messages.pageTitleOverview;
       default:
         return messages.pageTitleDefault;

--- a/src/components/userAccess/permissions.tsx
+++ b/src/components/userAccess/permissions.tsx
@@ -11,7 +11,7 @@ import { NotAvailable } from 'routes/state/notAvailable';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { featureFlagsSelectors } from 'store/featureFlags';
 import { userAccessQuery, userAccessSelectors } from 'store/userAccess';
-import { usePathname } from 'utils/paths';
+import { formatPath, usePathname } from 'utils/paths';
 import {
   hasAwsAccess,
   hasAzureAccess,
@@ -67,33 +67,33 @@ const PermissionsBase: React.FC<PermissionsProps> = ({
     const ros = isRosFeatureEnabled && hasRosAccess(userAccess);
 
     switch (pathname) {
-      case routes.explorer.pathname:
-      case routes.overview.pathname:
+      case formatPath(routes.explorer.path):
+      case formatPath(routes.overview.path):
         return aws || azure || costModel || gcp || ibm || ocp || oci;
-      case routes.awsDetails.pathname:
-      case routes.awsDetailsBreakdown.pathname:
+      case formatPath(routes.awsDetails.path):
+      case formatPath(routes.awsDetailsBreakdown.path):
         return aws;
-      case routes.azureDetails.pathname:
-      case routes.azureDetailsBreakdown.pathname:
+      case formatPath(routes.azureDetails.path):
+      case formatPath(routes.azureDetailsBreakdown.path):
         return azure;
-      case routes.costModelsDetails.pathname:
+      case formatPath(routes.costModelsDetails.path):
         return costModel;
-      case routes.gcpDetails.pathname:
-      case routes.gcpDetailsBreakdown.pathname:
+      case formatPath(routes.gcpDetails.path):
+      case formatPath(routes.gcpDetailsBreakdown.path):
         return gcp;
-      case routes.ociDetails.pathname:
-      case routes.ociDetailsBreakdown.pathname:
+      case formatPath(routes.ociDetails.path):
+      case formatPath(routes.ociDetailsBreakdown.path):
         return oci;
-      case routes.ibmDetails.pathname:
-      case routes.ibmDetailsBreakdown.pathname:
+      case formatPath(routes.ibmDetails.path):
+      case formatPath(routes.ibmDetailsBreakdown.path):
         return ibm;
-      case routes.ocpDetails.pathname:
-      case routes.ocpDetailsBreakdown.pathname:
+      case formatPath(routes.ocpDetails.path):
+      case formatPath(routes.ocpDetailsBreakdown.path):
         return ocp;
-      case routes.recommendations.pathname:
+      case formatPath(routes.recommendations.path):
         return ros;
-      case routes.rhelDetails.pathname:
-      case routes.rhelDetailsBreakdown.pathname:
+      case formatPath(routes.rhelDetails.path):
+      case formatPath(routes.rhelDetailsBreakdown.path):
         return rhel;
       default:
         return false;

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -26,103 +26,82 @@ const Recommendations = lazy(() => import(/* webpackChunkName: "ocpDetails" */ '
 const RhelDetails = lazy(() => import(/* webpackChunkName: "ocpDetails" */ 'routes/views/details/rhelDetails'));
 const RhelBreakdown = lazy(() => import(/* webpackChunkName: "ocpDetails" */ 'routes/views/details/rhelBreakdown'));
 
-const basename = '/openshift/cost-management';
-
 const routes = {
   awsDetails: {
     element: userAccess(AwsDetails),
-    pathname: `${basename}/aws`,
     path: '/aws',
   },
   awsDetailsBreakdown: {
     element: userAccess(AwsBreakdown),
-    pathname: `${basename}/aws/breakdown`,
     path: '/aws/breakdown',
   },
   azureDetails: {
     element: userAccess(AzureDetails),
-    pathname: `${basename}/azure`,
     path: '/azure',
   },
   azureDetailsBreakdown: {
     element: userAccess(AzureBreakdown),
-    pathname: `${basename}/azure/breakdown`,
     path: '/azure/breakdown',
   },
   costModelsDetails: {
     element: userAccess(CostModelsDetails),
-    pathname: `${basename}/cost-models`,
     path: '/cost-models',
   },
   costModels: {
-    // Note: Path order matters here (i.e., dynamic segment must be defined after costModelsDetails)
+    // Note: Order matters here (i.e., dynamic segment must be defined after costModelsDetails)
     element: userAccess(CostModel),
-    pathname: `${basename}/cost-models`,
     path: `/cost-models/:uuid`,
   },
   explorer: {
     element: userAccess(Explorer),
-    pathname: `${basename}/explorer`,
     path: '/explorer',
   },
   gcpDetails: {
     element: userAccess(GcpDetails),
-    pathname: `${basename}/gcp`,
     path: '/gcp',
   },
   gcpDetailsBreakdown: {
     element: userAccess(GcpBreakdown),
-    pathname: `${basename}/gcp/breakdown`,
     path: '/gcp/breakdown',
   },
   ibmDetails: {
     element: userAccess(IbmDetails),
-    pathname: `${basename}/ibm`,
     path: '/ibm',
   },
   ibmDetailsBreakdown: {
     element: userAccess(IbmBreakdown),
-    pathname: `${basename}/ibm/breakdown`,
     path: '/ibm/breakdown',
   },
   ociDetails: {
     element: userAccess(OciDetails),
-    pathname: `${basename}/oci`,
     path: '/oci',
   },
   ociDetailsBreakdown: {
     element: userAccess(OciBreakdown),
-    pathname: `${basename}/oci/breakdown`,
     path: '/oci/breakdown',
   },
   ocpDetails: {
     element: userAccess(OcpDetails),
-    pathname: `${basename}/ocp`,
     path: '/ocp',
   },
   ocpDetailsBreakdown: {
     element: userAccess(OcpBreakdown),
-    pathname: `${basename}/ocp/breakdown`,
     path: '/ocp/breakdown',
   },
   overview: {
     element: userAccess(Overview),
-    pathname: `${basename}`,
     path: '/',
   },
   recommendations: {
     element: userAccess(Recommendations),
-    pathname: `${basename}/recommendations`,
     path: '/recommendations',
   },
   rhelDetails: {
     element: userAccess(RhelDetails),
-    pathname: `${basename}/rhel`,
     path: '/rhel',
   },
   rhelDetailsBreakdown: {
     element: userAccess(RhelBreakdown),
-    pathname: `${basename}/rhel/breakdown`,
     path: '/rhel/breakdown',
   },
 };
@@ -146,4 +125,4 @@ const Routes = () => (
   </Suspense>
 );
 
-export { Routes, routes };
+export { routes, Routes };

--- a/src/routes/costModels/costModel/header.tsx
+++ b/src/routes/costModels/costModel/header.tsx
@@ -34,6 +34,7 @@ import UpdateCostModelModal from 'routes/costModels/costModel/updateCostModel';
 import { createMapStateToProps } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
 import { rbacSelectors } from 'store/rbac';
+import { formatPath } from 'utils/paths';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 interface Props extends RouterComponentProps, WrappedComponentProps {
@@ -107,7 +108,9 @@ const Header: React.FC<Props> = ({
           <Breadcrumb style={styles.breadcrumb}>
             <BreadcrumbItem
               render={() => (
-                <Link to={`${routes.costModelsDetails.pathname}`}>{intl.formatMessage(messages.costModels)}</Link>
+                <Link to={`${formatPath(routes.costModelsDetails.path)}`}>
+                  {intl.formatMessage(messages.costModels)}
+                </Link>
               )}
             />
             <BreadcrumbItem isActive>{current.name}</BreadcrumbItem>

--- a/src/routes/costModels/costModelsDetails/utils/table.tsx
+++ b/src/routes/costModels/costModelsDetails/utils/table.tsx
@@ -10,6 +10,7 @@ import { routes } from 'routes';
 import { EmptyFilterState } from 'routes/components/state/emptyFilterState';
 import { LoadingState } from 'routes/components/state/loadingState';
 import NoCostModels from 'routes/costModels/costModelsDetails/noCostModels';
+import { formatPath } from 'utils/paths';
 import type { RouteComponentProps } from 'utils/router';
 
 import type { CostModelsQuery } from './query';
@@ -57,7 +58,7 @@ export function getRowsByStateName(stateName: string, data: any) {
     return {
       cells: [
         {
-          title: <Link to={`${routes.costModels.pathname}/${item.uuid}`}>{item.name}</Link>,
+          title: <Link to={`${formatPath(routes.costModelsDetails.path)}/${item.uuid}`}>{item.name}</Link>,
         },
         item.description,
         item.source_type,

--- a/src/routes/state/notAuthorized/notAuthorizedState.tsx
+++ b/src/routes/state/notAuthorized/notAuthorizedState.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
 import { routes } from 'routes';
+import { formatPath } from 'utils/paths';
 
 interface NotAuthorizedStateOwnProps {
   pathname?: string;
@@ -18,41 +19,41 @@ class NotAuthorizedStateBase extends React.Component<NotAuthorizedStateProps> {
     let msg;
 
     switch (pathname) {
-      case routes.awsDetails.pathname:
-      case routes.awsDetailsBreakdown.pathname:
+      case formatPath(routes.awsDetails.path):
+      case formatPath(routes.awsDetailsBreakdown.path):
         msg = messages.notAuthorizedStateAws;
         break;
-      case routes.azureDetails.pathname:
-      case routes.azureDetailsBreakdown.pathname:
+      case formatPath(routes.azureDetails.path):
+      case formatPath(routes.azureDetailsBreakdown.path):
         msg = messages.notAuthorizedStateAzure;
         break;
-      case routes.costModelsDetails.pathname:
+      case formatPath(routes.costModelsDetails.path):
         msg = messages.notAuthorizedStateCostModels;
         break;
-      case routes.gcpDetails.pathname:
-      case routes.gcpDetailsBreakdown.pathname:
+      case formatPath(routes.gcpDetails.path):
+      case formatPath(routes.gcpDetailsBreakdown.path):
         msg = messages.notAuthorizedStateGcp;
         break;
-      case routes.ibmDetails.pathname:
-      case routes.ibmDetailsBreakdown.pathname:
+      case formatPath(routes.ibmDetails.path):
+      case formatPath(routes.ibmDetailsBreakdown.path):
         msg = messages.notAuthorizedStateIbm;
         break;
-      case routes.ociDetails.pathname:
-      case routes.ociDetailsBreakdown.pathname:
+      case formatPath(routes.ociDetails.path):
+      case formatPath(routes.ociDetailsBreakdown.path):
         msg = messages.notAuthorizedStateOci;
         break;
-      case routes.ocpDetails.pathname:
-      case routes.ocpDetailsBreakdown.pathname:
+      case formatPath(routes.ocpDetails.path):
+      case formatPath(routes.ocpDetailsBreakdown.path):
         msg = messages.notAuthorizedStateOcp;
         break;
-      case routes.rhelDetails.pathname:
-      case routes.rhelDetailsBreakdown.pathname:
+      case formatPath(routes.rhelDetails.path):
+      case formatPath(routes.rhelDetailsBreakdown.path):
         msg = messages.notAuthorizedStateRhel;
         break;
-      case routes.recommendations.pathname:
+      case formatPath(routes.recommendations.path):
         msg = messages.notAuthorizedStateRecommendations;
         break;
-      case routes.explorer.pathname:
+      case formatPath(routes.explorer.path):
       default:
         msg = messages.costManagement;
         break;

--- a/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
@@ -23,6 +23,7 @@ import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCostType } from 'utils/costType';
 import { getCurrency } from 'utils/localStorage';
+import { formatPath } from 'utils/paths';
 import { breakdownDescKey, breakdownTitleKey, logicalAndPrefix, orgUnitIdKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
@@ -52,7 +53,7 @@ interface BreakdownDispatchProps {
   fetchReport?: typeof reportActions.fetchReport;
 }
 
-const detailsURL = routes.awsDetails.pathname;
+const detailsURL = formatPath(routes.awsDetails.path);
 const reportType = ReportType.cost;
 const reportPathsType = ReportPathsType.aws;
 

--- a/src/routes/views/details/awsDetails/detailsTable.tsx
+++ b/src/routes/views/details/awsDetails/detailsTable.tsx
@@ -17,6 +17,7 @@ import type { ComputedReportItem } from 'utils/computedReport/getComputedReportI
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dates';
 import { formatCurrency, formatPercentage } from 'utils/format';
+import { formatPath } from 'utils/paths';
 import { noPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
@@ -135,7 +136,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       ) : (
         <Link
           to={getOrgBreakdownPath({
-            basePath: routes.awsDetailsBreakdown.pathname,
+            basePath: formatPath(routes.awsDetailsBreakdown.path),
             description: item.id,
             groupBy,
             groupByOrg,

--- a/src/routes/views/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/routes/views/details/azureBreakdown/azureBreakdown.tsx
@@ -22,6 +22,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCurrency } from 'utils/localStorage';
+import { formatPath } from 'utils/paths';
 import { breakdownDescKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
@@ -52,7 +53,7 @@ interface AzureCostDispatchProps {
   fetchReport?: typeof reportActions.fetchReport;
 }
 
-const detailsURL = routes.azureDetails.pathname;
+const detailsURL = formatPath(routes.azureDetails.path);
 const reportType = ReportType.cost;
 const reportPathsType = ReportPathsType.azure;
 

--- a/src/routes/views/details/azureDetails/detailsTable.tsx
+++ b/src/routes/views/details/azureDetails/detailsTable.tsx
@@ -17,6 +17,7 @@ import type { ComputedReportItem } from 'utils/computedReport/getComputedReportI
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dates';
 import { formatCurrency, formatPercentage } from 'utils/format';
+import { formatPath } from 'utils/paths';
 import { noPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
@@ -131,7 +132,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       ) : (
         <Link
           to={getBreakdownPath({
-            basePath: routes.azureDetailsBreakdown.pathname,
+            basePath: formatPath(routes.azureDetailsBreakdown.path),
             description: item.id,
             groupBy,
             id: item.id,

--- a/src/routes/views/details/gcpBreakdown/gcpBreakdown.tsx
+++ b/src/routes/views/details/gcpBreakdown/gcpBreakdown.tsx
@@ -23,6 +23,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCurrency } from 'utils/localStorage';
+import { formatPath } from 'utils/paths';
 import { breakdownDescKey, breakdownTitleKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
@@ -53,7 +54,7 @@ interface BreakdownDispatchProps {
   fetchReport?: typeof reportActions.fetchReport;
 }
 
-const detailsURL = routes.gcpDetails.pathname;
+const detailsURL = formatPath(routes.gcpDetails.path);
 const reportType = ReportType.cost;
 const reportPathsType = ReportPathsType.gcp;
 

--- a/src/routes/views/details/gcpDetails/detailsTable.tsx
+++ b/src/routes/views/details/gcpDetails/detailsTable.tsx
@@ -17,6 +17,7 @@ import type { ComputedReportItem } from 'utils/computedReport/getComputedReportI
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dates';
 import { formatCurrency, formatPercentage } from 'utils/format';
+import { formatPath } from 'utils/paths';
 import { noPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
@@ -131,7 +132,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       ) : (
         <Link
           to={getBreakdownPath({
-            basePath: routes.gcpDetailsBreakdown.pathname,
+            basePath: formatPath(routes.gcpDetailsBreakdown.path),
             description: item.id,
             groupBy,
             id: item.id,

--- a/src/routes/views/details/ibmBreakdown/ibmBreakdown.tsx
+++ b/src/routes/views/details/ibmBreakdown/ibmBreakdown.tsx
@@ -23,6 +23,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCurrency } from 'utils/localStorage';
+import { formatPath } from 'utils/paths';
 import { breakdownDescKey, breakdownTitleKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
@@ -53,7 +54,7 @@ interface BreakdownDispatchProps {
   fetchReport?: typeof reportActions.fetchReport;
 }
 
-const detailsURL = routes.ibmDetails.pathname;
+const detailsURL = formatPath(routes.ibmDetails.path);
 const reportType = ReportType.cost;
 const reportPathsType = ReportPathsType.ibm;
 

--- a/src/routes/views/details/ibmDetails/detailsTable.tsx
+++ b/src/routes/views/details/ibmDetails/detailsTable.tsx
@@ -17,6 +17,7 @@ import type { ComputedReportItem } from 'utils/computedReport/getComputedReportI
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dates';
 import { formatCurrency, formatPercentage } from 'utils/format';
+import { formatPath } from 'utils/paths';
 import { noPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
@@ -131,7 +132,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       ) : (
         <Link
           to={getBreakdownPath({
-            basePath: routes.ibmDetailsBreakdown.pathname,
+            basePath: formatPath(routes.ibmDetailsBreakdown.path),
             description: item.id,
             groupBy,
             id: item.id,

--- a/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
+++ b/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
@@ -23,6 +23,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCurrency } from 'utils/localStorage';
+import { formatPath } from 'utils/paths';
 import { breakdownDescKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
@@ -53,7 +54,7 @@ interface OciCostDispatchProps {
   fetchReport?: typeof reportActions.fetchReport;
 }
 
-const detailsURL = routes.ociDetails.pathname;
+const detailsURL = formatPath(routes.ociDetails.path);
 const reportType = ReportType.cost;
 const reportPathsType = ReportPathsType.oci;
 

--- a/src/routes/views/details/ociDetails/detailsTable.tsx
+++ b/src/routes/views/details/ociDetails/detailsTable.tsx
@@ -17,6 +17,7 @@ import type { ComputedReportItem } from 'utils/computedReport/getComputedReportI
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dates';
 import { formatCurrency, formatPercentage } from 'utils/format';
+import { formatPath } from 'utils/paths';
 import { noPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
@@ -131,7 +132,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       ) : (
         <Link
           to={getBreakdownPath({
-            basePath: routes.ociDetailsBreakdown.pathname,
+            basePath: formatPath(routes.ociDetailsBreakdown.path),
             description: item.id,
             groupBy,
             id: item.id,

--- a/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -22,6 +22,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCurrency } from 'utils/localStorage';
+import { formatPath } from 'utils/paths';
 import { breakdownDescKey, breakdownTitleKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
@@ -49,7 +50,7 @@ interface BreakdownDispatchProps {
   fetchReport?: typeof reportActions.fetchReport;
 }
 
-const detailsURL = routes.ocpDetails.pathname;
+const detailsURL = formatPath(routes.ocpDetails.path);
 const reportType = ReportType.cost;
 const reportPathsType = ReportPathsType.ocp;
 

--- a/src/routes/views/details/ocpDetails/detailsTable.tsx
+++ b/src/routes/views/details/ocpDetails/detailsTable.tsx
@@ -19,6 +19,7 @@ import type { ComputedReportItem } from 'utils/computedReport/getComputedReportI
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dates';
 import { formatCurrency, formatPercentage } from 'utils/format';
+import { formatPath } from 'utils/paths';
 import { classificationDefault, classificationPlatform, classificationUnallocated, noPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
@@ -191,7 +192,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       ) : (
         <Link
           to={getBreakdownPath({
-            basePath: routes.ocpDetailsBreakdown.pathname,
+            basePath: formatPath(routes.ocpDetailsBreakdown.path),
             description: item.id,
             id: item.id,
             isPlatformCosts,

--- a/src/routes/views/details/rhelBreakdown/rhelBreakdown.tsx
+++ b/src/routes/views/details/rhelBreakdown/rhelBreakdown.tsx
@@ -22,6 +22,7 @@ import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCurrency } from 'utils/localStorage';
+import { formatPath } from 'utils/paths';
 import { breakdownDescKey, breakdownTitleKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
@@ -49,7 +50,7 @@ interface BreakdownDispatchProps {
   fetchReport?: typeof reportActions.fetchReport;
 }
 
-const detailsURL = routes.rhelDetails.pathname;
+const detailsURL = formatPath(routes.rhelDetails.path);
 const reportType = ReportType.cost;
 const reportPathsType = ReportPathsType.rhel;
 

--- a/src/routes/views/details/rhelDetails/detailsTable.tsx
+++ b/src/routes/views/details/rhelDetails/detailsTable.tsx
@@ -19,6 +19,7 @@ import type { ComputedReportItem } from 'utils/computedReport/getComputedReportI
 import { getUnsortedComputedReportItems } from 'utils/computedReport/getComputedReportItems';
 import { getForDateRangeString, getNoDataForDateRangeString } from 'utils/dates';
 import { formatCurrency, formatPercentage } from 'utils/format';
+import { formatPath } from 'utils/paths';
 import { noPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
@@ -188,7 +189,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
       ) : (
         <Link
           to={getBreakdownPath({
-            basePath: routes.rhelDetailsBreakdown.pathname,
+            basePath: formatPath(routes.rhelDetailsBreakdown.path),
             description: item.id,
             groupBy,
             id: item.id,

--- a/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardWidgets.ts
@@ -10,6 +10,7 @@ import {
 } from 'routes/views/components/charts/common/chartDatum';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { formatCurrency, formatUnits } from 'utils/format';
+import { formatPath } from 'utils/paths';
 
 import type { AwsDashboardWidget } from './awsDashboardCommon';
 import { AwsDashboardTab } from './awsDashboardCommon';
@@ -62,7 +63,7 @@ export const costSummaryWidget: AwsDashboardWidget = {
     adjustContainerHeight: true,
     costKey: messages.cost,
     showHorizontal: true,
-    viewAllPath: routes.awsDetails.pathname,
+    viewAllPath: formatPath(routes.awsDetails.path),
   },
   tabsFilter: {
     limit: 3,

--- a/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardWidgets.ts
@@ -10,6 +10,7 @@ import {
 } from 'routes/views/components/charts/common/chartDatum';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { formatUnits } from 'utils/format';
+import { formatPath } from 'utils/paths';
 
 import type { AzureDashboardWidget } from './azureDashboardCommon';
 import { AzureDashboardTab } from './azureDashboardCommon';
@@ -36,7 +37,7 @@ export const costSummaryWidget: AzureDashboardWidget = {
     adjustContainerHeight: true,
     costKey: messages.cost,
     showHorizontal: true,
-    viewAllPath: routes.azureDetails.pathname,
+    viewAllPath: formatPath(routes.azureDetails.path),
   },
   tabsFilter: {
     limit: 3,

--- a/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardWidgets.ts
@@ -10,6 +10,7 @@ import {
 } from 'routes/views/components/charts/common/chartDatum';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { formatCurrency, formatUnits } from 'utils/format';
+import { formatPath } from 'utils/paths';
 
 import type { GcpDashboardWidget } from './gcpDashboardCommon';
 import { GcpDashboardTab } from './gcpDashboardCommon';
@@ -63,7 +64,7 @@ export const costSummaryWidget: GcpDashboardWidget = {
     adjustContainerHeight: true,
     costKey: messages.cost,
     showHorizontal: true,
-    viewAllPath: routes.gcpDetails.pathname,
+    viewAllPath: formatPath(routes.gcpDetails.path),
   },
   tabsFilter: {
     limit: 3,

--- a/src/store/dashboard/ibmDashboard/ibmDashboardWidgets.ts
+++ b/src/store/dashboard/ibmDashboard/ibmDashboardWidgets.ts
@@ -10,6 +10,7 @@ import {
 } from 'routes/views/components/charts/common/chartDatum';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { formatCurrency, formatUnits } from 'utils/format';
+import { formatPath } from 'utils/paths';
 
 import type { IbmDashboardWidget } from './ibmDashboardCommon';
 import { IbmDashboardTab } from './ibmDashboardCommon';
@@ -63,7 +64,7 @@ export const costSummaryWidget: IbmDashboardWidget = {
     adjustContainerHeight: true,
     costKey: messages.cost,
     showHorizontal: true,
-    viewAllPath: routes.ibmDetails.pathname,
+    viewAllPath: formatPath(routes.ibmDetails.path),
   },
   tabsFilter: {
     limit: 3,

--- a/src/store/dashboard/ociDashboard/ociDashboardWidgets.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboardWidgets.ts
@@ -10,6 +10,7 @@ import {
 } from 'routes/views/components/charts/common/chartDatum';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { formatUnits } from 'utils/format';
+import { formatPath } from 'utils/paths';
 
 import type { OciDashboardWidget } from './ociDashboardCommon';
 import { OciDashboardTab } from './ociDashboardCommon';
@@ -32,7 +33,7 @@ export const costSummaryWidget: OciDashboardWidget = {
     adjustContainerHeight: true,
     costKey: messages.cost,
     showHorizontal: true,
-    viewAllPath: routes.ociDetails.pathname,
+    viewAllPath: formatPath(routes.ociDetails.path),
   },
   tabsFilter: {
     limit: 3,

--- a/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardWidgets.ts
@@ -10,6 +10,7 @@ import {
 } from 'routes/views/components/charts/common/chartDatum';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { formatCurrency, formatUnits } from 'utils/format';
+import { formatPath } from 'utils/paths';
 
 import type { OcpDashboardWidget } from './ocpDashboardCommon';
 import { OcpDashboardTab } from './ocpDashboardCommon';
@@ -34,7 +35,7 @@ export const costSummaryWidget: OcpDashboardWidget = {
     costKey: messages.cost,
     showHorizontal: true,
     showTooltip: true,
-    viewAllPath: routes.ocpDetails.pathname,
+    viewAllPath: formatPath(routes.ocpDetails.path),
   },
   trend: {
     computedForecastItem: ComputedForecastItemType.cost,

--- a/src/store/dashboard/rhelDashboard/rhelDashboardWidgets.ts
+++ b/src/store/dashboard/rhelDashboard/rhelDashboardWidgets.ts
@@ -10,6 +10,7 @@ import {
 } from 'routes/views/components/charts/common/chartDatum';
 import { DashboardChartType } from 'store/dashboard/common/dashboardCommon';
 import { formatCurrency, formatUnits } from 'utils/format';
+import { formatPath } from 'utils/paths';
 
 import type { RhelDashboardWidget } from './rhelDashboardCommon';
 import { RhelDashboardTab } from './rhelDashboardCommon';
@@ -34,7 +35,7 @@ export const costSummaryWidget: RhelDashboardWidget = {
     costKey: messages.cost,
     showHorizontal: true,
     showTooltip: true,
-    viewAllPath: routes.rhelDetails.pathname,
+    viewAllPath: formatPath(routes.rhelDetails.path),
   },
   trend: {
     computedForecastItem: ComputedForecastItemType.cost,

--- a/src/utils/paths.ts
+++ b/src/utils/paths.ts
@@ -1,10 +1,15 @@
 import { useLocation } from 'react-router-dom';
+import { routes } from 'routes';
 
-import { routes } from '../routes';
+// Prefixes the given path with a basename
+//
+// Note the basename does not include a release prefix (/beta, /preview, etc.), unlike the getBaseName function from
+// @redhat-cloud-services/frontend-components-utilities/helpers
+export const formatPath = path => {
+  const basename = '/openshift/cost-management';
+  return path === routes.overview.path ? basename : `${basename}${path}`;
+};
 
-//
-// The getBaseName function from @redhat-cloud-services/frontend-components-utilities/helpers returns the same value
-//
 // export const getBaseName = pathname => {
 //   let release = '/';
 //   const pathName = pathname.split('/');
@@ -40,7 +45,6 @@ export const usePathname = () => {
   const location = useLocation();
 
   // cost models may include UUID in path
-  return location.pathname.startsWith(routes.costModelsDetails.pathname)
-    ? routes.costModelsDetails.pathname
-    : location.pathname;
+  const costModelsPath = formatPath(routes.costModelsDetails.path);
+  return location.pathname.startsWith(costModelsPath) ? costModelsPath : location.pathname.replace(/\/$/, '');
 };


### PR DESCRIPTION
Refactor to use Insights' shared router, formatting routes with a basename.

https://issues.redhat.com/browse/COST-3524