### PR TITLE
Added empty state for breakdown tabs

### DIFF
--- a/src/routes/views/details/components/dataTable/dataTable.tsx
+++ b/src/routes/views/details/components/dataTable/dataTable.tsx
@@ -10,8 +10,8 @@ import messages from 'locales/messages';
 import React from 'react';
 import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
-import { OptimizationIcon } from 'routes/components/icons/optimizationIcon';
 import { EmptyFilterState } from 'routes/components/state/emptyFilterState';
+import { NoOptimizationsState } from 'routes/state/noOptimizations/noOptimizationsState';
 import type { ComputedReportItem } from 'utils/computedReport/getComputedReportItems';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
@@ -49,12 +49,13 @@ class DataTable extends React.Component<DataTableProps, any> {
         }
       }
     }
+    if (isOptimizations) {
+      return <NoOptimizationsState />;
+    }
     return (
       <EmptyState>
-        <EmptyStateIcon icon={isOptimizations ? (OptimizationIcon as any) : CalculatorIcon} />
-        <EmptyStateBody>
-          {intl.formatMessage(isOptimizations ? messages.optimizationsEmptyState : messages.detailsEmptyState)}
-        </EmptyStateBody>
+        <EmptyStateIcon icon={CalculatorIcon} />
+        <EmptyStateBody>{intl.formatMessage(messages.detailsEmptyState)}</EmptyStateBody>
       </EmptyState>
     );
   };

--- a/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/routes/views/details/ocpBreakdown/ocpBreakdown.tsx
@@ -10,6 +10,7 @@ import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { routes } from 'routes';
+import { NoData } from 'routes/state/noData';
 import type { BreakdownStateProps } from 'routes/views/details/components/breakdown';
 import { BreakdownBase } from 'routes/views/details/components/breakdown';
 import { getGroupById, getGroupByValue } from 'routes/views/utils/groupBy';
@@ -91,10 +92,22 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, BreakdownSta
     providersQueryString
   );
 
+  // Show empty state when report cannot fetch optimization project
+  let hasData = false;
+  if (report && report.data) {
+    for (const item of report.data as any) {
+      const projects = item.projects;
+      if (projects.length > 0) {
+        hasData = true;
+        break;
+      }
+    }
+  }
+
   const title = queryFromRoute[breakdownTitleKey] ? queryFromRoute[breakdownTitleKey] : groupByValue;
 
   return {
-    costOverviewComponent: (
+    costOverviewComponent: hasData ? (
       <CostOverview
         currency={currency}
         groupBy={groupBy}
@@ -102,6 +115,8 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, BreakdownSta
         report={report}
         title={title}
       />
+    ) : (
+      <NoData />
     ),
     currency,
     description: queryFromRoute[breakdownDescKey],
@@ -109,7 +124,7 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, BreakdownSta
     emptyStateTitle: intl.formatMessage(messages.ocpDetailsTitle),
     groupBy,
     groupByValue,
-    historicalDataComponent: <HistoricalData currency={currency} />,
+    historicalDataComponent: hasData ? <HistoricalData currency={currency} /> : <NoData />,
     isOptimizationsTab: queryFromRoute.optimizationsTab !== undefined,
     isRosFeatureEnabled: featureFlagsSelectors.selectIsRosFeatureEnabled(state),
     optimizationsBadgeComponent: <OptimizationsBadge />,


### PR DESCRIPTION
When navigating from the Optimizations drawer to the breakdown page, the project may not exist for Cost Management APIs. In this case, the projects cost is zero and the "Cost overview" and "Historical data" tabs don't have data to show.

I used the empty state we show in the OpenShift details page when there is no data. I realize this is fake data, but feel we should have something in place. However, it is possible that the Cost and ROS APIs are not in sync when data is updated, sources are added / removed, etc.