### PR TITLE
Fix EC2 instances page refresh

### DIFF
--- a/src/routes/details/awsBreakdown/instances/instances.tsx
+++ b/src/routes/details/awsBreakdown/instances/instances.tsx
@@ -45,6 +45,7 @@ export interface InstancesStateProps {
   reportError: AxiosError;
   reportFetchStatus: FetchStatus;
   reportQueryString: string;
+  timeScopeValue?: number;
 }
 
 export interface InstancesMapProps {
@@ -92,12 +93,20 @@ const Instances: React.FC<InstancesProps> = ({ costType, currency }) => {
   const [selectedItems, setSelectedItems] = useState([]);
 
   const [query, setQuery] = useState({ ...baseQuery });
-  const { hasAccountFilter, hasRegionFilter, hasTagFilter, report, reportError, reportFetchStatus, reportQueryString } =
-    useMapToProps({
-      costType,
-      currency,
-      query,
-    });
+  const {
+    hasAccountFilter,
+    hasRegionFilter,
+    hasTagFilter,
+    report,
+    reportError,
+    reportFetchStatus,
+    reportQueryString,
+    timeScopeValue,
+  } = useMapToProps({
+    costType,
+    currency,
+    query,
+  });
 
   const getColumnManagementModal = () => {
     const options = cloneDeep(defaultColumnOptions);
@@ -218,6 +227,7 @@ const Instances: React.FC<InstancesProps> = ({ costType, currency }) => {
         pagination={getPagination(isDisabled)}
         query={query}
         selectedItems={selectedItems}
+        timeScopeValue={timeScopeValue}
       />
     );
   };
@@ -303,7 +313,7 @@ const Instances: React.FC<InstancesProps> = ({ costType, currency }) => {
 
   const itemsTotal = report?.meta ? report.meta.count : 0;
   const isDisabled = itemsTotal === 0;
-  const hasInstances = report?.meta && report.meta.count > 0;
+  const hasInstances = report?.meta?.count > 0;
 
   if (reportError) {
     return <NotAvailable title={intl.formatMessage(messages.optimizations)} />;
@@ -388,6 +398,7 @@ const useMapToProps = ({ costType, currency, query }): InstancesStateProps => {
     reportError,
     reportFetchStatus,
     reportQueryString,
+    timeScopeValue,
   };
 };
 

--- a/src/routes/details/awsBreakdown/instances/instancesToolbar.tsx
+++ b/src/routes/details/awsBreakdown/instances/instancesToolbar.tsx
@@ -13,11 +13,9 @@ import { DataToolbar } from 'routes/components/dataToolbar';
 import type { ComputedReportItem } from 'routes/utils/computedReport/getComputedReportItems';
 import { isEqual } from 'routes/utils/equal';
 import type { Filter } from 'routes/utils/filter';
-import { getTimeScopeValue } from 'routes/utils/timeScope';
 import type { FetchStatus } from 'store/common';
 import { createMapStateToProps } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
-import { useQueryState } from 'utils/hooks';
 import { accountKey, regionKey, tagKey } from 'utils/props';
 
 interface InstancesToolbarOwnProps {
@@ -39,6 +37,7 @@ interface InstancesToolbarOwnProps {
   pagination?: React.ReactNode;
   query?: AwsQuery;
   selectedItems?: ComputedReportItem[];
+  timeScopeValue?: number;
 }
 
 interface InstancesToolbarStateProps {
@@ -187,35 +186,33 @@ export class InstancesToolbarBase extends React.Component<InstancesToolbarProps,
   }
 }
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-const mapStateToProps = createMapStateToProps<InstancesToolbarOwnProps, InstancesToolbarStateProps>((state, props) => {
-  const queryState = useQueryState('details');
-  const timeScopeValue = getTimeScopeValue(queryState);
+const mapStateToProps = createMapStateToProps<InstancesToolbarOwnProps, InstancesToolbarStateProps>(
+  (state, { timeScopeValue }) => {
+    // Note: Omitting key_only would help to share a single, cached request. Only the toolbar requires key values;
+    // however, for better server-side performance, we chose to use key_only here.
+    const baseQuery = {
+      filter: {
+        resolution: 'monthly',
+        time_scope_units: 'month',
+        time_scope_value: timeScopeValue !== undefined ? timeScopeValue : -1,
+      },
+      key_only: true,
+      limit: 1000,
+    };
 
-  // Note: Omitting key_only would help to share a single, cached request. Only the toolbar requires key values;
-  // however, for better server-side performance, we chose to use key_only here.
-  const baseQuery = {
-    filter: {
-      resolution: 'monthly',
-      time_scope_units: 'month',
-      time_scope_value: timeScopeValue !== undefined ? timeScopeValue : -1,
-    },
-    key_only: true,
-    limit: 1000,
-  };
+    const tagQueryString = getQuery({
+      ...baseQuery,
+    });
+    const tagReport = tagSelectors.selectTag(state, tagPathsType, tagType, tagQueryString);
+    const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagPathsType, tagType, tagQueryString);
 
-  const tagQueryString = getQuery({
-    ...baseQuery,
-  });
-  const tagReport = tagSelectors.selectTag(state, tagPathsType, tagType, tagQueryString);
-  const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagPathsType, tagType, tagQueryString);
-
-  return {
-    tagReport,
-    tagReportFetchStatus,
-    tagQueryString,
-  };
-});
+    return {
+      tagReport,
+      tagReportFetchStatus,
+      tagQueryString,
+    };
+  }
+);
 
 const mapDispatchToProps: InstancesToolbarDispatchProps = {
   fetchTag: tagActions.fetchTag,

--- a/src/routes/utils/computedReport/getComputedReportItems.ts
+++ b/src/routes/utils/computedReport/getComputedReportItems.ts
@@ -319,7 +319,7 @@ export function initReportItems({ idKey, isDateMap, itemMap, report, type, val }
   const default_project = val.default_project && val.default_project.toLowerCase() === 'true';
 
   let label;
-  if (report.meta && report.meta.others && (id === 'Other' || id === 'Others')) {
+  if (report?.meta?.others && (id === 'Other' || id === 'Others')) {
     // Add count to "Others" label
     label = intl.formatMessage(messages.chartOthers, { count: report.meta.others });
   } else {

--- a/src/routes/utils/computedReport/getItemLabel.ts
+++ b/src/routes/utils/computedReport/getItemLabel.ts
@@ -8,7 +8,7 @@ export interface GetItemLabelParams {
 
 export function getItemLabel({ idKey, report, value }: GetItemLabelParams) {
   let itemLabelKey = String(idKey);
-  if (report.meta && report.meta.group_by) {
+  if (report?.meta?.group_by) {
     const group_by = report.meta.group_by;
     for (const key of Object.keys(group_by)) {
       if (key.indexOf(tagPrefix)) {


### PR DESCRIPTION
The EC2 instances page refreshes when there is no data. This change avoids using a React hook in the instances toolbar.

![Screenshot 2024-10-17 at 9 43 16 AM](https://github.com/user-attachments/assets/cdd3f1a1-1ddf-4706-bb93-36acbd3b9be8)
