### PR TITLE
Move "Others" to be the last legend label

### DIFF
--- a/src/routes/explorer/explorerChart.tsx
+++ b/src/routes/explorer/explorerChart.tsx
@@ -152,11 +152,27 @@ class ExplorerChartBase extends React.Component<ExplorerChartProps, ExplorerChar
   private getComputedItems = () => {
     const { report } = this.props;
 
-    return getUnsortedComputedReportItems({
+    const computedReportItems = getUnsortedComputedReportItems({
       report,
       idKey: this.getGroupBy(),
       isDateMap: true,
     });
+
+    // Move "Others" to be the last legend label
+    for (let i = 0; i < computedReportItems.length; i++) {
+      let found = false;
+      for (const item of computedReportItems[i]) {
+        if (item[item.length - 1].id === 'Others') {
+          computedReportItems.push(computedReportItems.splice(i, 1)[0]);
+          found = true;
+          break;
+        }
+      }
+      if (found) {
+        break;
+      }
+    }
+    return computedReportItems;
   };
 
   private getGroupBy = () => {
@@ -285,7 +301,7 @@ const mapStateToProps = createMapStateToProps<ExplorerChartOwnProps, ExplorerCha
       group_by,
       start_date,
       ...(costDistribution === ComputedReportItemValueType.distributed && {
-        order_by: { distributed_cost: 'asc' },
+        order_by: { distributed_cost: 'desc' },
       }),
     };
 


### PR DESCRIPTION
Move "Others" to be the last legend label. This will allow us to apply order_by[distributed_cost]=desc, so labels appear in the expected order.

https://issues.redhat.com/browse/COST-3681

![bad sort](https://github.com/project-koku/koku-ui/assets/17481322/3bef7ca9-141b-4919-a3c3-9c6560d5c962)
