### PR TITLE
Add cluster/node/project group by/filtering to OCP on cloud perspectives

### DIFF
--- a/src/api/resources/awsOcpResource.ts
+++ b/src/api/resources/awsOcpResource.ts
@@ -6,6 +6,9 @@ import { ResourceType } from './resource';
 export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
   [ResourceType.account]: 'resource-types/aws-accounts/',
   [ResourceType.aws_category]: 'resource-types/aws-categories/',
+  [ResourceType.cluster]: 'resource-types/openshift-clusters/',
+  [ResourceType.node]: 'resource-types/openshift-nodes/',
+  [ResourceType.project]: 'resource-types/openshift-projects/',
   [ResourceType.region]: 'resource-types/aws-regions/',
   [ResourceType.service]: 'resource-types/aws-services/',
 };

--- a/src/api/resources/azureOcpResource.ts
+++ b/src/api/resources/azureOcpResource.ts
@@ -4,6 +4,9 @@ import type { Resource } from './resource';
 import { ResourceType } from './resource';
 
 export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
+  [ResourceType.cluster]: 'resource-types/openshift-clusters/',
+  [ResourceType.node]: 'resource-types/openshift-nodes/',
+  [ResourceType.project]: 'resource-types/openshift-projects/',
   [ResourceType.resourceLocation]: 'resource-types/azure-regions/',
   [ResourceType.subscriptionGuid]: 'resource-types/azure-subscription-guids/',
   [ResourceType.serviceName]: 'resource-types/azure-services/',

--- a/src/api/resources/gcpOcpResource.ts
+++ b/src/api/resources/gcpOcpResource.ts
@@ -5,7 +5,10 @@ import { ResourceType } from './resource';
 
 export const ResourceTypePaths: Partial<Record<ResourceType, string>> = {
   [ResourceType.account]: 'resource-types/gcp-accounts/',
+  [ResourceType.cluster]: 'resource-types/openshift-clusters/',
   [ResourceType.gcpProject]: 'resource-types/gcp-projects/',
+  [ResourceType.node]: 'resource-types/openshift-nodes/',
+  [ResourceType.project]: 'resource-types/openshift-projects/',
   [ResourceType.region]: 'resource-types/gcp-regions/',
   [ResourceType.service]: 'resource-types/gcp-services/',
 };

--- a/src/routes/explorer/explorerFilter.tsx
+++ b/src/routes/explorer/explorerFilter.tsx
@@ -21,6 +21,7 @@ import type { Filter } from 'routes/utils/filter';
 import { getRouteForQuery } from 'routes/utils/query';
 import type { FetchStatus } from 'store/common';
 import { createMapStateToProps } from 'store/common';
+import { FeatureToggleSelectors } from 'store/featureToggle';
 import { orgActions, orgSelectors } from 'store/orgs';
 import { resourceActions, resourceSelectors } from 'store/resources';
 import { tagActions, tagSelectors } from 'store/tags';
@@ -53,6 +54,7 @@ interface ExplorerFilterOwnProps extends RouterComponentProps, WrappedComponentP
 
 interface ExplorerFilterStateProps {
   dateRangeType: DateRangeType;
+  isOcpCloudGroupBysToggleEnabled?: boolean;
   orgPathsType?: OrgPathsType;
   orgQueryString?: string;
   orgReport?: Org;
@@ -120,10 +122,10 @@ export class ExplorerFilterBase extends React.Component<ExplorerFilterProps, Exp
   }
 
   private getCategoryOptions = (): ToolbarChipGroup[] => {
-    const { orgReport, perspective, intl, resourceReport, tagReport } = this.props;
+    const { orgReport, perspective, intl, isOcpCloudGroupBysToggleEnabled, resourceReport, tagReport } = this.props;
 
     const options = [];
-    const groupByOptions = getGroupByOptions(perspective);
+    const groupByOptions = getGroupByOptions(perspective, isOcpCloudGroupBysToggleEnabled);
     groupByOptions.map(option => {
       options.push({
         name: intl.formatMessage(messages.filterByValues, { value: option.label }),
@@ -326,6 +328,7 @@ const mapStateToProps = createMapStateToProps<ExplorerFilterOwnProps, ExplorerFi
 
     return {
       dateRangeType,
+      isOcpCloudGroupBysToggleEnabled: FeatureToggleSelectors.selectIsOcpCloudGroupBysToggleEnabled(state),
       orgPathsType,
       orgQueryString,
       orgReport,

--- a/src/routes/explorer/explorerHeader.tsx
+++ b/src/routes/explorer/explorerHeader.tsx
@@ -83,6 +83,7 @@ interface ExplorerHeaderStateProps {
   isExportsToggleEnabled?: boolean;
   isFinsightsToggleEnabled?: boolean;
   isIbmToggleEnabled?: boolean;
+  isOcpCloudGroupBysToggleEnabled?: boolean;
   ociProviders?: Providers;
   ocpProviders?: Providers;
   providers: Providers;
@@ -255,6 +256,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps, ExplorerHe
       groupBy,
       intl,
       isExportsToggleEnabled,
+      isOcpCloudGroupBysToggleEnabled,
       onCostDistributionSelect,
       onCostTypeSelect,
       onCurrencySelect,
@@ -277,7 +279,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps, ExplorerHe
     const noProviders =
       noAwsProviders && noAzureProviders && noGcpProviders && noIbmProviders && noOcpProviders && noRhelProviders;
 
-    const groupByOptions = getGroupByOptions(perspective);
+    const groupByOptions = getGroupByOptions(perspective, isOcpCloudGroupBysToggleEnabled);
     const orgPathsType = getOrgReportPathsType(perspective);
     const resourcePathsType = getResourcePathsType(perspective);
     const tagPathsType = getTagReportPathsType(perspective);
@@ -387,6 +389,7 @@ const mapStateToProps = createMapStateToProps<ExplorerHeaderOwnProps, ExplorerHe
       isExportsToggleEnabled: FeatureToggleSelectors.selectIsExportsToggleEnabled(state),
       isFinsightsToggleEnabled: FeatureToggleSelectors.selectIsFinsightsToggleEnabled(state),
       isIbmToggleEnabled: FeatureToggleSelectors.selectIsIbmToggleEnabled(state),
+      isOcpCloudGroupBysToggleEnabled: FeatureToggleSelectors.selectIsOcpCloudGroupBysToggleEnabled(state),
       ociProviders: filterProviders(providers, ProviderType.oci),
       ocpProviders: filterProviders(providers, ProviderType.ocp),
       providers,

--- a/src/routes/explorer/explorerUtils.ts
+++ b/src/routes/explorer/explorerUtils.ts
@@ -244,22 +244,30 @@ export const getGroupByDefault = (perspective: string) => {
   return result;
 };
 
-export const getGroupByOptions = (perspective: string) => {
+export const getGroupByOptions = (perspective: string, isOcpCloudGroupBysToggleEnabled) => {
   let result;
   switch (perspective) {
     case PerspectiveType.aws:
-    case PerspectiveType.awsOcp:
       result = groupByAwsOptions;
       break;
+    case PerspectiveType.awsOcp:
+      result = isOcpCloudGroupBysToggleEnabled ? [...groupByAwsOptions, ...groupByOcpOptions] : [...groupByAwsOptions];
+      break;
     case PerspectiveType.azure:
-    case PerspectiveType.azureOcp:
       result = groupByAzureOptions;
+      break;
+    case PerspectiveType.azureOcp:
+      result = isOcpCloudGroupBysToggleEnabled
+        ? [...groupByAzureOptions, ...groupByOcpOptions]
+        : [...groupByAzureOptions];
       break;
     case PerspectiveType.gcp:
       result = groupByGcpOptions;
       break;
     case PerspectiveType.gcpOcp:
-      result = groupByGcpOcpOptions;
+      result = isOcpCloudGroupBysToggleEnabled
+        ? [...groupByGcpOcpOptions, ...groupByOcpOptions]
+        : [...groupByGcpOcpOptions];
       break;
     case PerspectiveType.ibm:
       result = groupByIbmOptions;


### PR DESCRIPTION
Add cluster/node/project group by/filtering to OCP on cloud perspectives

- Amazon Web Services filtered by OpenShift
- Microsoft Azure filtered by OpenShift
- Google Cloud Platform filtered by OpenShift

https://issues.redhat.com/browse/COST-5514

![Screenshot 2024-09-23 at 12 12 21 PM](https://github.com/user-attachments/assets/d1341f84-3db7-43b9-a114-0ae219022321)
