### PR TITLE
Reset delta when group by is changed

### DIFF
--- a/src/routes/views/details/ocpDetails/detailsTable.tsx
+++ b/src/routes/views/details/ocpDetails/detailsTable.tsx
@@ -139,7 +139,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
             style: styles.managedColumn,
           },
           {
-            orderBy: costDistribution === ComputedReportItemValueType.distributed ? 'distributed_cost' : 'cost',
+            orderBy:
+              groupBy === 'project' && costDistribution === ComputedReportItemValueType.distributed
+                ? 'distributed_cost'
+                : 'cost',
             name: intl.formatMessage(messages.cost),
             style: styles.costColumn,
             ...(computedItems.length && { isSortable: false }),
@@ -189,7 +192,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
             // ...(computedItems.length && { isSortable: true }),
           },
           {
-            orderBy: costDistribution === ComputedReportItemValueType.distributed ? 'distributed_cost' : 'cost',
+            orderBy:
+              groupBy === 'project' && costDistribution === ComputedReportItemValueType.distributed
+                ? 'distributed_cost'
+                : 'cost',
             name: intl.formatMessage(messages.cost),
             style: styles.costColumn,
             ...(computedItems.length && { isSortable: true }),
@@ -206,6 +212,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
       const supplementaryCost = this.getSupplementaryCost(item, index);
       const InfrastructureCost = this.getInfrastructureCost(item, index);
       const isOverheadCosts =
+        groupBy === 'project' &&
         costDistribution === ComputedReportItemValueType.distributed &&
         ((item.cost.platformDistributed && item.cost.platformDistributed.value > 0) ||
           (item.cost.workerUnallocatedDistributed && item.cost.workerUnallocatedDistributed.value > 0));

--- a/src/routes/views/details/ocpDetails/ocpDetails.tsx
+++ b/src/routes/views/details/ocpDetails/ocpDetails.tsx
@@ -21,7 +21,7 @@ import { ComputedReportItemValueType } from 'routes/views/components/charts/comm
 import { ExportModal } from 'routes/views/components/export';
 import type { ColumnManagementModalOption } from 'routes/views/details/components/columnManagement';
 import { ColumnManagementModal, initHiddenColumns } from 'routes/views/details/components/columnManagement';
-import { getGroupByTagKey } from 'routes/views/utils/groupBy';
+import { getGroupById, getGroupByTagKey } from 'routes/views/utils/groupBy';
 import {
   handleCostDistributionSelected,
   handleCurrencySelected,
@@ -353,6 +353,7 @@ class OcpDetails extends React.Component<OcpDetailsProps, OcpDetailsState> {
       },
       order_by: { cost: 'desc' },
       category: undefined, // Only applies to projects
+      delta: undefined,
     };
     this.setState({ isAllSelected: false, selectedItems: [] }, () => {
       router.navigate(getRouteForQuery(newQuery, router.location, true), { replace: true });
@@ -460,6 +461,7 @@ class OcpDetails extends React.Component<OcpDetailsProps, OcpDetailsState> {
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const mapStateToProps = createMapStateToProps<OcpDetailsOwnProps, OcpDetailsStateProps>((state, { router }) => {
   const queryFromRoute = parseQuery<OcpQuery>(router.location.search);
+  const groupBy = getGroupById(queryFromRoute);
   const costDistribution = getCostDistribution();
   const currency = getCurrency();
 
@@ -470,7 +472,10 @@ const mapStateToProps = createMapStateToProps<OcpDetailsOwnProps, OcpDetailsStat
   const reportQuery = {
     category: query.category,
     currency,
-    delta: costDistribution === ComputedReportItemValueType.distributed ? 'distributed_cost' : 'cost',
+    delta:
+      groupBy === 'project' && costDistribution === ComputedReportItemValueType.distributed
+        ? 'distributed_cost'
+        : 'cost',
     exclude: query.exclude,
     filter: {
       ...query.filter,


### PR DESCRIPTION
Reset delta when group by is changed. Also ensure we don't set order_by and/or overhead costs unless the group_by is 'project'