### PR TITLE
Normalize numeric values for API requests

### DIFF
--- a/src/routes/settings/costModels/components/rateForm/hasDiff.ts
+++ b/src/routes/settings/costModels/components/rateForm/hasDiff.ts
@@ -1,4 +1,5 @@
 import type { Rate } from 'api/rates';
+import { formatCurrencyRateRaw } from 'utils/format';
 
 import type { RateFormData } from './utils';
 
@@ -23,7 +24,8 @@ export function hasDiff(rate: Rate, rateFormData: RateFormData): boolean {
     return true;
   }
   if (rateKind === 'regular') {
-    if (Number(rate.tiered_rates[0].value) !== Number(rateFormData.tieredRates[0].value)) {
+    const value = formatCurrencyRateRaw(rate.tiered_rates[0].value, rate.tiered_rates[0].unit);
+    if (value !== rateFormData.tieredRates[0].value) {
       return true;
     }
   }
@@ -38,9 +40,10 @@ export function hasDiff(rate: Rate, rateFormData: RateFormData): boolean {
     const hasTagValuesDiff = tr.tag_values.some((tvalue, ix) => {
       const cur = rateFormData.taggingRates.tagValues[ix];
       const isCurDefault = rateFormData.taggingRates.defaultTag === ix;
+      const value = formatCurrencyRateRaw(tvalue.value, tvalue.unit);
       return (
         tvalue.tag_value !== cur.tagValue ||
-        Number(tvalue.value) !== Number(cur.inputValue) ||
+        value !== cur.value ||
         tvalue.description !== cur.description ||
         tvalue.default !== isCurDefault
       );

--- a/src/routes/settings/costModels/components/rateForm/rateForm.tsx
+++ b/src/routes/settings/costModels/components/rateForm/rateForm.tsx
@@ -46,7 +46,7 @@ const RateFormBase: React.FC<RateFormProps> = ({ currencyUnits, intl = defaultIn
       tagValues,
     },
     tieredRates: {
-      0: { inputValue, isDirty: regularDirty },
+      0: { value: tagValue, isDirty: regularDirty },
     },
     toggleTaggingRate,
     updateDefaultTag,
@@ -198,7 +198,7 @@ const RateFormBase: React.FC<RateFormProps> = ({ currencyUnits, intl = defaultIn
               onChange={(_evt, value) => setRegular(value)}
               style={style}
               validated={errors.tieredRates && regularDirty ? 'error' : 'default'}
-              value={inputValue}
+              value={tagValue}
             />
           ) : (
             <>

--- a/src/routes/settings/costModels/components/rateForm/taggingRatesForm.tsx
+++ b/src/routes/settings/costModels/components/rateForm/taggingRatesForm.tsx
@@ -67,7 +67,7 @@ const TaggingRatesFormBase: React.FC<TaggingRatesFormProps> = ({
                 onChange={(_evt, value) => updateTag({ value }, ix)}
                 style={style}
                 validated={tagValues[ix].isDirty && errors.tagValues[ix] ? 'error' : 'default'}
-                value={tag.inputValue}
+                value={tag.value}
               />
             </SplitItem>
             <SplitItem>

--- a/src/routes/settings/costModels/components/rateForm/useRateForm.tsx
+++ b/src/routes/settings/costModels/components/rateForm/useRateForm.tsx
@@ -1,13 +1,12 @@
 import type { MetricHash } from 'api/metrics';
 import type { Rate } from 'api/rates';
 import React from 'react';
-import { unFormat } from 'utils/format';
 
 import { textHelpers } from './constants';
 import type { RateFormData, RateFormTagValue } from './utils';
 import {
   descriptionErrors,
-  initialtaggingRates,
+  initialTaggingRates,
   isDuplicateTagRate,
   OtherTierFromRate,
   OtherTierFromRateForm,
@@ -123,8 +122,7 @@ export function rateFormReducer(state = initialRateFormData, action: Actions) {
         tieredRates: [
           {
             isDirty: true,
-            inputValue: action.value,
-            value: unFormat(action.value), // Normalize for API requests where USD decimal format is expected
+            value: action.value,
           },
         ],
         errors: {
@@ -199,8 +197,7 @@ export function rateFormReducer(state = initialRateFormData, action: Actions) {
               ...state.taggingRates.tagValues[action.index],
               ...action.payload,
               ...(action.payload.value !== undefined && {
-                inputValue: action.payload.value, // Original user input
-                value: unFormat(action.payload.value), // Normalize for API requests where USD decimal format is expected
+                value: action.payload.value,
               }),
               isDirty,
               isTagValueDirty,
@@ -275,7 +272,7 @@ export function rateFormReducer(state = initialRateFormData, action: Actions) {
         },
         taggingRates: {
           ...state.taggingRates,
-          tagValues: [...state.taggingRates.tagValues, { ...initialtaggingRates.tagValues[0] }],
+          tagValues: [...state.taggingRates.tagValues, { ...initialTaggingRates.tagValues[0] }],
         },
       };
     }
@@ -292,6 +289,7 @@ export type UseRateData = ReturnType<typeof useRateData>;
 
 export function useRateData(metricsHash: MetricHash, rate: Rate = undefined, tiers: Rate[] = []) {
   const initial = genFormDataFromRate(rate, undefined, tiers);
+
   const [state, dispatch] = React.useReducer(rateFormReducer, initial);
   return {
     ...state,

--- a/src/routes/settings/costModels/costModel/updateMarkupDialog.tsx
+++ b/src/routes/settings/costModels/costModel/updateMarkupDialog.tsx
@@ -107,7 +107,7 @@ class UpdateMarkupDialogBase extends React.Component<UpdateMarkupDialogProps, Up
 
     const helpText = this.markupValidator();
     const validated = helpText ? 'error' : 'default';
-    const markup = `${isDiscount ? '-' : ''}${unFormat(this.state.markup)}`;
+    const markup = `${isDiscount ? '-' : ''}${this.state.markup}`;
 
     return (
       <Modal
@@ -125,7 +125,7 @@ class UpdateMarkupDialogBase extends React.Component<UpdateMarkupDialogProps, Up
                 source_uuids: current.sources.map(provider => provider.uuid),
                 source_type: current.source_type === 'OpenShift Container Platform' ? 'OCP' : 'AWS',
                 markup: {
-                  value: markup,
+                  value: unFormat(markup),
                   unit: 'percent',
                 },
               };

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -36,11 +36,12 @@ export const formatCurrency: Formatter = (value: number, units: string, options:
     fValue = 0;
   }
   // Don't specify default fraction digits here, rely on react-intl instead
-  return intl.formatNumber(fValue, {
+  const test = intl.formatNumber(fValue, {
     style: 'currency',
     currency: units ? units.toUpperCase() : 'USD',
     ...options,
   });
+  return test;
 };
 
 export const formatCurrencyAbbreviation: Formatter = (value, units = 'USD') => {
@@ -116,8 +117,10 @@ export const formatCurrencyRaw: Formatter = (value: number, units: string, optio
     ...options,
   } as any)
     .toString()
+    .trim()
     .replace(units, '')
-    .trim();
+    .replace(/\u202f/g, '') // Small non-breaking space for group separator
+    .replace(/\xa0/g, ''); // Non-breaking space before currency
 };
 
 // Returns formatted units or currency with given currency-code
@@ -167,7 +170,11 @@ export const formatPercentageMarkup: PercentageFormatter = (
     maximumFractionDigits: 10,
   }
 ) => {
-  return value.toLocaleString(getLocale(), options);
+  return value
+    .toLocaleString(getLocale(), options)
+    .trim()
+    .replace(/\u202f/g, '') // Small non-breaking space for group separator
+    .replace(/\xa0/g, ''); // Non-breaking space before currency;
 };
 
 // Format optimization metrics
@@ -200,14 +207,14 @@ export const isCurrencyFormatValid = (value: string) => {
   // \d* The number can then have any number of any digits
   // (...)$ look at the next group from the end (...)$
   // (...)*(...)? Look for groups optionally. The first is for the comma, the second is for the decimal.
-  // (,\d{3}){1} Look for one occurrence of a comma followed by exactly three digits
-  // \.\d Look for a decimal followed by any number of any digits
+  // (,\d{3})* Look for one or more occurrences of a comma followed by three digits
+  // \.\d* Look for a decimal followed by any number of any digits
   //
-  // See https://stackoverflow.com/questions/2227370/currency-validation
-  const regex =
-    decimalSeparator === '.' ? /^-?[0-9]\d*(((,\d{3}){1})*(\.\d*)?)$/ : /^-?[0-9]\d*(((\.\d{3}){1})*(,\d*)?)$/;
+  // Based on https://stackoverflow.com/questions/2227370/currency-validation
+  const regex = decimalSeparator === ',' ? /^-?[0-9]\d*((\.\d{3})*(,\d*)?)$/ : /^-?[0-9]\d*((,\d{3})*(\.\d*)?)$/;
 
-  return regex.test(value);
+  const test = regex.test(value);
+  return test;
 };
 
 // Returns true if given percentage is valid for current locale
@@ -226,13 +233,17 @@ export const unFormat = (value: string) => {
   if (!value) {
     return value;
   }
-  const groupSeparator = intl.formatNumber(1111).toString().replace(/1/g, '');
+
   const decimalSeparator = intl.formatNumber(1.1).toString().replace(/1/g, '');
 
-  let rawValue = value.toString().replace(groupSeparator === ',' ? /,/g : /\./g, '');
-  rawValue = rawValue.replace(decimalSeparator === '.' ? /\./g : /,/g, '.');
-
-  return Number.isNaN(rawValue) ? '0' : rawValue;
+  let rawValue = value.toString();
+  if (decimalSeparator === ',') {
+    rawValue = rawValue.replace(/\./g, ''); // Remove group separator
+    rawValue = rawValue.replace(/,/g, '.'); // Replace decimal separator
+  } else {
+    rawValue = rawValue.replace(/,/g, ''); // Remove group separator
+  }
+  return rawValue;
 };
 
 const unknownTypeFormatter = (value: number, options: FormatOptions) => {


### PR DESCRIPTION
Normalize numeric values for API requests where USD decimal format is expected. The cost model API cannot handle special characters such as commas.

https://issues.redhat.com/browse/COST-5682