### PR TITLE
Update text for EC2 empty state

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -10985,7 +10985,7 @@
     "noInstancesDesc": [
       {
         "type": 0,
-        "value": "To view the cost of EC2 instances, label your resources with the following tag and key value pair in the AWS console."
+        "value": "To view the cost of EC2 instances, label your resources with the following tag key and value pair in the AWS console."
       }
     ],
     "noInstancesMoreInfo": [

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -414,7 +414,7 @@
   "noDataStateRefresh": "Refresh this page",
   "noDataStateTitle": "Still processing the data",
   "noExportsStateTitle": "There are no export files available",
-  "noInstancesDesc": "To view the cost of EC2 instances, label your resources with the following tag and key value pair in the AWS console.",
+  "noInstancesDesc": "To view the cost of EC2 instances, label your resources with the following tag key and value pair in the AWS console.",
   "noInstancesMoreInfo": "For more information, {seeDocumentation}.",
   "noInstancesTitle": "View cost of EC2 instances",
   "noMappedTags": "No mapped tags",

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -2646,9 +2646,9 @@ export default defineMessages({
   },
   noInstancesDesc: {
     defaultMessage:
-      'To view the cost of EC2 instances, label your resources with the following tag and key value pair in the AWS console.',
+      'To view the cost of EC2 instances, label your resources with the following tag key and value pair in the AWS console.',
     description:
-      'To view the cost of EC2 instances, label your resources with the following tag and key value pair in the AWS console.',
+      'To view the cost of EC2 instances, label your resources with the following tag key and value pair in the AWS console.',
     id: 'noInstancesDesc',
   },
   noInstancesMoreInfo: {


### PR DESCRIPTION
Spoke with Stefan, Chloe, and Neil. Chloe confirmed the description text should read:

> To view the cost of EC2 instances, label your resources with the following tag key and value pair in the AWS console.