### PR TITLE
EC2 page should use a common filter key for export

### DIFF
--- a/src/routes/details/awsBreakdown/instances/instances.tsx
+++ b/src/routes/details/awsBreakdown/instances/instances.tsx
@@ -135,7 +135,7 @@ const Instances: React.FC<InstancesProps> = ({ costType, currency }) => {
       <ExportModal
         count={isAllSelected ? itemsTotal : items.length}
         isAllItems={(isAllSelected || selectedItems.length === itemsTotal) && computedItems.length > 0}
-        groupBy="resource_id"
+        groupBy="instance"
         isOpen={isExportModalOpen}
         isTimeScoped
         items={items}

--- a/src/routes/details/awsBreakdown/instances/instancesTable.tsx
+++ b/src/routes/details/awsBreakdown/instances/instancesTable.tsx
@@ -202,7 +202,7 @@ const InstancesTable: React.FC<InstancesTableProps> = ({
     // There is no group by for instances, but we use it to format messages
     return (
       <Actions
-        groupBy={'resource_id'}
+        groupBy={'instance'}
         isDisabled={isDisabled}
         item={item}
         isTimeScoped


### PR DESCRIPTION
EC2 page should use a common filter key for export, in addition to filtering/excluding

https://issues.redhat.com/browse/COST-5524