### PR TITLE
OCP breakdown cluster name truncation

### DIFF
--- a/src/routes/views/details/components/cluster/cluster.tsx
+++ b/src/routes/views/details/components/cluster/cluster.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@patternfly/react-core';
 import type { Report } from 'api/reports/report';
 import messages from 'locales/messages';
 import React from 'react';
@@ -48,8 +49,8 @@ class ClusterBase extends React.Component<ClusterProps> {
     const { groupBy, intl, report, title } = this.props;
     const { isOpen, showAll } = this.state;
 
-    let charCount = 0;
-    const maxChars = 50;
+    const maxCharsPerName = 45; // Max (non-whitespace) characters that fit without overlapping card
+    const maxItems = 2; // Max items to show before adding "more" link
     const someClusters = [];
     const allClusters = [];
 
@@ -85,23 +86,21 @@ class ClusterBase extends React.Component<ClusterProps> {
     });
 
     for (const cluster of clusters) {
-      const prefix = someClusters.length > 0 ? ', ' : '';
-      const clusterString = `${prefix}${cluster}`;
+      let clusterString = someClusters.length > 0 ? `, ${cluster}` : cluster;
       if (showAll) {
         someClusters.push(clusterString);
-      } else if (charCount <= maxChars) {
-        if (charCount + clusterString.length > maxChars) {
+      } else if (someClusters.length < maxItems) {
+        if (clusterString.length > maxCharsPerName) {
+          clusterString = clusterString.slice(0, maxCharsPerName).trim().concat('...');
           someClusters.push(
-            clusterString
-              .slice(0, maxChars - charCount)
-              .trim()
-              .concat('...')
+            <Tooltip content={cluster} enableFlip>
+              <span>{clusterString}</span>
+            </Tooltip>
           );
         } else {
           someClusters.push(clusterString);
         }
       }
-      charCount += clusterString.length;
       allClusters.push(cluster);
     }
 


### PR DESCRIPTION
The OCP breakdown page shows a list of clusters, but some names are too long and must be truncated. It would be ideal if we could show a tooltip to display the full cluster name.

We also show a "more" link when the entire cluster string is greater than 50 characters. However, instead of 50 characters total, we can apply a limit to each cluster name. The cluster card is responsive, so cluster names will wrap onto the next line.

That said, max characters per cluster name should be 45 – assuming there is no whitespace. Otherwise, the cluster name may overlap the card.

Note: Max characters is 30 for this screenshot only
![Screen Shot 2023-02-22 at 11 09 51 AM](https://user-images.githubusercontent.com/17481322/220691743-67d65bbd-ccae-42eb-bb65-69e74b0a24af.png)

https://issues.redhat.com/browse/COST-3533