### PR TITLE
Update AWS EC2 instances table

### DIFF
--- a/src/api/resources/resource.ts
+++ b/src/api/resources/resource.ts
@@ -14,7 +14,7 @@ export interface Resource extends PagedResponse<ResourceData, PagedMetaData> {}
 export const enum ResourceType {
   account = 'account',
   aws_category = 'aws_category',
-  aws_ec2_instance = 'instance',
+  aws_ec2_instance = 'instance_name',
   aws_ec2_os = 'operating_system',
   cluster = 'cluster',
   gcpProject = 'gcp_project',

--- a/src/routes/details/awsBreakdown/instances/instancesTable.tsx
+++ b/src/routes/details/awsBreakdown/instances/instancesTable.tsx
@@ -78,7 +78,7 @@ const InstancesTable: React.FC<InstancesTableProps> = ({
         ...(computedItems.length && { isSortable: true }),
       },
       {
-        orderBy: 'account', // Todo: sort by account_alias
+        orderBy: 'account_alias',
         name: intl.formatMessage(messages.detailsResourceNames, { value: 'account' }),
         ...(computedItems.length && { isSortable: true }),
       },

--- a/src/routes/details/awsBreakdown/instances/instancesToolbar.tsx
+++ b/src/routes/details/awsBreakdown/instances/instancesToolbar.tsx
@@ -100,7 +100,7 @@ export class InstancesToolbarBase extends React.Component<InstancesToolbarProps,
     const options = [
       {
         name: intl.formatMessage(messages.filterByValues, { value: 'instance' }),
-        key: 'instance',
+        key: 'instance_name',
         resourceKey: 'instance_name',
       },
       {


### PR DESCRIPTION
Update AWS EC2 instances table to support account_alias sort and instance_name exclude filter