### PR TITLE
Optimizations drawer link should be disabled

### DIFF
--- a/src/components/drawers/optimzations/optimizationsDrawer.tsx
+++ b/src/components/drawers/optimzations/optimizationsDrawer.tsx
@@ -46,8 +46,9 @@ class OptimizationsDrawerBase extends React.Component<OptimizationsDrawerProps, 
   public render() {
     const { isOpen, payload } = this.props;
 
-    const title = payload ? payload.container : null;
     const id = payload ? payload.id : undefined;
+    const project = payload ? payload.project : undefined;
+    const title = payload ? payload.container : null;
 
     return (
       <DrawerPanelContent id="optimizationsDrawer" minSize={'750px'}>
@@ -64,7 +65,7 @@ class OptimizationsDrawerBase extends React.Component<OptimizationsDrawerProps, 
           </DrawerActions>
         </DrawerHead>
         <DrawerPanelBody>
-          <OptimizationsContent id={id} onClose={this.handleClose} />
+          <OptimizationsContent id={id} onClose={this.handleClose} project={project} />
         </DrawerPanelBody>
       </DrawerPanelContent>
     );

--- a/src/components/drawers/optimzations/optimizationsLink.tsx
+++ b/src/components/drawers/optimzations/optimizationsLink.tsx
@@ -1,0 +1,164 @@
+import './optimizations.scss';
+
+import { Button, Tooltip } from '@patternfly/react-core';
+import { getQuery } from 'api/queries/ocpQuery';
+import type { RosQuery } from 'api/queries/rosQuery';
+import { parseQuery } from 'api/queries/rosQuery';
+import type { OcpReport } from 'api/reports/ocpReports';
+import { ReportPathsType, ReportType } from 'api/reports/report';
+import type { AxiosError } from 'axios';
+import messages from 'locales/messages';
+import React from 'react';
+import type { WrappedComponentProps } from 'react-intl';
+import { injectIntl } from 'react-intl';
+import { connect } from 'react-redux';
+import { Link } from 'react-router-dom';
+import { routes } from 'routes';
+import { getUnsortedComputedReportItems } from 'routes/utils/computedReport/getComputedReportItems';
+import { getGroupById } from 'routes/utils/groupBy';
+import { getBreakdownPath } from 'routes/utils/paths';
+import type { FetchStatus } from 'store/common';
+import { createMapStateToProps } from 'store/common';
+import { reportActions, reportSelectors } from 'store/reports';
+import { formatPath } from 'utils/paths';
+import type { RouterComponentProps } from 'utils/router';
+import { withRouter } from 'utils/router';
+
+interface OptimizationsLinkOwnProps extends RouterComponentProps {
+  id?: string;
+  project?: string;
+}
+
+interface OptimizationsLinkStateProps {
+  isStandalone?: boolean;
+  report?: OcpReport;
+  reportError?: AxiosError;
+  reportFetchStatus?: FetchStatus;
+  reportQueryString?: string;
+}
+
+interface OptimizationsLinkDispatchProps {
+  fetchReport: typeof reportActions.fetchReport;
+}
+
+interface OptimizationsLinkState {
+  // TBD...
+}
+
+type OptimizationsLinkProps = OptimizationsLinkOwnProps &
+  OptimizationsLinkStateProps &
+  OptimizationsLinkDispatchProps &
+  WrappedComponentProps;
+
+const reportType = ReportType.cost;
+const reportPathsType = ReportPathsType.ocp;
+
+class OptimizationsLinkBase extends React.Component<OptimizationsLinkProps, any> {
+  protected defaultState: OptimizationsLinkState = {};
+  public state: OptimizationsLinkState = { ...this.defaultState };
+
+  public componentDidMount() {
+    this.updateReport();
+  }
+
+  public componentDidUpdate(prevProps: OptimizationsLinkProps) {
+    if (prevProps.id !== this.props.id) {
+      this.updateReport();
+    }
+  }
+
+  private updateReport() {
+    const { fetchReport, reportQueryString } = this.props;
+    fetchReport(reportPathsType, reportType, reportQueryString);
+  }
+
+  private getComputedItems = () => {
+    const { report } = this.props;
+
+    return getUnsortedComputedReportItems({
+      report,
+      idKey: 'project',
+    } as any);
+  };
+
+  public render() {
+    const { intl, isStandalone, project, report, router } = this.props;
+
+    if (!isStandalone || !report) {
+      return null;
+    }
+
+    const computedItems = this.getComputedItems();
+    const isDisabled = computedItems.length === 0;
+
+    const breakdownPath = getBreakdownPath({
+      basePath: formatPath(routes.ocpDetailsBreakdown.path),
+      groupBy: 'project',
+      id: project,
+      isOptimizationsPath: true,
+      isOptimizationsTab: true,
+      router,
+      title: project,
+    });
+
+    const buttonComponent = (
+      <Button
+        isAriaDisabled={isDisabled}
+        variant="link"
+        component={(props: any) => <Link {...props} to={breakdownPath} />}
+      >
+        {intl.formatMessage(messages.optimizationsViewAll)}
+      </Button>
+    );
+    if (isDisabled) {
+      return (
+        <Tooltip content={intl.formatMessage(messages.optimizationsViewAllDisabled)} removeFindDomNode>
+          {buttonComponent}
+        </Tooltip>
+      );
+    }
+    return buttonComponent;
+  }
+}
+
+const mapStateToProps = createMapStateToProps<OptimizationsLinkOwnProps, OptimizationsLinkStateProps>(
+  (state, { project, router }) => {
+    const queryFromRoute = parseQuery<RosQuery>(router.location.search);
+    const groupBy = getGroupById(queryFromRoute);
+
+    const reportQueryString = getQuery({
+      filter: {
+        resolution: 'monthly',
+        time_scope_units: 'month',
+        time_scope_value: -1,
+      },
+      group_by: {
+        project,
+      },
+    });
+    const report = reportSelectors.selectReport(state, reportPathsType, reportType, reportQueryString);
+    const reportError = reportSelectors.selectReportError(state, reportPathsType, reportType, reportQueryString);
+    const reportFetchStatus = reportSelectors.selectReportFetchStatus(
+      state,
+      reportPathsType,
+      reportType,
+      reportQueryString
+    );
+
+    return {
+      isStandalone: groupBy === undefined,
+      report,
+      reportError,
+      reportFetchStatus,
+      reportQueryString,
+    };
+  }
+);
+
+const mapDispatchToProps: OptimizationsLinkDispatchProps = {
+  fetchReport: reportActions.fetchReport,
+};
+
+const OptimizationsLink = injectIntl(withRouter(connect(mapStateToProps, mapDispatchToProps)(OptimizationsLinkBase)));
+
+export { OptimizationsLink };

--- a/src/routes/components/optimizations/optimizationsTable.tsx
+++ b/src/routes/components/optimizations/optimizationsTable.tsx
@@ -133,6 +133,7 @@ class OptimizationsTableBase extends React.Component<OptimizationsTableProps, Op
           optimization: {
             container: item.container,
             id: item.id,
+            project,
           },
         });
       });

--- a/src/utils/chrome.tsx
+++ b/src/utils/chrome.tsx
@@ -1,5 +1,5 @@
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
-import React, { useState } from 'react';
+import React, { useLayoutEffect, useRef, useState } from 'react';
 
 export interface ChromeComponentProps {
   chrome: {
@@ -22,9 +22,21 @@ export const withChrome = Component => {
     const [initialized, setInitialized] = useState(false);
     const [orgAdmin, setOrgAdmin] = useState(false);
 
-    isOrgAdmin(auth).then(val => {
-      setOrgAdmin(val);
-      setInitialized(true);
+    const isMounted = useRef(false);
+    useLayoutEffect(() => {
+      isMounted.current = true;
+      return () => {
+        isMounted.current = false;
+      };
+    }, []);
+
+    useLayoutEffect(() => {
+      isOrgAdmin(auth).then(val => {
+        if (isMounted.current) {
+          setOrgAdmin(val);
+          setInitialized(true);
+        }
+      });
     });
 
     return initialized ? <Component {...props} chrome={{ isOrgAdmin: orgAdmin }} /> : null;


### PR DESCRIPTION
The Optimizations drawer link should be disabled when there is no OpenShift source. In this scenario, there are no projects. When the user navigates to the breakdown page, they encounter a full page empty state.

As a solution, we will fetch a cost report to determine if the OpenShift project truly exists. That is, instead of assuming there is a project if the recommendations is within 24hrs.

https://issues.redhat.com/browse/COST-3789