### PR TITLE
Remove Unleash for released features

### DIFF
--- a/src/components/featureFlags/featureFlags.tsx
+++ b/src/components/featureFlags/featureFlags.tsx
@@ -6,14 +6,9 @@ import { featureFlagsActions } from 'store/featureFlags';
 // eslint-disable-next-line no-shadow
 export const enum FeatureToggle {
   costDistribution = 'cost-management.ui.cost-distribution', // Cost distribution https://issues.redhat.com/browse/COST-3249
-  costType = 'cost-management.ui.cost-type', // AWS as filtered by OpenShift cost types https://issues.redhat.com/browse/COST-3122
-  currency = 'cost-management.ui.currency', // Currency support https://issues.redhat.com/browse/COST-1277
   exports = 'cost-management.ui.exports', // Async exports https://issues.redhat.com/browse/COST-2223
   finsights = 'cost-management.ui.finsights', // RHEL support for FINsights https://issues.redhat.com/browse/COST-3306
   ibm = 'cost-management.ui.ibm', // IBM https://issues.redhat.com/browse/COST-935
-  negativeFiltering = 'cost-management.ui.negative-filtering', // Negative (aka exclude) filtering https://issues.redhat.com/browse/COST-2773
-  oci = 'cost-management.ui.oci', // Oracle Cloud Infrastructure https://issues.redhat.com/browse/COST-2358
-  platformCosts = 'cost-management.ui.platform-costs', // OCP platform costs https://issues.redhat.com/browse/COST-2774
   ros = 'cost-management.ui.ros', // ROS support https://issues.redhat.com/browse/COST-3477
 }
 
@@ -57,15 +52,10 @@ const useFeatureFlags = () => {
       await updateContext({ userId }).then(() => {
         dispatch(
           featureFlagsActions.setFeatureFlags({
-            isCurrencyFeatureEnabled: client.isEnabled(FeatureToggle.currency),
             isCostDistributionFeatureEnabled: client.isEnabled(FeatureToggle.costDistribution),
-            isCostTypeFeatureEnabled: client.isEnabled(FeatureToggle.costType),
             isExportsFeatureEnabled: client.isEnabled(FeatureToggle.exports),
             isFinsightsFeatureEnabled: client.isEnabled(FeatureToggle.finsights),
-            isNegativeFilteringFeatureEnabled: client.isEnabled(FeatureToggle.negativeFiltering),
             isIbmFeatureEnabled: client.isEnabled(FeatureToggle.ibm),
-            isOciFeatureEnabled: client.isEnabled(FeatureToggle.oci),
-            isPlatformCostsFeatureEnabled: client.isEnabled(FeatureToggle.platformCosts),
             isRosFeatureEnabled: client.isEnabled(FeatureToggle.ros),
           })
         );

--- a/src/components/permissions/permissions.tsx
+++ b/src/components/permissions/permissions.tsx
@@ -31,7 +31,6 @@ interface PermissionsOwnProps {
 interface PermissionsStateProps {
   isFinsightsFeatureEnabled?: boolean;
   isIbmFeatureEnabled?: boolean;
-  isOciFeatureEnabled?: boolean;
   isRosFeatureEnabled?: boolean;
   userAccess: UserAccess;
   userAccessError: AxiosError;
@@ -45,7 +44,6 @@ const PermissionsBase: React.FC<PermissionsProps> = ({
   children = null,
   isFinsightsFeatureEnabled,
   isIbmFeatureEnabled,
-  isOciFeatureEnabled,
   isRosFeatureEnabled,
   userAccess,
   userAccessError,
@@ -61,7 +59,7 @@ const PermissionsBase: React.FC<PermissionsProps> = ({
     const costModel = hasCostModelAccess(userAccess);
     const gcp = hasGcpAccess(userAccess);
     const ibm = isIbmFeatureEnabled && hasIbmAccess(userAccess);
-    const oci = isOciFeatureEnabled && hasOciAccess(userAccess);
+    const oci = hasOciAccess(userAccess);
     const ocp = hasOcpAccess(userAccess);
     const rhel = isFinsightsFeatureEnabled && hasRhelAccess(userAccess);
     const ros = isRosFeatureEnabled && hasRosAccess(userAccess);
@@ -128,7 +126,6 @@ const mapStateToProps = createMapStateToProps<PermissionsOwnProps, PermissionsSt
   return {
     isFinsightsFeatureEnabled: featureFlagsSelectors.selectIsFinsightsFeatureEnabled(state),
     isIbmFeatureEnabled: featureFlagsSelectors.selectIsIbmFeatureEnabled(state),
-    isOciFeatureEnabled: featureFlagsSelectors.selectIsOciFeatureEnabled(state),
     isRosFeatureEnabled: featureFlagsSelectors.selectIsRosFeatureEnabled(state),
     userAccess,
     userAccessError,

--- a/src/routes/costModels/costModelWizard/generalInformation.tsx
+++ b/src/routes/costModels/costModelWizard/generalInformation.tsx
@@ -17,7 +17,6 @@ import { currencyOptions } from 'routes/components/currency';
 import { Form } from 'routes/costModels/components/forms/form';
 import { Selector } from 'routes/costModels/components/inputs/selector';
 import { createMapStateToProps } from 'store/common';
-import { featureFlagsSelectors } from 'store/featureFlags';
 
 import { CostModelContext } from './context';
 import { descriptionErrors, nameErrors } from './steps';
@@ -28,7 +27,7 @@ interface GeneralInformationOwnProps {
 }
 
 interface GeneralInformationStateProps {
-  isCurrencyFeatureEnabled?: boolean;
+  // TBD..
 }
 
 interface GeneralInformationDispatchProps {
@@ -46,7 +45,7 @@ class GeneralInformation extends React.Component<GeneralInformationProps, any> {
       const val = options.find(o => o.value === valStr);
       return !val ? valStr : intl.formatMessage(val.label, { units: val.value });
     };
-    const { intl, isCurrencyFeatureEnabled } = this.props;
+    const { intl } = this.props;
     const sourceTypeOptions = [
       {
         label: messages.costModelsWizardOnboardAws,
@@ -138,24 +137,22 @@ class GeneralInformation extends React.Component<GeneralInformationProps, any> {
                   onChange={onTypeChange}
                   options={sourceTypeOptions}
                 />
-                {isCurrencyFeatureEnabled && (
-                  <Selector
-                    label={messages.currency}
-                    direction={SelectDirection.up}
-                    appendMenuTo="inline"
-                    maxHeight={styles.selector.maxHeight}
-                    toggleAriaLabel={intl.formatMessage(messages.costModelsWizardCurrencyToggleLabel)}
-                    value={getValueLabel(currencyUnits, currencyOptions)}
-                    onChange={onCurrencyChange}
-                    id="currency-units-selector"
-                    options={currencyOptions.map(o => {
-                      return {
-                        label: intl.formatMessage(o.label, { units: o.value }),
-                        value: o.value,
-                      };
-                    })}
-                  />
-                )}
+                <Selector
+                  label={messages.currency}
+                  direction={SelectDirection.up}
+                  appendMenuTo="inline"
+                  maxHeight={styles.selector.maxHeight}
+                  toggleAriaLabel={intl.formatMessage(messages.costModelsWizardCurrencyToggleLabel)}
+                  value={getValueLabel(currencyUnits, currencyOptions)}
+                  onChange={onCurrencyChange}
+                  id="currency-units-selector"
+                  options={currencyOptions.map(o => {
+                    return {
+                      label: intl.formatMessage(o.label, { units: o.value }),
+                      value: o.value,
+                    };
+                  })}
+                />
               </Form>
             </StackItem>
           </Stack>
@@ -167,7 +164,7 @@ class GeneralInformation extends React.Component<GeneralInformationProps, any> {
 
 const mapStateToProps = createMapStateToProps<GeneralInformationOwnProps, GeneralInformationStateProps>(state => {
   return {
-    isCurrencyFeatureEnabled: featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state),
+    // TBD...
   };
 });
 

--- a/src/routes/views/components/dataToolbar/dataToolbar.tsx
+++ b/src/routes/views/components/dataToolbar/dataToolbar.tsx
@@ -41,7 +41,6 @@ import { connect } from 'react-redux';
 import { ResourceTypeahead } from 'routes/views/components/resourceTypeahead';
 import type { Filter } from 'routes/views/utils/filter';
 import { createMapStateToProps } from 'store/common';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import { isEqual } from 'utils/equal';
 import { orgUnitIdKey, orgUnitNameKey, platformCategoryKey, tagKey, tagPrefix } from 'utils/props';
@@ -105,8 +104,7 @@ interface DataToolbarState {
 }
 
 interface DataToolbarStateProps {
-  isNegativeFilteringFeatureEnabled?: boolean;
-  isPlatformCostsFeatureEnabled?: boolean;
+  // TBD...
 }
 
 interface GroupByOrgOption extends SelectOptionObject {
@@ -1126,8 +1124,6 @@ export class DataToolbarBase extends React.Component<DataToolbarProps, DataToolb
       categoryOptions,
       dateRange,
       datePicker,
-      isNegativeFilteringFeatureEnabled,
-      isPlatformCostsFeatureEnabled,
       pagination,
       showBulkSelect,
       showColumnManagement,
@@ -1153,7 +1149,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps, DataToolb
               <ToolbarToggleGroup breakpoint="xl" toggleIcon={<FilterIcon />}>
                 <ToolbarGroup variant="filter-group">
                   {this.getCategorySelect(hasFilters)}
-                  {isNegativeFilteringFeatureEnabled && this.getExcludeSelect(hasFilters)}
+                  {this.getExcludeSelect(hasFilters)}
                   {this.getTagKeySelect(hasFilters)}
                   {this.getTagKeyOptions().map(option => this.getTagValueSelect(option, hasFilters))}
                   {this.getOrgUnitSelect(hasFilters)}
@@ -1167,7 +1163,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps, DataToolb
             {(showExport || showColumnManagement) && (
               <ToolbarGroup>
                 {showColumnManagement && this.getColumnManagement()}
-                {showPlatformCosts && isPlatformCostsFeatureEnabled && this.getPlatformCosts()}
+                {showPlatformCosts && this.getPlatformCosts()}
                 {showExport && this.getExportButton()}
                 {(showColumnManagement || showPlatformCosts) && this.getKebab()}
               </ToolbarGroup>
@@ -1190,8 +1186,7 @@ export class DataToolbarBase extends React.Component<DataToolbarProps, DataToolb
 
 const mapStateToProps = createMapStateToProps<DataToolbarOwnProps, DataToolbarStateProps>(state => {
   return {
-    isNegativeFilteringFeatureEnabled: featureFlagsSelectors.selectIsNegativeFilteringFeatureEnabled(state),
-    isPlatformCostsFeatureEnabled: featureFlagsSelectors.selectIsPlatformCostsFeatureEnabled(state),
+    // TBD...
   };
 });
 

--- a/src/routes/views/components/perspective/perspective.tsx
+++ b/src/routes/views/components/perspective/perspective.tsx
@@ -71,7 +71,6 @@ const getInfrastructureOptions = ({
   hasIbmOcp,
   hasOci,
   isIbmFeatureEnabled,
-  isOciFeatureEnabled,
 }) => {
   const options = [];
 
@@ -99,7 +98,7 @@ const getInfrastructureOptions = ({
   if (hasAzureOcp) {
     options.push(...infrastructureAzureOcpOptions);
   }
-  if (hasOci && isOciFeatureEnabled) {
+  if (hasOci) {
     options.push(...infrastructureOciOptions);
   }
   return options;
@@ -122,7 +121,6 @@ const Perspective: React.FC<PerspectiveProps> = ({
   isDisabled,
   isIbmFeatureEnabled,
   isInfrastructureTab,
-  isOciFeatureEnabled,
   isRhelTab,
   onSelected,
 }): any => {
@@ -147,7 +145,6 @@ const Perspective: React.FC<PerspectiveProps> = ({
           hasIbmOcp,
           hasOci,
           isIbmFeatureEnabled,
-          isOciFeatureEnabled,
         })
       );
     } else if (isRhelTab) {
@@ -179,7 +176,6 @@ const Perspective: React.FC<PerspectiveProps> = ({
         hasIbmOcp,
         hasOci,
         isIbmFeatureEnabled,
-        isOciFeatureEnabled,
       })
     );
   }

--- a/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
@@ -15,7 +15,6 @@ import { BreakdownBase } from 'routes/views/details/components/breakdown';
 import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'routes/views/utils/groupBy';
 import { filterProviders } from 'routes/views/utils/providers';
 import { createMapStateToProps } from 'store/common';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCostType } from 'utils/costType';
@@ -45,7 +44,7 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, BreakdownSta
   const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(queryFromRoute);
   const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(queryFromRoute);
   const costType = getCostType();
-  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
+  const currency = getCurrency();
 
   const newQuery: Query = {
     filter: {

--- a/src/routes/views/details/awsDetails/awsDetails.tsx
+++ b/src/routes/views/details/awsDetails/awsDetails.tsx
@@ -32,7 +32,6 @@ import {
 import { filterProviders, hasCurrentMonthData } from 'routes/views/utils/providers';
 import { getRouteForQuery } from 'routes/views/utils/query';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedAwsReportItems';
@@ -406,7 +405,7 @@ class AwsDetails extends React.Component<AwsDetailsProps, AwsDetailsState> {
 const mapStateToProps = createMapStateToProps<AwsDetailsOwnProps, AwsDetailsStateProps>((state, { router }) => {
   const queryFromRoute = parseQuery<AwsQuery>(router.location.search);
   const costType = getCostType();
-  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
+  const currency = getCurrency();
   const query = {
     delta: 'cost',
     filter: {
@@ -452,21 +451,6 @@ const mapStateToProps = createMapStateToProps<AwsDetailsOwnProps, AwsDetailsStat
     reportError,
     reportFetchStatus,
     reportQueryString,
-
-    // Testing...
-    //
-    // providers: {
-    //   meta: {
-    //     count: 0,
-    //   },
-    // } as any,
-    // providersError: {
-    //   response: {
-    //     // status: 401
-    //     status: 500
-    //   }
-    // } as any,
-    // providersFetchStatus: FetchStatus.inProgress,
   };
 });
 

--- a/src/routes/views/details/awsDetails/detailsHeader.tsx
+++ b/src/routes/views/details/awsDetails/detailsHeader.tsx
@@ -39,7 +39,6 @@ interface DetailsHeaderOwnProps {
 }
 
 interface DetailsHeaderStateProps {
-  isCurrencyFeatureEnabled?: boolean;
   isExportsFeatureEnabled?: boolean;
   providers: Providers;
   providersError: AxiosError;
@@ -75,7 +74,6 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, any> {
       costType,
       currency,
       groupBy,
-      isCurrencyFeatureEnabled,
       isExportsFeatureEnabled,
       onCurrencySelected,
       onGroupBySelected,
@@ -96,7 +94,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, any> {
             {intl.formatMessage(messages.awsDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency currency={currency} onSelect={onCurrencySelected} />}
+            <Currency currency={currency} onSelect={onCurrencySelected} />
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>
@@ -146,7 +144,6 @@ const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHead
   );
 
   return {
-    isCurrencyFeatureEnabled: featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state),
     isExportsFeatureEnabled: featureFlagsSelectors.selectIsExportsFeatureEnabled(state),
     providers: filterProviders(providers, ProviderType.aws),
     providersError,

--- a/src/routes/views/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/routes/views/details/azureBreakdown/azureBreakdown.tsx
@@ -15,7 +15,6 @@ import { BreakdownBase } from 'routes/views/details/components/breakdown';
 import { getGroupById, getGroupByValue } from 'routes/views/utils/groupBy';
 import { filterProviders } from 'routes/views/utils/providers';
 import { createMapStateToProps } from 'store/common';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCurrency } from 'utils/localStorage';
@@ -42,7 +41,7 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, BreakdownStateP
   const queryFromRoute = parseQuery<Query>(router.location.search);
   const groupBy = getGroupById(queryFromRoute);
   const groupByValue = getGroupByValue(queryFromRoute);
-  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
+  const currency = getCurrency();
 
   const newQuery: Query = {
     filter: {

--- a/src/routes/views/details/azureDetails/azureDetails.tsx
+++ b/src/routes/views/details/azureDetails/azureDetails.tsx
@@ -29,7 +29,6 @@ import {
 import { filterProviders, hasCurrentMonthData } from 'routes/views/utils/providers';
 import { getRouteForQuery } from 'routes/views/utils/query';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedAzureReportItems';
@@ -383,7 +382,7 @@ class AzureDetails extends React.Component<AzureDetailsProps, AzureDetailsState>
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<AzureDetailsOwnProps, AzureDetailsStateProps>((state, { router }) => {
   const queryFromRoute = parseQuery<AzureQuery>(router.location.search);
-  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
+  const currency = getCurrency();
   const query = {
     delta: 'cost',
     filter: {
@@ -427,21 +426,6 @@ const mapStateToProps = createMapStateToProps<AzureDetailsOwnProps, AzureDetails
     reportError,
     reportFetchStatus,
     reportQueryString,
-
-    // Testing...
-    //
-    // providers: {
-    //   meta: {
-    //     count: 0,
-    //   },
-    // } as any,
-    // providersError: {
-    //   response: {
-    //     // status: 401
-    //     status: 500
-    //   }
-    // } as any,
-    // providersFetchStatus: FetchStatus.inProgress,
   };
 });
 

--- a/src/routes/views/details/azureDetails/detailsHeader.tsx
+++ b/src/routes/views/details/azureDetails/detailsHeader.tsx
@@ -34,7 +34,6 @@ interface DetailsHeaderOwnProps {
 }
 
 interface DetailsHeaderStateProps {
-  isCurrencyFeatureEnabled?: boolean;
   isExportsFeatureEnabled?: boolean;
   providers: Providers;
   providersError: AxiosError;
@@ -60,7 +59,6 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, any> {
     const {
       currency,
       groupBy,
-      isCurrencyFeatureEnabled,
       isExportsFeatureEnabled,
       onCurrencySelected,
       onGroupBySelected,
@@ -81,7 +79,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, any> {
             {intl.formatMessage(messages.azureDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency currency={currency} onSelect={onCurrencySelected} />}
+            <Currency currency={currency} onSelect={onCurrencySelected} />
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>
@@ -126,7 +124,6 @@ const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHead
   );
 
   return {
-    isCurrencyFeatureEnabled: featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state),
     isExportsFeatureEnabled: featureFlagsSelectors.selectIsExportsFeatureEnabled(state),
     providers: filterProviders(providers, ProviderType.azure),
     providersError,

--- a/src/routes/views/details/components/breakdown/breakdownHeader.tsx
+++ b/src/routes/views/details/components/breakdown/breakdownHeader.tsx
@@ -18,7 +18,6 @@ import { CostType } from 'routes/views/components/costType';
 import { TagLink } from 'routes/views/details/components/tag';
 import { getGroupByOrgValue, getGroupByTagKey } from 'routes/views/utils/groupBy';
 import { createMapStateToProps } from 'store/common';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import type { CostTypes } from 'utils/costType';
 import { getTotalCostDateRangeString } from 'utils/dates';
 import { formatCurrency } from 'utils/format';
@@ -47,7 +46,6 @@ interface BreakdownHeaderOwnProps extends RouterComponentProps {
 
 interface BreakdownHeaderStateProps {
   isOptimizationsPath?: boolean;
-  isCurrencyFeatureEnabled?: boolean;
 }
 
 interface BreakdownHeaderDispatchProps {
@@ -131,7 +129,6 @@ class BreakdownHeader extends React.Component<BreakdownHeaderProps, any> {
       description,
       groupBy,
       intl,
-      isCurrencyFeatureEnabled,
       onCostTypeSelected,
       onCurrencySelected,
       query,
@@ -169,7 +166,7 @@ class BreakdownHeader extends React.Component<BreakdownHeaderProps, any> {
             </ol>
           </nav>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency currency={currency} onSelect={onCurrencySelected} />}
+            <Currency currency={currency} onSelect={onCurrencySelected} />
           </div>
         </div>
         <div style={styles.headerContent}>
@@ -216,7 +213,6 @@ const mapStateToProps = createMapStateToProps<BreakdownHeaderOwnProps, Breakdown
 
     return {
       isOptimizationsPath: queryFromRoute.optimizationsPath !== undefined,
-      isCurrencyFeatureEnabled: featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state),
     };
   }
 );

--- a/src/routes/views/details/gcpBreakdown/gcpBreakdown.tsx
+++ b/src/routes/views/details/gcpBreakdown/gcpBreakdown.tsx
@@ -16,7 +16,6 @@ import { BreakdownBase } from 'routes/views/details/components/breakdown';
 import { getGroupById, getGroupByValue } from 'routes/views/utils/groupBy';
 import { filterProviders } from 'routes/views/utils/providers';
 import { createMapStateToProps } from 'store/common';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCurrency } from 'utils/localStorage';
@@ -43,7 +42,7 @@ const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, BreakdownSta
   const queryFromRoute = parseQuery<GcpQuery>(router.location.search);
   const groupBy = getGroupById(queryFromRoute);
   const groupByValue = getGroupByValue(queryFromRoute);
-  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
+  const currency = getCurrency();
 
   const newQuery: Query = {
     filter: {

--- a/src/routes/views/details/gcpDetails/detailsHeader.tsx
+++ b/src/routes/views/details/gcpDetails/detailsHeader.tsx
@@ -34,7 +34,6 @@ interface DetailsHeaderOwnProps {
 }
 
 interface DetailsHeaderStateProps {
-  isCurrencyFeatureEnabled?: boolean;
   isExportsFeatureEnabled?: boolean;
   providers: Providers;
   providersError: AxiosError;
@@ -61,7 +60,6 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, any> {
     const {
       currency,
       groupBy,
-      isCurrencyFeatureEnabled,
       isExportsFeatureEnabled,
       onCurrencySelected,
       onGroupBySelected,
@@ -82,7 +80,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, any> {
             {intl.formatMessage(messages.gcpDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency currency={currency} onSelect={onCurrencySelected} />}
+            <Currency currency={currency} onSelect={onCurrencySelected} />
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>
@@ -127,7 +125,6 @@ const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHead
   );
 
   return {
-    isCurrencyFeatureEnabled: featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state),
     isExportsFeatureEnabled: featureFlagsSelectors.selectIsExportsFeatureEnabled(state),
     providers: filterProviders(providers, ProviderType.gcp),
     providersError,

--- a/src/routes/views/details/gcpDetails/gcpDetails.tsx
+++ b/src/routes/views/details/gcpDetails/gcpDetails.tsx
@@ -29,7 +29,6 @@ import {
 import { filterProviders, hasCurrentMonthData } from 'routes/views/utils/providers';
 import { getRouteForQuery } from 'routes/views/utils/query';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedGcpReportItems';
@@ -372,7 +371,7 @@ class GcpDetails extends React.Component<GcpDetailsProps, GcpDetailsState> {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<GcpDetailsOwnProps, GcpDetailsStateProps>((state, { router }) => {
   const queryFromRoute = parseQuery<GcpQuery>(router.location.search);
-  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
+  const currency = getCurrency();
   const query = {
     delta: 'cost',
     filter: {
@@ -416,21 +415,6 @@ const mapStateToProps = createMapStateToProps<GcpDetailsOwnProps, GcpDetailsStat
     reportError,
     reportFetchStatus,
     reportQueryString,
-
-    // Testing...
-    //
-    // providers: {
-    //   meta: {
-    //     count: 0,
-    //   },
-    // } as any,
-    // providersError: {
-    //   response: {
-    //     // status: 401
-    //     status: 500
-    //   }
-    // } as any,
-    // providersFetchStatus: FetchStatus.inProgress,
   };
 });
 

--- a/src/routes/views/details/ibmBreakdown/ibmBreakdown.tsx
+++ b/src/routes/views/details/ibmBreakdown/ibmBreakdown.tsx
@@ -16,7 +16,6 @@ import { BreakdownBase } from 'routes/views/details/components/breakdown';
 import { getGroupById, getGroupByValue } from 'routes/views/utils/groupBy';
 import { filterProviders } from 'routes/views/utils/providers';
 import { createMapStateToProps } from 'store/common';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCurrency } from 'utils/localStorage';
@@ -43,7 +42,7 @@ const mapStateToProps = createMapStateToProps<IbmBreakdownOwnProps, BreakdownSta
   const queryFromRoute = parseQuery<IbmQuery>(router.location.search);
   const groupBy = getGroupById(queryFromRoute);
   const groupByValue = getGroupByValue(queryFromRoute);
-  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
+  const currency = getCurrency();
 
   const newQuery: Query = {
     filter: {

--- a/src/routes/views/details/ibmDetails/detailsHeader.tsx
+++ b/src/routes/views/details/ibmDetails/detailsHeader.tsx
@@ -34,7 +34,6 @@ interface DetailsHeaderOwnProps {
 }
 
 interface DetailsHeaderStateProps {
-  isCurrencyFeatureEnabled?: boolean;
   isExportsFeatureEnabled?: boolean;
   providers: Providers;
   providersError: AxiosError;
@@ -61,7 +60,6 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, any> {
     const {
       currency,
       groupBy,
-      isCurrencyFeatureEnabled,
       isExportsFeatureEnabled,
       onCurrencySelected,
       onGroupBySelected,
@@ -82,7 +80,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, any> {
             {intl.formatMessage(messages.ibmDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency currency={currency} onSelect={onCurrencySelected} />}
+            <Currency currency={currency} onSelect={onCurrencySelected} />
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>
@@ -127,7 +125,6 @@ const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHead
   );
 
   return {
-    isCurrencyFeatureEnabled: featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state),
     isExportsFeatureEnabled: featureFlagsSelectors.selectIsExportsFeatureEnabled(state),
     providers: filterProviders(providers, ProviderType.ibm),
     providersError,

--- a/src/routes/views/details/ibmDetails/ibmDetails.tsx
+++ b/src/routes/views/details/ibmDetails/ibmDetails.tsx
@@ -30,7 +30,6 @@ import { hasCurrentMonthData } from 'routes/views/utils/providers';
 import { filterProviders } from 'routes/views/utils/providers';
 import { getRouteForQuery } from 'routes/views/utils/query';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedIbmReportItems';
@@ -374,7 +373,7 @@ class IbmDetails extends React.Component<IbmDetailsProps, IbmDetailsState> {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<IbmDetailsOwnProps, IbmDetailsStateProps>((state, { router }) => {
   const queryFromRoute = parseQuery<IbmQuery>(router.location.search);
-  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
+  const currency = getCurrency();
   const query = {
     delta: 'cost',
     filter: {

--- a/src/routes/views/details/ibmDetails/ibmDetails.tsx
+++ b/src/routes/views/details/ibmDetails/ibmDetails.tsx
@@ -417,21 +417,6 @@ const mapStateToProps = createMapStateToProps<IbmDetailsOwnProps, IbmDetailsStat
     reportError,
     reportFetchStatus,
     reportQueryString,
-
-    // Testing...
-    //
-    // providers: {
-    //   meta: {
-    //     count: 0,
-    //   },
-    // } as any,
-    // providersError: {
-    //   response: {
-    //     // status: 401
-    //     status: 500
-    //   }
-    // } as any,
-    // providersFetchStatus: FetchStatus.inProgress,
   };
 });
 

--- a/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
+++ b/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
@@ -16,7 +16,6 @@ import { BreakdownBase } from 'routes/views/details/components/breakdown';
 import { getGroupById, getGroupByValue } from 'routes/views/utils/groupBy';
 import { filterProviders } from 'routes/views/utils/providers';
 import { createMapStateToProps } from 'store/common';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCurrency } from 'utils/localStorage';
@@ -43,7 +42,7 @@ const mapStateToProps = createMapStateToProps<OciCostOwnProps, BreakdownStatePro
   const queryFromRoute = parseQuery<OcpQuery>(router.location.search);
   const groupBy = getGroupById(queryFromRoute);
   const groupByValue = getGroupByValue(queryFromRoute);
-  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
+  const currency = getCurrency();
 
   const newQuery: Query = {
     filter: {

--- a/src/routes/views/details/ociDetails/detailsHeader.tsx
+++ b/src/routes/views/details/ociDetails/detailsHeader.tsx
@@ -34,7 +34,6 @@ interface DetailsHeaderOwnProps {
 }
 
 interface DetailsHeaderStateProps {
-  isCurrencyFeatureEnabled?: boolean;
   isExportsFeatureEnabled?: boolean;
   providers: Providers;
   providersError: AxiosError;
@@ -60,7 +59,6 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, any> {
     const {
       currency,
       groupBy,
-      isCurrencyFeatureEnabled,
       isExportsFeatureEnabled,
       onCurrencySelected,
       onGroupBySelected,
@@ -81,7 +79,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, any> {
             {intl.formatMessage(messages.ociDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency currency={currency} onSelect={onCurrencySelected} />}
+            <Currency currency={currency} onSelect={onCurrencySelected} />
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>
@@ -126,7 +124,6 @@ const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHead
   );
 
   return {
-    isCurrencyFeatureEnabled: featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state),
     isExportsFeatureEnabled: featureFlagsSelectors.selectIsExportsFeatureEnabled(state),
     providers: filterProviders(providers, ProviderType.oci),
     providersError,

--- a/src/routes/views/details/ociDetails/ociDetails.tsx
+++ b/src/routes/views/details/ociDetails/ociDetails.tsx
@@ -426,21 +426,6 @@ const mapStateToProps = createMapStateToProps<OciDetailsOwnProps, OciDetailsStat
     reportError,
     reportFetchStatus,
     reportQueryString,
-
-    // Testing...
-    //
-    // providers: {
-    //   meta: {
-    //     count: 0,
-    //   },
-    // } as any,
-    // providersError: {
-    //   response: {
-    //     // status: 401
-    //     status: 500
-    //   }
-    // } as any,
-    // providersFetchStatus: FetchStatus.inProgress,
   };
 });
 

--- a/src/routes/views/details/ociDetails/ociDetails.tsx
+++ b/src/routes/views/details/ociDetails/ociDetails.tsx
@@ -29,7 +29,6 @@ import {
 import { filterProviders, hasCurrentMonthData } from 'routes/views/utils/providers';
 import { getRouteForQuery } from 'routes/views/utils/query';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getIdKeyForGroupBy } from 'utils/computedReport/getComputedOciReportItems';
@@ -383,7 +382,7 @@ class OciDetails extends React.Component<OciDetailsProps, OciDetailsState> {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<OciDetailsOwnProps, OciDetailsStateProps>((state, { router }) => {
   const queryFromRoute = parseQuery<OciQuery>(router.location.search);
-  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
+  const currency = getCurrency();
   const query = {
     delta: 'cost',
     filter: {

--- a/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -47,7 +47,7 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, BreakdownSta
   const queryFromRoute = parseQuery<Query>(router.location.search);
   const groupBy = getGroupById(queryFromRoute);
   const groupByValue = getGroupByValue(queryFromRoute);
-  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
+  const currency = getCurrency();
 
   const newQuery: Query = {
     filter: {

--- a/src/routes/views/details/ocpDetails/detailsHeader.tsx
+++ b/src/routes/views/details/ocpDetails/detailsHeader.tsx
@@ -35,7 +35,6 @@ interface DetailsHeaderOwnProps {
 }
 
 interface DetailsHeaderStateProps {
-  isCurrencyFeatureEnabled?: boolean;
   isExportsFeatureEnabled?: boolean;
   providers: Providers;
   providersError: AxiosError;
@@ -66,7 +65,6 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, DetailsHeade
     const {
       currency,
       groupBy,
-      isCurrencyFeatureEnabled,
       isExportsFeatureEnabled,
       onCurrencySelected,
       onGroupBySelected,
@@ -106,7 +104,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, DetailsHeade
             {intl.formatMessage(messages.ocpDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency currency={currency} onSelect={onCurrencySelected} />}
+            <Currency currency={currency} onSelect={onCurrencySelected} />
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>
@@ -156,7 +154,6 @@ const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHead
   );
 
   return {
-    isCurrencyFeatureEnabled: featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state),
     isExportsFeatureEnabled: featureFlagsSelectors.selectIsExportsFeatureEnabled(state),
     providers: filterProviders(providers, ProviderType.ocp),
     providersError,

--- a/src/routes/views/details/ocpDetails/ocpDetails.tsx
+++ b/src/routes/views/details/ocpDetails/ocpDetails.tsx
@@ -447,7 +447,7 @@ class OcpDetails extends React.Component<OcpDetailsProps, OcpDetailsState> {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<OcpDetailsOwnProps, OcpDetailsStateProps>((state, { router }) => {
   const queryFromRoute = parseQuery<OcpQuery>(router.location.search);
-  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
+  const currency = getCurrency();
   const query = {
     delta: 'cost',
     filter: {

--- a/src/routes/views/details/rhelBreakdown/rhelBreakdown.tsx
+++ b/src/routes/views/details/rhelBreakdown/rhelBreakdown.tsx
@@ -16,7 +16,6 @@ import { getGroupById, getGroupByValue } from 'routes/views/utils/groupBy';
 import { isPlatformCosts } from 'routes/views/utils/paths';
 import { filterProviders } from 'routes/views/utils/providers';
 import { createMapStateToProps } from 'store/common';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCurrency } from 'utils/localStorage';
@@ -43,7 +42,7 @@ const mapStateToProps = createMapStateToProps<RhelBreakdownOwnProps, BreakdownSt
   const queryFromRoute = parseQuery<Query>(router.location.search);
   const groupBy = getGroupById(queryFromRoute);
   const groupByValue = getGroupByValue(queryFromRoute);
-  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
+  const currency = getCurrency();
 
   const newQuery: Query = {
     filter: {

--- a/src/routes/views/details/rhelDetails/detailsHeader.tsx
+++ b/src/routes/views/details/rhelDetails/detailsHeader.tsx
@@ -35,7 +35,6 @@ interface DetailsHeaderOwnProps {
 }
 
 interface DetailsHeaderStateProps {
-  isCurrencyFeatureEnabled?: boolean;
   isExportsFeatureEnabled?: boolean;
   providers: Providers;
   providersError: AxiosError;
@@ -66,7 +65,6 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
     const {
       currency,
       groupBy,
-      isCurrencyFeatureEnabled,
       isExportsFeatureEnabled,
       onCurrencySelected,
       onGroupBySelected,
@@ -106,7 +104,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             {intl.formatMessage(messages.rhelDetailsTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency currency={currency} onSelect={onCurrencySelected} />}
+            <Currency currency={currency} onSelect={onCurrencySelected} />
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>
@@ -156,7 +154,6 @@ const mapStateToProps = createMapStateToProps<DetailsHeaderOwnProps, DetailsHead
   );
 
   return {
-    isCurrencyFeatureEnabled: featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state),
     isExportsFeatureEnabled: featureFlagsSelectors.selectIsExportsFeatureEnabled(state),
     providers: filterProviders(providers, ProviderType.rhel),
     providersError,

--- a/src/routes/views/details/rhelDetails/rhelDetails.tsx
+++ b/src/routes/views/details/rhelDetails/rhelDetails.tsx
@@ -32,7 +32,6 @@ import {
 import { filterProviders, hasCurrentMonthData } from 'routes/views/utils/providers';
 import { getRouteForQuery } from 'routes/views/utils/query';
 import { createMapStateToProps, FetchStatus } from 'store/common';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
@@ -445,7 +444,7 @@ class RhelDetails extends React.Component<RhelDetailsProps, RhelDetailsState> {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<RhelDetailsOwnProps, RhelDetailsStateProps>((state, { router }) => {
   const queryFromRoute = parseQuery<RhelQuery>(router.location.search);
-  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
+  const currency = getCurrency();
   const query = {
     delta: 'cost',
     filter: {

--- a/src/routes/views/explorer/explorer.tsx
+++ b/src/routes/views/explorer/explorer.tsx
@@ -567,12 +567,9 @@ const mapStateToProps = createMapStateToProps<ExplorerOwnProps, ExplorerStatePro
     groupBy = { [getGroupByDefault(perspective)]: '*' };
   }
 
-  const isCostTypeFeatureEnabled = featureFlagsSelectors.selectIsCostTypeFeatureEnabled(state);
   const costType =
-    perspective === PerspectiveType.aws || (perspective === PerspectiveType.awsOcp && isCostTypeFeatureEnabled)
-      ? getCostType()
-      : undefined;
-  const currency = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) ? getCurrency() : undefined;
+    perspective === PerspectiveType.aws || perspective === PerspectiveType.awsOcp ? getCostType() : undefined;
+  const currency = getCurrency();
 
   const query = {
     filter: {

--- a/src/routes/views/explorer/explorerHeader.tsx
+++ b/src/routes/views/explorer/explorerHeader.tsx
@@ -75,12 +75,9 @@ interface ExplorerHeaderStateProps {
   azureProviders?: Providers;
   gcpProviders?: Providers;
   ibmProviders?: Providers;
-  isCostTypeFeatureEnabled?: boolean;
-  isCurrencyFeatureEnabled?: boolean;
   isExportsFeatureEnabled?: boolean;
   isFinsightsFeatureEnabled?: boolean;
   isIbmFeatureEnabled?: boolean;
-  isOciFeatureEnabled?: boolean;
   ociProviders?: Providers;
   ocpProviders?: Providers;
   providers: Providers;
@@ -124,7 +121,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps, ExplorerHe
   }
 
   private getPerspective = (isDisabled: boolean) => {
-    const { isIbmFeatureEnabled, isOciFeatureEnabled } = this.props;
+    const { isIbmFeatureEnabled } = this.props;
     const { currentPerspective } = this.state;
 
     const hasAws = this.isAwsAvailable();
@@ -157,7 +154,6 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps, ExplorerHe
         hasRhel={hasRhel}
         isDisabled={isDisabled}
         isIbmFeatureEnabled={isIbmFeatureEnabled}
-        isOciFeatureEnabled={isOciFeatureEnabled}
         onSelected={this.handlePerspectiveSelected}
       />
     );
@@ -252,8 +248,6 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps, ExplorerHe
       currency,
       groupBy,
       intl,
-      isCostTypeFeatureEnabled,
-      isCurrencyFeatureEnabled,
       isExportsFeatureEnabled,
       onCostTypeSelected,
       onCurrencySelected,
@@ -287,7 +281,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps, ExplorerHe
             {intl.formatMessage(messages.explorerTitle)}
           </Title>
           <div style={styles.headerContentRight}>
-            {isCurrencyFeatureEnabled && <Currency currency={currency} onSelect={onCurrencySelected} />}
+            <Currency currency={currency} onSelect={onCurrencySelected} />
             {isExportsFeatureEnabled && <ExportsLink />}
           </div>
         </div>
@@ -307,8 +301,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps, ExplorerHe
               tagReportPathsType={tagReportPathsType}
             />
           </div>
-          {(perspective === PerspectiveType.aws ||
-            (perspective === PerspectiveType.awsOcp && isCostTypeFeatureEnabled)) && (
+          {(perspective === PerspectiveType.aws || perspective === PerspectiveType.awsOcp) && (
             <div style={styles.costType}>
               <CostType costType={costType} onSelect={onCostTypeSelected} />
             </div>
@@ -381,12 +374,9 @@ const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHe
       azureProviders: filterProviders(providers, ProviderType.azure),
       gcpProviders: filterProviders(providers, ProviderType.gcp),
       ibmProviders: filterProviders(providers, ProviderType.ibm),
-      isCostTypeFeatureEnabled: featureFlagsSelectors.selectIsCostTypeFeatureEnabled(state),
-      isCurrencyFeatureEnabled: featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state),
       isExportsFeatureEnabled: featureFlagsSelectors.selectIsExportsFeatureEnabled(state),
       isFinsightsFeatureEnabled: featureFlagsSelectors.selectIsFinsightsFeatureEnabled(state),
       isIbmFeatureEnabled: featureFlagsSelectors.selectIsIbmFeatureEnabled(state),
-      isOciFeatureEnabled: featureFlagsSelectors.selectIsOciFeatureEnabled(state),
       ociProviders: filterProviders(providers, ProviderType.oci),
       ocpProviders: filterProviders(providers, ProviderType.ocp),
       providers,

--- a/src/routes/views/overview/awsDashboard/awsDashboardWidget.tsx
+++ b/src/routes/views/overview/awsDashboard/awsDashboardWidget.tsx
@@ -4,7 +4,6 @@ import type { DashboardWidgetOwnProps, DashboardWidgetStateProps } from 'routes/
 import { DashboardWidgetBase } from 'routes/views/overview/components';
 import { createMapStateToProps } from 'store/common';
 import { awsDashboardActions, awsDashboardSelectors, AwsDashboardTab } from 'store/dashboard/awsDashboard';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedAwsReportItemsParams } from 'utils/computedReport/getComputedAwsReportItems';
@@ -34,7 +33,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = awsDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
-      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+      currency: getCurrency(),
       costType: getCostType(),
       getIdKeyForTab,
       currentQuery: queries.current,

--- a/src/routes/views/overview/awsOcpDashboard/awsOcpDashboardWidget.tsx
+++ b/src/routes/views/overview/awsOcpDashboard/awsOcpDashboardWidget.tsx
@@ -4,7 +4,6 @@ import type { DashboardWidgetOwnProps, DashboardWidgetStateProps } from 'routes/
 import { DashboardWidgetBase } from 'routes/views/overview/components';
 import { createMapStateToProps } from 'store/common';
 import { awsOcpDashboardActions, awsOcpDashboardSelectors, AwsOcpDashboardTab } from 'store/dashboard/awsOcpDashboard';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedAwsReportItemsParams } from 'utils/computedReport/getComputedAwsReportItems';
@@ -34,13 +33,9 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = awsOcpDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
-      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
-      ...(featureFlagsSelectors.selectIsCostTypeFeatureEnabled(state) && { costType: getCostType() }),
+      currency: getCurrency(),
+      costType: getCostType(),
       getIdKeyForTab,
-      currentQuery: queries.current,
-      forecastQuery: queries.forecast,
-      previousQuery: queries.previous,
-      tabsQuery: queries.tabs,
       currentReport: reportSelectors.selectReport(state, widget.reportPathsType, widget.reportType, queries.current),
       currentReportFetchStatus: reportSelectors.selectReportFetchStatus(
         state,

--- a/src/routes/views/overview/azureDashboard/azureDashboardWidget.tsx
+++ b/src/routes/views/overview/azureDashboard/azureDashboardWidget.tsx
@@ -4,7 +4,6 @@ import type { DashboardWidgetOwnProps, DashboardWidgetStateProps } from 'routes/
 import { DashboardWidgetBase } from 'routes/views/overview/components';
 import { createMapStateToProps } from 'store/common';
 import { azureDashboardActions, azureDashboardSelectors, AzureDashboardTab } from 'store/dashboard/azureDashboard';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedAzureReportItemsParams } from 'utils/computedReport/getComputedAzureReportItems';
@@ -33,7 +32,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = azureDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
-      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+      currency: getCurrency(),
       getIdKeyForTab,
       currentQuery: queries.current,
       forecastQuery: queries.forecast,

--- a/src/routes/views/overview/azureOcpDashboard/azureOcpDashboardWidget.tsx
+++ b/src/routes/views/overview/azureOcpDashboard/azureOcpDashboardWidget.tsx
@@ -8,7 +8,6 @@ import {
   azureOcpDashboardSelectors,
   AzureOcpDashboardTab,
 } from 'store/dashboard/azureOcpDashboard';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedAzureReportItemsParams } from 'utils/computedReport/getComputedAzureReportItems';
@@ -37,7 +36,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = azureOcpDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
-      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+      currency: getCurrency(),
       getIdKeyForTab,
       currentQuery: queries.current,
       forecastQuery: queries.forecast,

--- a/src/routes/views/overview/gcpDashboard/gcpDashboardWidget.tsx
+++ b/src/routes/views/overview/gcpDashboard/gcpDashboardWidget.tsx
@@ -4,7 +4,6 @@ import type { DashboardWidgetOwnProps, DashboardWidgetStateProps } from 'routes/
 import { DashboardWidgetBase } from 'routes/views/overview/components';
 import { createMapStateToProps } from 'store/common';
 import { gcpDashboardActions, gcpDashboardSelectors, GcpDashboardTab } from 'store/dashboard/gcpDashboard';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedGcpReportItemsParams } from 'utils/computedReport/getComputedGcpReportItems';
@@ -33,7 +32,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = gcpDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
-      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+      currency: getCurrency(),
       getIdKeyForTab,
       currentQuery: queries.current,
       previousQuery: queries.previous,

--- a/src/routes/views/overview/gcpOcpDashboard/gcpOcpDashboardWidget.tsx
+++ b/src/routes/views/overview/gcpOcpDashboard/gcpOcpDashboardWidget.tsx
@@ -4,7 +4,6 @@ import type { DashboardWidgetOwnProps, DashboardWidgetStateProps } from 'routes/
 import { DashboardWidgetBase } from 'routes/views/overview/components';
 import { createMapStateToProps } from 'store/common';
 import { gcpOcpDashboardActions, gcpOcpDashboardSelectors, GcpOcpDashboardTab } from 'store/dashboard/gcpOcpDashboard';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedGcpReportItemsParams } from 'utils/computedReport/getComputedGcpReportItems';
@@ -33,7 +32,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = gcpOcpDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
-      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+      currency: getCurrency(),
       getIdKeyForTab,
       currentQuery: queries.current,
       previousQuery: queries.previous,

--- a/src/routes/views/overview/ibmDashboard/ibmDashboardWidget.tsx
+++ b/src/routes/views/overview/ibmDashboard/ibmDashboardWidget.tsx
@@ -4,7 +4,6 @@ import type { DashboardWidgetOwnProps, DashboardWidgetStateProps } from 'routes/
 import { DashboardWidgetBase } from 'routes/views/overview/components';
 import { createMapStateToProps } from 'store/common';
 import { ibmDashboardActions, ibmDashboardSelectors, IbmDashboardTab } from 'store/dashboard/ibmDashboard';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedIbmReportItemsParams } from 'utils/computedReport/getComputedIbmReportItems';
@@ -33,7 +32,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = ibmDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
-      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+      currency: getCurrency(),
       getIdKeyForTab,
       currentQuery: queries.current,
       previousQuery: queries.previous,

--- a/src/routes/views/overview/ociDashboard/ociDashboardWidget.tsx
+++ b/src/routes/views/overview/ociDashboard/ociDashboardWidget.tsx
@@ -4,7 +4,6 @@ import type { DashboardWidgetOwnProps, DashboardWidgetStateProps } from 'routes/
 import { DashboardWidgetBase } from 'routes/views/overview/components';
 import { createMapStateToProps } from 'store/common';
 import { ociDashboardActions, ociDashboardSelectors, OciDashboardTab } from 'store/dashboard/ociDashboard';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedOciReportItemsParams } from 'utils/computedReport/getComputedOciReportItems';
@@ -33,7 +32,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = ociDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
-      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+      currency: getCurrency(),
       getIdKeyForTab,
       currentQuery: queries.current,
       forecastQuery: queries.forecast,

--- a/src/routes/views/overview/ocpCloudDashboard/ocpCloudDashboardWidget.tsx
+++ b/src/routes/views/overview/ocpCloudDashboard/ocpCloudDashboardWidget.tsx
@@ -8,7 +8,6 @@ import {
   ocpCloudDashboardSelectors,
   OcpCloudDashboardTab,
 } from 'store/dashboard/ocpCloudDashboard';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedOcpCloudReportItemsParams } from 'utils/computedReport/getComputedOcpCloudReportItems';
@@ -37,7 +36,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = ocpCloudDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
-      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+      currency: getCurrency(),
       getIdKeyForTab,
       currentQuery: queries.current,
       forecastQuery: queries.forecast,

--- a/src/routes/views/overview/ocpDashboard/ocpDashboardWidget.tsx
+++ b/src/routes/views/overview/ocpDashboard/ocpDashboardWidget.tsx
@@ -37,7 +37,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = ocpDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
-      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+      currency: getCurrency(),
       getIdKeyForTab,
       chartAltHeight: chartStyles.chartAltHeight,
       containerAltHeight: chartStyles.containerAltHeight,

--- a/src/routes/views/overview/overview.tsx
+++ b/src/routes/views/overview/overview.tsx
@@ -133,24 +133,21 @@ interface OverviewStateProps {
   currency?: string;
   gcpProviders?: Providers;
   ibmProviders?: Providers;
-  isCostTypeFeatureEnabled?: boolean;
-  isCurrencyFeatureEnabled?: boolean;
   isFinsightsFeatureEnabled?: boolean;
   isIbmFeatureEnabled?: boolean;
-  isOciFeatureEnabled?: boolean;
   ociProviders?: Providers;
   ocpProviders?: Providers;
-  providers: Providers;
-  providersError: AxiosError;
-  providersFetchStatus: FetchStatus;
+  providers?: Providers;
+  providersError?: AxiosError;
+  providersFetchStatus?: FetchStatus;
   perspective?: string;
   rhelProviders?: Providers;
   query: OverviewQuery;
   tabKey?: number;
-  userAccess: UserAccess;
-  userAccessError: AxiosError;
-  userAccessFetchStatus: FetchStatus;
-  userAccessQueryString: string;
+  userAccess?: UserAccess;
+  userAccessError?: AxiosError;
+  userAccessFetchStatus?: FetchStatus;
+  userAccessQueryString?: string;
 }
 
 interface AvailableTab {
@@ -258,16 +255,13 @@ class OverviewBase extends React.Component<OverviewProps, OverviewState> {
   };
 
   private getCostType = () => {
-    const { costType, isCostTypeFeatureEnabled } = this.props;
+    const { costType } = this.props;
     const { currentInfrastructurePerspective, currentOcpPerspective } = this.state;
 
     const currentItem =
       this.getCurrentTab() === OverviewTab.infrastructure ? currentInfrastructurePerspective : currentOcpPerspective;
 
-    if (
-      currentItem === InfrastructurePerspective.aws ||
-      (currentItem === InfrastructurePerspective.awsOcp && isCostTypeFeatureEnabled)
-    ) {
+    if (currentItem === InfrastructurePerspective.aws || currentItem === InfrastructurePerspective.awsOcp) {
       return (
         <div style={styles.costType}>
           <CostType costType={costType} onSelect={this.handleCostTypeSelected} />
@@ -395,7 +389,7 @@ class OverviewBase extends React.Component<OverviewProps, OverviewState> {
   };
 
   private getPerspective = () => {
-    const { isIbmFeatureEnabled, isOciFeatureEnabled } = this.props;
+    const { isIbmFeatureEnabled } = this.props;
     const { currentInfrastructurePerspective, currentOcpPerspective, currentRhelPerspective } = this.state;
 
     const hasAws = this.isAwsAvailable();
@@ -442,7 +436,6 @@ class OverviewBase extends React.Component<OverviewProps, OverviewState> {
         hasRhel={hasRhel}
         isIbmFeatureEnabled={isIbmFeatureEnabled}
         isInfrastructureTab={OverviewTab.infrastructure === currentTab}
-        isOciFeatureEnabled={isOciFeatureEnabled}
         isRhelTab={OverviewTab.rhel === currentTab}
         onSelected={this.handlePerspectiveSelected}
       />
@@ -712,15 +705,8 @@ class OverviewBase extends React.Component<OverviewProps, OverviewState> {
   };
 
   public render() {
-    const {
-      providersFetchStatus,
-      intl,
-      isCurrencyFeatureEnabled,
-      isFinsightsFeatureEnabled,
-      isIbmFeatureEnabled,
-      isOciFeatureEnabled,
-      userAccessFetchStatus,
-    } = this.props;
+    const { providersFetchStatus, intl, isFinsightsFeatureEnabled, isIbmFeatureEnabled, userAccessFetchStatus } =
+      this.props;
 
     // Note: No need to test OCP on cloud here, since that requires at least one provider
     const noProviders =
@@ -784,13 +770,9 @@ class OverviewBase extends React.Component<OverviewProps, OverviewState> {
                       <br />
                       <p style={styles.infoTitle}>{intl.formatMessage(messages.azure)}</p>
                       <p>{intl.formatMessage(messages.azureDesc)}</p>
-                      {isOciFeatureEnabled && (
-                        <>
-                          <br />
-                          <p style={styles.infoTitle}>{intl.formatMessage(messages.oci)}</p>
-                          <p>{intl.formatMessage(messages.ociDesc)}</p>
-                        </>
-                      )}
+                      <br />
+                      <p style={styles.infoTitle}>{intl.formatMessage(messages.oci)}</p>
+                      <p>{intl.formatMessage(messages.ociDesc)}</p>
                     </>
                   }
                 >
@@ -803,7 +785,7 @@ class OverviewBase extends React.Component<OverviewProps, OverviewState> {
                 </Popover>
               </span>
             </Title>
-            <div style={styles.headerContentRight}>{isCurrencyFeatureEnabled && this.getCurrency()}</div>
+            <div style={styles.headerContentRight}>{this.getCurrency()}</div>
           </div>
           <div style={styles.tabs}>{this.getTabs(availableTabs)}</div>
           <div style={styles.headerContent}>
@@ -825,14 +807,9 @@ const mapStateToProps = createMapStateToProps<OverviewOwnProps, OverviewStatePro
   const queryFromRoute = parseQuery<OverviewQuery>(router.location.search);
   const tabKey = queryFromRoute.tabKey && !Number.isNaN(queryFromRoute.tabKey) ? Number(queryFromRoute.tabKey) : 0;
   const perspective = queryFromRoute.perspective;
-
-  const isCurrencyFeatureEnabled = featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state);
-  const currency = isCurrencyFeatureEnabled ? getCurrency() : undefined;
-
-  const isCostTypeFeatureEnabled = featureFlagsSelectors.selectIsCostTypeFeatureEnabled(state);
+  const currency = getCurrency();
   const costType =
-    perspective === InfrastructurePerspective.aws ||
-    (perspective === InfrastructurePerspective.awsOcp && isCostTypeFeatureEnabled)
+    perspective === InfrastructurePerspective.aws || perspective === InfrastructurePerspective.awsOcp
       ? getCostType()
       : undefined;
 
@@ -866,11 +843,8 @@ const mapStateToProps = createMapStateToProps<OverviewOwnProps, OverviewStatePro
     currency,
     gcpProviders: filterProviders(providers, ProviderType.gcp),
     ibmProviders: filterProviders(providers, ProviderType.ibm),
-    isCostTypeFeatureEnabled,
-    isCurrencyFeatureEnabled,
     isFinsightsFeatureEnabled: featureFlagsSelectors.selectIsFinsightsFeatureEnabled(state),
     isIbmFeatureEnabled: featureFlagsSelectors.selectIsIbmFeatureEnabled(state),
-    isOciFeatureEnabled: featureFlagsSelectors.selectIsOciFeatureEnabled(state),
     ociProviders: filterProviders(providers, ProviderType.oci),
     ocpProviders: filterProviders(providers, ProviderType.ocp),
     providers,

--- a/src/routes/views/overview/rhelDashboard/rhelDashboardWidget.tsx
+++ b/src/routes/views/overview/rhelDashboard/rhelDashboardWidget.tsx
@@ -4,7 +4,6 @@ import type { DashboardWidgetOwnProps, DashboardWidgetStateProps } from 'routes/
 import { DashboardWidgetBase } from 'routes/views/overview/components';
 import { createMapStateToProps } from 'store/common';
 import { rhelDashboardActions, rhelDashboardSelectors, RhelDashboardTab } from 'store/dashboard/rhelDashboard';
-import { featureFlagsSelectors } from 'store/featureFlags';
 import { forecastSelectors } from 'store/forecasts';
 import { reportSelectors } from 'store/reports';
 import type { ComputedRhelReportItemsParams } from 'utils/computedReport/getComputedRhelReportItems';
@@ -35,7 +34,7 @@ const mapStateToProps = createMapStateToProps<DashboardWidgetOwnProps, Dashboard
     const queries = rhelDashboardSelectors.selectWidgetQueries(state, widgetId);
     return {
       ...widget,
-      ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+      currency: getCurrency(),
       getIdKeyForTab,
       chartAltHeight: chartStyles.chartAltHeight,
       containerAltHeight: chartStyles.containerAltHeight,

--- a/src/store/dashboard/awsDashboard/__snapshots__/awsDashboard.test.ts.snap
+++ b/src/store/dashboard/awsDashboard/__snapshots__/awsDashboard.test.ts.snap
@@ -5,17 +5,17 @@ exports[`fetch widget reports 1`] = `
   [
     "aws",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&cost_type=unblended_cost",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&cost_type=unblended_cost&currency=USD",
   ],
   [
     "aws",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily&cost_type=unblended_cost",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily&cost_type=unblended_cost&currency=USD",
   ],
   [
     "aws",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[service]=*&cost_type=unblended_cost",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[service]=*&cost_type=unblended_cost&currency=USD",
   ],
 ]
 `;

--- a/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
+++ b/src/store/dashboard/awsDashboard/awsDashboardSelectors.ts
@@ -1,4 +1,3 @@
-import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
 import { getCostType } from 'utils/costType';
 import { getCurrency } from 'utils/localStorage';
@@ -32,7 +31,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
   };
   const props = {
     cost_type: getCostType(),
-    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+    currency: getCurrency(),
   };
 
   return {

--- a/src/store/dashboard/awsOcpDashboard/awsOcpDashboardSelectors.ts
+++ b/src/store/dashboard/awsOcpDashboard/awsOcpDashboardSelectors.ts
@@ -1,4 +1,3 @@
-import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
 import { getCostType } from 'utils/costType';
 import { getCurrency } from 'utils/localStorage';
@@ -31,8 +30,8 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
   const props = {
-    ...(featureFlagsSelectors.selectIsCostTypeFeatureEnabled(state) && { cost_type: getCostType() }),
-    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+    cost_type: getCostType(),
+    currency: getCurrency(),
   };
 
   return {

--- a/src/store/dashboard/azureDashboard/__snapshots__/azureDashboard.test.ts.snap
+++ b/src/store/dashboard/azureDashboard/__snapshots__/azureDashboard.test.ts.snap
@@ -5,17 +5,17 @@ exports[`fetch widget reports 1`] = `
   [
     "azure",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&currency=USD",
   ],
   [
     "azure",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily&currency=USD",
   ],
   [
     "azure",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[service_name]=*",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[service_name]=*&currency=USD",
   ],
 ]
 `;

--- a/src/store/dashboard/azureDashboard/azureDashboardSelectors.ts
+++ b/src/store/dashboard/azureDashboard/azureDashboardSelectors.ts
@@ -1,4 +1,3 @@
-import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
 import { getCurrency } from 'utils/localStorage';
 
@@ -30,7 +29,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
   const props = {
-    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+    currency: getCurrency(),
   };
 
   return {

--- a/src/store/dashboard/azureOcpDashboard/azureOcpDashboardSelectors.ts
+++ b/src/store/dashboard/azureOcpDashboard/azureOcpDashboardSelectors.ts
@@ -1,4 +1,3 @@
-import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
 import { getCurrency } from 'utils/localStorage';
 
@@ -30,7 +29,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
   const props = {
-    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+    currency: getCurrency(),
   };
 
   return {

--- a/src/store/dashboard/gcpDashboard/__snapshots__/gcpDashboard.test.ts.snap
+++ b/src/store/dashboard/gcpDashboard/__snapshots__/gcpDashboard.test.ts.snap
@@ -5,17 +5,17 @@ exports[`fetch widget reports 1`] = `
   [
     "gcp",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&currency=USD",
   ],
   [
     "gcp",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily&currency=USD",
   ],
   [
     "gcp",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[service]=*",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[service]=*&currency=USD",
   ],
 ]
 `;

--- a/src/store/dashboard/gcpDashboard/gcpDashboardSelectors.ts
+++ b/src/store/dashboard/gcpDashboard/gcpDashboardSelectors.ts
@@ -1,4 +1,3 @@
-import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
 import { getCurrency } from 'utils/localStorage';
 
@@ -30,7 +29,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
   const props = {
-    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+    currency: getCurrency(),
   };
 
   return {

--- a/src/store/dashboard/gcpOcpDashboard/__snapshots__/gcpOcpDashboard.test.ts.snap
+++ b/src/store/dashboard/gcpOcpDashboard/__snapshots__/gcpOcpDashboard.test.ts.snap
@@ -5,17 +5,17 @@ exports[`fetch widget reports 1`] = `
   [
     "gcp_ocp",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&currency=USD",
   ],
   [
     "gcp_ocp",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily&currency=USD",
   ],
   [
     "gcp_ocp",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[service]=*",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[service]=*&currency=USD",
   ],
 ]
 `;

--- a/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardSelectors.ts
+++ b/src/store/dashboard/gcpOcpDashboard/gcpOcpDashboardSelectors.ts
@@ -1,4 +1,3 @@
-import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
 import { getCurrency } from 'utils/localStorage';
 
@@ -30,7 +29,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
   const props = {
-    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+    currency: getCurrency(),
   };
 
   return {

--- a/src/store/dashboard/ibmDashboard/__snapshots__/ibmDashboard.test.ts.snap
+++ b/src/store/dashboard/ibmDashboard/__snapshots__/ibmDashboard.test.ts.snap
@@ -5,17 +5,17 @@ exports[`fetch widget reports 1`] = `
   [
     "ibm",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&currency=USD",
   ],
   [
     "ibm",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily&currency=USD",
   ],
   [
     "ibm",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[service]=*",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[service]=*&currency=USD",
   ],
 ]
 `;

--- a/src/store/dashboard/ibmDashboard/ibmDashboardSelectors.ts
+++ b/src/store/dashboard/ibmDashboard/ibmDashboardSelectors.ts
@@ -1,4 +1,3 @@
-import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
 import { getCurrency } from 'utils/localStorage';
 
@@ -30,7 +29,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
   const props = {
-    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+    currency: getCurrency(),
   };
 
   return {

--- a/src/store/dashboard/ociDashboard/__snapshots__/ociDashboard.test.ts.snap
+++ b/src/store/dashboard/ociDashboard/__snapshots__/ociDashboard.test.ts.snap
@@ -5,17 +5,17 @@ exports[`fetch widget reports 1`] = `
   [
     "oci",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&currency=USD",
   ],
   [
     "oci",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily&currency=USD",
   ],
   [
     "oci",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[product_service]=*",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[product_service]=*&currency=USD",
   ],
 ]
 `;

--- a/src/store/dashboard/ociDashboard/ociDashboardSelectors.ts
+++ b/src/store/dashboard/ociDashboard/ociDashboardSelectors.ts
@@ -1,4 +1,3 @@
-import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
 import { getCurrency } from 'utils/localStorage';
 
@@ -30,7 +29,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
   const props = {
-    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+    currency: getCurrency(),
   };
 
   return {

--- a/src/store/dashboard/ocpCloudDashboard/__snapshots__/ocpCloudDashboard.test.ts.snap
+++ b/src/store/dashboard/ocpCloudDashboard/__snapshots__/ocpCloudDashboard.test.ts.snap
@@ -5,17 +5,17 @@ exports[`fetch widget reports 1`] = `
   [
     "ocp_cloud",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&currency=USD",
   ],
   [
     "ocp_cloud",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily&currency=USD",
   ],
   [
     "ocp_cloud",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[service]=*",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[service]=*&currency=USD",
   ],
 ]
 `;

--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardSelectors.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardSelectors.ts
@@ -1,4 +1,3 @@
-import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
 import { getCurrency } from 'utils/localStorage';
 
@@ -30,7 +29,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
   const props = {
-    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+    currency: getCurrency(),
   };
 
   return {
@@ -38,7 +37,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
       {
         ...defaultFilter,
         time_scope_value: -2,
-      },
+      } as any,
       props
     ),
     current: getQueryForWidget(defaultFilter, props),

--- a/src/store/dashboard/ocpDashboard/__snapshots__/ocpDashboard.test.ts.snap
+++ b/src/store/dashboard/ocpDashboard/__snapshots__/ocpDashboard.test.ts.snap
@@ -5,17 +5,17 @@ exports[`fetch widget reports 1`] = `
   [
     "ocp",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&currency=USD",
   ],
   [
     "ocp",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily&currency=USD",
   ],
   [
     "ocp",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[project]=*",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[project]=*&currency=USD",
   ],
 ]
 `;

--- a/src/store/dashboard/ocpDashboard/ocpDashboardSelectors.ts
+++ b/src/store/dashboard/ocpDashboard/ocpDashboardSelectors.ts
@@ -1,4 +1,3 @@
-import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
 import { getCurrency } from 'utils/localStorage';
 
@@ -30,7 +29,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...(widget.tabsFilter ? widget.tabsFilter : {}),
   };
   const props = {
-    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+    currency: getCurrency(),
   };
 
   return {

--- a/src/store/dashboard/rhelDashboard/__snapshots__/rhelDashboard.test.ts.snap
+++ b/src/store/dashboard/rhelDashboard/__snapshots__/rhelDashboard.test.ts.snap
@@ -5,17 +5,17 @@ exports[`fetch widget reports 1`] = `
   [
     "rhel",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=daily&currency=USD",
   ],
   [
     "rhel",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-2&filter[resolution]=daily&currency=USD",
   ],
   [
     "rhel",
     "cost",
-    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[project]=*",
+    "filter[time_scope_units]=month&filter[time_scope_value]=-1&filter[resolution]=monthly&filter[limit]=3&group_by[project]=*&currency=USD",
   ],
 ]
 `;

--- a/src/store/dashboard/rhelDashboard/rhelDashboardSelectors.ts
+++ b/src/store/dashboard/rhelDashboard/rhelDashboardSelectors.ts
@@ -1,4 +1,3 @@
-import { featureFlagsSelectors } from 'store/featureFlags';
 import type { RootState } from 'store/rootReducer';
 import { getCurrency } from 'utils/localStorage';
 
@@ -30,7 +29,7 @@ export const selectWidgetQueries = (state: RootState, id: number) => {
     ...(widget.tabsFilter ? widget.tabsFilter : ({} as any)),
   };
   const props = {
-    ...(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(state) && { currency: getCurrency() }),
+    currency: getCurrency(),
   };
 
   return {

--- a/src/store/featureFlags/__snapshots__/featureFlags.test.ts.snap
+++ b/src/store/featureFlags/__snapshots__/featureFlags.test.ts.snap
@@ -4,14 +4,9 @@ exports[`default state 1`] = `
 {
   "hasFeatureFlags": false,
   "isCostDistributionFeatureEnabled": false,
-  "isCostTypeFeatureEnabled": false,
-  "isCurrencyFeatureEnabled": false,
   "isExportsFeatureEnabled": false,
   "isFinsightsFeatureEnabled": false,
   "isIbmFeatureEnabled": false,
-  "isNegativeFilteringFeatureEnabled": false,
-  "isOciFeatureEnabled": false,
-  "isPlatformCostsFeatureEnabled": false,
   "isRosFeatureEnabled": false,
 }
 `;

--- a/src/store/featureFlags/featureFlags.test.ts
+++ b/src/store/featureFlags/featureFlags.test.ts
@@ -14,22 +14,10 @@ test('default state', async () => {
   expect(selectors.selectFeatureFlagsState(store.getState())).toMatchSnapshot();
 });
 
-test('currency feature is enabled', async () => {
-  const store = createUIStore();
-  store.dispatch(actions.setFeatureFlags({ isCurrencyFeatureEnabled: true }));
-  expect(featureFlagsSelectors.selectIsCurrencyFeatureEnabled(store.getState())).toBe(true);
-});
-
 test('cost distribution feature is enabled', async () => {
   const store = createUIStore();
   store.dispatch(actions.setFeatureFlags({ isCostDistributionFeatureEnabled: true }));
   expect(featureFlagsSelectors.selectIsCostDistributionFeatureEnabled(store.getState())).toBe(true);
-});
-
-test('cost type feature is enabled', async () => {
-  const store = createUIStore();
-  store.dispatch(actions.setFeatureFlags({ isCostTypeFeatureEnabled: true }));
-  expect(featureFlagsSelectors.selectIsCostTypeFeatureEnabled(store.getState())).toBe(true);
 });
 
 test('FINsights feature is enabled', async () => {
@@ -48,24 +36,6 @@ test('IBM feature is enabled', async () => {
   const store = createUIStore();
   store.dispatch(actions.setFeatureFlags({ isIbmFeatureEnabled: true }));
   expect(featureFlagsSelectors.selectIsIbmFeatureEnabled(store.getState())).toBe(true);
-});
-
-test('negative filtering feature is enabled', async () => {
-  const store = createUIStore();
-  store.dispatch(actions.setFeatureFlags({ isNegativeFilteringFeatureEnabled: true }));
-  expect(featureFlagsSelectors.selectIsNegativeFilteringFeatureEnabled(store.getState())).toBe(true);
-});
-
-test('OCI feature is enabled', async () => {
-  const store = createUIStore();
-  store.dispatch(actions.setFeatureFlags({ isOciFeatureEnabled: true }));
-  expect(featureFlagsSelectors.selectIsOciFeatureEnabled(store.getState())).toBe(true);
-});
-
-test('platform costs feature is enabled', async () => {
-  const store = createUIStore();
-  store.dispatch(actions.setFeatureFlags({ isPlatformCostsFeatureEnabled: true }));
-  expect(featureFlagsSelectors.selectIsPlatformCostsFeatureEnabled(store.getState())).toBe(true);
 });
 
 test('ROS feature is enabled', async () => {

--- a/src/store/featureFlags/featureFlagsActions.ts
+++ b/src/store/featureFlags/featureFlagsActions.ts
@@ -2,14 +2,9 @@ import { createAction } from 'typesafe-actions';
 
 export interface FeatureFlagsActionMeta {
   isCostDistributionFeatureEnabled?: boolean;
-  isCostTypeFeatureEnabled?: boolean;
-  isCurrencyFeatureEnabled?: boolean;
   isExportsFeatureEnabled?: boolean;
   isFinsightsFeatureEnabled?: boolean;
   isIbmFeatureEnabled?: boolean;
-  isNegativeFilteringFeatureEnabled?: boolean;
-  isOciFeatureEnabled?: boolean;
-  isPlatformCostsFeatureEnabled?: boolean;
   isRosFeatureEnabled?: boolean;
 }
 

--- a/src/store/featureFlags/featureFlagsReducer.ts
+++ b/src/store/featureFlags/featureFlagsReducer.ts
@@ -9,28 +9,18 @@ export type FeatureFlagsAction = ActionType<typeof setFeatureFlags | typeof rese
 export type FeatureFlagsState = Readonly<{
   hasFeatureFlags: boolean;
   isCostDistributionFeatureEnabled: boolean;
-  isCostTypeFeatureEnabled: boolean;
-  isCurrencyFeatureEnabled: boolean;
   isExportsFeatureEnabled: boolean;
   isFinsightsFeatureEnabled: boolean;
   isIbmFeatureEnabled: boolean;
-  isNegativeFilteringFeatureEnabled: boolean;
-  isOciFeatureEnabled: boolean;
-  isPlatformCostsFeatureEnabled: boolean;
   isRosFeatureEnabled: boolean;
 }>;
 
 export const defaultState: FeatureFlagsState = {
   hasFeatureFlags: false,
   isCostDistributionFeatureEnabled: false,
-  isCostTypeFeatureEnabled: false,
-  isCurrencyFeatureEnabled: false,
   isExportsFeatureEnabled: false,
   isFinsightsFeatureEnabled: false,
   isIbmFeatureEnabled: false,
-  isNegativeFilteringFeatureEnabled: false,
-  isOciFeatureEnabled: false,
-  isPlatformCostsFeatureEnabled: false,
   isRosFeatureEnabled: false,
 };
 
@@ -43,14 +33,9 @@ export function featureFlagsReducer(state = defaultState, action: FeatureFlagsAc
         ...state,
         hasFeatureFlags: true,
         isCostDistributionFeatureEnabled: action.payload.isCostDistributionFeatureEnabled,
-        isCostTypeFeatureEnabled: action.payload.isCostTypeFeatureEnabled,
-        isCurrencyFeatureEnabled: action.payload.isCurrencyFeatureEnabled,
         isExportsFeatureEnabled: action.payload.isExportsFeatureEnabled,
         isFinsightsFeatureEnabled: action.payload.isFinsightsFeatureEnabled,
         isIbmFeatureEnabled: action.payload.isIbmFeatureEnabled,
-        isNegativeFilteringFeatureEnabled: action.payload.isNegativeFilteringFeatureEnabled,
-        isOciFeatureEnabled: action.payload.isOciFeatureEnabled,
-        isPlatformCostsFeatureEnabled: action.payload.isPlatformCostsFeatureEnabled,
         isRosFeatureEnabled: action.payload.isRosFeatureEnabled,
       };
 

--- a/src/store/featureFlags/featureFlagsSelectors.ts
+++ b/src/store/featureFlags/featureFlagsSelectors.ts
@@ -6,20 +6,11 @@ export const selectFeatureFlagsState = (state: RootState) => state[stateKey];
 
 export const selectHasFeatureFlags = (state: RootState) => selectFeatureFlagsState(state).hasFeatureFlags;
 
-export const selectIsCurrencyFeatureEnabled = (state: RootState) =>
-  selectFeatureFlagsState(state)?.isCurrencyFeatureEnabled;
 export const selectIsCostDistributionFeatureEnabled = (state: RootState) =>
   selectFeatureFlagsState(state)?.isCostDistributionFeatureEnabled;
-export const selectIsCostTypeFeatureEnabled = (state: RootState) =>
-  selectFeatureFlagsState(state).isCostTypeFeatureEnabled;
 export const selectIsExportsFeatureEnabled = (state: RootState) =>
   selectFeatureFlagsState(state).isExportsFeatureEnabled;
 export const selectIsFinsightsFeatureEnabled = (state: RootState) =>
   selectFeatureFlagsState(state).isFinsightsFeatureEnabled;
 export const selectIsIbmFeatureEnabled = (state: RootState) => selectFeatureFlagsState(state).isIbmFeatureEnabled;
-export const selectIsNegativeFilteringFeatureEnabled = (state: RootState) =>
-  selectFeatureFlagsState(state).isNegativeFilteringFeatureEnabled;
-export const selectIsOciFeatureEnabled = (state: RootState) => selectFeatureFlagsState(state).isOciFeatureEnabled;
-export const selectIsPlatformCostsFeatureEnabled = (state: RootState) =>
-  selectFeatureFlagsState(state).isPlatformCostsFeatureEnabled;
 export const selectIsRosFeatureEnabled = (state: RootState) => selectFeatureFlagsState(state).isRosFeatureEnabled;


### PR DESCRIPTION
There are a few features that have been released, which no longer need to be wrapped with Unleash. To avoid accidentally disabling these features, we want to clean up the UI code.

- cost-management.ui.platform-costs (OCP platform costs)
- cost-management.ui.cost-type (AWS cost types)
- cost-management.ui.negative-filtering
- cost-management.ui.currency
- cost-management.ui.oci

https://issues.redhat.com/browse/COST-3598