### PR TITLE
Add support for Azure's subscription_name

### DIFF
--- a/src/api/queries/azureQuery.ts
+++ b/src/api/queries/azureQuery.ts
@@ -14,6 +14,7 @@ interface AzureGroupBys {
 
 interface AzureOrderBys {
   subscription_guid?: string;
+  subscription_name?: string;
   resource_location?: string;
   service_name?: string;
   cost?: string;

--- a/src/routes/details/awsDetails/detailsTable.tsx
+++ b/src/routes/details/awsDetails/detailsTable.tsx
@@ -166,7 +166,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
             groupByOrg,
             id: item.id,
             router,
-            title: item.label,
+            title: label.toString(), // Convert IDs if applicable
             type: item.type,
           })}
         >

--- a/src/routes/details/azureBreakdown/azureBreakdown.tsx
+++ b/src/routes/details/azureBreakdown/azureBreakdown.tsx
@@ -19,7 +19,7 @@ import { providersQuery, providersSelectors } from 'store/providers';
 import { reportActions, reportSelectors } from 'store/reports';
 import { getCurrency } from 'utils/localStorage';
 import { formatPath } from 'utils/paths';
-import { breakdownDescKey } from 'utils/props';
+import { breakdownDescKey, breakdownTitleKey } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 
@@ -86,6 +86,8 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, BreakdownStateP
     providersQueryString
   );
 
+  const title = queryFromRoute[breakdownTitleKey] ? queryFromRoute[breakdownTitleKey] : groupByValue;
+
   return {
     costOverviewComponent: <CostOverview currency={currency} groupBy={groupBy} report={report} />,
     currency,
@@ -107,7 +109,7 @@ const mapStateToProps = createMapStateToProps<AzureCostOwnProps, BreakdownStateP
     reportPathsType,
     reportQueryString,
     tagPathsType: TagPathsType.azure,
-    title: groupByValue,
+    title,
   };
 });
 

--- a/src/routes/details/azureDetails/detailsTable.tsx
+++ b/src/routes/details/azureDetails/detailsTable.tsx
@@ -103,7 +103,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
             name: '',
           },
           {
-            orderBy: groupBy,
+            orderBy: groupBy === 'subscription_guid' ? 'subscription_name' : groupBy,
             name: intl.formatMessage(messages.detailsResourceNames, { value: groupBy }),
             ...(computedItems.length && { isSortable: true }),
           },
@@ -123,7 +123,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
 
     computedItems.map((item, index) => {
       const cost = this.getTotalCost(item, index);
-      const label = item && item.label !== null ? item.label : '';
+      const label = item && item.label && item.label !== null ? item.label : '';
       const monthOverMonth = this.getMonthOverMonthCost(item, index);
       const isDisabled = label === `${noPrefix}${groupBy}` || label === `${noPrefix}${groupByTagKey}`;
       const desc = item.id && item.id !== item.label ? <div style={styles.infoDescription}>{item.id}</div> : null;
@@ -139,7 +139,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
             groupBy,
             id: item.id,
             router,
-            title: label.toString(),
+            title: label.toString(), // Convert IDs if applicable
           })}
         >
           {label}

--- a/src/routes/details/gcpDetails/detailsTable.tsx
+++ b/src/routes/details/gcpDetails/detailsTable.tsx
@@ -139,7 +139,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
             groupBy,
             id: item.id,
             router,
-            title: label.toString(),
+            title: label.toString(), // Convert IDs if applicable
           })}
         >
           {label}

--- a/src/routes/details/ibmDetails/detailsTable.tsx
+++ b/src/routes/details/ibmDetails/detailsTable.tsx
@@ -139,7 +139,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
             groupBy,
             id: item.id,
             router,
-            title: label.toString(),
+            title: label.toString(), // Convert IDs if applicable
           })}
         >
           {label}

--- a/src/routes/details/ociDetails/detailsTable.tsx
+++ b/src/routes/details/ociDetails/detailsTable.tsx
@@ -139,7 +139,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
             groupBy,
             id: item.id,
             router,
-            title: label.toString(),
+            title: label.toString(), // Convert IDs if applicable
           })}
         >
           {label}

--- a/src/routes/details/ocpDetails/detailsTable.tsx
+++ b/src/routes/details/ocpDetails/detailsTable.tsx
@@ -230,7 +230,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
             isPlatformCosts,
             groupBy,
             router,
-            title: label.toString(),
+            title: label.toString(), // Convert IDs if applicable
           })}
         >
           {label}

--- a/src/routes/details/rhelDetails/detailsTable.tsx
+++ b/src/routes/details/rhelDetails/detailsTable.tsx
@@ -196,7 +196,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
             groupBy,
             id: item.id,
             router,
-            title: label.toString(),
+            title: label.toString(), // Convert IDs if applicable
           })}
         >
           {label}

--- a/src/routes/explorer/explorerTable.tsx
+++ b/src/routes/explorer/explorerTable.tsx
@@ -145,6 +145,13 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps, ExplorerTabl
         : groupBy,
     });
 
+    let orderBy = groupBy;
+    if (perspective === PerspectiveType.aws || perspective === PerspectiveType.awsOcp) {
+      orderBy = groupBy === 'account' ? 'account_alias' : groupBy;
+    } else if (perspective === PerspectiveType.azure || perspective === PerspectiveType.azureOcp) {
+      orderBy = groupBy === 'subscription_guid' ? 'subscription_name' : groupBy;
+    }
+
     // Add first two column headings (i.e., select and name)
     const columns =
       groupByCostCategory || groupByTagKey || groupByOrg
@@ -167,7 +174,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps, ExplorerTabl
             {
               date: undefined,
               name: intl.formatMessage(messages.groupByValueNames, { groupBy }),
-              orderBy: groupBy === 'account' && perspective === PerspectiveType.aws ? 'account_alias' : groupBy,
+              orderBy,
               ...(computedItems.length && { isSortable: true }),
             },
             {
@@ -218,7 +225,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps, ExplorerTabl
     // Sort by date and fill in missing cells
     computedItems.map(rowItem => {
       const cells = [];
-      let desc; // First column description (i.e., show ID if different than label)
+      let desc; // First column description (i.e., show ID if different from label)
       let name; // For first column resource name
       let selectItem; // Save for row selection
       let isOverheadCosts = false; // True if item has overhead costs

--- a/src/routes/utils/computedReport/getComputedReportItems.ts
+++ b/src/routes/utils/computedReport/getComputedReportItems.ts
@@ -254,6 +254,8 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
             label = val.account_alias;
           } else if (itemLabelKey === 'cluster' && cluster_alias) {
             label = cluster_alias;
+          } else if (itemLabelKey === 'subscription_guid' && val.subscription_name) {
+            label = val.subscription_name;
           } else if (val[itemLabelKey] instanceof Object) {
             label = val[itemLabelKey].value;
           } else {


### PR DESCRIPTION
Add support for Azure's subscription_name

Note: The reports/openshift/infrastructures/aws API returns null for "account_alias" when using order_by[cost]
See https://issues.redhat.com/browse/COST-4014

https://issues.redhat.com/browse/COST-4011