### PR TITLE
Workaround for Consoledot's pf4-v5.css

### DIFF
--- a/src/components/drawers/commonDrawer/commonDrawer.scss
+++ b/src/components/drawers/commonDrawer/commonDrawer.scss
@@ -2,4 +2,9 @@
   .pf-c-drawer__content {
     background-color: unset;
   }
+  /* Todo: Remove when Optimizations drawer is replaced */
+  /* Workaround for Consoledot's pf4-v5.css */
+  .pf-c-drawer__body {
+    background-color: var(--pf-v5-global--BackgroundColor--200);
+  }
 }


### PR DESCRIPTION
Workaround for Consoledot's pf4-v5.css. Currently, the page background is white, but should be gray.