### PR TITLE
Update clamav-scan task image

### DIFF
--- a/.tekton/koku-frontend-pull-request.yaml
+++ b/.tekton/koku-frontend-pull-request.yaml
@@ -469,7 +469,7 @@ spec:
             - name: name
               value: clamav-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:747b43a12eddd40aa8ff12196767ca2648956d87d331d482e8883a7530bf4d5e
+              value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:0f7df2d188af2a18b47a927ec1502391d24a3617b04db10a6b229a983de67d08
             - name: kind
               value: task
           resolver: bundles

--- a/.tekton/koku-frontend-push.yaml
+++ b/.tekton/koku-frontend-push.yaml
@@ -466,7 +466,7 @@ spec:
             - name: name
               value: clamav-scan
             - name: bundle
-              value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:747b43a12eddd40aa8ff12196767ca2648956d87d331d482e8883a7530bf4d5e
+              value: quay.io/konflux-ci/tekton-catalog/task-clamav-scan:0.1@sha256:0f7df2d188af2a18b47a927ec1502391d24a3617b04db10a6b229a983de67d08
             - name: kind
               value: task
           resolver: bundles


### PR DESCRIPTION
Update the image used by the clamav task. This may fix the timeout issue we were seeing.