### PR TITLE
Deployment commit for prod-stable

### DIFF
--- a/src/components/featureToggle/featureToggle.tsx
+++ b/src/components/featureToggle/featureToggle.tsx
@@ -14,7 +14,6 @@ export const enum FeatureToggle {
   ocpCloudNetworking = 'cost-management.ui.ocp-cloud-networking', // https://issues.redhat.com/browse/COST-4781
   ocpProjectStorage = 'cost-management.ui.ocp-project-storage', // https://issues.redhat.com/browse/COST-4856
   ros = 'cost-management.ui.ros', // ROS support https://issues.redhat.com/browse/COST-3477
-  rosPreview = 'cost-management.ui.ros-preview', // ROS support https://issues.redhat.com/browse/COST-3477
 }
 
 const useIsToggleEnabled = (toggle: FeatureToggle) => {
@@ -51,10 +50,7 @@ export const useIsOcpProjectStorageToggleEnabled = () => {
 };
 
 export const useIsRosToggleEnabled = () => {
-  const { isBeta } = useChrome();
-  const isRosToggleEnabled = useIsToggleEnabled(FeatureToggle.ros);
-  const isRosFeaturePreviewEnabled = useIsToggleEnabled(FeatureToggle.rosPreview) && isBeta(); // Enabled for prod-beta
-  return isRosToggleEnabled || isRosFeaturePreviewEnabled;
+  return useIsToggleEnabled(FeatureToggle.ros);
 };
 
 // The FeatureToggle component saves feature toggles in store for places where Unleash hooks not available


### PR DESCRIPTION
Merged prod-beta branch to prod-stable.

Use latest commit to update namespace `ref` in app-interface repo. Don't use merge commit, SHAs must be unique when images are created for each branch.