### PR TITLE
EC2 fit and finish

### DIFF
--- a/src/routes/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/routes/details/awsBreakdown/awsBreakdown.tsx
@@ -122,7 +122,9 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, BreakdownSta
     groupByValue,
     historicalDataComponent: <HistoricalData costType={costType} currency={currency} />,
     instancesComponent:
-      groupBy === serviceKey && groupByValue === 'AmazonEC2' ? <Instances currency={currency} /> : undefined,
+      groupBy === serviceKey && groupByValue === 'AmazonEC2' ? (
+        <Instances costType={costType} currency={currency} />
+      ) : undefined,
     isAwsEc2InstancesToggleEnabled: FeatureToggleSelectors.selectIsAwsEc2InstancesToggleEnabled(state),
     providers: filterProviders(providers, ProviderType.aws),
     providersError,

--- a/src/routes/details/awsBreakdown/instances/instances.tsx
+++ b/src/routes/details/awsBreakdown/instances/instances.tsx
@@ -32,6 +32,7 @@ import { InstancesTable, InstanceTableColumnIds } from './instancesTable';
 import { InstancesToolbar } from './instancesToolbar';
 
 interface InstancesOwnProps {
+  costType?: string;
   currency?: string;
 }
 
@@ -75,7 +76,7 @@ const defaultColumnOptions: ColumnManagementModalOption[] = [
 const reportType = ReportType.ec2Compute;
 const reportPathsType = ReportPathsType.aws;
 
-const Instances: React.FC<InstancesProps> = ({ currency }) => {
+const Instances: React.FC<InstancesProps> = ({ costType, currency }) => {
   const intl = useIntl();
 
   const [hiddenColumns, setHiddenColumns] = useState(initHiddenColumns(defaultColumnOptions));
@@ -87,6 +88,7 @@ const Instances: React.FC<InstancesProps> = ({ currency }) => {
   const [query, setQuery] = useState({ ...baseQuery });
   const { hasAccountFilter, hasRegionFilter, hasTagFilter, report, reportError, reportFetchStatus, reportQueryString } =
     useMapToProps({
+      costType,
       currency,
       query,
     });
@@ -322,12 +324,13 @@ const Instances: React.FC<InstancesProps> = ({ currency }) => {
   );
 };
 
-const useMapToProps = ({ currency, query }): InstancesStateProps => {
+const useMapToProps = ({ costType, currency, query }): InstancesStateProps => {
   const dispatch: ThunkDispatch<RootState, any, AnyAction> = useDispatch();
   const queryFromRoute = useQueryFromRoute();
   const queryState = useQueryState('details');
 
   const reportQuery = {
+    cost_type: costType,
     currency,
     filter: {
       ...(query.filter || baseQuery.filter),
@@ -366,7 +369,7 @@ const useMapToProps = ({ currency, query }): InstancesStateProps => {
     if (!reportError && reportFetchStatus !== FetchStatus.inProgress) {
       dispatch(reportActions.fetchReport(reportPathsType, reportType, reportQueryString));
     }
-  }, [currency, query]);
+  }, [costType, currency, query]);
 
   return {
     hasAccountFilter:

--- a/src/routes/details/awsBreakdown/instances/instancesTable.tsx
+++ b/src/routes/details/awsBreakdown/instances/instancesTable.tsx
@@ -105,14 +105,12 @@ const InstancesTable: React.FC<InstancesTableProps> = ({
         name: intl.formatMessage(messages.detailsResourceNames, { value: 'vcpu' }),
         orderBy: 'vcpu',
         style: styles.managedColumn,
-        ...(computedItems.length && { isSortable: true }),
       },
       {
         id: InstanceTableColumnIds.memory,
         orderBy: 'memory',
         name: intl.formatMessage(messages.detailsResourceNames, { value: 'memory' }),
         style: styles.managedColumn,
-        ...(computedItems.length && { isSortable: true }),
       },
       {
         orderBy: 'cost',

--- a/src/routes/details/components/breakdown/breakdownBase.tsx
+++ b/src/routes/details/components/breakdown/breakdownBase.tsx
@@ -291,6 +291,7 @@ class BreakdownBase extends React.Component<BreakdownProps, BreakdownState> {
       detailsURL,
       emptyStateTitle,
       groupBy,
+      optimizationsComponent,
       providers,
       providersFetchStatus,
       providerType,
@@ -325,6 +326,7 @@ class BreakdownBase extends React.Component<BreakdownProps, BreakdownState> {
         return <NoData title={title} />;
       }
     }
+
     return (
       <>
         <BreakdownHeader
@@ -347,9 +349,9 @@ class BreakdownBase extends React.Component<BreakdownProps, BreakdownState> {
           onCurrencySelect={() => handleOnCurrencySelect(query, router, router.location.state)}
           query={query}
           report={report}
-          showCostDistribution={showCostDistribution && activeTabKey !== 2}
+          showCostDistribution={showCostDistribution && !(optimizationsComponent && activeTabKey === 2)}
           showCostType={showCostType}
-          showCurrency={activeTabKey !== 2}
+          showCurrency={!(optimizationsComponent && activeTabKey === 2)}
           tabs={this.getTabs(availableTabs)}
           tagPathsType={tagPathsType}
           title={title}

--- a/src/routes/settings/settings.tsx
+++ b/src/routes/settings/settings.tsx
@@ -212,7 +212,7 @@ const Settings: React.FC<SettingsProps> = () => {
           <div style={styles.tabs}>{getTabs(availableTabs)}</div>
         )}
       </header>
-      <div>{getTabContent(availableTabs)}</div>.
+      <div>{getTabContent(availableTabs)}</div>
     </div>
   );
 };


### PR DESCRIPTION
- COST-5464 Omit AWS details page filters from available EC2 filters
- COST-5468 Requests on EC2 page need to use cost_type param
- Include currency menu for EC2 tab
- Removed Konflux test

https://issues.redhat.com/browse/COST-5469
https://issues.redhat.com/browse/COST-5468