### PR TITLE
Disable table toolbar actions for no data

### DIFF
--- a/src/routes/views/components/dataToolbar/dataToolbar.tsx
+++ b/src/routes/views/components/dataToolbar/dataToolbar.tsx
@@ -318,6 +318,25 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
     }
   };
 
+  private hasFilters = () => {
+    const { filters } = this.state;
+
+    if (filters) {
+      for (const filterKey of Object.keys(filters)) {
+        if (filterKey === tagKey) {
+          for (const tagFilterKey of Object.keys(filters[filterKey])) {
+            if (filters[filterKey][tagFilterKey]) {
+              return true;
+            }
+          }
+        } else {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+
   // Bulk select
 
   public getBulkSelect = () => {
@@ -398,7 +417,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
 
   // Category select
 
-  public getCategorySelect() {
+  public getCategorySelect(hasFilters: boolean) {
     const { categoryOptions, isDisabled } = this.props;
     const { currentCategory, isCategorySelectOpen } = this.state;
 
@@ -413,7 +432,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
       <ToolbarItem>
         <Select
           id="category-select"
-          isDisabled={isDisabled}
+          isDisabled={isDisabled && !hasFilters}
           isOpen={isCategorySelectOpen}
           onSelect={this.handleOnCategorySelect}
           onToggle={this.handleOnCategoryToggle}
@@ -459,7 +478,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
   };
 
   // Category input
-  public getCategoryInput = (categoryOption: ToolbarChipGroup) => {
+  public getCategoryInput = (categoryOption: ToolbarChipGroup, hasFilters: boolean) => {
     const { intl, isDisabled, resourcePathsType } = this.props;
     const { currentCategory, filters, categoryInput } = this.state;
 
@@ -475,7 +494,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
           {isResourceTypeValid(resourcePathsType, categoryOption.key as ResourceType) ? (
             <ResourceTypeahead
               ariaLabel={intl.formatMessage(messages.filterByInputAriaLabel, { value: categoryOption.key })}
-              isDisabled={isDisabled}
+              isDisabled={isDisabled && !hasFilters}
               onSelect={value => this.onCategoryInputSelect(value, categoryOption.key)}
               placeholder={intl.formatMessage(messages.filterByPlaceholder, { value: categoryOption.key })}
               resourcePathsType={resourcePathsType}
@@ -484,7 +503,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
           ) : (
             <>
               <TextInput
-                isDisabled={isDisabled}
+                isDisabled={isDisabled && !hasFilters}
                 name={`category-input-${categoryOption.key}`}
                 id={`category-input-${categoryOption.key}`}
                 type="search"
@@ -495,7 +514,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
                 onKeyDown={evt => this.onCategoryInput(evt, categoryOption.key)}
               />
               <Button
-                isDisabled={isDisabled}
+                isDisabled={isDisabled && !hasFilters}
                 variant={ButtonVariant.control}
                 aria-label={intl.formatMessage(messages.filterByButtonAriaLabel, { value: categoryOption.key })}
                 onClick={evt => this.onCategoryInput(evt, categoryOption.key)}
@@ -540,7 +559,6 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
                 : prevItems
                 ? [...prevItems, filter]
                 : [filter],
-            categoryInput: '',
           },
         };
       },
@@ -567,7 +585,6 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
                 : prevItems
                 ? [...prevItems, filter]
                 : [filter],
-            categoryInput: '',
           },
         };
       },
@@ -579,7 +596,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
 
   // Exclude select
 
-  public getExcludeSelect() {
+  public getExcludeSelect(hasFilters: boolean) {
     const { isDisabled } = this.props;
     const { currentExclude, isExcludeSelectOpen } = this.state;
 
@@ -590,7 +607,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
       <ToolbarItem>
         <Select
           id="exclude-select"
-          isDisabled={isDisabled}
+          isDisabled={isDisabled && !hasFilters}
           isOpen={isExcludeSelectOpen}
           onSelect={this.handleOnExcludeSelect}
           onToggle={this.handleOnExcludeToggle}
@@ -637,7 +654,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
   };
 
   // Org unit select
-  public getOrgUnitSelect = () => {
+  public getOrgUnitSelect = (hasFilters: boolean) => {
     const { intl, isDisabled } = this.props;
     const { currentCategory, filters, isOrgUnitSelectExpanded } = this.state;
 
@@ -679,7 +696,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
         showToolbarItem={currentCategory === orgUnitIdKey}
       >
         <Select
-          isDisabled={isDisabled}
+          isDisabled={isDisabled && !hasFilters}
           className="selectOverride"
           variant={SelectVariant.checkbox}
           aria-label={intl.formatMessage(messages.filterByOrgUnitAriaLabel)}
@@ -779,7 +796,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
 
   // Tag key select
 
-  public getTagKeySelect = () => {
+  public getTagKeySelect = (hasFilters: boolean) => {
     const { intl, isDisabled } = this.props;
     const { currentCategory, currentTagKey, isTagKeySelectExpanded } = this.state;
 
@@ -794,7 +811,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
     return (
       <ToolbarItem>
         <Select
-          isDisabled={isDisabled}
+          isDisabled={isDisabled && !hasFilters}
           variant={SelectVariant.typeahead}
           typeAheadAriaLabel={intl.formatMessage(messages.filterByTagKeyAriaLabel)}
           onClear={this.handleOnTagKeyClear}
@@ -874,8 +891,8 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
 
   // Tag value select
 
-  public getTagValueSelect = (tagKeyOption: ToolbarChipGroup) => {
-    const { tagReportPathsType } = this.props;
+  public getTagValueSelect = (tagKeyOption: ToolbarChipGroup, hasFilters: boolean) => {
+    const { isDisabled, tagReportPathsType } = this.props;
     const { currentCategory, currentTagKey, filters, tagKeyValueInput } = this.state;
 
     // Todo: categoryName workaround for https://issues.redhat.com/browse/COST-2094
@@ -893,6 +910,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
         showToolbarItem={currentCategory === tagKey && currentTagKey === tagKeyOption.key}
       >
         <TagValue
+          isDisabled={isDisabled && this.hasFilters}
           onTagValueSelect={this.onTagValueSelect}
           onTagValueInput={this.onTagValueInput}
           onTagValueInputChange={this.onTagValueInputChange}
@@ -985,10 +1003,10 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
   // Column management
 
   public getColumnManagement = () => {
-    const { intl } = this.props;
+    const { intl, isDisabled } = this.props;
     return (
       <ToolbarItem visibility={{ default: 'hidden', '2xl': 'visible', xl: 'visible', lg: 'hidden' }}>
-        <Button onClick={this.handleColumnManagementClicked} variant={ButtonVariant.link}>
+        <Button isDisabled={isDisabled} onClick={this.handleColumnManagementClicked} variant={ButtonVariant.link}>
           {intl.formatMessage(messages.detailsColumnManagementTitle)}
         </Button>
       </ToolbarItem>
@@ -1021,7 +1039,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
   // Platform costs
 
   public getPlatformCosts = () => {
-    const { intl } = this.props;
+    const { intl, isDisabled } = this.props;
     const { isPlatformCostsChecked } = this.state;
     return (
       <ToolbarItem visibility={{ default: 'hidden', '2xl': 'visible', xl: 'visible', lg: 'hidden' }}>
@@ -1029,6 +1047,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
           id="platform-costs"
           label={intl.formatMessage(messages.sumPlatformCosts)}
           isChecked={isPlatformCostsChecked}
+          isDisabled={isDisabled}
           onChange={this.handlePlatformCostsChanged}
         />
       </ToolbarItem>
@@ -1101,6 +1120,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
       style,
     } = this.props;
     const options = categoryOptions ? categoryOptions : this.getDefaultCategoryOptions();
+    const hasFilters = this.hasFilters();
 
     // Todo: clearAllFilters workaround https://github.com/patternfly/patternfly-react/issues/4222
     return (
@@ -1111,15 +1131,15 @@ export class DataToolbarBase extends React.Component<DataToolbarProps> {
             {showFilter && (
               <ToolbarToggleGroup breakpoint="xl" toggleIcon={<FilterIcon />}>
                 <ToolbarGroup variant="filter-group">
-                  {this.getCategorySelect()}
-                  {isNegativeFilteringFeatureEnabled && this.getExcludeSelect()}
-                  {this.getTagKeySelect()}
-                  {this.getTagKeyOptions().map(option => this.getTagValueSelect(option))}
-                  {this.getOrgUnitSelect()}
+                  {this.getCategorySelect(hasFilters)}
+                  {isNegativeFilteringFeatureEnabled && this.getExcludeSelect(hasFilters)}
+                  {this.getTagKeySelect(hasFilters)}
+                  {this.getTagKeyOptions().map(option => this.getTagValueSelect(option, hasFilters))}
+                  {this.getOrgUnitSelect(hasFilters)}
                   {options &&
                     options
                       .filter(option => option.key !== tagKey && option.key !== orgUnitIdKey)
-                      .map(option => this.getCategoryInput(option))}
+                      .map(option => this.getCategoryInput(option, hasFilters))}
                 </ToolbarGroup>
               </ToolbarToggleGroup>
             )}

--- a/src/routes/views/details/awsDetails/awsDetails.tsx
+++ b/src/routes/views/details/awsDetails/awsDetails.tsx
@@ -180,7 +180,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     );
   };
 
-  private getPagination = (isBottom: boolean = false) => {
+  private getPagination = (isDisabled = false, isBottom = false) => {
     const { intl, query, router, report } = this.props;
 
     const count = report && report.meta ? report.meta.count : 0;
@@ -197,6 +197,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
     return (
       <Pagination
         isCompact={!isBottom}
+        isDisabled={isDisabled}
         itemCount={count}
         onPerPageSelect={(event, perPage) => handlePerPageSelect(query, router, perPage)}
         onSetPage={(event, pageNumber) => handleSetPage(query, router, report, pageNumber)}
@@ -244,20 +245,22 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByTagKey = getGroupByTagKey(query);
+    const isDisabled = computedItems.length === 0;
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
     return (
       <DetailsToolbar
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isAllSelected={isAllSelected}
-        isExportDisabled={computedItems.length === 0 || (!isAllSelected && selectedItems.length === 0)}
+        isDisabled={isDisabled}
+        isExportDisabled={isDisabled || (!isAllSelected && selectedItems.length === 0)}
         itemsPerPage={computedItems.length}
         itemsTotal={itemsTotal}
         onBulkSelected={this.handleBulkSelected}
         onExportClicked={this.handleExportModalOpen}
         onFilterAdded={filter => handleFilterAdded(query, router, filter)}
         onFilterRemoved={filter => handleFilterRemoved(query, router, filter)}
-        pagination={this.getPagination()}
+        pagination={this.getPagination(isDisabled)}
         query={query}
         selectedItems={selectedItems}
       />
@@ -348,8 +351,9 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
       router,
     } = this.props;
 
-    const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
+    const groupById = getIdKeyForGroupBy(query.group_by);
+    const isDisabled = computedItems.length === 0;
     const title = intl.formatMessage(messages.awsDetailsTitle);
 
     // Note: Providers are fetched via the AccountSettings component used by all routes
@@ -388,7 +392,7 @@ class AwsDetails extends React.Component<AwsDetailsProps> {
             <>
               <div style={styles.tableContainer}>{this.getTable()}</div>
               <div style={styles.paginationContainer}>
-                <div style={styles.pagination}>{this.getPagination(true)}</div>
+                <div style={styles.pagination}>{this.getPagination(isDisabled, true)}</div>
               </div>
             </>
           )}

--- a/src/routes/views/details/awsDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/awsDetails/detailsToolbar.tsx
@@ -23,6 +23,7 @@ import { orgUnitIdKey, tagKey } from 'utils/props';
 interface DetailsToolbarOwnProps {
   isAllSelected?: boolean;
   isBulkSelectDisabled?: boolean;
+  isDisabled?: boolean;
   isExportDisabled?: boolean;
   items?: ComputedReportItem[];
   itemsPerPage?: number;
@@ -150,6 +151,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       groupBy,
       isAllSelected,
       isBulkSelectDisabled,
+      isDisabled,
       isExportDisabled,
       itemsPerPage,
       itemsTotal,
@@ -170,6 +172,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         categoryOptions={categoryOptions}
         groupBy={groupBy}
         isAllSelected={isAllSelected}
+        isDisabled={isDisabled}
         isBulkSelectDisabled={isBulkSelectDisabled}
         isExportDisabled={isExportDisabled}
         itemsPerPage={itemsPerPage}

--- a/src/routes/views/details/azureDetails/azureDetails.tsx
+++ b/src/routes/views/details/azureDetails/azureDetails.tsx
@@ -172,7 +172,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     );
   };
 
-  private getPagination = (isBottom: boolean = false) => {
+  private getPagination = (isDisabled = false, isBottom = false) => {
     const { intl, query, router, report } = this.props;
 
     const count = report && report.meta ? report.meta.count : 0;
@@ -189,6 +189,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
     return (
       <Pagination
         isCompact={!isBottom}
+        isDisabled={isDisabled}
         itemCount={count}
         onPerPageSelect={(event, perPage) => handlePerPageSelect(query, router, perPage)}
         onSetPage={(event, pageNumber) => handleSetPage(query, router, report, pageNumber)}
@@ -234,20 +235,22 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByTagKey = getGroupByTagKey(query);
+    const isDisabled = computedItems.length === 0;
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
     return (
       <DetailsToolbar
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isAllSelected={isAllSelected}
-        isExportDisabled={computedItems.length === 0 || (!isAllSelected && selectedItems.length === 0)}
+        isDisabled={isDisabled}
+        isExportDisabled={isDisabled || (!isAllSelected && selectedItems.length === 0)}
         itemsPerPage={computedItems.length}
         itemsTotal={itemsTotal}
         onBulkSelected={this.handleBulkSelected}
         onExportClicked={this.handleExportModalOpen}
         onFilterAdded={filter => handleFilterAdded(query, router, filter)}
         onFilterRemoved={filter => handleFilterRemoved(query, router, filter)}
-        pagination={this.getPagination()}
+        pagination={this.getPagination(isDisabled)}
         query={query}
         selectedItems={selectedItems}
       />
@@ -328,8 +331,9 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
       router,
     } = this.props;
 
-    const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
+    const groupById = getIdKeyForGroupBy(query.group_by);
+    const isDisabled = computedItems.length === 0;
     const title = intl.formatMessage(messages.azureDetailsTitle);
 
     // Note: Providers are fetched via the AccountSettings component used by all routes
@@ -366,7 +370,7 @@ class AzureDetails extends React.Component<AzureDetailsProps> {
             <>
               <div style={styles.tableContainer}>{this.getTable()}</div>
               <div style={styles.paginationContainer}>
-                <div style={styles.pagination}>{this.getPagination(true)}</div>
+                <div style={styles.pagination}>{this.getPagination(isDisabled, true)}</div>
               </div>
             </>
           )}

--- a/src/routes/views/details/azureDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/azureDetails/detailsToolbar.tsx
@@ -20,6 +20,7 @@ import { tagKey } from 'utils/props';
 interface DetailsToolbarOwnProps {
   isAllSelected?: boolean;
   isExportDisabled: boolean;
+  isDisabled?: boolean;
   items?: ComputedReportItem[];
   itemsPerPage?: number;
   itemsTotal?: number;
@@ -120,6 +121,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     const {
       groupBy,
       isAllSelected,
+      isDisabled,
       isExportDisabled,
       itemsPerPage,
       itemsTotal,
@@ -139,6 +141,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         categoryOptions={categoryOptions}
         groupBy={groupBy}
         isAllSelected={isAllSelected}
+        isDisabled={isDisabled}
         isExportDisabled={isExportDisabled}
         itemsPerPage={itemsPerPage}
         itemsTotal={itemsTotal}

--- a/src/routes/views/details/gcpDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/gcpDetails/detailsToolbar.tsx
@@ -20,6 +20,7 @@ import { tagKey } from 'utils/props';
 interface DetailsToolbarOwnProps {
   isAllSelected?: boolean;
   isBulkSelectDisabled?: boolean;
+  isDisabled?: boolean;
   isExportDisabled?: boolean;
   items?: ComputedReportItem[];
   itemsPerPage?: number;
@@ -117,6 +118,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       groupBy,
       isAllSelected,
       isBulkSelectDisabled,
+      isDisabled,
       isExportDisabled,
       itemsPerPage,
       itemsTotal,
@@ -137,6 +139,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         groupBy={groupBy}
         isAllSelected={isAllSelected}
         isBulkSelectDisabled={isBulkSelectDisabled}
+        isDisabled={isDisabled}
         isExportDisabled={isExportDisabled}
         itemsPerPage={itemsPerPage}
         itemsTotal={itemsTotal}

--- a/src/routes/views/details/gcpDetails/gcpDetails.tsx
+++ b/src/routes/views/details/gcpDetails/gcpDetails.tsx
@@ -172,7 +172,7 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
     );
   };
 
-  private getPagination = (isBottom: boolean = false) => {
+  private getPagination = (isDisabled = false, isBottom = false) => {
     const { intl, query, router, report } = this.props;
 
     const count = report && report.meta ? report.meta.count : 0;
@@ -189,6 +189,7 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
     return (
       <Pagination
         isCompact={!isBottom}
+        isDisabled={isDisabled}
         itemCount={count}
         onPerPageSelect={(event, perPage) => handlePerPageSelect(query, router, perPage)}
         onSetPage={(event, pageNumber) => handleSetPage(query, router, report, pageNumber)}
@@ -233,20 +234,22 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByTagKey = getGroupByTagKey(query);
+    const isDisabled = computedItems.length === 0;
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
     return (
       <DetailsToolbar
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isAllSelected={isAllSelected}
-        isExportDisabled={computedItems.length === 0 || (!isAllSelected && selectedItems.length === 0)}
+        isDisabled={isDisabled}
+        isExportDisabled={isDisabled || (!isAllSelected && selectedItems.length === 0)}
         itemsPerPage={computedItems.length}
         itemsTotal={itemsTotal}
         onBulkSelected={this.handleBulkSelected}
         onExportClicked={this.handleExportModalOpen}
         onFilterAdded={filter => handleFilterAdded(query, router, filter)}
         onFilterRemoved={filter => handleFilterRemoved(query, router, filter)}
-        pagination={this.getPagination()}
+        pagination={this.getPagination(isDisabled)}
         query={query}
         selectedItems={selectedItems}
       />
@@ -317,8 +320,9 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
     const { currency, intl, providers, providersFetchStatus, query, report, reportError, reportFetchStatus, router } =
       this.props;
 
-    const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
+    const groupById = getIdKeyForGroupBy(query.group_by);
+    const isDisabled = computedItems.length === 0;
     const title = intl.formatMessage(messages.gcpDetailsTitle);
 
     // Note: Providers are fetched via the AccountSettings component used by all routes
@@ -355,7 +359,7 @@ class GcpDetails extends React.Component<GcpDetailsProps> {
             <>
               <div style={styles.tableContainer}>{this.getTable()}</div>
               <div style={styles.paginationContainer}>
-                <div style={styles.pagination}>{this.getPagination(true)}</div>
+                <div style={styles.pagination}>{this.getPagination(isDisabled, true)}</div>
               </div>
             </>
           )}

--- a/src/routes/views/details/ibmDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/ibmDetails/detailsToolbar.tsx
@@ -20,6 +20,7 @@ import { tagKey } from 'utils/props';
 interface DetailsToolbarOwnProps {
   isAllSelected?: boolean;
   isBulkSelectDisabled?: boolean;
+  isDisabled?: boolean;
   isExportDisabled?: boolean;
   items?: ComputedReportItem[];
   itemsPerPage?: number;
@@ -115,6 +116,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
       groupBy,
       isAllSelected,
       isBulkSelectDisabled,
+      isDisabled,
       isExportDisabled,
       itemsPerPage,
       itemsTotal,
@@ -135,6 +137,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         groupBy={groupBy}
         isAllSelected={isAllSelected}
         isBulkSelectDisabled={isBulkSelectDisabled}
+        isDisabled={isDisabled}
         isExportDisabled={isExportDisabled}
         itemsPerPage={itemsPerPage}
         itemsTotal={itemsTotal}

--- a/src/routes/views/details/ibmDetails/ibmDetails.tsx
+++ b/src/routes/views/details/ibmDetails/ibmDetails.tsx
@@ -173,7 +173,7 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
     );
   };
 
-  private getPagination = (isBottom: boolean = false) => {
+  private getPagination = (isDisabled = false, isBottom = false) => {
     const { intl, query, router, report } = this.props;
 
     const count = report && report.meta ? report.meta.count : 0;
@@ -190,6 +190,7 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
     return (
       <Pagination
         isCompact={!isBottom}
+        isDisabled={isDisabled}
         itemCount={count}
         onPerPageSelect={(event, perPage) => handlePerPageSelect(query, router, perPage)}
         onSetPage={(event, pageNumber) => handleSetPage(query, router, report, pageNumber)}
@@ -235,20 +236,22 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByTagKey = getGroupByTagKey(query);
+    const isDisabled = computedItems.length === 0;
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
     return (
       <DetailsToolbar
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isAllSelected={isAllSelected}
-        isExportDisabled={computedItems.length === 0 || (!isAllSelected && selectedItems.length === 0)}
+        isDisabled={isDisabled}
+        isExportDisabled={isDisabled || (!isAllSelected && selectedItems.length === 0)}
         itemsPerPage={computedItems.length}
         itemsTotal={itemsTotal}
         onBulkSelected={this.handleBulkSelected}
         onExportClicked={this.handleExportModalOpen}
         onFilterAdded={filter => handleFilterAdded(query, router, filter)}
         onFilterRemoved={filter => handleFilterRemoved(query, router, filter)}
-        pagination={this.getPagination()}
+        pagination={this.getPagination(isDisabled)}
         query={query}
         selectedItems={selectedItems}
       />
@@ -319,8 +322,9 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
     const { currency, intl, providers, providersFetchStatus, query, report, reportError, reportFetchStatus, router } =
       this.props;
 
-    const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
+    const groupById = getIdKeyForGroupBy(query.group_by);
+    const isDisabled = computedItems.length === 0;
     const title = intl.formatMessage(messages.ibmDetailsTitle);
 
     // Note: Providers are fetched via the AccountSettings component used by all routes
@@ -357,7 +361,7 @@ class IbmDetails extends React.Component<IbmDetailsProps> {
             <>
               <div style={styles.tableContainer}>{this.getTable()}</div>
               <div style={styles.paginationContainer}>
-                <div style={styles.pagination}>{this.getPagination(true)}</div>
+                <div style={styles.pagination}>{this.getPagination(isDisabled, true)}</div>
               </div>
             </>
           )}

--- a/src/routes/views/details/ociDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/ociDetails/detailsToolbar.tsx
@@ -20,6 +20,7 @@ import { tagKey } from 'utils/props';
 interface DetailsToolbarOwnProps {
   isAllSelected?: boolean;
   isExportDisabled: boolean;
+  isDisabled?: boolean;
   items?: ComputedReportItem[];
   itemsPerPage?: number;
   itemsTotal?: number;
@@ -123,6 +124,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     const {
       groupBy,
       isAllSelected,
+      isDisabled,
       isExportDisabled,
       itemsPerPage,
       itemsTotal,
@@ -142,6 +144,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         categoryOptions={categoryOptions}
         groupBy={groupBy}
         isAllSelected={isAllSelected}
+        isDisabled={isDisabled}
         isExportDisabled={isExportDisabled}
         itemsPerPage={itemsPerPage}
         itemsTotal={itemsTotal}

--- a/src/routes/views/details/ociDetails/ociDetails.tsx
+++ b/src/routes/views/details/ociDetails/ociDetails.tsx
@@ -172,7 +172,7 @@ class OciDetails extends React.Component<OciDetailsProps> {
     );
   };
 
-  private getPagination = (isBottom: boolean = false) => {
+  private getPagination = (isDisabled = false, isBottom = false) => {
     const { intl, query, report, router } = this.props;
 
     const count = report && report.meta ? report.meta.count : 0;
@@ -189,6 +189,7 @@ class OciDetails extends React.Component<OciDetailsProps> {
     return (
       <Pagination
         isCompact={!isBottom}
+        isDisabled={isDisabled}
         itemCount={count}
         onPerPageSelect={(event, perPage) => handlePerPageSelect(query, router, perPage)}
         onSetPage={(event, pageNumber) => handleSetPage(query, router, report, pageNumber)}
@@ -234,12 +235,14 @@ class OciDetails extends React.Component<OciDetailsProps> {
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByTagKey = getGroupByTagKey(query);
+    const isDisabled = computedItems.length === 0;
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
     return (
       <DetailsToolbar
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isAllSelected={isAllSelected}
+        isDisabled={isDisabled}
         isExportDisabled={computedItems.length === 0 || (!isAllSelected && selectedItems.length === 0)}
         itemsPerPage={computedItems.length}
         itemsTotal={itemsTotal}
@@ -247,7 +250,7 @@ class OciDetails extends React.Component<OciDetailsProps> {
         onExportClicked={this.handleExportModalOpen}
         onFilterAdded={filter => handleFilterAdded(query, router, filter)}
         onFilterRemoved={filter => handleFilterRemoved(query, router, filter)}
-        pagination={this.getPagination()}
+        pagination={this.getPagination(isDisabled)}
         query={query}
         selectedItems={selectedItems}
       />
@@ -328,8 +331,9 @@ class OciDetails extends React.Component<OciDetailsProps> {
       router,
     } = this.props;
 
-    const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
+    const groupById = getIdKeyForGroupBy(query.group_by);
+    const isDisabled = computedItems.length === 0;
     const title = intl.formatMessage(messages.ociDetailsTitle);
 
     // Note: Providers are fetched via the AccountSettings component used by all routes
@@ -366,7 +370,7 @@ class OciDetails extends React.Component<OciDetailsProps> {
             <>
               <div style={styles.tableContainer}>{this.getTable()}</div>
               <div style={styles.paginationContainer}>
-                <div style={styles.pagination}>{this.getPagination(true)}</div>
+                <div style={styles.pagination}>{this.getPagination(isDisabled, true)}</div>
               </div>
             </>
           )}

--- a/src/routes/views/details/ocpDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/ocpDetails/detailsToolbar.tsx
@@ -19,6 +19,7 @@ import { tagKey } from 'utils/props';
 
 interface DetailsToolbarOwnProps {
   isAllSelected?: boolean;
+  isDisabled?: boolean;
   isExportDisabled: boolean;
   itemsPerPage?: number;
   itemsTotal?: number;
@@ -115,6 +116,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     const {
       groupBy,
       isAllSelected,
+      isDisabled,
       isExportDisabled,
       itemsPerPage,
       itemsTotal,
@@ -136,6 +138,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         categoryOptions={categoryOptions}
         groupBy={groupBy}
         isAllSelected={isAllSelected}
+        isDisabled={isDisabled}
         isExportDisabled={isExportDisabled}
         itemsPerPage={itemsPerPage}
         itemsTotal={itemsTotal}

--- a/src/routes/views/details/ocpDetails/ocpDetails.tsx
+++ b/src/routes/views/details/ocpDetails/ocpDetails.tsx
@@ -216,7 +216,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     );
   };
 
-  private getPagination = (isBottom: boolean = false) => {
+  private getPagination = (isDisabled = false, isBottom = false) => {
     const { intl, query, report, router } = this.props;
 
     const count = report && report.meta ? report.meta.count : 0;
@@ -233,6 +233,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     return (
       <Pagination
         isCompact={!isBottom}
+        isDisabled={isDisabled}
         itemCount={count}
         onPerPageSelect={(event, perPage) => handlePerPageSelect(query, router, perPage)}
         onSetPage={(event, pageNumber) => handleSetPage(query, router, report, pageNumber)}
@@ -279,13 +280,15 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByTagKey = getGroupByTagKey(query);
+    const isDisabled = computedItems.length === 0;
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
     return (
       <DetailsToolbar
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isAllSelected={isAllSelected}
-        isExportDisabled={computedItems.length === 0 || (!isAllSelected && selectedItems.length === 0)}
+        isDisabled={isDisabled}
+        isExportDisabled={isDisabled || (!isAllSelected && selectedItems.length === 0)}
         itemsPerPage={computedItems.length}
         itemsTotal={itemsTotal}
         onBulkSelected={this.handleBulkSelected}
@@ -294,7 +297,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
         onFilterAdded={filter => handleFilterAdded(query, router, filter)}
         onFilterRemoved={filter => handleFilterRemoved(query, router, filter)}
         onPlatformCostsChanged={this.handlePlatformCostsChanged}
-        pagination={this.getPagination()}
+        pagination={this.getPagination(isDisabled)}
         query={query}
         selectedItems={selectedItems}
       />
@@ -389,8 +392,9 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
     const { currency, intl, providers, providersFetchStatus, query, report, reportError, reportFetchStatus, router } =
       this.props;
 
-    const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
+    const groupById = getIdKeyForGroupBy(query.group_by);
+    const isDisabled = computedItems.length === 0;
     const title = intl.formatMessage(messages.ocpDetailsTitle);
 
     // Note: Providers are fetched via the AccountSettings component used by all routes
@@ -428,7 +432,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
             <>
               <div style={styles.tableContainer}>{this.getTable()}</div>
               <div style={styles.paginationContainer}>
-                <div style={styles.pagination}>{this.getPagination(true)}</div>
+                <div style={styles.pagination}>{this.getPagination(isDisabled, true)}</div>
               </div>
             </>
           )}

--- a/src/routes/views/details/rhelDetails/detailsToolbar.tsx
+++ b/src/routes/views/details/rhelDetails/detailsToolbar.tsx
@@ -20,6 +20,7 @@ import { tagKey } from 'utils/props';
 interface DetailsToolbarOwnProps {
   isAllSelected?: boolean;
   isExportDisabled: boolean;
+  isDisabled?: boolean;
   itemsPerPage?: number;
   itemsTotal?: number;
   groupBy: string;
@@ -115,6 +116,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
     const {
       groupBy,
       isAllSelected,
+      isDisabled,
       isExportDisabled,
       itemsPerPage,
       itemsTotal,
@@ -136,6 +138,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps> {
         categoryOptions={categoryOptions}
         groupBy={groupBy}
         isAllSelected={isAllSelected}
+        isDisabled={isDisabled}
         isExportDisabled={isExportDisabled}
         itemsPerPage={itemsPerPage}
         itemsTotal={itemsTotal}

--- a/src/routes/views/details/rhelDetails/rhelDetails.tsx
+++ b/src/routes/views/details/rhelDetails/rhelDetails.tsx
@@ -216,7 +216,7 @@ class RhelDetails extends React.Component<OcpDetailsProps> {
     );
   };
 
-  private getPagination = (isBottom: boolean = false) => {
+  private getPagination = (isDisabled = false, isBottom = false) => {
     const { intl, query, report, router } = this.props;
 
     const count = report && report.meta ? report.meta.count : 0;
@@ -233,6 +233,7 @@ class RhelDetails extends React.Component<OcpDetailsProps> {
     return (
       <Pagination
         isCompact={!isBottom}
+        isDisabled={isDisabled}
         itemCount={count}
         onPerPageSelect={(event, perPage) => handlePerPageSelect(query, router, perPage)}
         onSetPage={(event, pageNumber) => handleSetPage(query, router, report, pageNumber)}
@@ -279,13 +280,15 @@ class RhelDetails extends React.Component<OcpDetailsProps> {
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByTagKey = getGroupByTagKey(query);
+    const isDisabled = computedItems.length === 0;
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
     return (
       <DetailsToolbar
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isAllSelected={isAllSelected}
-        isExportDisabled={computedItems.length === 0 || (!isAllSelected && selectedItems.length === 0)}
+        isDisabled={isDisabled}
+        isExportDisabled={isDisabled || (!isAllSelected && selectedItems.length === 0)}
         itemsPerPage={computedItems.length}
         itemsTotal={itemsTotal}
         onBulkSelected={this.handleBulkSelected}
@@ -389,8 +392,9 @@ class RhelDetails extends React.Component<OcpDetailsProps> {
     const { currency, intl, providers, providersFetchStatus, query, report, reportError, reportFetchStatus, router } =
       this.props;
 
-    const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
+    const groupById = getIdKeyForGroupBy(query.group_by);
+    const isDisabled = computedItems.length === 0;
     const title = intl.formatMessage(messages.ocpDetailsTitle);
 
     // Note: Providers are fetched via the AccountSettings component used by all routes
@@ -428,7 +432,7 @@ class RhelDetails extends React.Component<OcpDetailsProps> {
             <>
               <div style={styles.tableContainer}>{this.getTable()}</div>
               <div style={styles.paginationContainer}>
-                <div style={styles.pagination}>{this.getPagination(true)}</div>
+                <div style={styles.pagination}>{this.getPagination(isDisabled, true)}</div>
               </div>
             </>
           )}

--- a/src/routes/views/explorer/explorer.tsx
+++ b/src/routes/views/explorer/explorer.tsx
@@ -203,7 +203,7 @@ class Explorer extends React.Component<ExplorerProps> {
     );
   };
 
-  private getPagination = (isBottom: boolean = false) => {
+  private getPagination = (isDisabled = false, isBottom = false) => {
     const { intl, query, report, router } = this.props;
 
     const count = report && report.meta ? report.meta.count : 0;
@@ -220,6 +220,7 @@ class Explorer extends React.Component<ExplorerProps> {
     return (
       <Pagination
         isCompact={!isBottom}
+        isDisabled={isDisabled}
         itemCount={count}
         onPerPageSelect={(event, perPage) => handlePerPageSelect(query, router, perPage)}
         onSetPage={(event, pageNumber) => handleSetPage(query, router, report, pageNumber)}
@@ -268,17 +269,19 @@ class Explorer extends React.Component<ExplorerProps> {
     const { perspective, report } = this.props;
     const { isAllSelected, selectedItems } = this.state;
 
+    const isDisabled = computedItems.length === 0;
     const itemsTotal = report && report.meta ? report.meta.count : 0;
 
     return (
       <ExplorerToolbar
         isAllSelected={isAllSelected}
-        isExportDisabled={computedItems.length === 0 || (!isAllSelected && selectedItems.length === 0)}
+        isDisabled={isDisabled}
+        isExportDisabled={isDisabled || (!isAllSelected && selectedItems.length === 0)}
         itemsPerPage={computedItems.length}
         itemsTotal={itemsTotal}
         onBulkSelected={this.handleBulkSelected}
         onExportClicked={this.handleExportModalOpen}
-        pagination={this.getPagination()}
+        pagination={this.getPagination(isDisabled)}
         perspective={perspective}
         selectedItems={selectedItems}
       />
@@ -439,10 +442,11 @@ class Explorer extends React.Component<ExplorerProps> {
     const isLoading =
       providersFetchStatus === FetchStatus.inProgress || userAccessFetchStatus === FetchStatus.inProgress;
 
+    const computedItems = this.getComputedItems();
+    const isDisabled = computedItems.length === 0;
+    const itemsTotal = report && report.meta ? report.meta.count : 0;
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByTagKey = getGroupByTagKey(query);
-    const computedItems = this.getComputedItems();
-    const itemsTotal = report && report.meta ? report.meta.count : 0;
     const title = intl.formatMessage(messages.explorerTitle);
 
     // Note: Providers are fetched via the AccountSettings component used by all routes
@@ -502,7 +506,7 @@ class Explorer extends React.Component<ExplorerProps> {
             <>
               <div style={styles.tableContainer}>{this.getTable()}</div>
               <div style={styles.paginationContainer}>
-                <div style={styles.pagination}>{this.getPagination(true)}</div>
+                <div style={styles.pagination}>{this.getPagination(isDisabled, true)}</div>
               </div>
             </>
           )}

--- a/src/routes/views/explorer/explorerToolbar.tsx
+++ b/src/routes/views/explorer/explorerToolbar.tsx
@@ -13,6 +13,7 @@ import { getTagReportPathsType } from './explorerUtils';
 interface ExplorerToolbarOwnProps {
   isAllSelected?: boolean;
   isBulkSelectDisabled?: boolean;
+  isDisabled?: boolean;
   isExportDisabled?: boolean;
   itemsPerPage?: number;
   itemsTotal?: number;
@@ -48,6 +49,7 @@ export class ExplorerToolbarBase extends React.Component<ExplorerToolbarProps> {
     const {
       isAllSelected,
       isBulkSelectDisabled,
+      isDisabled,
       isExportDisabled,
       itemsPerPage,
       itemsTotal,
@@ -64,6 +66,7 @@ export class ExplorerToolbarBase extends React.Component<ExplorerToolbarProps> {
       <DataToolbar
         isAllSelected={isAllSelected}
         isBulkSelectDisabled={isBulkSelectDisabled}
+        isDisabled={isDisabled}
         isExportDisabled={isExportDisabled}
         itemsPerPage={itemsPerPage}
         itemsTotal={itemsTotal}

--- a/src/routes/views/ros/recommendations/recommendations.tsx
+++ b/src/routes/views/ros/recommendations/recommendations.tsx
@@ -217,7 +217,7 @@ class Recommendations extends React.Component<RecommendationsProps> {
     );
   };
 
-  private getPagination = (isBottom: boolean = false) => {
+  private getPagination = (isDisabled = false, isBottom = false) => {
     const { intl, query, recommendation, router } = this.props;
 
     const count = recommendation && recommendation.meta ? recommendation.meta.count : 0;
@@ -234,6 +234,7 @@ class Recommendations extends React.Component<RecommendationsProps> {
     return (
       <Pagination
         isCompact={!isBottom}
+        isDisabled={isDisabled}
         itemCount={count}
         onPerPageSelect={(event, perPage) => handlePerPageSelect(query, router, perPage)}
         onSetPage={(event, pageNumber) => handleSetPage(query, router, recommendation, pageNumber)}
@@ -280,13 +281,15 @@ class Recommendations extends React.Component<RecommendationsProps> {
 
     const groupById = getIdKeyForGroupBy(query.group_by);
     const groupByTagKey = getGroupByTagKey(query);
+    const isDisabled = computedItems.length === 0;
     const itemsTotal = recommendation && recommendation.meta ? recommendation.meta.count : 0;
 
     return (
       <RosToolbar
         groupBy={groupByTagKey ? `${tagPrefix}${groupByTagKey}` : groupById}
         isAllSelected={isAllSelected}
-        isExportDisabled={computedItems.length === 0 || (!isAllSelected && selectedItems.length === 0)}
+        isDisabled={isDisabled}
+        isExportDisabled={isDisabled || (!isAllSelected && selectedItems.length === 0)}
         itemsPerPage={computedItems.length}
         itemsTotal={itemsTotal}
         onBulkSelected={this.handleBulkSelected}
@@ -295,7 +298,7 @@ class Recommendations extends React.Component<RecommendationsProps> {
         onFilterAdded={filter => handleFilterAdded(query, router, filter)}
         onFilterRemoved={filter => handleFilterRemoved(query, router, filter)}
         onPlatformCostsChanged={this.handlePlatformCostsChanged}
-        pagination={this.getPagination()}
+        pagination={this.getPagination(isDisabled)}
         query={query}
         selectedItems={selectedItems}
       />
@@ -399,8 +402,9 @@ class Recommendations extends React.Component<RecommendationsProps> {
       router,
     } = this.props;
 
-    const groupById = getIdKeyForGroupBy(query.group_by);
     const computedItems = this.getComputedItems();
+    const groupById = getIdKeyForGroupBy(query.group_by);
+    const isDisabled = computedItems.length === 0;
     const title = intl.formatMessage(messages.ocpDetailsTitle);
 
     // Note: Providers are fetched via the AccountSettings component used by all routes
@@ -438,7 +442,7 @@ class Recommendations extends React.Component<RecommendationsProps> {
             <>
               <div style={styles.tableContainer}>{this.getTable()}</div>
               <div style={styles.paginationContainer}>
-                <div style={styles.pagination}>{this.getPagination(true)}</div>
+                <div style={styles.pagination}>{this.getPagination(isDisabled, true)}</div>
               </div>
             </>
           )}

--- a/src/routes/views/ros/recommendations/rosToolbar.tsx
+++ b/src/routes/views/ros/recommendations/rosToolbar.tsx
@@ -19,6 +19,7 @@ import { tagKey } from 'utils/props';
 
 interface RosToolbarOwnProps {
   isAllSelected?: boolean;
+  isDisabled?: boolean;
   isExportDisabled: boolean;
   itemsPerPage?: number;
   itemsTotal?: number;
@@ -112,6 +113,7 @@ export class RosToolbarBase extends React.Component<RosToolbarProps> {
     const {
       groupBy,
       isAllSelected,
+      isDisabled,
       isExportDisabled,
       itemsPerPage,
       itemsTotal,
@@ -133,6 +135,7 @@ export class RosToolbarBase extends React.Component<RosToolbarProps> {
         categoryOptions={categoryOptions}
         groupBy={groupBy}
         isAllSelected={isAllSelected}
+        isDisabled={isDisabled}
         isExportDisabled={isExportDisabled}
         itemsPerPage={itemsPerPage}
         itemsTotal={itemsTotal}


### PR DESCRIPTION
There are scenarios when table toolbar actions should be disabled. Including the bulk select, filter, include/exclude, export, manage columns, platform costs, and pagination.

1. While the page is loading, all toolbar actions are disabled
2. If the API returns no data, all toolbar actions are disabled
3. If there is no data due to filtering, only the filter actions remain enabled

https://issues.redhat.com/browse/COST-3537