### PR TITLE
Group-by should refresh with dateRange selection

### DIFF
--- a/src/routes/components/groupBy/groupBy.tsx
+++ b/src/routes/components/groupBy/groupBy.tsx
@@ -30,6 +30,7 @@ import { GroupByOrg } from './groupByOrg';
 import { GroupBySelect } from './groupBySelect';
 
 interface GroupByOwnProps extends RouterComponentProps, WrappedComponentProps {
+  dateRangeType?: string;
   endDate?: string;
   getIdKeyForGroupBy: (groupBy: Query['group_by']) => string;
   groupBy?: string;
@@ -122,8 +123,12 @@ class GroupByBase extends React.Component<GroupByProps, GroupByState> {
   }
 
   public componentDidUpdate(prevProps: GroupByProps) {
-    const { groupBy, perspective } = this.props;
-    if (prevProps.groupBy !== groupBy || prevProps.perspective !== perspective) {
+    const { dateRangeType, groupBy, perspective } = this.props;
+    if (
+      prevProps.groupBy !== groupBy ||
+      prevProps.perspective !== perspective ||
+      prevProps.dateRangeType !== dateRangeType
+    ) {
       let options;
       if (prevProps.perspective !== perspective) {
         options = {

--- a/src/routes/details/awsDetails/detailsHeader.tsx
+++ b/src/routes/details/awsDetails/detailsHeader.tsx
@@ -157,6 +157,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, any> {
             <Flex style={isAccountInfoDetailsToggleEnabled ? undefined : styles.perspective}>
               <FlexItem>
                 <GroupBy
+                  dateRangeType={currentDateRangeType}
                   getIdKeyForGroupBy={getIdKeyForGroupBy}
                   groupBy={groupBy}
                   isDisabled={!showContent}

--- a/src/routes/details/azureDetails/detailsHeader.tsx
+++ b/src/routes/details/azureDetails/detailsHeader.tsx
@@ -141,6 +141,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, any> {
             <Flex>
               <FlexItem style={isAccountInfoDetailsToggleEnabled ? undefined : styles.perspective}>
                 <GroupBy
+                  dateRangeType={currentDateRangeType}
                   getIdKeyForGroupBy={getIdKeyForGroupBy}
                   groupBy={groupBy}
                   isDisabled={!showContent}

--- a/src/routes/details/gcpDetails/detailsHeader.tsx
+++ b/src/routes/details/gcpDetails/detailsHeader.tsx
@@ -142,6 +142,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, any> {
             <Flex>
               <FlexItem style={isAccountInfoDetailsToggleEnabled ? undefined : styles.perspective}>
                 <GroupBy
+                  dateRangeType={currentDateRangeType}
                   getIdKeyForGroupBy={getIdKeyForGroupBy}
                   groupBy={groupBy}
                   isDisabled={!showContent}

--- a/src/routes/details/ibmDetails/detailsHeader.tsx
+++ b/src/routes/details/ibmDetails/detailsHeader.tsx
@@ -142,6 +142,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, any> {
             <Flex>
               <FlexItem style={isAccountInfoDetailsToggleEnabled ? undefined : styles.perspective}>
                 <GroupBy
+                  dateRangeType={currentDateRangeType}
                   getIdKeyForGroupBy={getIdKeyForGroupBy}
                   groupBy={groupBy}
                   isDisabled={!showContent}

--- a/src/routes/details/ociDetails/detailsHeader.tsx
+++ b/src/routes/details/ociDetails/detailsHeader.tsx
@@ -141,6 +141,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, any> {
             <Flex>
               <FlexItem style={isAccountInfoDetailsToggleEnabled ? undefined : styles.perspective}>
                 <GroupBy
+                  dateRangeType={currentDateRangeType}
                   getIdKeyForGroupBy={getIdKeyForGroupBy}
                   groupBy={groupBy}
                   isDisabled={!showContent}

--- a/src/routes/details/ocpDetails/detailsHeader.tsx
+++ b/src/routes/details/ocpDetails/detailsHeader.tsx
@@ -172,6 +172,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps, DetailsHeade
             <Flex style={isAccountInfoDetailsToggleEnabled ? undefined : styles.perspective}>
               <FlexItem>
                 <GroupBy
+                  dateRangeType={currentDateRangeType}
                   getIdKeyForGroupBy={getIdKeyForGroupBy}
                   groupBy={groupBy}
                   isDisabled={!showContent}

--- a/src/routes/details/rhelDetails/detailsHeader.tsx
+++ b/src/routes/details/rhelDetails/detailsHeader.tsx
@@ -165,6 +165,7 @@ class DetailsHeaderBase extends React.Component<DetailsHeaderProps> {
             <Flex>
               <FlexItem style={isAccountInfoDetailsToggleEnabled ? undefined : styles.perspective}>
                 <GroupBy
+                  dateRangeType={currentDateRangeType}
                   getIdKeyForGroupBy={getIdKeyForGroupBy}
                   groupBy={groupBy}
                   isDisabled={!showContent}

--- a/src/routes/explorer/explorerHeader.tsx
+++ b/src/routes/explorer/explorerHeader.tsx
@@ -320,6 +320,7 @@ class ExplorerHeaderBase extends React.Component<ExplorerHeaderProps, ExplorerHe
               <FlexItem>{this.getPerspective(noProviders)}</FlexItem>
               <FlexItem>
                 <GroupBy
+                  dateRangeType={dateRangeType}
                   endDate={endDate}
                   getIdKeyForGroupBy={getIdKeyForGroupBy}
                   groupBy={groupBy}


### PR DESCRIPTION
Group-by dropdown on Details pages lacks Tag option with Previous month view

https://issues.redhat.com/browse/COST-5753