### PR TITLE
Ensure chrome user exists before making API requests

### DIFF
--- a/src/api/accountSettings.ts
+++ b/src/api/accountSettings.ts
@@ -1,6 +1,7 @@
 import axios from 'axios';
 
 import type { PagedLinks, PagedMetaData } from './api';
+import type { AwsOcpTag } from './tags/awsOcpTags';
 
 export interface AccountSettingsData {
   cost_type?: string;
@@ -14,12 +15,12 @@ export interface AccountSettings {
 }
 
 export function fetchAccountSettings() {
+  const fetch = () => axios.get<AwsOcpTag>(`account-settings/`);
+
   const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<AccountSettings>(`account-settings/`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<AccountSettings>(`account-settings/`);
+    return fetch();
   }
 }

--- a/src/api/costModels.ts
+++ b/src/api/costModels.ts
@@ -40,21 +40,56 @@ export interface CostModelRequest {
 export type CostModels = PagedResponse<CostModel>;
 
 export function fetchCostModels(query = '') {
-  return axios.get<CostModels>(`cost-models/${query && '?'}${query}`);
+  const fetch = () => axios.get<CostModels>(`cost-models/${query && '?'}${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }
 
 export function fetchCostModel(uuid: string) {
-  return axios.get<CostModel>(`cost-models/${uuid}/`);
+  const fetch = () => axios.get<CostModels>(`cost-models/${uuid}/`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }
 
 export function addCostModel(request: CostModelRequest) {
-  return axios.post('cost-models/', request);
+  const fetch = () => axios.post(`cost-models/`, request);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }
 
 export function updateCostModel(uuid: string, request: CostModelRequest) {
-  return axios.put(`cost-models/${uuid}/`, request);
+  const fetch = () => axios.put(`cost-models/${uuid}/`, request);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }
 
 export function deleteCostModel(uuid: string) {
-  return axios.delete(`cost-models/${uuid}/`);
+  const fetch = () => axios.delete(`cost-models/${uuid}/`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/export/awsExport.ts
+++ b/src/api/export/awsExport.ts
@@ -4,9 +4,17 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<string>(`${path}?${query}`, {
-    headers: {
-      Accept: 'text/csv',
-    },
-  });
+  const fetch = () =>
+    axios.get<string>(`${path}?${query}`, {
+      headers: {
+        Accept: 'text/csv',
+      },
+    });
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/export/awsOcpExport.ts
+++ b/src/api/export/awsOcpExport.ts
@@ -4,9 +4,17 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<string>(`${path}?${query}`, {
-    headers: {
-      Accept: 'text/csv',
-    },
-  });
+  const fetch = () =>
+    axios.get<string>(`${path}?${query}`, {
+      headers: {
+        Accept: 'text/csv',
+      },
+    });
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/export/azureExport.ts
+++ b/src/api/export/azureExport.ts
@@ -4,9 +4,17 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<string>(`${path}?${query}`, {
-    headers: {
-      Accept: 'text/csv',
-    },
-  });
+  const fetch = () =>
+    axios.get<string>(`${path}?${query}`, {
+      headers: {
+        Accept: 'text/csv',
+      },
+    });
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/export/azureOcpExport.ts
+++ b/src/api/export/azureOcpExport.ts
@@ -4,9 +4,17 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<string>(`${path}?${query}`, {
-    headers: {
-      Accept: 'text/csv',
-    },
-  });
+  const fetch = () =>
+    axios.get<string>(`${path}?${query}`, {
+      headers: {
+        Accept: 'text/csv',
+      },
+    });
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/export/gcpExport.ts
+++ b/src/api/export/gcpExport.ts
@@ -4,9 +4,17 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<string>(`${path}?${query}`, {
-    headers: {
-      Accept: 'text/csv',
-    },
-  });
+  const fetch = () =>
+    axios.get<string>(`${path}?${query}`, {
+      headers: {
+        Accept: 'text/csv',
+      },
+    });
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/export/gcpOcpExport.ts
+++ b/src/api/export/gcpOcpExport.ts
@@ -4,9 +4,17 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<string>(`${path}?${query}`, {
-    headers: {
-      Accept: 'text/csv',
-    },
-  });
+  const fetch = () =>
+    axios.get<string>(`${path}?${query}`, {
+      headers: {
+        Accept: 'text/csv',
+      },
+    });
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/export/ibmExport.ts
+++ b/src/api/export/ibmExport.ts
@@ -4,9 +4,17 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<string>(`${path}?${query}`, {
-    headers: {
-      Accept: 'text/csv',
-    },
-  });
+  const fetch = () =>
+    axios.get<string>(`${path}?${query}`, {
+      headers: {
+        Accept: 'text/csv',
+      },
+    });
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/export/ociExport.ts
+++ b/src/api/export/ociExport.ts
@@ -4,9 +4,17 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<string>(`${path}?${query}`, {
-    headers: {
-      Accept: 'text/csv',
-    },
-  });
+  const fetch = () =>
+    axios.get<string>(`${path}?${query}`, {
+      headers: {
+        Accept: 'text/csv',
+      },
+    });
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/export/ocpCloudExport.ts
+++ b/src/api/export/ocpCloudExport.ts
@@ -4,9 +4,17 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<string>(`${path}?${query}`, {
-    headers: {
-      Accept: 'text/csv',
-    },
-  });
+  const fetch = () =>
+    axios.get<string>(`${path}?${query}`, {
+      headers: {
+        Accept: 'text/csv',
+      },
+    });
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/export/ocpExport.ts
+++ b/src/api/export/ocpExport.ts
@@ -4,9 +4,17 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<string>(`${path}?${query}`, {
-    headers: {
-      Accept: 'text/csv',
-    },
-  });
+  const fetch = () =>
+    axios.get<string>(`${path}?${query}`, {
+      headers: {
+        Accept: 'text/csv',
+      },
+    });
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/export/rhelExport.ts
+++ b/src/api/export/rhelExport.ts
@@ -4,9 +4,17 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<string>(`${path}?${query}`, {
-    headers: {
-      Accept: 'text/csv',
-    },
-  });
+  const fetch = () =>
+    axios.get<string>(`${path}?${query}`, {
+      headers: {
+        Accept: 'text/csv',
+      },
+    });
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/forecasts/awsForecast.ts
+++ b/src/api/forecasts/awsForecast.ts
@@ -8,13 +8,13 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 };
 
 export function runForecast(forecastType: ForecastType, query: string) {
-  const insights = (window as any).insights;
   const path = ForecastTypePaths[forecastType];
+  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Forecast>(`${path}?${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Forecast>(`${path}?${query}`);
+    return fetch();
   }
 }

--- a/src/api/forecasts/awsOcpForecast.ts
+++ b/src/api/forecasts/awsOcpForecast.ts
@@ -8,13 +8,13 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 };
 
 export function runForecast(forecastType: ForecastType, query: string) {
-  const insights = (window as any).insights;
   const path = ForecastTypePaths[forecastType];
+  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Forecast>(`${path}?${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Forecast>(`${path}?${query}`);
+    return fetch();
   }
 }

--- a/src/api/forecasts/azureForecast.ts
+++ b/src/api/forecasts/azureForecast.ts
@@ -8,13 +8,13 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 };
 
 export function runForecast(forecastType: ForecastType, query: string) {
-  const insights = (window as any).insights;
   const path = ForecastTypePaths[forecastType];
+  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Forecast>(`${path}?${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Forecast>(`${path}?${query}`);
+    return fetch();
   }
 }

--- a/src/api/forecasts/azureOcpForecast.ts
+++ b/src/api/forecasts/azureOcpForecast.ts
@@ -8,13 +8,13 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 };
 
 export function runForecast(forecastType: ForecastType, query: string) {
-  const insights = (window as any).insights;
   const path = ForecastTypePaths[forecastType];
+  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Forecast>(`${path}?${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Forecast>(`${path}?${query}`);
+    return fetch();
   }
 }

--- a/src/api/forecasts/gcpForecast.ts
+++ b/src/api/forecasts/gcpForecast.ts
@@ -8,13 +8,13 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 };
 
 export function runForecast(forecastType: ForecastType, query: string) {
-  const insights = (window as any).insights;
   const path = ForecastTypePaths[forecastType];
+  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Forecast>(`${path}?${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Forecast>(`${path}?${query}`);
+    return fetch();
   }
 }

--- a/src/api/forecasts/gcpOcpForecast.ts
+++ b/src/api/forecasts/gcpOcpForecast.ts
@@ -8,13 +8,13 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 };
 
 export function runForecast(forecastType: ForecastType, query: string) {
-  const insights = (window as any).insights;
   const path = ForecastTypePaths[forecastType];
+  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Forecast>(`${path}?${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Forecast>(`${path}?${query}`);
+    return fetch();
   }
 }

--- a/src/api/forecasts/ibmForecast.ts
+++ b/src/api/forecasts/ibmForecast.ts
@@ -8,13 +8,13 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 };
 
 export function runForecast(forecastType: ForecastType, query: string) {
-  const insights = (window as any).insights;
   const path = ForecastTypePaths[forecastType];
+  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Forecast>(`${path}?${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Forecast>(`${path}?${query}`);
+    return fetch();
   }
 }

--- a/src/api/forecasts/ociForecast.ts
+++ b/src/api/forecasts/ociForecast.ts
@@ -8,13 +8,13 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 };
 
 export function runForecast(forecastType: ForecastType, query: string) {
-  const insights = (window as any).insights;
   const path = ForecastTypePaths[forecastType];
+  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Forecast>(`${path}?${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Forecast>(`${path}?${query}`);
+    return fetch();
   }
 }

--- a/src/api/forecasts/ocpCloudForecast.ts
+++ b/src/api/forecasts/ocpCloudForecast.ts
@@ -8,13 +8,13 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 };
 
 export function runForecast(forecastType: ForecastType, query: string) {
-  const insights = (window as any).insights;
   const path = ForecastTypePaths[forecastType];
+  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Forecast>(`${path}?${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Forecast>(`${path}?${query}`);
+    return fetch();
   }
 }

--- a/src/api/forecasts/ocpForecast.ts
+++ b/src/api/forecasts/ocpForecast.ts
@@ -10,13 +10,13 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 };
 
 export function runForecast(forecastType: ForecastType, query: string) {
-  const insights = (window as any).insights;
   const path = ForecastTypePaths[forecastType];
+  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Forecast>(`${path}?${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Forecast>(`${path}?${query}`);
+    return fetch();
   }
 }

--- a/src/api/forecasts/rhelForecast.ts
+++ b/src/api/forecasts/rhelForecast.ts
@@ -10,13 +10,13 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 };
 
 export function runForecast(forecastType: ForecastType, query: string) {
-  const insights = (window as any).insights;
   const path = ForecastTypePaths[forecastType];
+  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Forecast>(`${path}?${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Forecast>(`${path}?${query}`);
+    return fetch();
   }
 }

--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -20,5 +20,12 @@ export type Metrics = PagedResponse<Metric>;
 
 export function fetchRateMetrics(source_type = '') {
   const query = source_type ? `&source_type=${source_type}` : '';
-  return axios.get<Metrics>(`metrics/?limit=20${query}`);
+  const fetch = () => axios.get<Metrics>(`metrics/?limit=20${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/orgs/awsOrgs.ts
+++ b/src/api/orgs/awsOrgs.ts
@@ -11,5 +11,12 @@ export const OrgTypePaths: Partial<Record<OrgType, string>> = {
 
 export function runOrg(orgType: OrgType, query: string) {
   const path = OrgTypePaths[orgType];
-  return axios.get<AwsOrg>(`${path}?${query}`);
+  const fetch = () => axios.get<AwsOrg>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/providers.ts
+++ b/src/api/providers.ts
@@ -69,13 +69,13 @@ export const enum ProviderType {
 }
 
 export function fetchProviders(query: string) {
-  const insights = (window as any).insights;
   const queryString = query ? `?${query}` : '';
+  const fetch = () => axios.get<Providers>(`sources/${queryString}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Providers>(`sources/${queryString}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Providers>(`sources/${queryString}`);
+    return fetch();
   }
 }

--- a/src/api/rates.ts
+++ b/src/api/rates.ts
@@ -47,5 +47,12 @@ export type Rates = PagedResponse<Rate>;
 
 export function fetchRate(uuid = null) {
   const query = uuid ? `?source_uuid=${uuid}` : '';
-  return axios.get<Rates>(`cost-models/${query}`);
+  const fetch = () => axios.get<Rates>(`cost-models/${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/reports/awsOcpReports.ts
+++ b/src/api/reports/awsOcpReports.ts
@@ -52,5 +52,12 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<AwsOcpReport>(`${path}?${query}`);
+  const fetch = () => axios.get<AwsOcpReport>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/reports/awsReports.ts
+++ b/src/api/reports/awsReports.ts
@@ -53,5 +53,12 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<AwsReport>(`${path}?${query}`);
+  const fetch = () => axios.get<AwsReport>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/reports/azureOcpReports.ts
+++ b/src/api/reports/azureOcpReports.ts
@@ -51,5 +51,12 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<AzureOcpReport>(`${path}?${query}`);
+  const fetch = () => axios.get<AzureOcpReport>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/reports/azureReports.ts
+++ b/src/api/reports/azureReports.ts
@@ -52,5 +52,12 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<AzureReport>(`${path}?${query}`);
+  const fetch = () => axios.get<AzureReport>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/reports/gcpOcpReports.ts
+++ b/src/api/reports/gcpOcpReports.ts
@@ -57,5 +57,12 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<GcpOcpReport>(`${path}?${query}`);
+  const fetch = () => axios.get<GcpOcpReport>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/reports/gcpReports.ts
+++ b/src/api/reports/gcpReports.ts
@@ -58,5 +58,12 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<GcpReport>(`${path}?${query}`);
+  const fetch = () => axios.get<GcpReport>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/reports/ibmReports.ts
+++ b/src/api/reports/ibmReports.ts
@@ -58,5 +58,12 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<IbmReport>(`${path}?${query}`);
+  const fetch = () => axios.get<IbmReport>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/reports/ociReports.ts
+++ b/src/api/reports/ociReports.ts
@@ -52,5 +52,12 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<OciReport>(`${path}?${query}`);
+  const fetch = () => axios.get<OciReport>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/reports/ocpCloudReports.ts
+++ b/src/api/reports/ocpCloudReports.ts
@@ -81,5 +81,12 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<OcpCloudReport>(`${path}?${query}`);
+  const fetch = () => axios.get<OcpCloudReport>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/reports/ocpReports.ts
+++ b/src/api/reports/ocpReports.ts
@@ -57,5 +57,12 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<OcpReport>(`${path}?${query}`);
+  const fetch = () => axios.get<OcpReport>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/reports/rhelReports.ts
+++ b/src/api/reports/rhelReports.ts
@@ -57,5 +57,12 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  return axios.get<RhelReport>(`${path}?${query}`);
+  const fetch = () => axios.get<RhelReport>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/resources/awsOcpResource.ts
+++ b/src/api/resources/awsOcpResource.ts
@@ -10,13 +10,13 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 };
 
 export function runResource(resourceType: ResourceType, query: string) {
-  const insights = (window as any).insights;
   const path = ResourceTypePaths[resourceType];
+  const fetch = () => axios.get<Resource>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Resource>(`${path}?openshift=true&${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Resource>(`${path}?openshift=true&${query}`);
+    return fetch();
   }
 }

--- a/src/api/resources/awsResource.ts
+++ b/src/api/resources/awsResource.ts
@@ -10,13 +10,13 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 };
 
 export function runResource(resourceType: ResourceType, query: string) {
-  const insights = (window as any).insights;
   const path = ResourceTypePaths[resourceType];
+  const fetch = () => axios.get<Resource>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Resource>(`${path}?${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Resource>(`${path}?${query}`);
+    return fetch();
   }
 }

--- a/src/api/resources/azureOcpResource.ts
+++ b/src/api/resources/azureOcpResource.ts
@@ -10,13 +10,13 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 };
 
 export function runResource(resourceType: ResourceType, query: string) {
-  const insights = (window as any).insights;
   const path = ResourceTypePaths[resourceType];
+  const fetch = () => axios.get<Resource>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Resource>(`${path}?openshift=true&${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Resource>(`${path}?openshift=true&${query}`);
+    return fetch();
   }
 }

--- a/src/api/resources/azureResource.ts
+++ b/src/api/resources/azureResource.ts
@@ -10,13 +10,13 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 };
 
 export function runResource(resourceType: ResourceType, query: string) {
-  const insights = (window as any).insights;
   const path = ResourceTypePaths[resourceType];
+  const fetch = () => axios.get<Resource>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Resource>(`${path}?${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Resource>(`${path}?${query}`);
+    return fetch();
   }
 }

--- a/src/api/resources/gcpOcpResource.ts
+++ b/src/api/resources/gcpOcpResource.ts
@@ -11,13 +11,13 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 };
 
 export function runResource(resourceType: ResourceType, query: string) {
-  const insights = (window as any).insights;
   const path = ResourceTypePaths[resourceType];
+  const fetch = () => axios.get<Resource>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Resource>(`${path}?openshift=true&${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Resource>(`${path}?openshift=true&${query}`);
+    return fetch();
   }
 }

--- a/src/api/resources/gcpResource.ts
+++ b/src/api/resources/gcpResource.ts
@@ -11,13 +11,13 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 };
 
 export function runResource(resourceType: ResourceType, query: string) {
-  const insights = (window as any).insights;
   const path = ResourceTypePaths[resourceType];
+  const fetch = () => axios.get<Resource>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Resource>(`${path}?${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Resource>(`${path}?${query}`);
+    return fetch();
   }
 }

--- a/src/api/resources/ibmResource.ts
+++ b/src/api/resources/ibmResource.ts
@@ -11,13 +11,13 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 };
 
 export function runResource(resourceType: ResourceType, query: string) {
-  const insights = (window as any).insights;
   const path = ResourceTypePaths[resourceType];
+  const fetch = () => axios.get<Resource>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Resource>(`${path}?${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Resource>(`${path}?${query}`);
+    return fetch();
   }
 }

--- a/src/api/resources/ociResource.ts
+++ b/src/api/resources/ociResource.ts
@@ -10,13 +10,13 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 };
 
 export function runResource(resourceType: ResourceType, query: string) {
-  const insights = (window as any).insights;
   const path = ResourceTypePaths[resourceType];
+  const fetch = () => axios.get<Resource>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Resource>(`${path}?${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Resource>(`${path}?${query}`);
+    return fetch();
   }
 }

--- a/src/api/resources/ocpResource.ts
+++ b/src/api/resources/ocpResource.ts
@@ -10,13 +10,13 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 };
 
 export function runResource(resourceType: ResourceType, query: string) {
-  const insights = (window as any).insights;
   const path = ResourceTypePaths[resourceType];
+  const fetch = () => axios.get<Resource>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Resource>(`${path}?${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Resource>(`${path}?${query}`);
+    return fetch();
   }
 }

--- a/src/api/resources/rhelResource.ts
+++ b/src/api/resources/rhelResource.ts
@@ -10,13 +10,13 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 };
 
 export function runResource(resourceType: ResourceType, query: string) {
-  const insights = (window as any).insights;
   const path = ResourceTypePaths[resourceType];
+  const fetch = () => axios.get<Resource>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<Resource>(`${path}?${query}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<Resource>(`${path}?${query}`);
+    return fetch();
   }
 }

--- a/src/api/ros/recommendations.ts
+++ b/src/api/ros/recommendations.ts
@@ -67,5 +67,12 @@ export function runRosReport(reportType: RosType, query: string) {
 // This fetches a recommendations list
 export function runRosReports(reportType: RosType, query: string) {
   const path = RosTypePaths[reportType];
-  return axios.get<RecommendationReport>(query ? `${path}?${query}` : path);
+  const fetch = () => axios.get<RecommendationReport>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/tags/awsOcpTags.ts
+++ b/src/api/tags/awsOcpTags.ts
@@ -11,5 +11,12 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  return axios.get<AwsOcpTag>(`${path}?${query}`);
+  const fetch = () => axios.get<AwsOcpTag>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/tags/awsTags.ts
+++ b/src/api/tags/awsTags.ts
@@ -11,5 +11,12 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  return axios.get<AwsTag>(`${path}?${query}`);
+  const fetch = () => axios.get<AwsTag>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/tags/azureOcpTags.ts
+++ b/src/api/tags/azureOcpTags.ts
@@ -11,5 +11,12 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  return axios.get<AzureOcpTag>(`${path}?${query}`);
+  const fetch = () => axios.get<AzureOcpTag>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/tags/azureTags.ts
+++ b/src/api/tags/azureTags.ts
@@ -11,5 +11,12 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  return axios.get<AzureTag>(`${path}?${query}`);
+  const fetch = () => axios.get<AzureTag>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/tags/gcpOcpTags.ts
+++ b/src/api/tags/gcpOcpTags.ts
@@ -11,5 +11,12 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  return axios.get<GcpOcpTag>(`${path}?${query}`);
+  const fetch = () => axios.get<GcpOcpTag>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/tags/gcpTags.ts
+++ b/src/api/tags/gcpTags.ts
@@ -11,5 +11,12 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  return axios.get<GcpTag>(`${path}?${query}`);
+  const fetch = () => axios.get<GcpTag>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/tags/ibmTags.ts
+++ b/src/api/tags/ibmTags.ts
@@ -11,5 +11,12 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  return axios.get<IbmTag>(`${path}?${query}`);
+  const fetch = () => axios.get<IbmTag>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/tags/ociTags.ts
+++ b/src/api/tags/ociTags.ts
@@ -11,5 +11,12 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  return axios.get<OciTag>(`${path}?${query}`);
+  const fetch = () => axios.get<OciTag>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/tags/ocpCloudTags.ts
+++ b/src/api/tags/ocpCloudTags.ts
@@ -11,5 +11,12 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  return axios.get<OcpCloudTag>(`${path}?${query}`);
+  const fetch = () => axios.get<OcpCloudTag>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/tags/ocpTags.ts
+++ b/src/api/tags/ocpTags.ts
@@ -11,5 +11,12 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  return axios.get<OcpTag>(`${path}?${query}`);
+  const fetch = () => axios.get<OcpTag>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/tags/rhelTags.ts
+++ b/src/api/tags/rhelTags.ts
@@ -11,5 +11,12 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  return axios.get<RhelTag>(`${path}?${query}`);
+  const fetch = () => axios.get<RhelTag>(`${path}?${query}`);
+
+  const insights = (window as any).insights;
+  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
+    return insights.chrome.auth.getUser().then(() => fetch());
+  } else {
+    return fetch();
+  }
 }

--- a/src/api/userAccess.ts
+++ b/src/api/userAccess.ts
@@ -30,13 +30,13 @@ export const enum UserAccessType {
 
 // If the user-access API is called without a query parameter, all types are returned in the response
 export function fetchUserAccess(query: string) {
-  const insights = (window as any).insights;
   const queryString = query ? `?${query}` : '';
+  const fetch = () => axios.get<UserAccess>(`user-access/${queryString}`);
+
+  const insights = (window as any).insights;
   if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => {
-      return axios.get<UserAccess>(`user-access/${queryString}`);
-    });
+    return insights.chrome.auth.getUser().then(() => fetch());
   } else {
-    return axios.get<UserAccess>(`user-access/${queryString}`);
+    return fetch();
   }
 }


### PR DESCRIPTION
When Boaz introduced `insightsAuthInterceptor` via https://github.com/project-koku/koku-ui/pull/1250, the intention was to skip testing for window.insights.

Now that `insightsAuthInterceptor` has been removed via https://github.com/project-koku/koku-ui/pull/3041, I've restored those tests in this PR. This will ensure the insights `user` exists before making requests.

Closes https://issues.redhat.com/browse/COST-3671