### PR TITLE
Fix missing breadcrumb

### DIFF
--- a/src/routes/details/components/breakdown/breakdownHeader.tsx
+++ b/src/routes/details/components/breakdown/breakdownHeader.tsx
@@ -57,28 +57,6 @@ interface BreakdownHeaderDispatchProps {
 type BreakdownHeaderProps = BreakdownHeaderOwnProps & BreakdownHeaderStateProps & WrappedComponentProps;
 
 class BreakdownHeader extends React.Component<BreakdownHeaderProps, any> {
-  // private buildDetailsLink = url => {
-  //   const { groupBy, query, router } = this.props;
-  //
-  //   let groupByKey = groupBy;
-  //   let value = '*';
-  //
-  //   // Retrieve org unit used by the details page
-  //   if (query[orgUnitIdKey]) {
-  //     groupByKey = orgUnitIdKey;
-  //     value = query[orgUnitIdKey];
-  //   }
-  //
-  //   const queryState = getQueryState(router.location, 'details');
-  //   const newQuery = {
-  //     ...(queryState && queryState),
-  //     group_by: {
-  //       [groupByKey]: value,
-  //     },
-  //   };
-  //   return `${url}?${getQueryRoute(newQuery)}`;
-  // };
-
   private getBackToLink = groupByKey => {
     const { breadcrumb, intl, router, tagPathsType } = this.props;
 
@@ -94,19 +72,6 @@ class BreakdownHeader extends React.Component<BreakdownHeaderProps, any> {
       </Link>
     );
   };
-
-  // private getBackToLink = groupByKey => {
-  //   const { detailsURL, intl, router, tagPathsType } = this.props;
-  //
-  //   return (
-  //     <Link to={this.buildDetailsLink(detailsURL)} state={{ ...router.location.state }}>
-  //       {intl.formatMessage(messages.breakdownBackToDetails, {
-  //         value: intl.formatMessage(messages.breakdownBackToTitles, { value: tagPathsType }),
-  //         groupBy: groupByKey,
-  //       })}
-  //     </Link>
-  //   );
-  // };
 
   private getTotalCost = () => {
     const { costDistribution, report } = this.props;

--- a/src/routes/utils/queryNavigate.ts
+++ b/src/routes/utils/queryNavigate.ts
@@ -7,7 +7,7 @@ import { getRouteForQuery } from './query';
 
 export const handleOnCurrencySelected = (query: Query, router: RouteComponentProps) => {
   const newQuery = queryUtils.handleOnCurrencySelected(query);
-  router.navigate(getRouteForQuery(newQuery, router.location), { replace: true }); // Don't reset pagination
+  router.navigate(getRouteForQuery(newQuery, router.location), { replace: true, state: router.location.state }); // Don't reset pagination
 };
 
 export const handleOnCostTypeSelected = (query: Query, router: RouteComponentProps) => {
@@ -17,7 +17,7 @@ export const handleOnCostTypeSelected = (query: Query, router: RouteComponentPro
 
 export const handleOnCostDistributionSelected = (query: Query, router: RouteComponentProps) => {
   const newQuery = queryUtils.handleOnCostDistributionSelected(query);
-  router.navigate(getRouteForQuery(newQuery, router.location), { replace: true }); // Don't reset pagination
+  router.navigate(getRouteForQuery(newQuery, router.location), { replace: true, state: router.location.state }); // Don't reset pagination
 };
 
 export const handleOnFilterAdded = (query: Query, router: RouteComponentProps, filter: Filter) => {


### PR DESCRIPTION
When changing currency or cost distribution, the details breakdown breadcrumb is missing because the page was refreshed without maintaining state.