### PR TITLE
Fixed workload_type in ROS drawer

### DIFF
--- a/src/components/drawers/optimzations/optimizations.styles.ts
+++ b/src/components/drawers/optimzations/optimizations.styles.ts
@@ -8,7 +8,7 @@ export const styles = {
     marginTop: global_spacer_lg.value,
   },
   firstColumn: {
-    width: '250px',
+    width: '225px',
   },
   tableContainer: {
     marginTop: global_spacer_lg.value,

--- a/src/components/drawers/optimzations/optimizationsContent.tsx
+++ b/src/components/drawers/optimzations/optimizationsContent.tsx
@@ -168,11 +168,11 @@ class OptimizationsContentBase extends React.Component<OptimizationsContentProps
           <TextListItem component={TextListItemVariants.dt}>
             {intl.formatMessage(messages.optimizationsValues, { value: 'workload_type' })}
           </TextListItem>
-          <TextListItem component={TextListItemVariants.dd}>{workload}</TextListItem>
+          <TextListItem component={TextListItemVariants.dd}>{workloadType}</TextListItem>
           <TextListItem component={TextListItemVariants.dt}>
             {intl.formatMessage(messages.optimizationsValues, { value: 'workload' })}
           </TextListItem>
-          <TextListItem component={TextListItemVariants.dd}>{workloadType}</TextListItem>
+          <TextListItem component={TextListItemVariants.dd}>{workload}</TextListItem>
         </TextList>
       </TextContent>
     );


### PR DESCRIPTION
The workload type and workload name were switched in ROS drawer. Also Adjusted drawer's table column width due to long decimal places.