### PR TITLE
Refactor tag mapping for new data structure

### DIFF
--- a/src/routes/components/dataTable/expandableTable.tsx
+++ b/src/routes/components/dataTable/expandableTable.tsx
@@ -175,7 +175,7 @@ class ExpandableTable extends React.Component<ExpandableTableProps, ExpandableTa
                         )
                       )}
                     </Tr>
-                    {row?.children.map((child, childIndex) => (
+                    {row?.children?.map((child, childIndex) => (
                       <Tr
                         isExpanded={isExpanded}
                         key={`row-children-${childIndex}-${rowIndex}`}

--- a/src/routes/settings/tagLabels/tagMapping/tagMappingTable.tsx
+++ b/src/routes/settings/tagLabels/tagMapping/tagMappingTable.tsx
@@ -80,7 +80,7 @@ const TagMappingTable: React.FC<TagMappingTableProps> = ({
             value: <Actions canWrite={canWrite} isDisabled={isDisabled} item={parent} onClose={onClose} />,
           },
         ],
-        children: parent.children.map(child => {
+        children: item.children?.map(child => {
           return {
             cells: [
               {}, // Empty cell for expand toggle


### PR DESCRIPTION
The tag mapping API changed its data structure. We need to refactor the UI to match that.