### PR TITLE
Broken currency selector on the OCP Overview page

### DIFF
--- a/src/routes/views/overview/components/dashboardWidgetBase.tsx
+++ b/src/routes/views/overview/components/dashboardWidgetBase.tsx
@@ -119,7 +119,7 @@ class DashboardWidgetBase extends React.Component<DashboardWidgetProps> {
 
     if (prevProps.costType !== costType || prevProps.currency !== currency) {
       fetchReports(widgetId);
-      if (trend.computedForecastItem !== undefined) {
+      if (trend && trend.computedForecastItem !== undefined) {
         fetchForecasts(widgetId);
       }
     }

--- a/src/store/dashboard/ocpDashboard/ocpDashboardActions.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardActions.ts
@@ -24,19 +24,26 @@ export const fetchWidgetReports = (id: number): ThunkAction => {
     const state = getState();
     const widget = selectWidget(state, id);
     const { previous, current, tabs } = selectWidgetQueries(state, id);
-    dispatch(reportActions.fetchReport(widget.reportPathsType, widget.reportType, current));
-    dispatch(reportActions.fetchReport(widget.reportPathsType, widget.reportType, previous));
-    if (widget.availableTabs) {
-      dispatch(reportActions.fetchReport(widget.reportPathsType, widget.reportType, tabs));
+
+    if (widget.reportPathsType && widget.reportType) {
+      dispatch(reportActions.fetchReport(widget.reportPathsType, widget.reportType, current));
+      dispatch(reportActions.fetchReport(widget.reportPathsType, widget.reportType, previous));
+      if (widget.availableTabs) {
+        dispatch(reportActions.fetchReport(widget.reportPathsType, widget.reportType, tabs));
+      }
     }
   };
 };
+
 export const fetchWidgetRos = (id: number): ThunkAction => {
   return (dispatch, getState) => {
     const state = getState();
     const widget = selectWidget(state, id);
     const { ros } = selectWidgetQueries(state, id);
-    dispatch(rosActions.fetchRos(widget.rosPathsType, widget.rosType, ros));
+
+    if (widget.rosPathsType && widget.rosType) {
+      dispatch(rosActions.fetchRos(widget.rosPathsType, widget.rosType, ros));
+    }
   };
 };
 


### PR DESCRIPTION
This fixes an issue with the ROS widget, newly added to the overview page.

https://issues.redhat.com/browse/COST-3576