### PR TITLE
rates.tag_key may not be blank

### DIFF
--- a/src/routes/costModels/components/rateForm/useRateForm.tsx
+++ b/src/routes/costModels/components/rateForm/useRateForm.tsx
@@ -49,7 +49,7 @@ export function rateFormReducer(state = initialRateFormData, action: Actions) {
       const newMeasurement = state.measurement;
       if (newMeasurement.isDirty) {
         newMeasurement.value = '';
-        // Past discussions we've agreed this required error should show on measurement when metric updates
+        // Past discussions, we've agreed this required error should show on measurement when metric updates
         errors.measurement = textHelpers.required;
       }
       let step = state.step;
@@ -225,6 +225,8 @@ export function rateFormReducer(state = initialRateFormData, action: Actions) {
             error,
             ...state.errors.tagValues.slice(action.index + 1),
           ],
+          // "Create rate" button must remain disabled if tag key not set -- see https://issues.redhat.com/browse/COST-3977
+          tagKey: tagKeyValueErrors(state.taggingRates.tagKey.value),
         },
       };
     }

--- a/src/routes/settings/costModels/components/rateForm/useRateForm.tsx
+++ b/src/routes/settings/costModels/components/rateForm/useRateForm.tsx
@@ -49,7 +49,7 @@ export function rateFormReducer(state = initialRateFormData, action: Actions) {
       const newMeasurement = state.measurement;
       if (newMeasurement.isDirty) {
         newMeasurement.value = '';
-        // Past discussions we've agreed this required error should show on measurement when metric updates
+        // Past discussions, we've agreed this required error should show on measurement when metric updates
         errors.measurement = textHelpers.required;
       }
       let step = state.step;
@@ -225,6 +225,8 @@ export function rateFormReducer(state = initialRateFormData, action: Actions) {
             error,
             ...state.errors.tagValues.slice(action.index + 1),
           ],
+          // "Create rate" button must remain disabled if tag key not set -- see https://issues.redhat.com/browse/COST-3977
+          tagKey: tagKeyValueErrors(state.taggingRates.tagKey.value),
         },
       };
     }


### PR DESCRIPTION
The cost model "Create rate" button must remain disabled if tag key not set.

https://issues.redhat.com/browse/COST-3977

![Screenshot 2023-06-29 at 12 38 54 PM](https://github.com/project-koku/koku-ui/assets/17481322/a71eb2bb-7f6a-4656-b443-768ea8f4f03a)
