### PR TITLE
Platform projects table wraps names incorrectly

### DIFF
--- a/src/routes/components/dataTable/dataTable.tsx
+++ b/src/routes/components/dataTable/dataTable.tsx
@@ -155,6 +155,7 @@ class DataTable extends React.Component<DataTableProps, any> {
                   {row.cells.map((item, cellIndex) =>
                     cellIndex === 0 && isSelectable ? (
                       <Td
+                        className={item.className}
                         dataLabel={columns[cellIndex].name}
                         key={`cell-${cellIndex}-${rowIndex}`}
                         modifier="nowrap"
@@ -169,6 +170,7 @@ class DataTable extends React.Component<DataTableProps, any> {
                       />
                     ) : (
                       <Td
+                        className={item.className}
                         dataLabel={columns[cellIndex].name}
                         key={`cell-${rowIndex}-${cellIndex}`}
                         modifier="nowrap"

--- a/src/routes/settings/platformProjects/platformProjects.scss
+++ b/src/routes/settings/platformProjects/platformProjects.scss
@@ -1,0 +1,10 @@
+@media only screen and (min-width: 1450px) {
+  .pf-v5-c-table__td {
+     &.defaultColumn {
+       width: 70%;
+     }
+     &.groupColumn {
+       width: 20%;
+     }
+  }
+}

--- a/src/routes/settings/platformProjects/platformProjects.styles.ts
+++ b/src/routes/settings/platformProjects/platformProjects.styles.ts
@@ -6,20 +6,11 @@ export const styles = {
   action: {
     marginLeft: global_spacer_md.var,
   },
-  defaultColumn: {
-    width: '20%',
-  },
   descContainer: {
     backgroundColor: global_BackgroundColor_light_100.value,
     paddingLeft: global_spacer_md.value,
     paddingRight: global_spacer_md.value,
     paddingTop: global_spacer_md.value,
-  },
-  groupColumn: {
-    width: '20%',
-  },
-  nameColumn: {
-    width: '1%',
   },
   pagination: {
     backgroundColor: global_BackgroundColor_light_100.value,

--- a/src/routes/settings/platformProjects/platformProjectsTable.tsx
+++ b/src/routes/settings/platformProjects/platformProjectsTable.tsx
@@ -1,4 +1,5 @@
 import 'routes/components/dataTable/dataTable.scss';
+import './platformProjects.scss';
 
 import { Label } from '@patternfly/react-core';
 import type { Settings, SettingsData } from 'api/settings';
@@ -7,8 +8,6 @@ import React, { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
 import { Cluster } from 'routes/components/cluster';
 import { DataTable } from 'routes/components/dataTable';
-
-import { styles } from './platformProjects.styles';
 
 interface PlatformProjectsTableOwnProps {
   canWrite?: boolean;
@@ -75,17 +74,17 @@ const PlatformProjectsTable: React.FC<PlatformProjectsTableProps> = ({
           {}, // Empty cell for row selection
           {
             value: item.project ? item.project : '',
-            style: styles.nameColumn,
           },
           {
+            className: 'defaultColumn',
             value: item.default ? <Label color="green">{intl.formatMessage(messages.default)}</Label> : null,
           },
           {
+            className: 'groupColumn',
             value:
               item.group === 'Platform' ? <Label color="green">{intl.formatMessage(messages.platform)}</Label> : null,
-            style: styles.defaultColumn,
           },
-          { value: <Cluster clusters={item.clusters} groupBy="clusters" />, style: styles.groupColumn },
+          { value: <Cluster clusters={item.clusters} groupBy="clusters" /> },
         ],
         item,
         selected: selectedItems && selectedItems.find(val => val.project === item.project) !== undefined,


### PR DESCRIPTION
The "platform projects" table, in the settings page, is wrapping names unexpectedly for small window sizes.

https://issues.redhat.com/browse/COST-5016

![Screenshot 2024-05-06 at 12 37 26 PM](https://github.com/project-koku/koku-ui/assets/17481322/79508d77-9cbc-44d3-a574-3117e442858e)
