### PR TITLE
Close recommendations drawer upon breakdown tab click

### DIFF
--- a/src/routes/views/details/components/breakdown/breakdownBase.tsx
+++ b/src/routes/views/details/components/breakdown/breakdownBase.tsx
@@ -18,6 +18,7 @@ import { handleCostTypeSelected, handleCurrencySelected } from 'routes/views/uti
 import { hasCurrentMonthData } from 'routes/views/utils/providers';
 import { FetchStatus } from 'store/common';
 import type { reportActions } from 'store/reports';
+import type { uiActions } from 'store/ui';
 import type { CostTypes } from 'utils/costType';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
@@ -77,6 +78,7 @@ export interface BreakdownStateProps {
 }
 
 interface BreakdownDispatchProps {
+  closeRecommendationsDrawer?: typeof uiActions.closeRecommendationsDrawer;
   fetchReport?: typeof reportActions.fetchReport;
 }
 
@@ -209,11 +211,20 @@ class BreakdownBase extends React.Component<BreakdownProps, BreakdownState> {
   };
 
   private handleTabClick = (event, tabIndex) => {
+    const { closeRecommendationsDrawer } = this.props;
     const { activeTabKey } = this.state;
+
     if (activeTabKey !== tabIndex) {
-      this.setState({
-        activeTabKey: tabIndex,
-      });
+      this.setState(
+        {
+          activeTabKey: tabIndex,
+        },
+        () => {
+          if (closeRecommendationsDrawer) {
+            closeRecommendationsDrawer();
+          }
+        }
+      );
     }
   };
 

--- a/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -20,6 +20,7 @@ import { createMapStateToProps } from 'store/common';
 import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
+import { uiActions } from 'store/ui';
 import { getCurrency } from 'utils/localStorage';
 import { formatPath } from 'utils/paths';
 import { breakdownDescKey, breakdownTitleKey } from 'utils/props';
@@ -30,6 +31,7 @@ import { CostOverview } from './costOverview';
 import { HistoricalData } from './historicalData';
 
 interface BreakdownDispatchProps {
+  closeRecommendationsDrawer?: typeof uiActions.closeRecommendationsDrawer;
   fetchReport?: typeof reportActions.fetchReport;
 }
 
@@ -128,6 +130,7 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, BreakdownSta
 });
 
 const mapDispatchToProps: BreakdownDispatchProps = {
+  closeRecommendationsDrawer: uiActions.closeRecommendationsDrawer,
   fetchReport: reportActions.fetchReport,
 };
 


### PR DESCRIPTION
Recommendations drawer should close when tabs are selected in breakdown page.

https://issues.redhat.com/browse/COST-3652