### PR TITLE
Deployment commit for stage-stable

### DIFF
--- a/scripts/release-branch.sh
+++ b/scripts/release-branch.sh
@@ -74,9 +74,8 @@ pullRequest()
   echo "\n*** Pushing $NEW_BRANCH..."
   git push -u origin HEAD
 
-  COMMIT=`git rev-parse HEAD`
   TITLE="Deployment commit for $BRANCH"
-  BODY="Merged $REMOTE_BRANCH branch to $BRANCH. Use commit $COMMIT to update namespace \`ref\` in app-interface repo"
+  BODY="Merged $REMOTE_BRANCH branch to $BRANCH. Use latest commit to update namespace \`ref\` in app-interface repo. Don't use merge commit, SHAs must be unique when images are created for each branch."
 
   gh pr create -t "$TITLE" -b "$BODY" -B $BRANCH
 }

--- a/src/components/permissions/permissions.tsx
+++ b/src/components/permissions/permissions.tsx
@@ -69,7 +69,7 @@ const PermissionsBase: React.FC<PermissionsProps> = ({
     const ocp = hasOcpAccess(userAccess);
     const rhel = isFinsightsFeatureEnabled && hasRhelAccess(userAccess);
     const ros = isRosFeatureEnabled && hasRosAccess(userAccess);
-    const settings = isSettingsFeatureEnabled && hasSettingsAccess(userAccess);
+    const settings = (costModel || hasSettingsAccess(userAccess)) && isSettingsFeatureEnabled;
 
     switch (pathname) {
       case formatPath(routes.explorer.path):
@@ -102,7 +102,7 @@ const PermissionsBase: React.FC<PermissionsProps> = ({
       case formatPath(routes.rhelDetailsBreakdown.path):
         return rhel;
       case formatPath(routes.settings.path):
-        return costModel || settings;
+        return settings;
       default:
         return false;
     }

--- a/src/store/costModels/actions.ts
+++ b/src/store/costModels/actions.ts
@@ -128,7 +128,7 @@ export const redirectToCostModelFromSourceUuid = (source_uuid: string, router: R
         const uuid = res.data.data[0].uuid;
         router.navigate(
           `${formatPath(
-            selectIsSettingsFeatureEnabled(getState()) ? routes.settings.path : routes.costModelsDetails.path
+            selectIsSettingsFeatureEnabled(getState()) ? routes.costModel.basePath : routes.costModelsDetails.path
           )}/${uuid}`
         );
       })


### PR DESCRIPTION
Merged main branch to stage-stable. Use latest commit to update namespace `ref` in app-interface repo. Don't use merge commit, SHAs must be unique when images are created for each branch.