### PR TITLE
[COST-3554] Use new field for amortized cost

### DIFF
--- a/src/routes/components/costType/costType.tsx
+++ b/src/routes/components/costType/costType.tsx
@@ -43,7 +43,7 @@ type CostTypeProps = CostTypeOwnProps & CostTypeDispatchProps & CostTypeStatePro
 
 // eslint-disable-next-line no-shadow
 export const enum CostTypes {
-  amortized = 'savingsplan_effective_cost',
+  amortized = 'calculated_amortized_cost',
   blended = 'blended_cost',
   unblended = 'unblended_cost',
 }


### PR DESCRIPTION
The value in `savingsplan_effective_cost` does not accurately reflect the amortized cost as reported by AWS. There is a new field that calculates the correct amortized cost the same way that AWS does. Use this new field when amortized cost is selected.