### PR TITLE
Overhead costs default

### DIFF
--- a/src/utils/localStorage.ts
+++ b/src/utils/localStorage.ts
@@ -108,7 +108,7 @@ export const deleteCostDistribution = () => {
 // Returns cost distribution
 export const getCostDistribution = () => {
   const costDistribution = getItem(costDistributionID);
-  return costDistribution && costDistribution !== null ? costDistribution : ComputedReportItemValueType.total;
+  return costDistribution && costDistribution !== null ? costDistribution : ComputedReportItemValueType.distributed;
 };
 
 // Returns true if cost distribution is available


### PR DESCRIPTION
Set dropdown default to distribute overhead costs through cost model. Users should not need to enable the overhead cost feature twice; once in the cost model, then again via the dropdown.

https://issues.redhat.com/browse/COST-3681