### PR TITLE
Remove onBlur

### DIFF
--- a/src/routes/components/resourceTypeahead/resourceInput.tsx
+++ b/src/routes/components/resourceTypeahead/resourceInput.tsx
@@ -64,7 +64,6 @@ const ResourceInput: React.FC<ResourceInputProps> = ({
             onChange={onChange}
             onFocus={() => setIsOpen(true)}
             onKeyDown={handleOnTextInputKeyDown}
-            onBlur={onClear}
             placeholder={placeholder}
           />
           {search && search.length && (


### PR DESCRIPTION
Adding onBlur to the resource type-ahead works as expected on Firefox, but not Chrome

https://issues.redhat.com/browse/COST-5596