### PR TITLE
Broken cost explorer sort

### DIFF
--- a/src/routes/explorer/explorerTable.tsx
+++ b/src/routes/explorer/explorerTable.tsx
@@ -395,7 +395,7 @@ class ExplorerTableBase extends React.Component<ExplorerTableProps, ExplorerTabl
   private getSortParams = (index: number): ThProps['sort'] => {
     return {
       sortBy: this.getSortBy(index),
-      onSort: this.handleOnSort,
+      onSort: (_evt, i, direction) => this.handleOnSort(i, direction),
       columnIndex: index,
     };
   };


### PR DESCRIPTION
This is due to the PatternFly v5 upgrade. There is a new event property, which was added to the sort function.

https://issues.redhat.com/browse/COST-4276