### PR TITLE
Close optimizations drawer

### DIFF
--- a/src/routes/views/components/optimizations/optimizationsTable.tsx
+++ b/src/routes/views/components/optimizations/optimizationsTable.tsx
@@ -25,6 +25,7 @@ interface OptimizationsTableOwnProps extends RouterComponentProps {
 }
 
 interface OptimizationsTableState {
+  currentRow?: number;
   columns?: any[];
   rows?: any[];
 }
@@ -147,14 +148,29 @@ class OptimizationsTableBase extends React.Component<OptimizationsTableProps, Op
   };
 
   private handleOnRowClick = (event: React.KeyboardEvent | React.MouseEvent, rowIndex: number) => {
-    const { openOptimizationsDrawer } = this.props;
-    const { rows } = this.state;
+    const { closeOptimizationsDrawer, isOpen, openOptimizationsDrawer } = this.props;
+    const { currentRow, rows } = this.state;
 
-    openOptimizationsDrawer(rows[rowIndex].optimization);
+    this.setState({ currentRow: rowIndex }, () => {
+      if (currentRow === rowIndex && isOpen) {
+        closeOptimizationsDrawer();
+      } else {
+        openOptimizationsDrawer(rows[rowIndex].optimization);
+      }
+    });
+  };
+
+  private handleOnSort = (value: string, isSortAscending: boolean) => {
+    const { closeOptimizationsDrawer, onSort } = this.props;
+
+    closeOptimizationsDrawer();
+    if (onSort) {
+      onSort(value, isSortAscending);
+    }
   };
 
   public render() {
-    const { isLoading, onSort } = this.props;
+    const { isLoading } = this.props;
     const { columns, rows } = this.state;
 
     return (
@@ -162,7 +178,7 @@ class OptimizationsTableBase extends React.Component<OptimizationsTableProps, Op
         columns={columns}
         isLoading={isLoading}
         isOptimizations
-        onSort={onSort}
+        onSort={this.handleOnSort}
         rows={rows}
         onRowClick={this.handleOnRowClick}
       />

--- a/src/routes/views/components/optimizations/optimizationsToolbar.tsx
+++ b/src/routes/views/components/optimizations/optimizationsToolbar.tsx
@@ -8,6 +8,7 @@ import { connect } from 'react-redux';
 import { DataToolbar } from 'routes/views/components/dataToolbar';
 import type { Filter } from 'routes/views/utils/filter';
 import { createMapStateToProps } from 'store/common';
+import { uiActions } from 'store/ui';
 
 interface OptimizationsToolbarOwnProps {
   isDisabled?: boolean;
@@ -25,7 +26,7 @@ interface OptimizationsToolbarStateProps {
 }
 
 interface OptimizationsToolbarDispatchProps {
-  // TBD...
+  closeOptimizationsDrawer: typeof uiActions.closeOptimizationsDrawer;
 }
 
 interface OptimizationsToolbarState {
@@ -60,8 +61,26 @@ export class OptimizationsToolbarBase extends React.Component<OptimizationsToolb
     return isProject ? options : options.filter(option => option.key !== 'project');
   };
 
+  private handleOnFilterAdded = (filter: Filter) => {
+    const { closeOptimizationsDrawer, onFilterAdded } = this.props;
+
+    closeOptimizationsDrawer();
+    if (onFilterAdded) {
+      onFilterAdded(filter);
+    }
+  };
+
+  private handleOnFilterRemoved = (filter: Filter) => {
+    const { closeOptimizationsDrawer, onFilterRemoved } = this.props;
+
+    closeOptimizationsDrawer();
+    if (onFilterRemoved) {
+      onFilterRemoved(filter);
+    }
+  };
+
   public render() {
-    const { isDisabled, itemsPerPage, itemsTotal, onFilterAdded, onFilterRemoved, pagination, query } = this.props;
+    const { isDisabled, itemsPerPage, itemsTotal, pagination, query } = this.props;
     const { categoryOptions } = this.state;
 
     return (
@@ -70,8 +89,8 @@ export class OptimizationsToolbarBase extends React.Component<OptimizationsToolb
         isDisabled={isDisabled}
         itemsPerPage={itemsPerPage}
         itemsTotal={itemsTotal}
-        onFilterAdded={onFilterAdded}
-        onFilterRemoved={onFilterRemoved}
+        onFilterAdded={this.handleOnFilterAdded}
+        onFilterRemoved={this.handleOnFilterRemoved}
         pagination={pagination}
         query={query}
         showFilter
@@ -88,7 +107,7 @@ const mapStateToProps = createMapStateToProps<OptimizationsToolbarOwnProps, Opti
 });
 
 const mapDispatchToProps: OptimizationsToolbarDispatchProps = {
-  // TBD...
+  closeOptimizationsDrawer: uiActions.closeOptimizationsDrawer,
 };
 
 const OptimizationsToolbarConnect = connect(mapStateToProps, mapDispatchToProps)(OptimizationsToolbarBase);

--- a/src/routes/views/details/awsDetails/awsDetails.tsx
+++ b/src/routes/views/details/awsDetails/awsDetails.tsx
@@ -21,13 +21,13 @@ import { NotAvailable } from 'routes/state/notAvailable';
 import { ExportModal } from 'routes/views/components/export';
 import { getGroupByCostCategory, getGroupByOrgValue, getGroupByTagKey } from 'routes/views/utils/groupBy';
 import {
-  handleCostTypeSelected,
-  handleCurrencySelected,
-  handleFilterAdded,
-  handleFilterRemoved,
-  handlePerPageSelect,
-  handleSetPage,
-  handleSort,
+  handleOnCostTypeSelected,
+  handleOnCurrencySelected,
+  handleOnFilterAdded,
+  handleOnFilterRemoved,
+  handleOnPerPageSelect,
+  handleOnSetPage,
+  handleOnSort,
 } from 'routes/views/utils/handles';
 import { filterProviders, hasCurrentMonthData } from 'routes/views/utils/providers';
 import { getRouteForQuery } from 'routes/views/utils/query';
@@ -199,8 +199,8 @@ class AwsDetails extends React.Component<AwsDetailsProps, AwsDetailsState> {
         isCompact={!isBottom}
         isDisabled={isDisabled}
         itemCount={count}
-        onPerPageSelect={(event, perPage) => handlePerPageSelect(query, router, perPage)}
-        onSetPage={(event, pageNumber) => handleSetPage(query, router, report, pageNumber)}
+        onPerPageSelect={(event, perPage) => handleOnPerPageSelect(query, router, perPage)}
+        onSetPage={(event, pageNumber) => handleOnSetPage(query, router, report, pageNumber)}
         page={page}
         perPage={limit}
         titles={{
@@ -239,7 +239,7 @@ class AwsDetails extends React.Component<AwsDetailsProps, AwsDetailsState> {
         isAllSelected={isAllSelected}
         isLoading={reportFetchStatus === FetchStatus.inProgress}
         onSelected={this.handleSelected}
-        onSort={(sortType, isSortAscending) => handleSort(query, router, sortType, isSortAscending)}
+        onSort={(sortType, isSortAscending) => handleOnSort(query, router, sortType, isSortAscending)}
         report={report}
         reportQueryString={reportQueryString}
         selectedItems={selectedItems}
@@ -273,8 +273,8 @@ class AwsDetails extends React.Component<AwsDetailsProps, AwsDetailsState> {
         itemsTotal={itemsTotal}
         onBulkSelected={this.handleBulkSelected}
         onExportClicked={this.handleExportModalOpen}
-        onFilterAdded={filter => handleFilterAdded(query, router, filter)}
-        onFilterRemoved={filter => handleFilterRemoved(query, router, filter)}
+        onFilterAdded={filter => handleOnFilterAdded(query, router, filter)}
+        onFilterRemoved={filter => handleOnFilterRemoved(query, router, filter)}
         pagination={this.getPagination(isDisabled)}
         query={query}
         selectedItems={selectedItems}
@@ -393,8 +393,8 @@ class AwsDetails extends React.Component<AwsDetailsProps, AwsDetailsState> {
           costType={costType}
           currency={currency}
           groupBy={groupById}
-          onCostTypeSelected={value => handleCostTypeSelected(query, router, value)}
-          onCurrencySelected={value => handleCurrencySelected(query, router, value)}
+          onCostTypeSelected={value => handleOnCostTypeSelected(query, router, value)}
+          onCurrencySelected={value => handleOnCurrencySelected(query, router, value)}
           onGroupBySelected={this.handleGroupBySelected}
           report={report}
         />

--- a/src/routes/views/details/awsDetails/detailsHeader.tsx
+++ b/src/routes/views/details/awsDetails/detailsHeader.tsx
@@ -62,7 +62,7 @@ const resourcePathsType = ResourcePathsType.aws;
 const tagPathsType = TagPathsType.aws;
 
 class DetailsHeaderBase extends React.Component<DetailsHeaderProps, any> {
-  private handleCostTypeSelected = (value: string) => {
+  private handleOnCostTypeSelected = (value: string) => {
     const { onCostTypeSelected } = this.props;
 
     if (onCostTypeSelected) {
@@ -115,7 +115,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, any> {
               tagPathsType={tagPathsType}
             />
             <div style={styles.costType}>
-              <CostType costType={costType} onSelect={this.handleCostTypeSelected} />
+              <CostType costType={costType} onSelect={this.handleOnCostTypeSelected} />
             </div>
           </div>
           {showContent && (

--- a/src/routes/views/details/azureDetails/azureDetails.tsx
+++ b/src/routes/views/details/azureDetails/azureDetails.tsx
@@ -19,12 +19,12 @@ import { NotAvailable } from 'routes/state/notAvailable';
 import { ExportModal } from 'routes/views/components/export';
 import { getGroupByTagKey } from 'routes/views/utils/groupBy';
 import {
-  handleCurrencySelected,
-  handleFilterAdded,
-  handleFilterRemoved,
-  handlePerPageSelect,
-  handleSetPage,
-  handleSort,
+  handleOnCurrencySelected,
+  handleOnFilterAdded,
+  handleOnFilterRemoved,
+  handleOnPerPageSelect,
+  handleOnSetPage,
+  handleOnSort,
 } from 'routes/views/utils/handles';
 import { filterProviders, hasCurrentMonthData } from 'routes/views/utils/providers';
 import { getRouteForQuery } from 'routes/views/utils/query';
@@ -186,8 +186,8 @@ class AzureDetails extends React.Component<AzureDetailsProps, AzureDetailsState>
         isCompact={!isBottom}
         isDisabled={isDisabled}
         itemCount={count}
-        onPerPageSelect={(event, perPage) => handlePerPageSelect(query, router, perPage)}
-        onSetPage={(event, pageNumber) => handleSetPage(query, router, report, pageNumber)}
+        onPerPageSelect={(event, perPage) => handleOnPerPageSelect(query, router, perPage)}
+        onSetPage={(event, pageNumber) => handleOnSetPage(query, router, report, pageNumber)}
         page={page}
         perPage={limit}
         titles={{
@@ -216,7 +216,7 @@ class AzureDetails extends React.Component<AzureDetailsProps, AzureDetailsState>
         isAllSelected={isAllSelected}
         isLoading={reportFetchStatus === FetchStatus.inProgress}
         onSelected={this.handleSelected}
-        onSort={(sortType, isSortAscending) => handleSort(query, router, sortType, isSortAscending)}
+        onSort={(sortType, isSortAscending) => handleOnSort(query, router, sortType, isSortAscending)}
         report={report}
         reportQueryString={reportQueryString}
         selectedItems={selectedItems}
@@ -243,8 +243,8 @@ class AzureDetails extends React.Component<AzureDetailsProps, AzureDetailsState>
         itemsTotal={itemsTotal}
         onBulkSelected={this.handleBulkSelected}
         onExportClicked={this.handleExportModalOpen}
-        onFilterAdded={filter => handleFilterAdded(query, router, filter)}
-        onFilterRemoved={filter => handleFilterRemoved(query, router, filter)}
+        onFilterAdded={filter => handleOnFilterAdded(query, router, filter)}
+        onFilterRemoved={filter => handleOnFilterRemoved(query, router, filter)}
         pagination={this.getPagination(isDisabled)}
         query={query}
         selectedItems={selectedItems}
@@ -352,7 +352,7 @@ class AzureDetails extends React.Component<AzureDetailsProps, AzureDetailsState>
         <DetailsHeader
           currency={currency}
           groupBy={groupById}
-          onCurrencySelected={value => handleCurrencySelected(query, router, value)}
+          onCurrencySelected={value => handleOnCurrencySelected(query, router, value)}
           onGroupBySelected={this.handleGroupBySelected}
           report={report}
         />

--- a/src/routes/views/details/components/breakdown/breakdownBase.tsx
+++ b/src/routes/views/details/components/breakdown/breakdownBase.tsx
@@ -15,9 +15,9 @@ import { NoData } from 'routes/state/noData';
 import { NoProviders } from 'routes/state/noProviders';
 import { NotAvailable } from 'routes/state/notAvailable';
 import {
-  handleCostDistributionSelected,
-  handleCostTypeSelected,
-  handleCurrencySelected,
+  handleOnCostDistributionSelected,
+  handleOnCostTypeSelected,
+  handleOnCurrencySelected,
 } from 'routes/views/utils/handles';
 import { hasCurrentMonthData } from 'routes/views/utils/providers';
 import { FetchStatus } from 'store/common';
@@ -303,9 +303,9 @@ class BreakdownBase extends React.Component<BreakdownProps, BreakdownState> {
           description={description}
           detailsURL={detailsURL}
           groupBy={groupBy}
-          onCostDistributionSelected={value => handleCostDistributionSelected(query, router, value)}
-          onCostTypeSelected={value => handleCostTypeSelected(query, router, value)}
-          onCurrencySelected={value => handleCurrencySelected(query, router, value)}
+          onCostDistributionSelected={value => handleOnCostDistributionSelected(query, router, value)}
+          onCostTypeSelected={value => handleOnCostTypeSelected(query, router, value)}
+          onCurrencySelected={value => handleOnCurrencySelected(query, router, value)}
           query={query}
           report={report}
           showCostDistribution={showCostDistribution}

--- a/src/routes/views/details/gcpDetails/gcpDetails.tsx
+++ b/src/routes/views/details/gcpDetails/gcpDetails.tsx
@@ -19,12 +19,12 @@ import { NotAvailable } from 'routes/state/notAvailable';
 import { ExportModal } from 'routes/views/components/export';
 import { getGroupByTagKey } from 'routes/views/utils/groupBy';
 import {
-  handleCurrencySelected,
-  handleFilterAdded,
-  handleFilterRemoved,
-  handlePerPageSelect,
-  handleSetPage,
-  handleSort,
+  handleOnCurrencySelected,
+  handleOnFilterAdded,
+  handleOnFilterRemoved,
+  handleOnPerPageSelect,
+  handleOnSetPage,
+  handleOnSort,
 } from 'routes/views/utils/handles';
 import { filterProviders, hasCurrentMonthData } from 'routes/views/utils/providers';
 import { getRouteForQuery } from 'routes/views/utils/query';
@@ -186,8 +186,8 @@ class GcpDetails extends React.Component<GcpDetailsProps, GcpDetailsState> {
         isCompact={!isBottom}
         isDisabled={isDisabled}
         itemCount={count}
-        onPerPageSelect={(event, perPage) => handlePerPageSelect(query, router, perPage)}
-        onSetPage={(event, pageNumber) => handleSetPage(query, router, report, pageNumber)}
+        onPerPageSelect={(event, perPage) => handleOnPerPageSelect(query, router, perPage)}
+        onSetPage={(event, pageNumber) => handleOnSetPage(query, router, report, pageNumber)}
         page={page}
         perPage={limit}
         titles={{
@@ -215,7 +215,7 @@ class GcpDetails extends React.Component<GcpDetailsProps, GcpDetailsState> {
         isAllSelected={isAllSelected}
         isLoading={reportFetchStatus === FetchStatus.inProgress}
         onSelected={this.handleSelected}
-        onSort={(sortType, isSortAscending) => handleSort(query, router, sortType, isSortAscending)}
+        onSort={(sortType, isSortAscending) => handleOnSort(query, router, sortType, isSortAscending)}
         report={report}
         reportQueryString={reportQueryString}
         selectedItems={selectedItems}
@@ -242,8 +242,8 @@ class GcpDetails extends React.Component<GcpDetailsProps, GcpDetailsState> {
         itemsTotal={itemsTotal}
         onBulkSelected={this.handleBulkSelected}
         onExportClicked={this.handleExportModalOpen}
-        onFilterAdded={filter => handleFilterAdded(query, router, filter)}
-        onFilterRemoved={filter => handleFilterRemoved(query, router, filter)}
+        onFilterAdded={filter => handleOnFilterAdded(query, router, filter)}
+        onFilterRemoved={filter => handleOnFilterRemoved(query, router, filter)}
         pagination={this.getPagination(isDisabled)}
         query={query}
         selectedItems={selectedItems}
@@ -341,7 +341,7 @@ class GcpDetails extends React.Component<GcpDetailsProps, GcpDetailsState> {
         <DetailsHeader
           currency={currency}
           groupBy={groupById}
-          onCurrencySelected={value => handleCurrencySelected(query, router, value)}
+          onCurrencySelected={value => handleOnCurrencySelected(query, router, value)}
           onGroupBySelected={this.handleGroupBySelected}
           report={report}
         />

--- a/src/routes/views/details/ibmDetails/ibmDetails.tsx
+++ b/src/routes/views/details/ibmDetails/ibmDetails.tsx
@@ -19,12 +19,12 @@ import { NotAvailable } from 'routes/state/notAvailable';
 import { ExportModal } from 'routes/views/components/export';
 import { getGroupByTagKey } from 'routes/views/utils/groupBy';
 import {
-  handleCurrencySelected,
-  handleFilterAdded,
-  handleFilterRemoved,
-  handlePerPageSelect,
-  handleSetPage,
-  handleSort,
+  handleOnCurrencySelected,
+  handleOnFilterAdded,
+  handleOnFilterRemoved,
+  handleOnPerPageSelect,
+  handleOnSetPage,
+  handleOnSort,
 } from 'routes/views/utils/handles';
 import { hasCurrentMonthData } from 'routes/views/utils/providers';
 import { filterProviders } from 'routes/views/utils/providers';
@@ -187,8 +187,8 @@ class IbmDetails extends React.Component<IbmDetailsProps, IbmDetailsState> {
         isCompact={!isBottom}
         isDisabled={isDisabled}
         itemCount={count}
-        onPerPageSelect={(event, perPage) => handlePerPageSelect(query, router, perPage)}
-        onSetPage={(event, pageNumber) => handleSetPage(query, router, report, pageNumber)}
+        onPerPageSelect={(event, perPage) => handleOnPerPageSelect(query, router, perPage)}
+        onSetPage={(event, pageNumber) => handleOnSetPage(query, router, report, pageNumber)}
         page={page}
         perPage={limit}
         titles={{
@@ -217,7 +217,7 @@ class IbmDetails extends React.Component<IbmDetailsProps, IbmDetailsState> {
         isAllSelected={isAllSelected}
         isLoading={reportFetchStatus === FetchStatus.inProgress}
         onSelected={this.handleSelected}
-        onSort={(sortType, isSortAscending) => handleSort(query, router, sortType, isSortAscending)}
+        onSort={(sortType, isSortAscending) => handleOnSort(query, router, sortType, isSortAscending)}
         report={report}
         reportQueryString={reportQueryString}
         selectedItems={selectedItems}
@@ -244,8 +244,8 @@ class IbmDetails extends React.Component<IbmDetailsProps, IbmDetailsState> {
         itemsTotal={itemsTotal}
         onBulkSelected={this.handleBulkSelected}
         onExportClicked={this.handleExportModalOpen}
-        onFilterAdded={filter => handleFilterAdded(query, router, filter)}
-        onFilterRemoved={filter => handleFilterRemoved(query, router, filter)}
+        onFilterAdded={filter => handleOnFilterAdded(query, router, filter)}
+        onFilterRemoved={filter => handleOnFilterRemoved(query, router, filter)}
         pagination={this.getPagination(isDisabled)}
         query={query}
         selectedItems={selectedItems}
@@ -343,7 +343,7 @@ class IbmDetails extends React.Component<IbmDetailsProps, IbmDetailsState> {
         <DetailsHeader
           currency={currency}
           groupBy={groupById}
-          onCurrencySelected={value => handleCurrencySelected(query, router, value)}
+          onCurrencySelected={value => handleOnCurrencySelected(query, router, value)}
           onGroupBySelected={this.handleGroupBySelected}
           report={report}
         />

--- a/src/routes/views/details/ociDetails/ociDetails.tsx
+++ b/src/routes/views/details/ociDetails/ociDetails.tsx
@@ -19,12 +19,12 @@ import { NotAvailable } from 'routes/state/notAvailable';
 import { ExportModal } from 'routes/views/components/export';
 import { getGroupByTagKey } from 'routes/views/utils/groupBy';
 import {
-  handleCurrencySelected,
-  handleFilterAdded,
-  handleFilterRemoved,
-  handlePerPageSelect,
-  handleSetPage,
-  handleSort,
+  handleOnCurrencySelected,
+  handleOnFilterAdded,
+  handleOnFilterRemoved,
+  handleOnPerPageSelect,
+  handleOnSetPage,
+  handleOnSort,
 } from 'routes/views/utils/handles';
 import { filterProviders, hasCurrentMonthData } from 'routes/views/utils/providers';
 import { getRouteForQuery } from 'routes/views/utils/query';
@@ -186,8 +186,8 @@ class OciDetails extends React.Component<OciDetailsProps, OciDetailsState> {
         isCompact={!isBottom}
         isDisabled={isDisabled}
         itemCount={count}
-        onPerPageSelect={(event, perPage) => handlePerPageSelect(query, router, perPage)}
-        onSetPage={(event, pageNumber) => handleSetPage(query, router, report, pageNumber)}
+        onPerPageSelect={(event, perPage) => handleOnPerPageSelect(query, router, perPage)}
+        onSetPage={(event, pageNumber) => handleOnSetPage(query, router, report, pageNumber)}
         page={page}
         perPage={limit}
         titles={{
@@ -216,7 +216,7 @@ class OciDetails extends React.Component<OciDetailsProps, OciDetailsState> {
         isAllSelected={isAllSelected}
         isLoading={reportFetchStatus === FetchStatus.inProgress}
         onSelected={this.handleSelected}
-        onSort={(sortType, isSortAscending) => handleSort(query, router, sortType, isSortAscending)}
+        onSort={(sortType, isSortAscending) => handleOnSort(query, router, sortType, isSortAscending)}
         report={report}
         reportQueryString={reportQueryString}
         selectedItems={selectedItems}
@@ -243,8 +243,8 @@ class OciDetails extends React.Component<OciDetailsProps, OciDetailsState> {
         itemsTotal={itemsTotal}
         onBulkSelected={this.handleBulkSelected}
         onExportClicked={this.handleExportModalOpen}
-        onFilterAdded={filter => handleFilterAdded(query, router, filter)}
-        onFilterRemoved={filter => handleFilterRemoved(query, router, filter)}
+        onFilterAdded={filter => handleOnFilterAdded(query, router, filter)}
+        onFilterRemoved={filter => handleOnFilterRemoved(query, router, filter)}
         pagination={this.getPagination(isDisabled)}
         query={query}
         selectedItems={selectedItems}
@@ -352,7 +352,7 @@ class OciDetails extends React.Component<OciDetailsProps, OciDetailsState> {
         <DetailsHeader
           currency={currency}
           groupBy={groupById}
-          onCurrencySelected={value => handleCurrencySelected(query, router, value)}
+          onCurrencySelected={value => handleOnCurrencySelected(query, router, value)}
           onGroupBySelected={this.handleGroupBySelected}
           report={report}
         />

--- a/src/routes/views/details/ocpBreakdown/optimizationsBreakdown.tsx
+++ b/src/routes/views/details/ocpBreakdown/optimizationsBreakdown.tsx
@@ -15,7 +15,7 @@ import { NotAvailable } from 'routes/state/notAvailable';
 import { OptimizationsTable, OptimizationsToolbar } from 'routes/views/components/optimizations';
 import { styles } from 'routes/views/optimizations/optimizations.styles';
 import { getGroupById, getGroupByValue } from 'routes/views/utils/groupBy';
-import { handleFilterAdded, handleFilterRemoved, handleSort } from 'routes/views/utils/handles';
+import { handleOnFilterAdded, handleOnFilterRemoved, handleOnSort } from 'routes/views/utils/handles';
 import { getOrderById, getOrderByValue } from 'routes/views/utils/orderBy';
 import { getRouteForQuery } from 'routes/views/utils/query';
 import { createMapStateToProps, FetchStatus } from 'store/common';
@@ -95,8 +95,8 @@ class OptimizationsBreakdownBase extends React.Component<OptimizationsBreakdownP
         isCompact={!isBottom}
         isDisabled={isDisabled}
         itemCount={count}
-        onPerPageSelect={(event, perPage) => this.handlePerPageSelect(perPage)}
-        onSetPage={(event, pageNumber) => this.handleSetPage(pageNumber)}
+        onPerPageSelect={(event, perPage) => this.handleOnPerPageSelect(perPage)}
+        onSetPage={(event, pageNumber) => this.handleOnSetPage(pageNumber)}
         page={page}
         perPage={limit}
         titles={{
@@ -117,7 +117,7 @@ class OptimizationsBreakdownBase extends React.Component<OptimizationsBreakdownP
     return (
       <OptimizationsTable
         isLoading={reportFetchStatus === FetchStatus.inProgress}
-        onSort={(sortType, isSortAscending) => handleSort(query, router, sortType, isSortAscending)}
+        onSort={(sortType, isSortAscending) => handleOnSort(query, router, sortType, isSortAscending)}
         report={report}
         reportQueryString={reportQueryString}
       />
@@ -136,15 +136,15 @@ class OptimizationsBreakdownBase extends React.Component<OptimizationsBreakdownP
         isDisabled={isDisabled}
         itemsPerPage={itemsPerPage}
         itemsTotal={itemsTotal}
-        onFilterAdded={filter => handleFilterAdded(query, router, filter)}
-        onFilterRemoved={filter => handleFilterRemoved(query, router, filter)}
+        onFilterAdded={filter => handleOnFilterAdded(query, router, filter)}
+        onFilterRemoved={filter => handleOnFilterRemoved(query, router, filter)}
         pagination={this.getPagination(isDisabled)}
         query={query}
       />
     );
   };
 
-  private handlePerPageSelect = (perPage: number) => {
+  private handleOnPerPageSelect = (perPage: number) => {
     const { query, router } = this.props;
 
     const newQuery = {
@@ -155,7 +155,7 @@ class OptimizationsBreakdownBase extends React.Component<OptimizationsBreakdownP
     router.navigate(filteredQuery, { replace: true });
   };
 
-  private handleSetPage = (pageNumber: number) => {
+  private handleOnSetPage = (pageNumber: number) => {
     const { query, report, router } = this.props;
 
     const limit = report && report.meta && report.meta.limit ? report.meta.limit : baseQuery.limit;

--- a/src/routes/views/details/ocpDetails/ocpDetails.tsx
+++ b/src/routes/views/details/ocpDetails/ocpDetails.tsx
@@ -23,13 +23,13 @@ import type { ColumnManagementModalOption } from 'routes/views/details/component
 import { ColumnManagementModal, initHiddenColumns } from 'routes/views/details/components/columnManagement';
 import { getGroupById, getGroupByTagKey } from 'routes/views/utils/groupBy';
 import {
-  handleCostDistributionSelected,
-  handleCurrencySelected,
-  handleFilterAdded,
-  handleFilterRemoved,
-  handlePerPageSelect,
-  handleSetPage,
-  handleSort,
+  handleOnCostDistributionSelected,
+  handleOnCurrencySelected,
+  handleOnFilterAdded,
+  handleOnFilterRemoved,
+  handleOnPerPageSelect,
+  handleOnSetPage,
+  handleOnSort,
 } from 'routes/views/utils/handles';
 import { filterProviders, hasCurrentMonthData } from 'routes/views/utils/providers';
 import { getRouteForQuery } from 'routes/views/utils/query';
@@ -235,8 +235,8 @@ class OcpDetails extends React.Component<OcpDetailsProps, OcpDetailsState> {
         isCompact={!isBottom}
         isDisabled={isDisabled}
         itemCount={count}
-        onPerPageSelect={(event, perPage) => handlePerPageSelect(query, router, perPage)}
-        onSetPage={(event, pageNumber) => handleSetPage(query, router, report, pageNumber)}
+        onPerPageSelect={(event, perPage) => handleOnPerPageSelect(query, router, perPage)}
+        onSetPage={(event, pageNumber) => handleOnSetPage(query, router, report, pageNumber)}
         page={page}
         perPage={limit}
         titles={{
@@ -269,7 +269,7 @@ class OcpDetails extends React.Component<OcpDetailsProps, OcpDetailsState> {
         isLoading={reportFetchStatus === FetchStatus.inProgress}
         isRosFeatureEnabled={isRosFeatureEnabled}
         onSelected={this.handleSelected}
-        onSort={(sortType, isSortAscending) => handleSort(query, router, sortType, isSortAscending)}
+        onSort={(sortType, isSortAscending) => handleOnSort(query, router, sortType, isSortAscending)}
         report={report}
         reportQueryString={reportQueryString}
         selectedItems={selectedItems}
@@ -297,8 +297,8 @@ class OcpDetails extends React.Component<OcpDetailsProps, OcpDetailsState> {
         onBulkSelected={this.handleBulkSelected}
         onColumnManagementClicked={this.handleColumnManagementModalOpen}
         onExportClicked={this.handleExportModalOpen}
-        onFilterAdded={filter => handleFilterAdded(query, router, filter)}
-        onFilterRemoved={filter => handleFilterRemoved(query, router, filter)}
+        onFilterAdded={filter => handleOnFilterAdded(query, router, filter)}
+        onFilterRemoved={filter => handleOnFilterRemoved(query, router, filter)}
         onPlatformCostsChanged={this.handlePlatformCostsChanged}
         pagination={this.getPagination(isDisabled)}
         query={query}
@@ -433,8 +433,8 @@ class OcpDetails extends React.Component<OcpDetailsProps, OcpDetailsState> {
           costDistribution={costDistribution}
           currency={currency}
           groupBy={groupById}
-          onCostDistributionSelected={value => handleCostDistributionSelected(query, router, value)}
-          onCurrencySelected={value => handleCurrencySelected(query, router, value)}
+          onCostDistributionSelected={value => handleOnCostDistributionSelected(query, router, value)}
+          onCurrencySelected={value => handleOnCurrencySelected(query, router, value)}
           onGroupBySelected={this.handleGroupBySelected}
           report={report}
         />

--- a/src/routes/views/details/rhelDetails/rhelDetails.tsx
+++ b/src/routes/views/details/rhelDetails/rhelDetails.tsx
@@ -22,12 +22,12 @@ import type { ColumnManagementModalOption } from 'routes/views/details/component
 import { ColumnManagementModal, initHiddenColumns } from 'routes/views/details/components/columnManagement';
 import { getGroupByTagKey } from 'routes/views/utils/groupBy';
 import {
-  handleCurrencySelected,
-  handleFilterAdded,
-  handleFilterRemoved,
-  handlePerPageSelect,
-  handleSetPage,
-  handleSort,
+  handleOnCurrencySelected,
+  handleOnFilterAdded,
+  handleOnFilterRemoved,
+  handleOnPerPageSelect,
+  handleOnSetPage,
+  handleOnSort,
 } from 'routes/views/utils/handles';
 import { filterProviders, hasCurrentMonthData } from 'routes/views/utils/providers';
 import { getRouteForQuery } from 'routes/views/utils/query';
@@ -229,8 +229,8 @@ class RhelDetails extends React.Component<RhelDetailsProps, RhelDetailsState> {
         isCompact={!isBottom}
         isDisabled={isDisabled}
         itemCount={count}
-        onPerPageSelect={(event, perPage) => handlePerPageSelect(query, router, perPage)}
-        onSetPage={(event, pageNumber) => handleSetPage(query, router, report, pageNumber)}
+        onPerPageSelect={(event, perPage) => handleOnPerPageSelect(query, router, perPage)}
+        onSetPage={(event, pageNumber) => handleOnSetPage(query, router, report, pageNumber)}
         page={page}
         perPage={limit}
         titles={{
@@ -260,7 +260,7 @@ class RhelDetails extends React.Component<RhelDetailsProps, RhelDetailsState> {
         isAllSelected={isAllSelected}
         isLoading={reportFetchStatus === FetchStatus.inProgress}
         onSelected={this.handleSelected}
-        onSort={(sortType, isSortAscending) => handleSort(query, router, sortType, isSortAscending)}
+        onSort={(sortType, isSortAscending) => handleOnSort(query, router, sortType, isSortAscending)}
         report={report}
         reportQueryString={reportQueryString}
         selectedItems={selectedItems}
@@ -288,8 +288,8 @@ class RhelDetails extends React.Component<RhelDetailsProps, RhelDetailsState> {
         onBulkSelected={this.handleBulkSelected}
         onColumnManagementClicked={this.handleColumnManagementModalOpen}
         onExportClicked={this.handleExportModalOpen}
-        onFilterAdded={filter => handleFilterAdded(query, router, filter)}
-        onFilterRemoved={filter => handleFilterRemoved(query, router, filter)}
+        onFilterAdded={filter => handleOnFilterAdded(query, router, filter)}
+        onFilterRemoved={filter => handleOnFilterRemoved(query, router, filter)}
         pagination={this.getPagination()}
         query={query}
         selectedItems={selectedItems}
@@ -400,7 +400,7 @@ class RhelDetails extends React.Component<RhelDetailsProps, RhelDetailsState> {
         <DetailsHeader
           currency={currency}
           groupBy={groupById}
-          onCurrencySelected={value => handleCurrencySelected(query, router, value)}
+          onCurrencySelected={value => handleOnCurrencySelected(query, router, value)}
           onGroupBySelected={this.handleGroupBySelected}
           report={report}
         />

--- a/src/routes/views/explorer/explorer.tsx
+++ b/src/routes/views/explorer/explorer.tsx
@@ -24,14 +24,14 @@ import type { DateRangeType } from 'routes/views/utils/dateRange';
 import { getDateRangeFromQuery, getDateRangeTypeDefault } from 'routes/views/utils/dateRange';
 import { getGroupByCostCategory, getGroupById, getGroupByOrgValue, getGroupByTagKey } from 'routes/views/utils/groupBy';
 import {
-  handleCostDistributionSelected,
-  handleCostTypeSelected,
-  handleCurrencySelected,
-  handleFilterAdded,
-  handleFilterRemoved,
-  handlePerPageSelect,
-  handleSetPage,
-  handleSort,
+  handleOnCostDistributionSelected,
+  handleOnCostTypeSelected,
+  handleOnCurrencySelected,
+  handleOnFilterAdded,
+  handleOnFilterRemoved,
+  handleOnPerPageSelect,
+  handleOnSetPage,
+  handleOnSort,
 } from 'routes/views/utils/handles';
 import { filterProviders, hasData } from 'routes/views/utils/providers';
 import { getRouteForQuery } from 'routes/views/utils/query';
@@ -238,8 +238,8 @@ class Explorer extends React.Component<ExplorerProps, ExplorerState> {
         isCompact={!isBottom}
         isDisabled={isDisabled}
         itemCount={count}
-        onPerPageSelect={(event, perPage) => handlePerPageSelect(query, router, perPage)}
-        onSetPage={(event, pageNumber) => handleSetPage(query, router, report, pageNumber)}
+        onPerPageSelect={(event, perPage) => handleOnPerPageSelect(query, router, perPage)}
+        onSetPage={(event, pageNumber) => handleOnSetPage(query, router, report, pageNumber)}
         page={page}
         perPage={limit}
         titles={{
@@ -279,7 +279,9 @@ class Explorer extends React.Component<ExplorerProps, ExplorerState> {
         isAllSelected={isAllSelected}
         isLoading={reportFetchStatus === FetchStatus.inProgress}
         onSelected={this.handleSelected}
-        onSort={(sortType, isSortAscending, date: string) => handleSort(query, router, sortType, isSortAscending, date)}
+        onSort={(sortType, isSortAscending, date: string) =>
+          handleOnSort(query, router, sortType, isSortAscending, date)
+        }
         perspective={perspective}
         query={query}
         report={report}
@@ -511,12 +513,12 @@ class Explorer extends React.Component<ExplorerProps, ExplorerState> {
               ? `${tagPrefix}${groupByTagKey}`
               : groupById
           }
-          onCostDistributionSelected={value => handleCostDistributionSelected(query, router, value)}
-          onCostTypeSelected={value => handleCostTypeSelected(query, router, value)}
-          onCurrencySelected={value => handleCurrencySelected(query, router, value)}
+          onCostDistributionSelected={value => handleOnCostDistributionSelected(query, router, value)}
+          onCostTypeSelected={value => handleOnCostTypeSelected(query, router, value)}
+          onCurrencySelected={value => handleOnCurrencySelected(query, router, value)}
           onDatePickerSelected={this.handleDatePickerSelected}
-          onFilterAdded={filter => handleFilterAdded(query, router, filter)}
-          onFilterRemoved={filter => handleFilterRemoved(query, router, filter)}
+          onFilterAdded={filter => handleOnFilterAdded(query, router, filter)}
+          onFilterRemoved={filter => handleOnFilterRemoved(query, router, filter)}
           onGroupBySelected={this.handleGroupBySelected}
           onPerspectiveClicked={this.handlePerspectiveClick}
           perspective={perspective}

--- a/src/routes/views/optimizations/optimizations.tsx
+++ b/src/routes/views/optimizations/optimizations.tsx
@@ -13,11 +13,12 @@ import { Loading } from 'routes/state/loading';
 import { NoOptimizations } from 'routes/state/noOptimizations';
 import { NotAvailable } from 'routes/state/notAvailable';
 import { OptimizationsTable, OptimizationsToolbar } from 'routes/views/components/optimizations';
-import { handleFilterAdded, handleFilterRemoved, handleSort } from 'routes/views/utils/handles';
+import { handleOnFilterAdded, handleOnFilterRemoved, handleOnSort } from 'routes/views/utils/handles';
 import { getOrderById, getOrderByValue } from 'routes/views/utils/orderBy';
 import { getRouteForQuery } from 'routes/views/utils/query';
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { rosActions, rosSelectors } from 'store/ros';
+import { uiActions } from 'store/ui';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 
@@ -37,6 +38,7 @@ interface OptimizationsStateProps {
 }
 
 interface OptimizationsDispatchProps {
+  closeOptimizationsDrawer: typeof uiActions.closeOptimizationsDrawer;
   fetchRosReport: typeof rosActions.fetchRosReport;
 }
 
@@ -94,8 +96,8 @@ class Optimizations extends React.Component<OptimizationsProps, OptimizationsSta
         isCompact={!isBottom}
         isDisabled={isDisabled}
         itemCount={count}
-        onPerPageSelect={(event, perPage) => this.handlePerPageSelect(perPage)}
-        onSetPage={(event, pageNumber) => this.handleSetPage(pageNumber)}
+        onPerPageSelect={(event, perPage) => this.handleOnPerPageSelect(perPage)}
+        onSetPage={(event, pageNumber) => this.handleOnSetPage(pageNumber)}
         page={page}
         perPage={limit}
         titles={{
@@ -116,7 +118,7 @@ class Optimizations extends React.Component<OptimizationsProps, OptimizationsSta
     return (
       <OptimizationsTable
         isLoading={reportFetchStatus === FetchStatus.inProgress}
-        onSort={(sortType, isSortAscending) => handleSort(query, router, sortType, isSortAscending)}
+        onSort={(sortType, isSortAscending) => handleOnSort(query, router, sortType, isSortAscending)}
         report={report}
         reportQueryString={reportQueryString}
       />
@@ -136,16 +138,16 @@ class Optimizations extends React.Component<OptimizationsProps, OptimizationsSta
         isProject
         itemsPerPage={itemsPerPage}
         itemsTotal={itemsTotal}
-        onFilterAdded={filter => handleFilterAdded(query, router, filter)}
-        onFilterRemoved={filter => handleFilterRemoved(query, router, filter)}
+        onFilterAdded={filter => handleOnFilterAdded(query, router, filter)}
+        onFilterRemoved={filter => handleOnFilterRemoved(query, router, filter)}
         pagination={this.getPagination(isDisabled)}
         query={query}
       />
     );
   };
 
-  private handlePerPageSelect = (perPage: number) => {
-    const { query, router } = this.props;
+  private handleOnPerPageSelect = (perPage: number) => {
+    const { closeOptimizationsDrawer, query, router } = this.props;
 
     const newQuery = {
       ...JSON.parse(JSON.stringify(query)),
@@ -153,10 +155,11 @@ class Optimizations extends React.Component<OptimizationsProps, OptimizationsSta
     };
     const filteredQuery = getRouteForQuery(newQuery, router.location, true);
     router.navigate(filteredQuery, { replace: true });
+    closeOptimizationsDrawer();
   };
 
-  private handleSetPage = (pageNumber: number) => {
-    const { query, report, router } = this.props;
+  private handleOnSetPage = (pageNumber: number) => {
+    const { closeOptimizationsDrawer, query, report, router } = this.props;
 
     const limit = report && report.meta && report.meta.limit ? report.meta.limit : baseQuery.limit;
     const offset = pageNumber * limit - limit;
@@ -168,6 +171,7 @@ class Optimizations extends React.Component<OptimizationsProps, OptimizationsSta
     };
     const filteredQuery = getRouteForQuery(newQuery, router.location);
     router.navigate(filteredQuery, { replace: true });
+    closeOptimizationsDrawer();
   };
 
   private updateReport = () => {
@@ -243,6 +247,7 @@ const mapStateToProps = createMapStateToProps<OptimizationsOwnProps, Optimizatio
 });
 
 const mapDispatchToProps: OptimizationsDispatchProps = {
+  closeOptimizationsDrawer: uiActions.closeOptimizationsDrawer,
   fetchRosReport: rosActions.fetchRosReport,
 };
 

--- a/src/routes/views/overview/overview.tsx
+++ b/src/routes/views/overview/overview.tsx
@@ -262,7 +262,7 @@ class OverviewBase extends React.Component<OverviewProps, OverviewState> {
     if (currentItem === InfrastructurePerspective.aws || currentItem === InfrastructurePerspective.awsOcp) {
       return (
         <div style={styles.costType}>
-          <CostType costType={costType} onSelect={this.handleCostTypeSelected} />
+          <CostType costType={costType} onSelect={this.handleOnCostTypeSelected} />
         </div>
       );
     }
@@ -272,7 +272,7 @@ class OverviewBase extends React.Component<OverviewProps, OverviewState> {
   private getCurrency = () => {
     const { currency } = this.props;
 
-    return <Currency onSelect={this.handleCurrencySelected} currency={currency} />;
+    return <Currency onSelect={this.handleOnCurrencySelected} currency={currency} />;
   };
 
   private getCurrentTab = () => {
@@ -579,7 +579,7 @@ class OverviewBase extends React.Component<OverviewProps, OverviewState> {
     }
   };
 
-  private handleCostTypeSelected = () => {
+  private handleOnCostTypeSelected = () => {
     const { query, router } = this.props;
 
     const newQuery = {
@@ -588,7 +588,7 @@ class OverviewBase extends React.Component<OverviewProps, OverviewState> {
     router.navigate(this.getRouteForQuery(newQuery), { replace: true });
   };
 
-  private handleCurrencySelected = () => {
+  private handleOnCurrencySelected = () => {
     const { router, query } = this.props;
 
     const newQuery = {

--- a/src/routes/views/utils/handles.ts
+++ b/src/routes/views/utils/handles.ts
@@ -12,7 +12,7 @@ export const handleSelected = (query: Query, router: RouteComponentProps, value:
   router.navigate(getRouteForQuery(newQuery, router.location, reset), { replace: true }); // Don't reset pagination
 };
 
-export const handleCurrencySelected = (
+export const handleOnCurrencySelected = (
   query: Query,
   router: RouteComponentProps,
   value: string,
@@ -21,7 +21,7 @@ export const handleCurrencySelected = (
   handleSelected(query, router, value, reset);
 };
 
-export const handleCostTypeSelected = (
+export const handleOnCostTypeSelected = (
   query: Query,
   router: RouteComponentProps,
   value: string,
@@ -30,7 +30,7 @@ export const handleCostTypeSelected = (
   handleSelected(query, router, value, reset);
 };
 
-export const handleCostDistributionSelected = (
+export const handleOnCostDistributionSelected = (
   query: Query,
   router: RouteComponentProps,
   value: string,
@@ -43,17 +43,17 @@ export const handleCostDistributionSelected = (
   handleSelected(newQuery, router, value, reset);
 };
 
-export const handleFilterAdded = (query: Query, router: RouteComponentProps, filter: Filter) => {
+export const handleOnFilterAdded = (query: Query, router: RouteComponentProps, filter: Filter) => {
   const filteredQuery = addFilterToQuery(query, filter);
   router.navigate(getRouteForQuery(filteredQuery, router.location, true), { replace: true });
 };
 
-export const handleFilterRemoved = (query: Query, router: RouteComponentProps, filter: Filter) => {
+export const handleOnFilterRemoved = (query: Query, router: RouteComponentProps, filter: Filter) => {
   const filteredQuery = removeFilterFromQuery(query, filter);
   router.navigate(getRouteForQuery(filteredQuery, router.location, true), { replace: true });
 };
 
-export const handlePerPageSelect = (query: Query, router: RouteComponentProps, perPage: number) => {
+export const handleOnPerPageSelect = (query: Query, router: RouteComponentProps, perPage: number) => {
   const newQuery = { ...JSON.parse(JSON.stringify(query)) };
   newQuery.filter = {
     ...query.filter,
@@ -63,7 +63,7 @@ export const handlePerPageSelect = (query: Query, router: RouteComponentProps, p
   router.navigate(filteredQuery, { replace: true });
 };
 
-export const handleSetPage = (query: Query, router: RouteComponentProps, report, pageNumber) => {
+export const handleOnSetPage = (query: Query, router: RouteComponentProps, report, pageNumber) => {
   const limit = report && report.meta && report.meta.filter && report.meta.filter.limit ? report.meta.filter.limit : 10;
   const offset = pageNumber * limit - limit;
 
@@ -76,7 +76,7 @@ export const handleSetPage = (query: Query, router: RouteComponentProps, report,
   router.navigate(filteredQuery, { replace: true });
 };
 
-export const handleSort = (
+export const handleOnSort = (
   query: Query,
   router: RouteComponentProps,
   sortType: string,


### PR DESCRIPTION
Pau reported that the optimizations drawer was open, but the table row didn't show a blue bar. The drawer likely remained opened while another action was performed in the page.

- Close optimizations drawer if filtering, pagination, or sort is applied
- Rename handle methods to better match property names
