### PR TITLE
Replace remaining deprecated PatternFly Select component

### DIFF
--- a/src/routes/components/selectWrapper/selectWrapper.tsx
+++ b/src/routes/components/selectWrapper/selectWrapper.tsx
@@ -12,30 +12,40 @@ export interface SelectWrapperOption {
 }
 
 interface SelectWrapperOwnProps {
+  appendTo?: HTMLElement | (() => HTMLElement) | 'inline' | 'parent';
   ariaLabel?: string;
   className?: string;
+  direction?: 'up' | 'down';
   id?: string;
   isDisabled?: boolean;
+  maxMenuHeight?: string;
   onSelect?: (event, value: SelectWrapperOption) => void;
   placeholder?: string;
   options?: SelectWrapperOption[];
   position?: 'right' | 'left' | 'center' | 'start' | 'end';
   selection?: string | SelectWrapperOption;
+  status?: 'success' | 'warning' | 'danger';
+  toggleAriaLabel?: string;
   toggleIcon?: React.ReactNode;
 }
 
 type SelectWrapperProps = SelectWrapperOwnProps;
 
 const SelectWrapper: React.FC<SelectWrapperProps> = ({
+  appendTo,
   ariaLabel,
   className,
+  direction,
   id,
   isDisabled,
+  maxMenuHeight,
   onSelect = () => {},
   options,
   placeholder = null,
   position,
   selection,
+  status,
+  toggleAriaLabel,
   toggleIcon,
 }) => {
   const [isOpen, setIsOpen] = useState(false);
@@ -72,28 +82,34 @@ const SelectWrapper: React.FC<SelectWrapperProps> = ({
 
   const toggle = toggleRef => (
     <MenuToggle
+      aria-label={toggleAriaLabel}
       icon={toggleIcon && <Icon>{toggleIcon}</Icon>}
       isDisabled={isDisabled}
       isExpanded={isOpen}
+      isFullWidth
       onClick={handleOnToggle}
       ref={toggleRef}
+      status={status}
     >
       {getPlaceholder()}
     </MenuToggle>
   );
 
   return (
-    <div className={className ? `selectWrapper ${className}` : 'selectWrapper'}>
+    <div className={className ? `${className} selectWrapper` : 'selectWrapper'}>
       <Select
         id={id}
+        isScrollable={maxMenuHeight !== undefined}
+        maxMenuHeight={maxMenuHeight}
         onOpenChange={isExpanded => setIsOpen(isExpanded)}
         onSelect={handleOnSelect}
+        ouiaId={id}
         isOpen={isOpen}
-        popperProps={
-          position && {
-            position,
-          }
-        }
+        popperProps={{
+          appendTo: appendTo as any,
+          direction,
+          position,
+        }}
         selected={selection}
         toggle={toggle}
       >

--- a/src/routes/settings/costModels/components/addPriceList.test.tsx
+++ b/src/routes/settings/costModels/components/addPriceList.test.tsx
@@ -134,7 +134,7 @@ describe('add-a-new-rate', () => {
     // select first option for measurement
     await act(async () => user.click(screen.getByLabelText('Select Measurement')));
     options = await screen.findAllByRole('option');
-    await act(async () => user.click(options[0]));
+    await act(async () => user.click(options[3])); // Previous select options are not being removed from page
 
     // make sure the default cost type is selected
     expect(screen.getByLabelText(qr.infraradio)).toHaveProperty('checked', true);
@@ -159,7 +159,7 @@ describe('add-a-new-rate', () => {
 
     await act(async () => user.click(screen.getByLabelText('Select Measurement')));
     options = await screen.findAllByRole('option');
-    await act(async () => user.click(options[0]));
+    await act(async () => user.click(options[3])); // Previous select options are not being removed from page
 
     expect(screen.getByLabelText(qr.supplradio)).toHaveProperty('checked', true);
     await act(async () => user.click(screen.getByLabelText(qr.infraradio)));
@@ -186,13 +186,14 @@ describe('add-a-new-rate', () => {
     expect(createButton.getAttribute('aria-disabled')).toBe('false');
     await act(async () => user.click(createButton));
     expect(submit).toHaveBeenCalled();
-  });
+  }, 7000);
 
   test('tag rates', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     const submit = jest.fn();
     const cancel = jest.fn();
     let options = null;
+
     render(<RenderFormDataUI submit={submit} cancel={cancel} />);
 
     await act(async () => user.type(screen.getByLabelText('Description'), 'tag rate test'));
@@ -203,7 +204,7 @@ describe('add-a-new-rate', () => {
 
     await act(async () => user.click(screen.getByLabelText('Select Measurement')));
     options = await screen.findAllByRole('option');
-    await act(async () => user.click(options[0]));
+    await act(async () => user.click(options[3])); // Previous select options are not being removed from page
 
     await act(async () => user.click(screen.getByLabelText(regExp(messages.costModelsEnterTagRate))));
 
@@ -258,13 +259,14 @@ describe('add-a-new-rate', () => {
     expect(createButton.getAttribute('aria-disabled')).toBe('false');
     await act(async () => user.click(createButton));
     expect(submit).toHaveBeenCalled();
-  });
+  }, 15000);
 
   test('tag rates duplicate tag key', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     const submit = jest.fn();
     const cancel = jest.fn();
     let options = null;
+
     render(<RenderFormDataUI submit={submit} cancel={cancel} />);
 
     await act(async () => user.click(screen.getByLabelText('Select Metric')));
@@ -273,7 +275,7 @@ describe('add-a-new-rate', () => {
 
     await act(async () => user.click(screen.getByLabelText('Select Measurement')));
     options = await screen.findAllByRole('option');
-    await act(async () => user.click(options[0]));
+    await act(async () => user.click(options[3])); // Previous select options are not being removed from page
 
     await act(async () => user.click(screen.getByLabelText(regExp(messages.costModelsEnterTagRate))));
 
@@ -297,7 +299,7 @@ describe('add-a-new-rate', () => {
 
     await act(async () => user.click(screen.getByLabelText('Select Measurement')));
     options = await screen.findAllByRole('option');
-    await act(async () => user.click(options[0]));
+    await act(async () => user.click(options[3]));
 
     expect(screen.getByText(regExp(messages.priceListDuplicate))).not.toBeNull();
   });

--- a/src/routes/settings/costModels/components/rateForm/rateForm.tsx
+++ b/src/routes/settings/costModels/components/rateForm/rateForm.tsx
@@ -113,7 +113,7 @@ const RateFormBase: React.FC<RateFormProps> = ({ currencyUnits, intl = defaultIn
             label={intl.formatMessage(messages.metric)}
             placeholderText={intl.formatMessage(messages.select)}
             value={metric}
-            onChange={(_evt, value) => setMetric(value)}
+            onSelect={(_evt, value) => setMetric(value)}
             options={[
               ...metricOptions.map(opt => {
                 return {
@@ -140,8 +140,8 @@ const RateFormBase: React.FC<RateFormProps> = ({ currencyUnits, intl = defaultIn
                   ? measurement
                   : getMeasurementLabel(measurement, metricsHash[metric][measurement].label_measurement_unit)
               }
-              onChange={(_evt, value) => setMeasurement(value)}
-              placeholderText="Select..."
+              onSelect={(_evt, value) => setMeasurement(value)}
+              placeholderText={intl.formatMessage(messages.select)}
               options={[
                 ...measurementOptions.map(opt => {
                   const unit = metricsHash[metric][opt].label_measurement_unit;

--- a/src/routes/settings/costModels/costModel/addRateModal.tsx
+++ b/src/routes/settings/costModels/costModel/addRateModal.tsx
@@ -60,6 +60,7 @@ export const AddRateModalBase: React.FC<AddRateModalProps> = ({
 
   return (
     <Modal
+      className="costManagement"
       title={intl.formatMessage(messages.priceListAddRate)}
       isOpen={isOpen}
       onClose={onClose}

--- a/src/routes/settings/costModels/costModel/updateCostModel.tsx
+++ b/src/routes/settings/costModels/costModel/updateCostModel.tsx
@@ -146,10 +146,10 @@ class UpdateCostModelBase extends React.Component<UpdateCostModelProps, UpdateCo
                 label={messages.currency}
                 direction="up"
                 appendMenuTo="inline"
-                maxHeight={styles.selector.maxHeight}
+                maxMenuHeight={styles.selector.maxHeight as string}
                 toggleAriaLabel={intl.formatMessage(messages.costModelsWizardCurrencyToggleLabel)}
                 value={getValueLabel(this.state.currency, currencyOptions)}
-                onChange={(_evt, value) => this.setState({ currency: value })}
+                onSelect={(_evt, value) => this.setState({ currency: value })}
                 id="currency-units-selector"
                 options={currencyOptions.map(o => {
                   return {

--- a/src/routes/settings/costModels/costModel/updateRateModel.test.tsx
+++ b/src/routes/settings/costModels/costModel/updateRateModel.test.tsx
@@ -267,13 +267,17 @@ describe('update-rate', () => {
 
   test('Description', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+
     render(<RenderFormDataUI index={0} />);
+
     const descInput = screen.getByDisplayValue('openshift-aws-node');
     const saveButton = screen.getByText(regExp(messages.save));
     expect(saveButton.getAttribute('disabled')).not.toBeNull();
+
     await act(async () => user.clear(descInput));
     await act(async () => user.type(descInput, 'a new description'));
     expect(saveButton.getAttribute('disabled')).toBeNull();
+
     await act(async () => user.clear(descInput));
     await act(async () => user.type(descInput, 'openshift-aws-node'));
     expect(saveButton.getAttribute('disabled')).not.toBeNull();
@@ -282,7 +286,9 @@ describe('update-rate', () => {
   test('Select Measurement', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
     let options = null;
+
     render(<RenderFormDataUI index={0} />);
+
     const saveButton = screen.getByText(regExp(messages.save));
 
     await act(async () => user.click(screen.getByLabelText('Select Measurement')));
@@ -303,7 +309,7 @@ describe('update-rate', () => {
 
     await act(async () => user.click(screen.getByLabelText('Select Measurement')));
     options = await screen.findAllByRole('option');
-    await act(async () => user.click(options[0]));
+    await act(async () => user.click(options[5])); // Previous select options are not being removed from page
 
     expect(saveButton.getAttribute('disabled')).toBeNull();
 
@@ -316,7 +322,7 @@ describe('update-rate', () => {
     await act(async () => user.click(options[0]));
 
     expect(saveButton.getAttribute('disabled')).not.toBeNull();
-  });
+  }, 7000);
 
   test('regular', async () => {
     const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });

--- a/src/routes/settings/costModels/costModel/updateRateModel.tsx
+++ b/src/routes/settings/costModels/costModel/updateRateModel.tsx
@@ -99,8 +99,10 @@ const UpdateRateModalBase: React.FC<UpdateRateModalProps> = ({
       )
     );
   }, [isOpen]);
+
   return (
     <Modal
+      className="costManagement"
       title={intl.formatMessage(messages.priceListEditRate)}
       isOpen={isOpen}
       onClose={onClose}
@@ -110,7 +112,7 @@ const UpdateRateModalBase: React.FC<UpdateRateModalProps> = ({
           key="proceed"
           variant="primary"
           onClick={onProceed}
-          isDisabled={!canSubmit || isProcessing || !gotDiffs}
+          isDisabled={isProcessing || !canSubmit || !gotDiffs}
         >
           {intl.formatMessage(messages.save)}
         </Button>,

--- a/src/routes/settings/costModels/costModelWizard/costModelWizard.tsx
+++ b/src/routes/settings/costModels/costModelWizard/costModelWizard.tsx
@@ -93,6 +93,7 @@ const InternalWizardBase: React.FC<InternalWizardBaseProps> = ({
 
   return isOpen ? (
     <Wizard
+      className="costManagement"
       isOpen
       title={intl.formatMessage(messages.createCostModelTitle)}
       description={intl.formatMessage(messages.createCostModelDesc)}

--- a/src/routes/settings/costModels/costModelWizard/generalInformation.tsx
+++ b/src/routes/settings/costModels/costModelWizard/generalInformation.tsx
@@ -133,22 +133,22 @@ class GeneralInformation extends React.Component<GeneralInformationProps, any> {
                   id="source-type-selector"
                   direction="up"
                   appendMenuTo="inline"
-                  maxHeight={styles.selector.maxHeight}
+                  maxMenuHeight={styles.selector.maxHeight as string}
                   label={messages.sourceType}
                   toggleAriaLabel={intl.formatMessage(messages.costModelsWizardEmptySourceTypeLabel)}
                   placeholderText={intl.formatMessage(messages.costModelsWizardEmptySourceTypeLabel)}
                   value={getValueLabel(type, sourceTypeOptions)}
-                  onChange={(_evt, value) => onTypeChange(value)}
+                  onSelect={(_evt, value) => onTypeChange(value)}
                   options={sourceTypeOptions}
                 />
                 <Selector
                   label={messages.currency}
                   direction="up"
                   appendMenuTo="inline"
-                  maxHeight={styles.selector.maxHeight}
+                  maxMenuHeight={styles.selector.maxHeight as string}
                   toggleAriaLabel={intl.formatMessage(messages.costModelsWizardCurrencyToggleLabel)}
                   value={getValueLabel(currencyUnits, currencyOptions)}
-                  onChange={(_evt, value) => onCurrencyChange(value)}
+                  onSelect={(_evt, value) => onCurrencyChange(value)}
                   id="currency-units-selector"
                   options={currencyOptions.map(o => {
                     return {


### PR DESCRIPTION
Replace remaining deprecated PatternFly Select component.

Depends on PatternFly milestone https://github.com/project-koku/koku-ui/pull/3753 -- must merge that for tests to pass

Closes https://issues.redhat.com/browse/COST-4585