### PR TITLE
Fix CSS scope name

### DIFF
--- a/fec.config.js
+++ b/fec.config.js
@@ -21,7 +21,7 @@ class WatchRunPlugin {
     compiler.hooks.watchRun.tap('WatchRun', comp => {
       if (comp.modifiedFiles) {
         const changedFiles = Array.from(comp.modifiedFiles, file => `\n  ${file}`).join('');
-        const logger = compiler.getInfrastructureLogger('cost-management');
+        const logger = compiler.getInfrastructureLogger(insights.appname);
         logger.info(' ');
         logger.info('===============================');
         logger.info('FILES CHANGED:', changedFiles);
@@ -36,6 +36,7 @@ module.exports = {
   debug: true,
   interceptChromeConfig: false, // Change to false after your app is registered in configuration files
   proxyVerbose: true,
+  sassPrefix: `.${moduleName}`,
   stats,
   standalone: process.env.LOCAL_API_PORT ? true : false,
   useCache: true,

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -34,7 +34,6 @@ const App = () => {
   useLayoutEffect(() => {
     const el = document.querySelector<HTMLDivElement>('.chr-scope__default-layout');
     if (el) {
-      el.className = 'chr-scope__default-layout cost-management';
       el.style.overflow = 'auto';
     }
   }, []);

--- a/src/components/drawers/recommendations/recommendationsToolbar.tsx
+++ b/src/components/drawers/recommendations/recommendationsToolbar.tsx
@@ -79,11 +79,9 @@ export class RecommendationsToolbarBase extends React.Component<RecommendationsT
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const mapStateToProps = createMapStateToProps<RecommendationsToolbarOwnProps, RecommendationsToolbarStateProps>(
-  (state, props) => {
-    return {};
-  }
-);
+const mapStateToProps = createMapStateToProps<RecommendationsToolbarOwnProps, RecommendationsToolbarStateProps>(() => {
+  return {};
+});
 
 const mapDispatchToProps: RecommendationsToolbarDispatchProps = {};
 

--- a/src/routes/views/recommendations/recommendations.tsx
+++ b/src/routes/views/recommendations/recommendations.tsx
@@ -99,7 +99,7 @@ class Recommendations extends React.Component<RecommendationsProps> {
     this.updateRecommendation();
   }
 
-  public componentDidUpdate(prevProps: RecommendationsProps, prevState: RecommendationsState) {
+  public componentDidUpdate(prevProps: RecommendationsProps) {
     const { recommendation, recommendationError, recommendationQueryString, router } = this.props;
 
     const newQuery = prevProps.recommendationQueryString !== recommendationQueryString;

--- a/src/routes/views/recommendations/recommendationsHeader.tsx
+++ b/src/routes/views/recommendations/recommendationsHeader.tsx
@@ -42,13 +42,11 @@ class RecommendationsHeaderBase extends React.Component<RecommendationsHeaderPro
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const mapStateToProps = createMapStateToProps<RecommendationsHeaderOwnProps, RecommendationsHeaderStateProps>(
-  (state, props) => {
-    return {
-      // TBD...
-    };
-  }
-);
+const mapStateToProps = createMapStateToProps<RecommendationsHeaderOwnProps, RecommendationsHeaderStateProps>(() => {
+  return {
+    // TBD...
+  };
+});
 
 const RecommendationsHeader = injectIntl(connect(mapStateToProps, {})(RecommendationsHeaderBase));
 

--- a/src/routes/views/recommendations/recommendationsToolbar.tsx
+++ b/src/routes/views/recommendations/recommendationsToolbar.tsx
@@ -47,10 +47,6 @@ export class RecommendationsToolbarBase extends React.Component<RecommendationsT
     });
   }
 
-  public componentDidUpdate(prevProps: RecommendationsToolbarProps) {
-    // TBD...
-  }
-
   private getCategoryOptions = (): ToolbarChipGroup[] => {
     const { intl } = this.props;
 
@@ -86,13 +82,11 @@ export class RecommendationsToolbarBase extends React.Component<RecommendationsT
 }
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const mapStateToProps = createMapStateToProps<RecommendationsToolbarOwnProps, RecommendationsToolbarStateProps>(
-  (state, props) => {
-    return {
-      // TBD...
-    };
-  }
-);
+const mapStateToProps = createMapStateToProps<RecommendationsToolbarOwnProps, RecommendationsToolbarStateProps>(() => {
+  return {
+    // TBD...
+  };
+});
 
 const mapDispatchToProps: RecommendationsToolbarDispatchProps = {
   // TBD...


### PR DESCRIPTION
Fix CSS scope name to eliminate extra div tag / selector, which helps make ROS drawer sticky