### PR TITLE
Update release script to not use fast forward merge

### DIFF
--- a/scripts/release-branch.sh
+++ b/scripts/release-branch.sh
@@ -57,7 +57,7 @@ merge()
   git checkout $BRANCH
 
   git fetch origin $REMOTE_BRANCH
-  git merge origin/$REMOTE_BRANCH --commit --no-edit
+  git merge origin/$REMOTE_BRANCH --commit --no-edit --no-ff
 }
 
 push()


### PR DESCRIPTION
"main and stage-stable branches have the same commit" - that's the problem then that's not doable with containerized apps. when you merge to a branch it kicks off a build, and it determines if it is a beta or stable build based on the branch. the container is pulled from quay via the SHA - so if you have master and stage-stable with the same SHA at HEAD you will end up with one build stomping over the other and the same build in both environments. stage-stable should be behind master. -- Andrew D