### PR TITLE
Ensure platform project retains filters

### DIFF
--- a/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/routes/views/details/awsBreakdown/awsBreakdown.tsx
@@ -55,7 +55,6 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, BreakdownSta
     filter_by: {
       // Add filters here to apply logical OR/AND
       ...(queryFromRoute && queryFromRoute.filter_by && queryFromRoute.filter_by),
-      ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
       ...(queryFromRoute &&
         queryFromRoute.filter &&
         queryFromRoute.filter.account && { [`${logicalAndPrefix}account`]: queryFromRoute.filter.account }),
@@ -72,6 +71,11 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, BreakdownSta
     ...newQuery,
     cost_type: costType,
     currency,
+    filter_by: {
+      ...newQuery.filter_by,
+      // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+      ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }),
+    },
   });
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);

--- a/src/routes/views/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/routes/views/details/azureBreakdown/azureBreakdown.tsx
@@ -52,7 +52,6 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, BreakdownStateP
     filter_by: {
       // Add filters here to apply logical OR/AND
       ...(queryFromRoute && queryFromRoute.filter_by && queryFromRoute.filter_by),
-      ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
     },
     exclude: {
       ...(queryFromRoute && queryFromRoute.exclude && queryFromRoute.exclude),
@@ -65,6 +64,11 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, BreakdownStateP
   const reportQueryString = getQuery({
     ...newQuery,
     currency,
+    filter_by: {
+      ...newQuery.filter_by,
+      // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+      ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }),
+    },
   });
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);

--- a/src/routes/views/details/components/historicalData/historicalDataCostChart.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataCostChart.tsx
@@ -154,7 +154,6 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
         // Add filters here to apply logical OR/AND
         ...(queryFromRoute && queryFromRoute.filter_by && queryFromRoute.filter_by),
         ...(queryFromRoute && queryFromRoute.filter && { category: queryFromRoute.filter.category }),
-        ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
       },
       exclude: {
         ...(queryFromRoute && queryFromRoute.exclude && queryFromRoute.exclude),
@@ -175,6 +174,11 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
       ...currentQuery,
       cost_type: costType,
       currency,
+      filter_by: {
+        ...currentQuery.filter_by,
+        // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+        ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }),
+      },
     });
     const previousQuery: Query = {
       ...baseQuery,
@@ -188,6 +192,11 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
       ...previousQuery,
       cost_type: costType,
       currency,
+      filter_by: {
+        ...previousQuery.filter_by,
+        // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+        ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }),
+      },
     });
 
     // Current report

--- a/src/routes/views/details/components/historicalData/historicalDataTrendChart.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataTrendChart.tsx
@@ -176,7 +176,6 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
         ...(queryFromRoute &&
           queryFromRoute.filter &&
           queryFromRoute.filter.category && { category: queryFromRoute.filter.category }),
-        ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
       },
       exclude: {
         ...(queryFromRoute && queryFromRoute.exclude && queryFromRoute.exclude),
@@ -197,6 +196,11 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
       ...currentQuery,
       cost_type: costType,
       currency,
+      filter_by: {
+        ...currentQuery.filter_by,
+        // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+        ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }),
+      },
     });
     const previousQuery: Query = {
       ...baseQuery,
@@ -210,6 +214,11 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
       ...previousQuery,
       cost_type: costType,
       currency,
+      filter_by: {
+        ...previousQuery.filter_by,
+        // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+        ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }),
+      },
     });
 
     // Current report

--- a/src/routes/views/details/components/historicalData/historicalDataUsageChart.tsx
+++ b/src/routes/views/details/components/historicalData/historicalDataUsageChart.tsx
@@ -143,7 +143,6 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
         ...(queryFromRoute &&
           queryFromRoute.filter &&
           queryFromRoute.filter.category && { category: queryFromRoute.filter.category }),
-        ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
         ...(groupByOrgValue && useFilter && { [orgUnitIdKey]: groupByOrgValue }),
       },
       exclude: {
@@ -164,7 +163,14 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
         time_scope_value: -1,
       },
     };
-    const currentQueryString = getQuery(currentQuery);
+    const currentQueryString = getQuery({
+      ...currentQuery,
+      filter_by: {
+        ...currentQuery.filter_by,
+        // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+        ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }),
+      },
+    });
     const currentReport = reportSelectors.selectReport(state, reportPathsType, reportType, currentQueryString);
     const currentReportFetchStatus = reportSelectors.selectReportFetchStatus(
       state,
@@ -182,7 +188,14 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
         time_scope_value: -2,
       },
     };
-    const previousQueryString = getQuery(previousQuery);
+    const previousQueryString = getQuery({
+      ...previousQuery,
+      filter_by: {
+        ...previousQuery.filter_by,
+        // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+        ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }),
+      },
+    });
     const previousReport = reportSelectors.selectReport(state, reportPathsType, reportType, previousQueryString);
     const previousReportFetchStatus = reportSelectors.selectReportFetchStatus(
       state,

--- a/src/routes/views/details/components/summary/summaryCard.tsx
+++ b/src/routes/views/details/components/summary/summaryCard.tsx
@@ -217,8 +217,6 @@ const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps
         ...(queryFromRoute &&
           queryFromRoute.filter &&
           queryFromRoute.filter.category && { category: queryFromRoute.filter.category }),
-        ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
-        ...(groupBy && { [groupBy]: groupByValue }), // group bys must appear in filter to show costs by region, account, etc
       },
       exclude: {
         ...(queryFromRoute && queryFromRoute.exclude && queryFromRoute.exclude),
@@ -232,6 +230,11 @@ const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps
       ...query,
       cost_type: costType,
       currency,
+      filter_by: {
+        ...query.filter_by,
+        // Related to https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+        ...(groupBy && groupByValue !== '*' && { [groupBy]: groupByValue }), // group bys must appear in filter to show costs by region, account, etc
+      },
     });
     const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
     const reportFetchStatus = reportSelectors.selectReportFetchStatus(

--- a/src/routes/views/details/components/summary/summaryModalContent.tsx
+++ b/src/routes/views/details/components/summary/summaryModalContent.tsx
@@ -119,7 +119,6 @@ const mapStateToProps = createMapStateToProps<SummaryModalContentOwnProps, Summa
         ...(queryFromRoute &&
           queryFromRoute.filter &&
           queryFromRoute.filter.category && { category: queryFromRoute.filter.category }),
-        ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
         ...(groupBy && { [groupBy]: groupByValue }), // group bys must appear in filter to show costs by regions, accounts, etc
       },
       exclude: {
@@ -134,6 +133,11 @@ const mapStateToProps = createMapStateToProps<SummaryModalContentOwnProps, Summa
       ...newQuery,
       cost_type: costType,
       currency,
+      filter_by: {
+        ...newQuery.filter_by,
+        // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+        ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }),
+      },
     });
     const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
     const reportFetchStatus = reportSelectors.selectReportFetchStatus(

--- a/src/routes/views/details/components/tag/tagLink.tsx
+++ b/src/routes/views/details/components/tag/tagLink.tsx
@@ -138,10 +138,16 @@ const mapStateToProps = createMapStateToProps<TagLinkOwnProps, TagLinkStateProps
         ...(queryFromRoute &&
           queryFromRoute.filter &&
           queryFromRoute.filter.category && { category: queryFromRoute.filter.category }),
-        ...(groupBy && groupBy.indexOf(tagPrefix) === -1 && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
       },
     };
-    const tagQueryString = getQuery(query);
+    const tagQueryString = getQuery({
+      ...query,
+      filter_by: {
+        ...query.filter_by,
+        // Related to https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+        ...(groupBy && groupByValue !== '*' && groupBy.indexOf(tagPrefix) === -1 && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
+      },
+    });
     const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, tagQueryString);
     const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(
       state,

--- a/src/routes/views/details/components/tag/tagModal.tsx
+++ b/src/routes/views/details/components/tag/tagModal.tsx
@@ -137,11 +137,17 @@ const mapStateToProps = createMapStateToProps<TagModalOwnProps, TagModalStatePro
         ...(queryFromRoute &&
           queryFromRoute.filter &&
           queryFromRoute.filter.category && { category: queryFromRoute.filter.category }),
-        ...(groupBy && groupBy.indexOf(tagPrefix) === -1 && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
       },
     };
 
-    const tagQueryString = getQuery(query);
+    const tagQueryString = getQuery({
+      ...query,
+      filter_by: {
+        ...query.filter_by,
+        // Related to https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+        ...(groupBy && groupByValue !== '*' && groupBy.indexOf(tagPrefix) === -1 && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
+      },
+    });
     const tagReport = tagSelectors.selectTag(state, tagReportPathsType, tagReportType, tagQueryString);
     const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(
       state,

--- a/src/routes/views/details/components/usageChart/usageChart.tsx
+++ b/src/routes/views/details/components/usageChart/usageChart.tsx
@@ -387,7 +387,6 @@ const mapStateToProps = createMapStateToProps<UsageChartOwnProps, UsageChartStat
         // Add filters here to apply logical OR/AND
         ...(queryFromRoute && queryFromRoute.filter_by && queryFromRoute.filter_by),
         ...(queryFromRoute && queryFromRoute.filter && { category: queryFromRoute.filter.category }),
-        ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
       },
       exclude: {
         ...(queryFromRoute && queryFromRoute.exclude && queryFromRoute.exclude),
@@ -399,6 +398,11 @@ const mapStateToProps = createMapStateToProps<UsageChartOwnProps, UsageChartStat
 
     const reportQueryString = getQuery({
       ...query,
+      filter_by: {
+        ...query.filter_by,
+        // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+        ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }),
+      },
     });
     const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
     const reportFetchStatus = reportSelectors.selectReportFetchStatus(

--- a/src/routes/views/details/gcpBreakdown/gcpBreakdown.tsx
+++ b/src/routes/views/details/gcpBreakdown/gcpBreakdown.tsx
@@ -53,7 +53,6 @@ const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, BreakdownSta
     filter_by: {
       // Add filters here to apply logical OR/AND
       ...(queryFromRoute && queryFromRoute.filter_by && queryFromRoute.filter_by),
-      ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
     },
     exclude: {
       ...(queryFromRoute && queryFromRoute.exclude && queryFromRoute.exclude),
@@ -66,6 +65,11 @@ const mapStateToProps = createMapStateToProps<GcpBreakdownOwnProps, BreakdownSta
   const reportQueryString = getQuery({
     ...newQuery,
     currency,
+    filter_by: {
+      ...newQuery.filter_by,
+      // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+      ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }),
+    },
   });
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);

--- a/src/routes/views/details/ibmBreakdown/ibmBreakdown.tsx
+++ b/src/routes/views/details/ibmBreakdown/ibmBreakdown.tsx
@@ -53,7 +53,6 @@ const mapStateToProps = createMapStateToProps<IbmBreakdownOwnProps, BreakdownSta
     filter_by: {
       // Add filters here to apply logical OR/AND
       ...(queryFromRoute && queryFromRoute.filter_by && queryFromRoute.filter_by),
-      ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
     },
     exclude: {
       ...(queryFromRoute && queryFromRoute.exclude && queryFromRoute.exclude),
@@ -66,6 +65,11 @@ const mapStateToProps = createMapStateToProps<IbmBreakdownOwnProps, BreakdownSta
   const reportQueryString = getQuery({
     ...newQuery,
     currency,
+    filter_by: {
+      ...newQuery.filter_by,
+      // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+      ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }),
+    },
   });
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);

--- a/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
+++ b/src/routes/views/details/ociBreakdown/ociBreakdown.tsx
@@ -53,7 +53,6 @@ const mapStateToProps = createMapStateToProps<OciCostOwnProps, BreakdownStatePro
     filter_by: {
       // Add filters here to apply logical OR/AND
       ...(queryFromRoute && queryFromRoute.filter_by && queryFromRoute.filter_by),
-      ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
     },
     exclude: {
       ...(queryFromRoute && queryFromRoute.exclude && queryFromRoute.exclude),
@@ -66,6 +65,11 @@ const mapStateToProps = createMapStateToProps<OciCostOwnProps, BreakdownStatePro
   const reportQueryString = getQuery({
     ...newQuery,
     currency,
+    filter_by: {
+      ...newQuery.filter_by,
+      // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+      ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }),
+    },
   });
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);

--- a/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -73,13 +73,13 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, BreakdownSta
 
   const reportQueryString = getQuery({
     ...newQuery,
+    category: undefined,
+    currency,
     filter_by: {
       ...newQuery.filter_by,
       // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
       ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }),
     },
-    category: undefined,
-    currency,
   });
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);

--- a/src/routes/views/details/rhelBreakdown/rhelBreakdown.tsx
+++ b/src/routes/views/details/rhelBreakdown/rhelBreakdown.tsx
@@ -54,7 +54,6 @@ const mapStateToProps = createMapStateToProps<RhelBreakdownOwnProps, BreakdownSt
       // Add filters here to apply logical OR/AND
       ...(queryFromRoute && queryFromRoute.filter_by && queryFromRoute.filter_by),
       ...(queryFromRoute && queryFromRoute.filter && { category: queryFromRoute.filter.category }),
-      ...(groupBy && { [groupBy]: undefined }), // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131
     },
     exclude: {
       ...(queryFromRoute && queryFromRoute.exclude && queryFromRoute.exclude),
@@ -69,6 +68,11 @@ const mapStateToProps = createMapStateToProps<RhelBreakdownOwnProps, BreakdownSt
     ...newQuery,
     category: undefined,
     currency,
+    filter_by: {
+      ...newQuery.filter_by,
+      // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+      ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }),
+    },
   });
   const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
   const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);


### PR DESCRIPTION
There are multiple API requests in the breakdown page where we need to ensure filters are not cleared for the OCP platform project.

https://issues.redhat.com/browse/COST-3642