### PR TITLE
Stub-out OCP details page for ROS

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -10334,6 +10334,12 @@
         "value": "Failed to get RBAC information"
       }
     ],
+    "recommendations": [
+      {
+        "type": 0,
+        "value": "Recommendations"
+      }
+    ],
     "redHatStatusUrl": [
       {
         "type": 0,

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -447,6 +447,7 @@
   "rawCostTitle": "Raw cost",
   "rbacErrorDescription": "There was a problem receiving user permissions. Refreshing this page may fix it. If it does not, please contact your admin.",
   "rbacErrorTitle": "Failed to get RBAC information",
+  "recommendations": "Recommendations",
   "redHatStatusUrl": "https://status.redhat.com",
   "remove": "Remove",
   "requests": "Requests",

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -2758,6 +2758,11 @@ export default defineMessages({
     description: 'RBAC error title',
     id: 'rbacErrorTitle',
   },
+  recommendations: {
+    defaultMessage: 'Recommendations',
+    description: 'Recommendations',
+    id: 'recommendations',
+  },
   redHatStatusUrl: {
     defaultMessage: 'https://status.redhat.com',
     description: 'Red Hat status url for cloud services',
@@ -2914,7 +2919,7 @@ export default defineMessages({
   },
   rosRecommendationsDetails: {
     defaultMessage: '{count, plural, =0 {No recommendations} other {{count} recommendations}}',
-    description: 'Recommendations',
+    description: 'Recommendation details',
     id: 'rosRecommendationsDetails',
   },
   rosRecommendationsTitle: {

--- a/src/routes/views/details/ocpDetails/detailsTable.tsx
+++ b/src/routes/views/details/ocpDetails/detailsTable.tsx
@@ -30,6 +30,7 @@ interface DetailsTableOwnProps extends RouterComponentProps, WrappedComponentPro
   hiddenColumns: Set<string>;
   isAllSelected?: boolean;
   isLoading?: boolean;
+  isRosFeatureEnabled?: boolean;
   onSelected(items: ComputedReportItem[], isSelected: boolean);
   onSort(value: string, isSortAscending: boolean);
   report: OcpReport;
@@ -77,7 +78,17 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
   }
 
   private initDatum = () => {
-    const { groupBy, groupByTagKey, hiddenColumns, intl, isAllSelected, report, router, selectedItems } = this.props;
+    const {
+      groupBy,
+      groupByTagKey,
+      hiddenColumns,
+      intl,
+      isAllSelected,
+      isRosFeatureEnabled,
+      report,
+      router,
+      selectedItems,
+    } = this.props;
     if (!report) {
       return;
     }
@@ -103,6 +114,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           {
             hidden: !showDefaultProject,
             name: '', // Default column
+          },
+          {
+            hidden: !isRosFeatureEnabled,
+            name: intl.formatMessage(messages.recommendations),
           },
           {
             name: intl.formatMessage(messages.monthOverMonthChange),
@@ -140,6 +155,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
           {
             hidden: !showDefaultProject,
             name: '', // Default column
+          },
+          {
+            hidden: !isRosFeatureEnabled,
+            name: intl.formatMessage(messages.recommendations),
           },
           {
             id: DetailsTableColumnIds.monthOverMonth,
@@ -228,6 +247,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps> {
               ) : (
                 <div style={styles.defaultLabel} />
               ),
+          },
+          {
+            hidden: !isRosFeatureEnabled,
+            value: <div>N/A</div>,
           },
           { value: <div>{monthOverMonth}</div>, id: DetailsTableColumnIds.monthOverMonth },
           {

--- a/src/routes/views/details/ocpDetails/ocpDetails.tsx
+++ b/src/routes/views/details/ocpDetails/ocpDetails.tsx
@@ -50,6 +50,7 @@ import { styles } from './ocpDetails.styles';
 
 interface OcpDetailsStateProps {
   currency?: string;
+  isRosFeatureEnabled?: boolean;
   providers: Providers;
   providersFetchStatus: FetchStatus;
   query: OcpQuery;
@@ -252,7 +253,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
   };
 
   private getTable = () => {
-    const { query, report, reportFetchStatus, reportQueryString, router } = this.props;
+    const { isRosFeatureEnabled, query, report, reportFetchStatus, reportQueryString, router } = this.props;
     const { hiddenColumns, isAllSelected, selectedItems } = this.state;
 
     const groupById = getIdKeyForGroupBy(query.group_by);
@@ -265,6 +266,7 @@ class OcpDetails extends React.Component<OcpDetailsProps> {
         hiddenColumns={hiddenColumns}
         isAllSelected={isAllSelected}
         isLoading={reportFetchStatus === FetchStatus.inProgress}
+        isRosFeatureEnabled={isRosFeatureEnabled}
         onSelected={this.handleSelected}
         onSort={(sortType, isSortAscending) => handleSort(query, router, sortType, isSortAscending)}
         report={report}
@@ -481,6 +483,7 @@ const mapStateToProps = createMapStateToProps<OcpDetailsOwnProps, OcpDetailsStat
 
   return {
     currency,
+    isRosFeatureEnabled: featureFlagsSelectors.selectIsRosFeatureEnabled(state),
     providers: filterProviders(providers, ProviderType.ocp),
     providersFetchStatus,
     query,


### PR DESCRIPTION
Stubbed out the recommendations column. Will update with data when API is available

https://issues.redhat.com/browse/COST-3492

![Screenshot 2023-03-09 at 2 58 33 PM](https://user-images.githubusercontent.com/17481322/224141504-5b474f56-8875-46f1-8d6e-76e8a0ebc180.png)
