### PR TITLE
Revert previous API update

### DIFF
--- a/src/api/accountSettings.ts
+++ b/src/api/accountSettings.ts
@@ -1,7 +1,6 @@
 import axios from 'axios';
 
 import type { PagedLinks, PagedMetaData } from './api';
-import type { AwsOcpTag } from './tags/awsOcpTags';
 
 export interface AccountSettingsData {
   cost_type?: string;
@@ -15,12 +14,5 @@ export interface AccountSettings {
 }
 
 export function fetchAccountSettings() {
-  const fetch = () => axios.get<AwsOcpTag>(`account-settings/`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<AccountSettings>(`account-settings/`);
 }

--- a/src/api/costModels.ts
+++ b/src/api/costModels.ts
@@ -40,56 +40,21 @@ export interface CostModelRequest {
 export type CostModels = PagedResponse<CostModel>;
 
 export function fetchCostModels(query = '') {
-  const fetch = () => axios.get<CostModels>(`cost-models/${query && '?'}${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<CostModels>(`cost-models/${query && '?'}${query}`);
 }
 
 export function fetchCostModel(uuid: string) {
-  const fetch = () => axios.get<CostModels>(`cost-models/${uuid}/`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<CostModels>(`cost-models/${uuid}/`);
 }
 
 export function addCostModel(request: CostModelRequest) {
-  const fetch = () => axios.post(`cost-models/`, request);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.post(`cost-models/`, request);
 }
 
 export function updateCostModel(uuid: string, request: CostModelRequest) {
-  const fetch = () => axios.put(`cost-models/${uuid}/`, request);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.put(`cost-models/${uuid}/`, request);
 }
 
 export function deleteCostModel(uuid: string) {
-  const fetch = () => axios.delete(`cost-models/${uuid}/`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.delete(`cost-models/${uuid}/`);
 }

--- a/src/api/export/awsExport.ts
+++ b/src/api/export/awsExport.ts
@@ -4,17 +4,9 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () =>
-    axios.get<string>(`${path}?${query}`, {
-      headers: {
-        Accept: 'text/csv',
-      },
-    });
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<string>(`${path}?${query}`, {
+    headers: {
+      Accept: 'text/csv',
+    },
+  });
 }

--- a/src/api/export/awsOcpExport.ts
+++ b/src/api/export/awsOcpExport.ts
@@ -4,17 +4,9 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () =>
-    axios.get<string>(`${path}?${query}`, {
-      headers: {
-        Accept: 'text/csv',
-      },
-    });
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<string>(`${path}?${query}`, {
+    headers: {
+      Accept: 'text/csv',
+    },
+  });
 }

--- a/src/api/export/azureExport.ts
+++ b/src/api/export/azureExport.ts
@@ -4,17 +4,9 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () =>
-    axios.get<string>(`${path}?${query}`, {
-      headers: {
-        Accept: 'text/csv',
-      },
-    });
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<string>(`${path}?${query}`, {
+    headers: {
+      Accept: 'text/csv',
+    },
+  });
 }

--- a/src/api/export/azureOcpExport.ts
+++ b/src/api/export/azureOcpExport.ts
@@ -4,17 +4,9 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () =>
-    axios.get<string>(`${path}?${query}`, {
-      headers: {
-        Accept: 'text/csv',
-      },
-    });
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<string>(`${path}?${query}`, {
+    headers: {
+      Accept: 'text/csv',
+    },
+  });
 }

--- a/src/api/export/gcpExport.ts
+++ b/src/api/export/gcpExport.ts
@@ -4,17 +4,9 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () =>
-    axios.get<string>(`${path}?${query}`, {
-      headers: {
-        Accept: 'text/csv',
-      },
-    });
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<string>(`${path}?${query}`, {
+    headers: {
+      Accept: 'text/csv',
+    },
+  });
 }

--- a/src/api/export/gcpOcpExport.ts
+++ b/src/api/export/gcpOcpExport.ts
@@ -4,17 +4,9 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () =>
-    axios.get<string>(`${path}?${query}`, {
-      headers: {
-        Accept: 'text/csv',
-      },
-    });
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<string>(`${path}?${query}`, {
+    headers: {
+      Accept: 'text/csv',
+    },
+  });
 }

--- a/src/api/export/ibmExport.ts
+++ b/src/api/export/ibmExport.ts
@@ -4,17 +4,9 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () =>
-    axios.get<string>(`${path}?${query}`, {
-      headers: {
-        Accept: 'text/csv',
-      },
-    });
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<string>(`${path}?${query}`, {
+    headers: {
+      Accept: 'text/csv',
+    },
+  });
 }

--- a/src/api/export/ociExport.ts
+++ b/src/api/export/ociExport.ts
@@ -4,17 +4,9 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () =>
-    axios.get<string>(`${path}?${query}`, {
-      headers: {
-        Accept: 'text/csv',
-      },
-    });
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<string>(`${path}?${query}`, {
+    headers: {
+      Accept: 'text/csv',
+    },
+  });
 }

--- a/src/api/export/ocpCloudExport.ts
+++ b/src/api/export/ocpCloudExport.ts
@@ -4,17 +4,9 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () =>
-    axios.get<string>(`${path}?${query}`, {
-      headers: {
-        Accept: 'text/csv',
-      },
-    });
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<string>(`${path}?${query}`, {
+    headers: {
+      Accept: 'text/csv',
+    },
+  });
 }

--- a/src/api/export/ocpExport.ts
+++ b/src/api/export/ocpExport.ts
@@ -4,17 +4,9 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () =>
-    axios.get<string>(`${path}?${query}`, {
-      headers: {
-        Accept: 'text/csv',
-      },
-    });
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<string>(`${path}?${query}`, {
+    headers: {
+      Accept: 'text/csv',
+    },
+  });
 }

--- a/src/api/export/rhelExport.ts
+++ b/src/api/export/rhelExport.ts
@@ -4,17 +4,9 @@ import axios from 'axios';
 
 export function runExport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () =>
-    axios.get<string>(`${path}?${query}`, {
-      headers: {
-        Accept: 'text/csv',
-      },
-    });
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<string>(`${path}?${query}`, {
+    headers: {
+      Accept: 'text/csv',
+    },
+  });
 }

--- a/src/api/forecasts/awsForecast.ts
+++ b/src/api/forecasts/awsForecast.ts
@@ -9,12 +9,5 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 
 export function runForecast(forecastType: ForecastType, query: string) {
   const path = ForecastTypePaths[forecastType];
-  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Forecast>(`${path}?${query}`);
 }

--- a/src/api/forecasts/awsOcpForecast.ts
+++ b/src/api/forecasts/awsOcpForecast.ts
@@ -9,12 +9,5 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 
 export function runForecast(forecastType: ForecastType, query: string) {
   const path = ForecastTypePaths[forecastType];
-  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Forecast>(`${path}?${query}`);
 }

--- a/src/api/forecasts/azureForecast.ts
+++ b/src/api/forecasts/azureForecast.ts
@@ -9,12 +9,5 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 
 export function runForecast(forecastType: ForecastType, query: string) {
   const path = ForecastTypePaths[forecastType];
-  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Forecast>(`${path}?${query}`);
 }

--- a/src/api/forecasts/azureOcpForecast.ts
+++ b/src/api/forecasts/azureOcpForecast.ts
@@ -9,12 +9,5 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 
 export function runForecast(forecastType: ForecastType, query: string) {
   const path = ForecastTypePaths[forecastType];
-  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Forecast>(`${path}?${query}`);
 }

--- a/src/api/forecasts/gcpForecast.ts
+++ b/src/api/forecasts/gcpForecast.ts
@@ -9,12 +9,5 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 
 export function runForecast(forecastType: ForecastType, query: string) {
   const path = ForecastTypePaths[forecastType];
-  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Forecast>(`${path}?${query}`);
 }

--- a/src/api/forecasts/gcpOcpForecast.ts
+++ b/src/api/forecasts/gcpOcpForecast.ts
@@ -9,12 +9,5 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 
 export function runForecast(forecastType: ForecastType, query: string) {
   const path = ForecastTypePaths[forecastType];
-  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Forecast>(`${path}?${query}`);
 }

--- a/src/api/forecasts/ibmForecast.ts
+++ b/src/api/forecasts/ibmForecast.ts
@@ -9,12 +9,5 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 
 export function runForecast(forecastType: ForecastType, query: string) {
   const path = ForecastTypePaths[forecastType];
-  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Forecast>(`${path}?${query}`);
 }

--- a/src/api/forecasts/ociForecast.ts
+++ b/src/api/forecasts/ociForecast.ts
@@ -9,12 +9,5 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 
 export function runForecast(forecastType: ForecastType, query: string) {
   const path = ForecastTypePaths[forecastType];
-  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Forecast>(`${path}?${query}`);
 }

--- a/src/api/forecasts/ocpCloudForecast.ts
+++ b/src/api/forecasts/ocpCloudForecast.ts
@@ -9,12 +9,5 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 
 export function runForecast(forecastType: ForecastType, query: string) {
   const path = ForecastTypePaths[forecastType];
-  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Forecast>(`${path}?${query}`);
 }

--- a/src/api/forecasts/ocpForecast.ts
+++ b/src/api/forecasts/ocpForecast.ts
@@ -11,12 +11,5 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 
 export function runForecast(forecastType: ForecastType, query: string) {
   const path = ForecastTypePaths[forecastType];
-  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Forecast>(`${path}?${query}`);
 }

--- a/src/api/forecasts/rhelForecast.ts
+++ b/src/api/forecasts/rhelForecast.ts
@@ -11,12 +11,5 @@ export const ForecastTypePaths: Partial<Record<ForecastType, string>> = {
 
 export function runForecast(forecastType: ForecastType, query: string) {
   const path = ForecastTypePaths[forecastType];
-  const fetch = () => axios.get<Forecast>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Forecast>(`${path}?${query}`);
 }

--- a/src/api/metrics.ts
+++ b/src/api/metrics.ts
@@ -20,12 +20,5 @@ export type Metrics = PagedResponse<Metric>;
 
 export function fetchRateMetrics(source_type = '') {
   const query = source_type ? `&source_type=${source_type}` : '';
-  const fetch = () => axios.get<Metrics>(`metrics/?limit=20${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Metrics>(`metrics/?limit=20${query}`);
 }

--- a/src/api/orgs/awsOrgs.ts
+++ b/src/api/orgs/awsOrgs.ts
@@ -11,12 +11,5 @@ export const OrgTypePaths: Partial<Record<OrgType, string>> = {
 
 export function runOrg(orgType: OrgType, query: string) {
   const path = OrgTypePaths[orgType];
-  const fetch = () => axios.get<AwsOrg>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<AwsOrg>(`${path}?${query}`);
 }

--- a/src/api/providers.ts
+++ b/src/api/providers.ts
@@ -70,12 +70,5 @@ export const enum ProviderType {
 
 export function fetchProviders(query: string) {
   const queryString = query ? `?${query}` : '';
-  const fetch = () => axios.get<Providers>(`sources/${queryString}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Providers>(`sources/${queryString}`);
 }

--- a/src/api/rates.ts
+++ b/src/api/rates.ts
@@ -47,12 +47,5 @@ export type Rates = PagedResponse<Rate>;
 
 export function fetchRate(uuid = null) {
   const query = uuid ? `?source_uuid=${uuid}` : '';
-  const fetch = () => axios.get<Rates>(`cost-models/${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Rates>(`cost-models/${query}`);
 }

--- a/src/api/rbac.ts
+++ b/src/api/rbac.ts
@@ -6,16 +6,16 @@ export interface RBAC {
 }
 
 export async function getRBAC(): Promise<RBAC> {
-  const _insights = (window as any).insights;
+  const insights = (window as any).insights;
   if (
-    _insights &&
-    _insights.chrome &&
-    _insights.chrome.auth &&
-    _insights.chrome.auth.getUser &&
-    _insights.chrome.getUserPermissions
+    insights &&
+    insights.chrome &&
+    insights.chrome.auth &&
+    insights.chrome.auth.getUser &&
+    insights.chrome.getUserPermissions
   ) {
-    const user = await _insights.chrome.auth.getUser();
-    const permissions = await _insights.chrome.getUserPermissions();
+    const user = await insights.chrome.auth.getUser();
+    const permissions = await insights.chrome.getUserPermissions();
     return {
       isOrgAdmin: user.identity.user.is_org_admin,
       permissions,

--- a/src/api/reports/awsOcpReports.ts
+++ b/src/api/reports/awsOcpReports.ts
@@ -52,12 +52,5 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () => axios.get<AwsOcpReport>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<AwsOcpReport>(`${path}?${query}`);
 }

--- a/src/api/reports/awsReports.ts
+++ b/src/api/reports/awsReports.ts
@@ -53,12 +53,5 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () => axios.get<AwsReport>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<AwsReport>(`${path}?${query}`);
 }

--- a/src/api/reports/azureOcpReports.ts
+++ b/src/api/reports/azureOcpReports.ts
@@ -51,12 +51,5 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () => axios.get<AzureOcpReport>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<AzureOcpReport>(`${path}?${query}`);
 }

--- a/src/api/reports/azureReports.ts
+++ b/src/api/reports/azureReports.ts
@@ -52,12 +52,5 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () => axios.get<AzureReport>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<AzureReport>(`${path}?${query}`);
 }

--- a/src/api/reports/gcpOcpReports.ts
+++ b/src/api/reports/gcpOcpReports.ts
@@ -57,12 +57,5 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () => axios.get<GcpOcpReport>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<GcpOcpReport>(`${path}?${query}`);
 }

--- a/src/api/reports/gcpReports.ts
+++ b/src/api/reports/gcpReports.ts
@@ -58,12 +58,5 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () => axios.get<GcpReport>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<GcpReport>(`${path}?${query}`);
 }

--- a/src/api/reports/ibmReports.ts
+++ b/src/api/reports/ibmReports.ts
@@ -58,12 +58,5 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () => axios.get<IbmReport>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<IbmReport>(`${path}?${query}`);
 }

--- a/src/api/reports/ociReports.ts
+++ b/src/api/reports/ociReports.ts
@@ -52,12 +52,5 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () => axios.get<OciReport>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<OciReport>(`${path}?${query}`);
 }

--- a/src/api/reports/ocpCloudReports.ts
+++ b/src/api/reports/ocpCloudReports.ts
@@ -81,12 +81,5 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () => axios.get<OcpCloudReport>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<OcpCloudReport>(`${path}?${query}`);
 }

--- a/src/api/reports/ocpReports.ts
+++ b/src/api/reports/ocpReports.ts
@@ -57,12 +57,5 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () => axios.get<OcpReport>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<OcpReport>(`${path}?${query}`);
 }

--- a/src/api/reports/rhelReports.ts
+++ b/src/api/reports/rhelReports.ts
@@ -57,12 +57,5 @@ export const ReportTypePaths: Partial<Record<ReportType, string>> = {
 
 export function runReport(reportType: ReportType, query: string) {
   const path = ReportTypePaths[reportType];
-  const fetch = () => axios.get<RhelReport>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<RhelReport>(`${path}?${query}`);
 }

--- a/src/api/resources/awsOcpResource.ts
+++ b/src/api/resources/awsOcpResource.ts
@@ -11,12 +11,5 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 
 export function runResource(resourceType: ResourceType, query: string) {
   const path = ResourceTypePaths[resourceType];
-  const fetch = () => axios.get<Resource>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Resource>(`${path}?${query}`);
 }

--- a/src/api/resources/awsResource.ts
+++ b/src/api/resources/awsResource.ts
@@ -11,12 +11,5 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 
 export function runResource(resourceType: ResourceType, query: string) {
   const path = ResourceTypePaths[resourceType];
-  const fetch = () => axios.get<Resource>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Resource>(`${path}?${query}`);
 }

--- a/src/api/resources/azureOcpResource.ts
+++ b/src/api/resources/azureOcpResource.ts
@@ -11,12 +11,5 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 
 export function runResource(resourceType: ResourceType, query: string) {
   const path = ResourceTypePaths[resourceType];
-  const fetch = () => axios.get<Resource>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Resource>(`${path}?${query}`);
 }

--- a/src/api/resources/azureResource.ts
+++ b/src/api/resources/azureResource.ts
@@ -11,12 +11,5 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 
 export function runResource(resourceType: ResourceType, query: string) {
   const path = ResourceTypePaths[resourceType];
-  const fetch = () => axios.get<Resource>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Resource>(`${path}?${query}`);
 }

--- a/src/api/resources/gcpOcpResource.ts
+++ b/src/api/resources/gcpOcpResource.ts
@@ -12,12 +12,5 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 
 export function runResource(resourceType: ResourceType, query: string) {
   const path = ResourceTypePaths[resourceType];
-  const fetch = () => axios.get<Resource>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Resource>(`${path}?${query}`);
 }

--- a/src/api/resources/gcpResource.ts
+++ b/src/api/resources/gcpResource.ts
@@ -12,12 +12,5 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 
 export function runResource(resourceType: ResourceType, query: string) {
   const path = ResourceTypePaths[resourceType];
-  const fetch = () => axios.get<Resource>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Resource>(`${path}?${query}`);
 }

--- a/src/api/resources/ibmResource.ts
+++ b/src/api/resources/ibmResource.ts
@@ -12,12 +12,5 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 
 export function runResource(resourceType: ResourceType, query: string) {
   const path = ResourceTypePaths[resourceType];
-  const fetch = () => axios.get<Resource>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Resource>(`${path}?${query}`);
 }

--- a/src/api/resources/ociResource.ts
+++ b/src/api/resources/ociResource.ts
@@ -11,12 +11,5 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 
 export function runResource(resourceType: ResourceType, query: string) {
   const path = ResourceTypePaths[resourceType];
-  const fetch = () => axios.get<Resource>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Resource>(`${path}?${query}`);
 }

--- a/src/api/resources/ocpResource.ts
+++ b/src/api/resources/ocpResource.ts
@@ -11,12 +11,5 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 
 export function runResource(resourceType: ResourceType, query: string) {
   const path = ResourceTypePaths[resourceType];
-  const fetch = () => axios.get<Resource>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Resource>(`${path}?${query}`);
 }

--- a/src/api/resources/rhelResource.ts
+++ b/src/api/resources/rhelResource.ts
@@ -11,12 +11,5 @@ export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
 
 export function runResource(resourceType: ResourceType, query: string) {
   const path = ResourceTypePaths[resourceType];
-  const fetch = () => axios.get<Resource>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<Resource>(`${path}?${query}`);
 }

--- a/src/api/ros/recommendations.ts
+++ b/src/api/ros/recommendations.ts
@@ -67,12 +67,5 @@ export function runRosReport(reportType: RosType, query: string) {
 // This fetches a recommendations list
 export function runRosReports(reportType: RosType, query: string) {
   const path = RosTypePaths[reportType];
-  const fetch = () => axios.get<RecommendationReport>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<RecommendationReport>(`${path}?${query}`);
 }

--- a/src/api/tags/awsOcpTags.ts
+++ b/src/api/tags/awsOcpTags.ts
@@ -11,12 +11,5 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  const fetch = () => axios.get<AwsOcpTag>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<AwsOcpTag>(`${path}?${query}`);
 }

--- a/src/api/tags/awsTags.ts
+++ b/src/api/tags/awsTags.ts
@@ -11,12 +11,5 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  const fetch = () => axios.get<AwsTag>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<AwsTag>(`${path}?${query}`);
 }

--- a/src/api/tags/azureOcpTags.ts
+++ b/src/api/tags/azureOcpTags.ts
@@ -11,12 +11,5 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  const fetch = () => axios.get<AzureOcpTag>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<AzureOcpTag>(`${path}?${query}`);
 }

--- a/src/api/tags/azureTags.ts
+++ b/src/api/tags/azureTags.ts
@@ -11,12 +11,5 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  const fetch = () => axios.get<AzureTag>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<AzureTag>(`${path}?${query}`);
 }

--- a/src/api/tags/gcpOcpTags.ts
+++ b/src/api/tags/gcpOcpTags.ts
@@ -11,12 +11,5 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  const fetch = () => axios.get<GcpOcpTag>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<GcpOcpTag>(`${path}?${query}`);
 }

--- a/src/api/tags/gcpTags.ts
+++ b/src/api/tags/gcpTags.ts
@@ -11,12 +11,5 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  const fetch = () => axios.get<GcpTag>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<GcpTag>(`${path}?${query}`);
 }

--- a/src/api/tags/ibmTags.ts
+++ b/src/api/tags/ibmTags.ts
@@ -11,12 +11,5 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  const fetch = () => axios.get<IbmTag>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<IbmTag>(`${path}?${query}`);
 }

--- a/src/api/tags/ociTags.ts
+++ b/src/api/tags/ociTags.ts
@@ -11,12 +11,5 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  const fetch = () => axios.get<OciTag>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<OciTag>(`${path}?${query}`);
 }

--- a/src/api/tags/ocpCloudTags.ts
+++ b/src/api/tags/ocpCloudTags.ts
@@ -11,12 +11,5 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  const fetch = () => axios.get<OcpCloudTag>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<OcpCloudTag>(`${path}?${query}`);
 }

--- a/src/api/tags/ocpTags.ts
+++ b/src/api/tags/ocpTags.ts
@@ -11,12 +11,5 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  const fetch = () => axios.get<OcpTag>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<OcpTag>(`${path}?${query}`);
 }

--- a/src/api/tags/rhelTags.ts
+++ b/src/api/tags/rhelTags.ts
@@ -11,12 +11,5 @@ export const TagTypePaths: Partial<Record<TagType, string>> = {
 
 export function runTag(tagType: TagType, query: string) {
   const path = TagTypePaths[tagType];
-  const fetch = () => axios.get<RhelTag>(`${path}?${query}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<RhelTag>(`${path}?${query}`);
 }

--- a/src/api/userAccess.ts
+++ b/src/api/userAccess.ts
@@ -25,18 +25,11 @@ export const enum UserAccessType {
   oci = 'oci',
   ocp = 'ocp',
   rhel = 'ocp', // Todo: update to use RHEL when APIs are available
-  ros = 'ocp', // Todo: update to use ROS when APIs are available
+  ros = 'ocp',
 }
 
 // If the user-access API is called without a query parameter, all types are returned in the response
 export function fetchUserAccess(query: string) {
   const queryString = query ? `?${query}` : '';
-  const fetch = () => axios.get<UserAccess>(`user-access/${queryString}`);
-
-  const insights = (window as any).insights;
-  if (insights && insights.chrome && insights.chrome.auth && insights.chrome.auth.getUser) {
-    return insights.chrome.auth.getUser().then(() => fetch());
-  } else {
-    return fetch();
-  }
+  return axios.get<UserAccess>(`user-access/${queryString}`);
 }

--- a/src/routes/views/components/charts/costExplorerChart/costExplorerChart.tsx
+++ b/src/routes/views/components/charts/costExplorerChart/costExplorerChart.tsx
@@ -245,7 +245,7 @@ class CostExplorerChartBase extends React.Component<CostExplorerChartProps, Stat
   // If bar width exceeds max and domainPadding is true, extra width is returned to help center bars horizontally
   private getBarWidth = (domainPadding: boolean = false) => {
     const { hiddenSeries, series, width } = this.state;
-    const maxWidth = 200;
+    const maxWidth = 20;
     let maxValue = -1;
 
     if (series) {

--- a/src/store/accountSettings/accountSettingsActions.ts
+++ b/src/store/accountSettings/accountSettingsActions.ts
@@ -1,6 +1,7 @@
 import type { AccountSettings } from 'api/accountSettings';
 import { fetchAccountSettings as apiGetAccountSettings } from 'api/accountSettings';
 import type { AxiosError } from 'axios';
+import type { ThunkAction } from 'store/common';
 import { createAction } from 'typesafe-actions';
 
 import { getFetchId } from './accountSettingsCommon';
@@ -19,7 +20,7 @@ export const fetchAccountSettingsFailure = createAction('accountSettings/fetch/f
   AccountSettingsActionMeta
 >();
 
-export function fetchAccountSettings() {
+export function fetchAccountSettings(): ThunkAction {
   return dispatch => {
     const meta: AccountSettingsActionMeta = {
       fetchId: getFetchId(),

--- a/src/store/providers/providersActions.ts
+++ b/src/store/providers/providersActions.ts
@@ -2,6 +2,7 @@ import type { Providers } from 'api/providers';
 import type { ProviderType } from 'api/providers';
 import { fetchProviders as apiGetProviders } from 'api/providers';
 import type { AxiosError } from 'axios';
+import type { ThunkAction } from 'store/common';
 import { createAction } from 'typesafe-actions';
 
 import { getFetchId } from './providersCommon';
@@ -14,7 +15,7 @@ export const fetchProvidersRequest = createAction('providers/fetch/request')<Pro
 export const fetchProvidersSuccess = createAction('providers/fetch/success')<Providers, ProvidersActionMeta>();
 export const fetchProvidersFailure = createAction('providers/fetch/failure')<AxiosError, ProvidersActionMeta>();
 
-export function fetchProviders(reportType: ProviderType, reportQueryString: string) {
+export function fetchProviders(reportType: ProviderType, reportQueryString: string): ThunkAction {
   return dispatch => {
     const meta: ProvidersActionMeta = {
       fetchId: getFetchId(reportType, reportQueryString),

--- a/src/store/sourceSettings/actions.ts
+++ b/src/store/sourceSettings/actions.ts
@@ -3,6 +3,7 @@ import { fetchProviders as apiGetSources } from 'api/providers';
 import type { AxiosResponse } from 'axios';
 import type { AxiosError } from 'axios';
 import type { Dispatch } from 'redux';
+import type { ThunkAction } from 'store/common';
 import { createAction, createAsyncAction } from 'typesafe-actions';
 
 interface FilterQuery {
@@ -22,7 +23,7 @@ export const {
   AxiosError
 >();
 
-export const fetchSources = (sourcesQueryString: string = '') => {
+export const fetchSources = (sourcesQueryString: string = ''): ThunkAction => {
   return (dispatch: Dispatch) => {
     dispatch(fetchSourcesRequest());
 

--- a/src/store/userAccess/userAccessActions.ts
+++ b/src/store/userAccess/userAccessActions.ts
@@ -2,6 +2,7 @@ import type { UserAccess } from 'api/userAccess';
 import type { UserAccessType } from 'api/userAccess';
 import { fetchUserAccess as apiGetUserAccess } from 'api/userAccess';
 import type { AxiosError } from 'axios';
+import type { ThunkAction } from 'store/common';
 import { createAction } from 'typesafe-actions';
 
 import { getFetchId } from './userAccessCommon';
@@ -14,7 +15,7 @@ export const fetchUserAccessRequest = createAction('userAccess/fetch/request')<U
 export const fetchUserAccessSuccess = createAction('userAccess/fetch/success')<UserAccess, UserAccessActionMeta>();
 export const fetchUserAccessFailure = createAction('userAccess/fetch/failure')<AxiosError, UserAccessActionMeta>();
 
-export function fetchUserAccess(userAccessType: UserAccessType, userAccessQueryString: string) {
+export function fetchUserAccess(userAccessType: UserAccessType, userAccessQueryString: string): ThunkAction {
   return dispatch => {
     const meta: UserAccessActionMeta = {
       fetchId: getFetchId(userAccessType, userAccessQueryString),


### PR DESCRIPTION
Reverting previous API update to call insights.chrome.auth.getUser. No longer seems necessary to obtain the user prior to making API requests.