### PR TITLE
Enable column management for instances table

### DIFF
--- a/src/routes/details/awsBreakdown/instances/instancesToolbar.tsx
+++ b/src/routes/details/awsBreakdown/instances/instancesToolbar.tsx
@@ -166,6 +166,7 @@ export class InstancesToolbarBase extends React.Component<InstancesToolbarProps,
         resourcePathsType={resourcePathsType}
         selectedItems={selectedItems}
         showBulkSelect
+        showColumnManagement
         showExcludes
         showExport
         showFilter


### PR DESCRIPTION
Column management flag was missing from instances table

![Screenshot 2024-04-25 at 10 57 14 AM](https://github.com/project-koku/koku-ui/assets/17481322/9da07c03-8b3d-45c1-9dab-1fb56378158f)
