### PR TITLE
Current prop

### DIFF
--- a/src/routes/components/charts/costChart/costChart.tsx
+++ b/src/routes/components/charts/costChart/costChart.tsx
@@ -70,7 +70,7 @@ class CostChartBase extends React.Component<CostChartProps, State> {
 
   public componentDidMount() {
     this.initDatum();
-    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
+    this.observer = getResizeObserver(this.containerRef?.current, this.handleResize);
   }
 
   public componentDidUpdate(prevProps: CostChartProps) {
@@ -301,7 +301,7 @@ class CostChartBase extends React.Component<CostChartProps, State> {
 
   private handleResize = () => {
     const { width } = this.state;
-    const { clientWidth = 0 } = this.containerRef.current || {};
+    const { clientWidth = 0 } = this.containerRef?.current || {};
 
     if (clientWidth !== width) {
       this.setState({ width: clientWidth });

--- a/src/routes/components/charts/costExplorerChart/costExplorerChart.tsx
+++ b/src/routes/components/charts/costExplorerChart/costExplorerChart.tsx
@@ -74,7 +74,7 @@ class CostExplorerChartBase extends React.Component<CostExplorerChartProps, Stat
 
   public componentDidMount() {
     this.initDatum();
-    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
+    this.observer = getResizeObserver(this.containerRef?.current, this.handleResize);
   }
 
   public componentDidUpdate(prevProps: CostExplorerChartProps) {
@@ -422,7 +422,7 @@ class CostExplorerChartBase extends React.Component<CostExplorerChartProps, Stat
 
   private handleResize = () => {
     const { width } = this.state;
-    const { clientWidth = 0 } = this.containerRef.current || {};
+    const { clientWidth = 0 } = this.containerRef?.current || {};
 
     if (clientWidth !== width) {
       this.setState({ width: clientWidth });

--- a/src/routes/components/charts/dailyCostChart/dailyCostChart.tsx
+++ b/src/routes/components/charts/dailyCostChart/dailyCostChart.tsx
@@ -73,7 +73,7 @@ class DailyCostChartBase extends React.Component<DailyCostChartProps, State> {
 
   public componentDidMount() {
     this.initDatum();
-    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
+    this.observer = getResizeObserver(this.containerRef?.current, this.handleResize);
   }
 
   public componentDidUpdate(prevProps: DailyCostChartProps) {
@@ -352,7 +352,7 @@ class DailyCostChartBase extends React.Component<DailyCostChartProps, State> {
 
   private handleResize = () => {
     const { width } = this.state;
-    const { clientWidth = 0 } = this.containerRef.current || {};
+    const { clientWidth = 0 } = this.containerRef?.current || {};
 
     if (clientWidth !== width) {
       this.setState({ width: clientWidth });

--- a/src/routes/components/charts/dailyTrendChart/dailyTrendChart.tsx
+++ b/src/routes/components/charts/dailyTrendChart/dailyTrendChart.tsx
@@ -76,7 +76,7 @@ class DailyTrendChartBase extends React.Component<DailyTrendChartProps, State> {
 
   public componentDidMount() {
     this.initDatum();
-    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
+    this.observer = getResizeObserver(this.containerRef?.current, this.handleResize);
   }
 
   public componentDidUpdate(prevProps: DailyTrendChartProps) {
@@ -374,7 +374,7 @@ class DailyTrendChartBase extends React.Component<DailyTrendChartProps, State> {
 
   private handleResize = () => {
     const { width } = this.state;
-    const { clientWidth = 0 } = this.containerRef.current || {};
+    const { clientWidth = 0 } = this.containerRef?.current || {};
 
     if (clientWidth !== width) {
       this.setState({ width: clientWidth });

--- a/src/routes/components/charts/historicalCostChart/historicalCostChart.tsx
+++ b/src/routes/components/charts/historicalCostChart/historicalCostChart.tsx
@@ -71,7 +71,7 @@ class HistoricalCostChartBase extends React.Component<HistoricalCostChartProps, 
 
   public componentDidMount() {
     this.initDatum();
-    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
+    this.observer = getResizeObserver(this.containerRef?.current, this.handleResize);
   }
 
   public componentDidUpdate(prevProps: HistoricalCostChartProps) {
@@ -247,7 +247,7 @@ class HistoricalCostChartBase extends React.Component<HistoricalCostChartProps, 
 
   private handleResize = () => {
     const { width } = this.state;
-    const { clientWidth = 0 } = this.containerRef.current || {};
+    const { clientWidth = 0 } = this.containerRef?.current || {};
 
     if (clientWidth !== width) {
       this.setState({ width: clientWidth });

--- a/src/routes/components/charts/historicalTrendChart/historicalTrendChart.tsx
+++ b/src/routes/components/charts/historicalTrendChart/historicalTrendChart.tsx
@@ -71,7 +71,7 @@ class HistoricalTrendChartBase extends React.Component<HistoricalTrendChartProps
 
   public componentDidMount() {
     this.initDatum();
-    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
+    this.observer = getResizeObserver(this.containerRef?.current, this.handleResize);
   }
 
   public componentDidUpdate(prevProps: HistoricalTrendChartProps) {
@@ -237,7 +237,7 @@ class HistoricalTrendChartBase extends React.Component<HistoricalTrendChartProps
 
   private handleResize = () => {
     const { width } = this.state;
-    const { clientWidth = 0 } = this.containerRef.current || {};
+    const { clientWidth = 0 } = this.containerRef?.current || {};
 
     if (clientWidth !== width) {
       this.setState({ width: clientWidth });

--- a/src/routes/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/routes/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -84,7 +84,7 @@ class HistoricalUsageChartBase extends React.Component<HistoricalUsageChartProps
 
   public componentDidMount() {
     this.initDatum();
-    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
+    this.observer = getResizeObserver(this.containerRef?.current, this.handleResize);
   }
 
   public componentDidUpdate(prevProps: HistoricalUsageChartProps) {
@@ -351,7 +351,7 @@ class HistoricalUsageChartBase extends React.Component<HistoricalUsageChartProps
 
   private handleResize = () => {
     const { width } = this.state;
-    const { clientWidth = 0 } = this.containerRef.current || {};
+    const { clientWidth = 0 } = this.containerRef?.current || {};
 
     if (clientWidth !== width) {
       this.setState({ width: clientWidth });

--- a/src/routes/components/charts/trendChart/trendChart.tsx
+++ b/src/routes/components/charts/trendChart/trendChart.tsx
@@ -73,7 +73,7 @@ class TrendChartBase extends React.Component<TrendChartProps, State> {
 
   public componentDidMount() {
     this.initDatum();
-    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
+    this.observer = getResizeObserver(this.containerRef?.current, this.handleResize);
   }
 
   public componentDidUpdate(prevProps: TrendChartProps) {
@@ -325,7 +325,7 @@ class TrendChartBase extends React.Component<TrendChartProps, State> {
 
   private handleResize = () => {
     const { width } = this.state;
-    const { clientWidth = 0 } = this.containerRef.current || {};
+    const { clientWidth = 0 } = this.containerRef?.current || {};
 
     if (clientWidth !== width) {
       this.setState({ width: clientWidth });

--- a/src/routes/components/charts/usageChart/usageChart.tsx
+++ b/src/routes/components/charts/usageChart/usageChart.tsx
@@ -69,7 +69,7 @@ class UsageChartBase extends React.Component<UsageChartProps, State> {
 
   public componentDidMount() {
     this.initDatum();
-    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
+    this.observer = getResizeObserver(this.containerRef?.current, this.handleResize);
   }
 
   public componentDidUpdate(prevProps: UsageChartProps) {
@@ -262,7 +262,7 @@ class UsageChartBase extends React.Component<UsageChartProps, State> {
 
   private handleResize = () => {
     const { width } = this.state;
-    const { clientWidth = 0 } = this.containerRef.current || {};
+    const { clientWidth = 0 } = this.containerRef?.current || {};
 
     if (clientWidth !== width) {
       this.setState({ width: clientWidth });

--- a/src/routes/details/components/pvcChart/pvcChart.tsx
+++ b/src/routes/details/components/pvcChart/pvcChart.tsx
@@ -92,7 +92,7 @@ class PvcChartBase extends React.Component<PvcChartProps, PvcChartState> {
   };
 
   public componentDidMount() {
-    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
+    this.observer = getResizeObserver(this.containerRef?.current, this.handleResize);
     this.updateReport();
   }
 
@@ -111,7 +111,7 @@ class PvcChartBase extends React.Component<PvcChartProps, PvcChartState> {
 
   private handleResize = () => {
     const { width } = this.state;
-    const { clientWidth = 0 } = this.containerRef.current || {};
+    const { clientWidth = 0 } = this.containerRef?.current || {};
 
     if (clientWidth !== width) {
       this.setState({ width: clientWidth });

--- a/src/routes/details/components/usageChart/usageChart.tsx
+++ b/src/routes/details/components/usageChart/usageChart.tsx
@@ -67,7 +67,7 @@ class UsageChartBase extends React.Component<UsageChartProps, UsageChartState> {
   };
 
   public componentDidMount() {
-    this.observer = getResizeObserver(this.containerRef.current, this.handleResize);
+    this.observer = getResizeObserver(this.containerRef?.current, this.handleResize);
     this.updateReport();
   }
 
@@ -86,7 +86,7 @@ class UsageChartBase extends React.Component<UsageChartProps, UsageChartState> {
 
   private handleResize = () => {
     const { width } = this.state;
-    const { clientWidth = 0 } = this.containerRef.current || {};
+    const { clientWidth = 0 } = this.containerRef?.current || {};
 
     if (clientWidth !== width) {
       this.setState({ width: clientWidth });

--- a/src/utils/chrome.tsx
+++ b/src/utils/chrome.tsx
@@ -32,7 +32,7 @@ export const withChrome = Component => {
 
     useLayoutEffect(() => {
       isOrgAdmin(auth).then(val => {
-        if (isMounted.current) {
+        if (isMounted?.current) {
           setOrgAdmin(val);
           setInitialized(true);
         }

--- a/src/utils/hooks.ts
+++ b/src/utils/hooks.ts
@@ -30,7 +30,7 @@ export const useStateCallback = <T>(initialState: T): [T, (state: T, cb?: (_stat
   useEffect(() => {
     // cb.current is `undefined` on initial render,
     // so we only invoke callback on state *updates*
-    if (cbRef.current) {
+    if (cbRef?.current) {
       cbRef.current(state);
       cbRef.current = undefined; // reset callback after execution
     }


### PR DESCRIPTION
The token refresh issue below shows an "u.current is null" error somewhere in Cost Management. This will ensure we check the `current` prop for any refs.

Error
<img width="673" alt="Screenshot 2024-09-28 at 1 35 17 PM" src="https://github.com/user-attachments/assets/0075be5d-f734-45e1-a7e5-0074a1bde099">

Slack
https://redhat-internal.slack.com/archives/C023VGW21NU/p1727158886930129

Token refresh issue
https://issues.redhat.com/browse/RHINENG-10155

Token refresh PR
https://github.com/RedHatInsights/insights-chrome/pull/2945