### PR TITLE
Omit unsupported tag API query params

### DIFF
--- a/src/routes/details/components/tag/tagLink.tsx
+++ b/src/routes/details/components/tag/tagLink.tsx
@@ -123,6 +123,7 @@ const mapStateToProps = createMapStateToProps<TagLinkOwnProps, TagLinkStateProps
     if (
       key.indexOf('node') !== -1 ||
       key.indexOf('region') !== -1 ||
+      key.indexOf('resource_location') !== -1 ||
       key.indexOf('service') !== -1 ||
       key.indexOf(tagPrefix) !== -1
     ) {

--- a/src/routes/details/components/tag/tagModal.tsx
+++ b/src/routes/details/components/tag/tagModal.tsx
@@ -122,6 +122,7 @@ const mapStateToProps = createMapStateToProps<TagModalOwnProps, TagModalStatePro
       if (
         key.indexOf('node') !== -1 ||
         key.indexOf('region') !== -1 ||
+        key.indexOf('resource_location') !== -1 ||
         key.indexOf('service') !== -1 ||
         key.indexOf(tagPrefix) !== -1
       ) {


### PR DESCRIPTION
Omit unsupported resource_location query params from tag API requests

https://issues.redhat.com/browse/COST-3834
