### PR TITLE
PatternFly toolbar controls scroll page when clicked

### DIFF
--- a/src/routes/components/dataToolbar/utils/bulkSelect.tsx
+++ b/src/routes/components/dataToolbar/utils/bulkSelect.tsx
@@ -101,6 +101,7 @@ export const getBulkSelect = ({
       onOpenChange={isOpen => onBulkSelectToggle(isOpen)}
       onSelect={onBulkSelect}
       popperProps={{
+        appendTo: () => document.body, // Page scroll workaround https://issues.redhat.com/browse/COST-5320
         position: 'left',
       }}
       toggle={toggle}

--- a/src/routes/explorer/explorer.tsx
+++ b/src/routes/explorer/explorer.tsx
@@ -234,6 +234,7 @@ class Explorer extends React.Component<ExplorerProps, ExplorerState> {
         isCompact={!isBottom}
         isDisabled={isDisabled}
         itemCount={count}
+        menuAppendTo={document.body} // Page scroll workaround https://issues.redhat.com/browse/COST-5320
         onPerPageSelect={(event, perPage) => handleOnPerPageSelect(query, router, perPage)}
         onSetPage={(event, pageNumber) => handleOnSetPage(query, router, report, pageNumber)}
         page={page}


### PR DESCRIPTION
This workaround, provided by the PatternFly team, appends the underlying menu components to the document body.

https://issues.redhat.com/browse/COST-5320

Must be merged after https://github.com/project-koku/koku-ui/pull/3943