### PR TITLE
Show cost.total for group by cluster

### DIFF
--- a/src/routes/details/components/costOverview/costOverviewBase.tsx
+++ b/src/routes/details/components/costOverview/costOverviewBase.tsx
@@ -19,7 +19,6 @@ import messages from 'locales/messages';
 import React from 'react';
 import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
-import { ComputedReportItemValueType } from 'routes/components/charts/common';
 import { Cluster } from 'routes/details/components/cluster';
 import { CostChart } from 'routes/details/components/costChart';
 import { OverheadCostChart } from 'routes/details/components/overheadCostChart';
@@ -263,7 +262,7 @@ class CostOverviewsBase extends React.Component<CostOverviewProps, any> {
     if (showWidget) {
       return (
         <SummaryCard
-          costDistribution={groupBy === 'cluster' ? ComputedReportItemValueType.distributed : costDistribution}
+          costDistribution={costDistribution}
           costType={costType}
           currency={currency}
           isPlatformCosts={isPlatformCosts}


### PR DESCRIPTION
When grouped by cluster, the breakdown page's summary card should show cost.total instead of cost.distributed. We are not showing distributed costs for group by cluster, so the pie chart is showing cost.total.

https://issues.redhat.com/browse/COST-4462