### PR TITLE
UI should display decimals for Cost Explorer y-axis label

### DIFF
--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -72,7 +72,7 @@ export const formatCurrencyAbbreviation: Formatter = (value, units = 'USD') => {
       symbol,
       value: formatCurrency(fValue / val, units, {
         minimumFractionDigits: 0,
-        maximumFractionDigits: 0,
+        maximumFractionDigits: 2,
       }),
     }) as string;
   }


### PR DESCRIPTION
Modified y-axis label to show up to 2 decimal places

https://issues.redhat.com/browse/COST-5829