### PR TITLE
Use PatternFly sticky table props

### DIFF
--- a/src/routes/views/explorer/explorerTable.scss
+++ b/src/routes/views/explorer/explorerTable.scss
@@ -33,28 +33,8 @@
 
 .explorerTableOverride {
   &.pf-c-table {
-    thead th + th + th {
-      min-width: 125px;
-    }
-    thead th:first-child, tbody td:first-child {
-      background-clip: padding-box;
-      background-color: var(--pf-global--BackgroundColor--light-100);
-      left: 0px;
-      position: sticky;
-      z-index: 199;
-    }
-    thead th:nth-child(2), tbody td:nth-child(2) {
-      background-clip: padding-box;
-      background-color: var(--pf-global--BackgroundColor--light-100);
-      left: 45px;
-      min-width: 200px;
-      position: sticky;
-      z-index: 199;
-    }
-    @media (min-width: 1200px) {
-      thead th:nth-child(2), tbody td:nth-child(2) {
-        left: 53px;
-      }
+    .pf-c-table__sticky-column {
+      z-index: 99;
     }
   }
 }

--- a/src/routes/views/explorer/explorerTable.tsx
+++ b/src/routes/views/explorer/explorerTable.tsx
@@ -341,16 +341,31 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps, ExplorerTabl
         >
           <Thead>
             <Tr>
-              {columns.map((col, index) => (
-                <Th
-                  key={`col-${index}-${col.value}`}
-                  modifier="nowrap"
-                  sort={col.isSortable ? this.getSortParams(index) : undefined}
-                  style={col.style}
-                >
-                  {col.name}
-                </Th>
-              ))}
+              {columns.map((col, index) =>
+                index === 0 ? (
+                  <Th isStickyColumn key={`col-${index}-${col.value}`} stickyMinWidth="53px" />
+                ) : index === 1 ? (
+                  <Th
+                    hasRightBorder
+                    isStickyColumn
+                    key={`col-${index}-${col.value}`}
+                    modifier="nowrap"
+                    sort={col.isSortable ? this.getSortParams(index) : undefined}
+                    stickyMinWidth="100px"
+                    stickyLeftOffset="53px"
+                  >
+                    {col.name}
+                  </Th>
+                ) : (
+                  <Th
+                    key={`col-${index}-${col.value}`}
+                    modifier="nowrap"
+                    sort={col.isSortable ? this.getSortParams(index) : undefined}
+                  >
+                    {col.name}
+                  </Th>
+                )
+              )}
             </Tr>
           </Thead>
           <Tbody>
@@ -371,22 +386,30 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps, ExplorerTabl
                     cellIndex === 0 ? (
                       <Td
                         dataLabel={columns[cellIndex].name}
+                        isStickyColumn
                         key={`cell-${cellIndex}-${rowIndex}`}
-                        modifier="nowrap"
                         select={{
                           disable: row.selectionDisabled, // Disable select for "no-project"
                           isSelected: row.selected,
                           onSelect: (_event, isSelected) => this.handleOnSelect(_event, isSelected, rowIndex),
                           rowIndex,
                         }}
+                        stickyMinWidth="53px"
                       />
-                    ) : (
+                    ) : cellIndex === 1 ? (
                       <Td
                         dataLabel={columns[cellIndex].name}
+                        hasRightBorder
+                        isStickyColumn
                         key={`cell-${rowIndex}-${cellIndex}`}
                         modifier="nowrap"
-                        isActionCell={cellIndex === row.cells.length - 1}
+                        stickyMinWidth="100px"
+                        stickyLeftOffset="53px"
                       >
+                        {item.value}
+                      </Td>
+                    ) : (
+                      <Td dataLabel={columns[cellIndex].name} key={`cell-${rowIndex}-${cellIndex}`} modifier="nowrap">
                         {item.value}
                       </Td>
                     )


### PR DESCRIPTION
Refactor explorer table to use PatternFly sticky column props

https://issues.redhat.com/browse/COST-3633

![Screenshot 2023-03-21 at 7 51 30 PM](https://user-images.githubusercontent.com/17481322/226767149-a7ce6227-facb-4926-ab9b-a5adff6c283d.png)
