### PR TITLE
The source API may return null for status

### DIFF
--- a/src/routes/details/ocpBreakdown/providerDetails/dataDetails/components/cloudIData.tsx
+++ b/src/routes/details/ocpBreakdown/providerDetails/dataDetails/components/cloudIData.tsx
@@ -52,26 +52,26 @@ const CloudIData: React.FC<CloudDataProps> = ({ provider }: CloudDataProps) => {
         </ProgressStep>
         <ProgressStep
           aria-label={intl.formatMessage(messages.dataDetailsRetrieval)}
-          icon={getProgressStepIcon(provider.status.download.state)}
+          icon={getProgressStepIcon(provider.status?.download?.state)}
           id="step2"
           titleId="step2-title"
-          variant={getProgressStepVariant(provider.status.download.state)}
+          variant={getProgressStepVariant(provider.status?.download?.state)}
         >
           {intl.formatMessage(messages.dataDetailsRetrieval)}
           <div style={styles.description}>
-            {formatDate(provider.status.download.end || provider.status.download.start)}
+            {formatDate(provider.status?.download?.end || provider.status?.download?.start)}
           </div>
         </ProgressStep>
         <ProgressStep
           aria-label={intl.formatMessage(messages.dataDetailsProcessing, { count: 3 })}
-          icon={getProgressStepIcon(provider.status.processing.state)}
+          icon={getProgressStepIcon(provider.status?.processing?.state)}
           id="step3"
           titleId="step3-title"
-          variant={getProgressStepVariant(provider.status.processing.state)}
+          variant={getProgressStepVariant(provider.status?.processing?.state)}
         >
           {intl.formatMessage(messages.dataDetailsProcessing)}
           <div style={styles.description}>
-            {formatDate(provider.status.processing.end || provider.status.processing.start)}
+            {formatDate(provider.status?.processing?.end || provider.status?.processing?.start)}
           </div>
         </ProgressStep>
       </ProgressStepper>

--- a/src/routes/details/ocpBreakdown/providerDetails/dataDetails/components/clusterData.tsx
+++ b/src/routes/details/ocpBreakdown/providerDetails/dataDetails/components/clusterData.tsx
@@ -47,26 +47,26 @@ const ClusterData: React.FC<ClusterDataProps> = ({ provider }: ClusterDataProps)
         </ProgressStep>
         <ProgressStep
           aria-label={intl.formatMessage(messages.dataDetailsRetrieval)}
-          icon={getProgressStepIcon(provider.status.download.state)}
+          icon={getProgressStepIcon(provider.status?.download?.state)}
           id="step1"
           titleId="step1-title"
-          variant={getProgressStepVariant(provider.status.download.state)}
+          variant={getProgressStepVariant(provider.status?.download?.state)}
         >
           {intl.formatMessage(messages.dataDetailsRetrieval)}
           <div style={styles.description}>
-            {formatDate(provider.status.download.end || provider.status.download.start)}
+            {formatDate(provider.status?.download?.end || provider.status?.download?.start)}
           </div>
         </ProgressStep>
         <ProgressStep
           aria-label={intl.formatMessage(messages.dataDetailsProcessing)}
-          icon={getProgressStepIcon(provider.status.processing.state)}
+          icon={getProgressStepIcon(provider.status?.processing?.state)}
           id="step2"
           titleId="step2-title"
-          variant={getProgressStepVariant(provider.status.processing.state)}
+          variant={getProgressStepVariant(provider.status?.processing?.state)}
         >
           {intl.formatMessage(messages.dataDetailsProcessing)}
           <div style={styles.description}>
-            {formatDate(provider.status.processing.end || provider.status.processing.start)}
+            {formatDate(provider.status?.processing?.end || provider.status?.processing?.start)}
           </div>
         </ProgressStep>
       </ProgressStepper>

--- a/src/routes/details/ocpBreakdown/providerDetails/dataDetails/components/costData.tsx
+++ b/src/routes/details/ocpBreakdown/providerDetails/dataDetails/components/costData.tsx
@@ -33,14 +33,14 @@ const CostData: React.FC<CostDataProps> = ({ provider }: CostDataProps) => {
       >
         <ProgressStep
           aria-label={intl.formatMessage(messages.dataDetailsIntegrationAndFinalization)}
-          icon={getProgressStepIcon(provider.status.summary.state)}
+          icon={getProgressStepIcon(provider.status?.summary?.state)}
           id="step1"
           titleId="step1-title"
-          variant={getProgressStepVariant(provider.status.summary.state)}
+          variant={getProgressStepVariant(provider.status?.summary?.state)}
         >
           {intl.formatMessage(messages.dataDetailsIntegrationAndFinalization)}
           <div style={styles.description}>
-            {formatDate(provider.status.summary.end || provider.status.summary.start)}
+            {formatDate(provider.status?.summary?.end || provider.status?.summary?.start)}
           </div>
         </ProgressStep>
       </ProgressStepper>

--- a/src/routes/details/ocpBreakdown/providerDetails/dataDetails/utils/status.ts
+++ b/src/routes/details/ocpBreakdown/providerDetails/dataDetails/utils/status.ts
@@ -87,9 +87,9 @@ export const getProviderStatus = (
   }
 
   // Skip summaryState for cloud
-  const downloadState = lookupKey(provider.status.download.state);
-  const processingState = lookupKey(provider.status.processing.state);
-  const summaryState = isCloud ? StatusType.complete : lookupKey(provider.status.summary.state);
+  const downloadState = lookupKey(provider.status?.download?.state);
+  const processingState = lookupKey(provider.status?.processing?.state);
+  const summaryState = isCloud ? StatusType.complete : lookupKey(provider.status?.summary?.state);
 
   if (
     downloadState === StatusType.failed ||


### PR DESCRIPTION
The source API may return null for status in prod. In addition to testing for undefined, the UI must also check for null.

https://issues.redhat.com/browse/COST-4836