### PR TITLE
Incorrect alignment of Infra and Supp cost columns

### DIFF
--- a/src/routes/views/details/awsDetails/detailsTable.tsx
+++ b/src/routes/views/details/awsDetails/detailsTable.tsx
@@ -162,7 +162,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             ),
           },
           { value: <div>{monthOverMonth}</div> },
-          { value: <div>{cost}</div> },
+          { value: <div>{cost}</div>, style: styles.managedColumn },
           { value: <div>{actions}</div> },
         ],
         item,

--- a/src/routes/views/details/azureDetails/detailsTable.tsx
+++ b/src/routes/views/details/azureDetails/detailsTable.tsx
@@ -156,7 +156,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             ),
           },
           { value: <div>{monthOverMonth}</div> },
-          { value: <div>{cost}</div> },
+          { value: <div>{cost}</div>, style: styles.managedColumn },
           { value: <div>{actions}</div> },
         ],
         isOpen: false,

--- a/src/routes/views/details/components/dataTable/dataTable.styles.ts
+++ b/src/routes/views/details/components/dataTable/dataTable.styles.ts
@@ -8,6 +8,9 @@ import type React from 'react';
 export const styles = {
   costColumn: {
     textAlign: 'right',
+    display: 'flex',
+    justifyContent: 'flex-end',
+    paddingRight: 0,
   },
   defaultLabel: {
     minWidth: '63px',
@@ -29,6 +32,9 @@ export const styles = {
   infoDescription: {
     color: global_disabled_color_100.value,
     fontSize: global_FontSize_xs.value,
+  },
+  managedColumn: {
+    textAlign: 'right',
   },
   nameColumn: {
     width: '1%',

--- a/src/routes/views/details/components/dataTable/dataTable.tsx
+++ b/src/routes/views/details/components/dataTable/dataTable.tsx
@@ -153,6 +153,7 @@ class DataTable extends React.Component<DataTableProps> {
                           onSelect: (_event, isSelected) => this.handleOnSelect(_event, isSelected, rowIndex),
                           rowIndex,
                         }}
+                        style={item.style}
                       />
                     ) : (
                       <Td
@@ -160,6 +161,7 @@ class DataTable extends React.Component<DataTableProps> {
                         key={`cell-${rowIndex}-${cellIndex}`}
                         modifier="nowrap"
                         isActionCell={cellIndex === row.cells.length - 1}
+                        style={item.style}
                       >
                         {item.value}
                       </Td>

--- a/src/routes/views/details/gcpDetails/detailsTable.tsx
+++ b/src/routes/views/details/gcpDetails/detailsTable.tsx
@@ -156,7 +156,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             ),
           },
           { value: <div>{monthOverMonth}</div> },
-          { value: <div>{cost}</div> },
+          { value: <div>{cost}</div>, style: styles.managedColumn },
           { value: <div>{actions}</div> },
         ],
         isOpen: false,

--- a/src/routes/views/details/ibmDetails/detailsTable.tsx
+++ b/src/routes/views/details/ibmDetails/detailsTable.tsx
@@ -156,7 +156,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             ),
           },
           { value: <div>{monthOverMonth}</div> },
-          { value: <div>{cost}</div> },
+          { value: <div>{cost}</div>, style: styles.managedColumn },
           { value: <div>{actions}</div> },
         ],
         isOpen: false,

--- a/src/routes/views/details/ociDetails/detailsTable.tsx
+++ b/src/routes/views/details/ociDetails/detailsTable.tsx
@@ -156,7 +156,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             ),
           },
           { value: <div>{monthOverMonth}</div> },
-          { value: <div>{cost}</div> },
+          { value: <div>{cost}</div>, style: styles.managedColumn },
           { value: <div>{actions}</div> },
         ],
         isOpen: false,

--- a/src/routes/views/details/ocpDetails/detailsTable.tsx
+++ b/src/routes/views/details/ocpDetails/detailsTable.tsx
@@ -110,18 +110,18 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           {
             id: DetailsTableColumnIds.infrastructure,
             name: intl.formatMessage(messages.ocpDetailsInfrastructureCost),
-            style: styles.costColumn,
+            style: styles.managedColumn,
           },
           {
             id: DetailsTableColumnIds.supplementary,
             name: intl.formatMessage(messages.ocpDetailsSupplementaryCost),
-            style: styles.costColumn,
+            style: styles.managedColumn,
           },
           {
             orderBy: 'cost',
             name: intl.formatMessage(messages.cost),
             style: styles.costColumn,
-            ...(computedItems.length && { isSortable: true }),
+            ...(computedItems.length && { isSortable: false }),
           },
           {
             name: '',
@@ -149,7 +149,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             id: DetailsTableColumnIds.infrastructure,
             orderBy: 'infrastructure_cost',
             name: intl.formatMessage(messages.ocpDetailsInfrastructureCost),
-            style: styles.costColumn,
+            style: styles.managedColumn,
 
             // Sort by infrastructure_cost is not supported -- https://github.com/project-koku/koku/issues/796
             // ...(computedItems.length && { isSortable: true }),
@@ -158,7 +158,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             id: DetailsTableColumnIds.supplementary,
             orderBy: 'supplementary_cost',
             name: intl.formatMessage(messages.ocpDetailsSupplementaryCost),
-            style: styles.costColumn,
+            style: styles.managedColumn,
 
             // Sort by supplementary_cost is not supported -- https://github.com/project-koku/koku/issues/796
             // ...(computedItems.length && { isSortable: true }),
@@ -230,9 +230,17 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
               ),
           },
           { value: <div>{monthOverMonth}</div>, id: DetailsTableColumnIds.monthOverMonth },
-          { value: <div>{InfrastructureCost}</div>, id: DetailsTableColumnIds.infrastructure },
-          { value: <div>{supplementaryCost}</div>, id: DetailsTableColumnIds.supplementary },
-          { value: <div>{cost}</div> },
+          {
+            value: <div>{InfrastructureCost}</div>,
+            id: DetailsTableColumnIds.infrastructure,
+            style: styles.managedColumn,
+          },
+          {
+            value: <div>{supplementaryCost}</div>,
+            id: DetailsTableColumnIds.supplementary,
+            style: styles.managedColumn,
+          },
+          { value: <div>{cost}</div>, style: styles.managedColumn },
           { value: <div>{actions}</div> },
         ],
         item,

--- a/src/routes/views/details/rhelDetails/detailsTable.tsx
+++ b/src/routes/views/details/rhelDetails/detailsTable.tsx
@@ -110,12 +110,12 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           {
             id: DetailsTableColumnIds.infrastructure,
             name: intl.formatMessage(messages.rhelDetailsInfrastructureCost),
-            style: styles.costColumn,
+            style: styles.managedColumn,
           },
           {
             id: DetailsTableColumnIds.supplementary,
             name: intl.formatMessage(messages.rhelDetailsSupplementaryCost),
-            style: styles.costColumn,
+            style: styles.managedColumn,
           },
           {
             orderBy: 'cost',
@@ -149,7 +149,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             id: DetailsTableColumnIds.infrastructure,
             orderBy: 'infrastructure_cost',
             name: intl.formatMessage(messages.rhelDetailsInfrastructureCost),
-            style: styles.costColumn,
+            style: styles.managedColumn,
 
             // Sort by infrastructure_cost is not supported -- https://github.com/project-koku/koku/issues/796
             // ...(computedItems.length && { isSortable: true }),
@@ -158,7 +158,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             id: DetailsTableColumnIds.supplementary,
             orderBy: 'supplementary_cost',
             name: intl.formatMessage(messages.rhelDetailsSupplementaryCost),
-            style: styles.costColumn,
+            style: styles.managedColumn,
 
             // Sort by supplementary_cost is not supported -- https://github.com/project-koku/koku/issues/796
             // ...(computedItems.length && { isSortable: true }),
@@ -225,9 +225,17 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
             ),
           },
           { value: <div>{monthOverMonth}</div>, id: DetailsTableColumnIds.monthOverMonth },
-          { value: <div>{InfrastructureCost}</div>, id: DetailsTableColumnIds.infrastructure },
-          { value: <div>{supplementaryCost}</div>, id: DetailsTableColumnIds.supplementary },
-          { value: <div>{cost}</div> },
+          {
+            value: <div>{InfrastructureCost}</div>,
+            id: DetailsTableColumnIds.infrastructure,
+            style: styles.managedColumn,
+          },
+          {
+            value: <div>{supplementaryCost}</div>,
+            id: DetailsTableColumnIds.supplementary,
+            style: styles.managedColumn,
+          },
+          { value: <div>{cost}</div>, style: styles.managedColumn },
           { value: <div>{actions}</div> },
         ],
         item,

--- a/src/routes/views/ros/recommendations/rosTable.tsx
+++ b/src/routes/views/ros/recommendations/rosTable.tsx
@@ -106,12 +106,12 @@ class RosTableBase extends React.Component<RosTableProps> {
           {
             id: RosTableColumnIds.infrastructure,
             name: intl.formatMessage(messages.rhelDetailsInfrastructureCost),
-            style: styles.costColumn,
+            style: styles.managedColumn,
           },
           {
             id: RosTableColumnIds.supplementary,
             name: intl.formatMessage(messages.rhelDetailsSupplementaryCost),
-            style: styles.costColumn,
+            style: styles.managedColumn,
           },
           {
             orderBy: 'cost',
@@ -145,7 +145,7 @@ class RosTableBase extends React.Component<RosTableProps> {
             id: RosTableColumnIds.infrastructure,
             orderBy: 'infrastructure_cost',
             name: intl.formatMessage(messages.rhelDetailsInfrastructureCost),
-            style: styles.costColumn,
+            style: styles.managedColumn,
 
             // Sort by infrastructure_cost is not supported -- https://github.com/project-koku/koku/issues/796
             // ...(computedItems.length && { isSortable: true }),
@@ -154,7 +154,7 @@ class RosTableBase extends React.Component<RosTableProps> {
             id: RosTableColumnIds.supplementary,
             orderBy: 'supplementary_cost',
             name: intl.formatMessage(messages.rhelDetailsSupplementaryCost),
-            style: styles.costColumn,
+            style: styles.managedColumn,
 
             // Sort by supplementary_cost is not supported -- https://github.com/project-koku/koku/issues/796
             // ...(computedItems.length && { isSortable: true }),
@@ -204,9 +204,9 @@ class RosTableBase extends React.Component<RosTableProps> {
             ),
           },
           { value: <div>{monthOverMonth}</div>, id: RosTableColumnIds.monthOverMonth },
-          { value: <div>{InfrastructureCost}</div>, id: RosTableColumnIds.infrastructure },
-          { value: <div>{supplementaryCost}</div>, id: RosTableColumnIds.supplementary },
-          { value: <div>{cost}</div> },
+          { value: <div>{InfrastructureCost}</div>, id: RosTableColumnIds.infrastructure, style: styles.managedColumn },
+          { value: <div>{supplementaryCost}</div>, id: RosTableColumnIds.supplementary, style: styles.managedColumn },
+          { value: <div>{cost}</div>, style: styles.managedColumn },
           { value: <div>{actions}</div> },
         ],
         item,


### PR DESCRIPTION
The PatternFly composable table appears to have changed and broke our previous column alignments

https://issues.redhat.com/browse/COST-3568

![Screenshot 2023-03-08 at 6 00 30 PM](https://user-images.githubusercontent.com/17481322/223873594-9cd6e8ab-bde5-4965-aecd-6daa1ec5f100.png)
