### PR TITLE
Sankey Diagram: Simplify cost breakdown and overhead representation

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -891,6 +891,12 @@
         "value": "day"
       }
     ],
+    "chartDestination": [
+      {
+        "type": 0,
+        "value": "Destination"
+      }
+    ],
     "chartLimitLabel": [
       {
         "type": 0,
@@ -997,6 +1003,12 @@
       {
         "type": 0,
         "value": ")"
+      }
+    ],
+    "chartSource": [
+      {
+        "type": 0,
+        "value": "Source"
       }
     ],
     "chartSupplementaryCostLabel": [
@@ -13450,6 +13462,12 @@
         "value": "Filter by metrics"
       }
     ],
+    "totalCost": [
+      {
+        "type": 0,
+        "value": "Total cost"
+      }
+    ],
     "typeaheadAriaClear": [
       {
         "type": 0,
@@ -13943,6 +13961,12 @@
       {
         "type": 0,
         "value": "Distribute unused and non-reserved resource costs to projects"
+      }
+    ],
+    "workloadCost": [
+      {
+        "type": 0,
+        "value": "Workload cost"
       }
     ],
     "yes": [

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -51,6 +51,7 @@
   "chartDataOutLabelNoData": "Data out (no data)",
   "chartDataOutTooltip": "Data out ({month})",
   "chartDayOfTheMonth": "Day {day}",
+  "chartDestination": "Destination",
   "chartLimitLabel": "Limit ({dateRange})",
   "chartLimitLabelNoData": "Limit (no data)",
   "chartLimitTooltip": "Limit ({month})",
@@ -59,6 +60,7 @@
   "chartRequestsLabel": "Requests ({dateRange})",
   "chartRequestsLabelNoData": "Requests (no data)",
   "chartRequestsTooltip": "Requests ({month})",
+  "chartSource": "Source",
   "chartSupplementaryCostLabel": "Supplementary cost ({dateRange})",
   "chartSupplementaryCostLabelNoData": "Supplementary cost (no data)",
   "chartSupplementaryCostTooltip": "Supplementary cost ({month})",
@@ -670,6 +672,7 @@
   "toolBarBulkSelectPage": "Select page ({value} items)",
   "toolBarPriceListMeasurementPlaceHolder": "Filter by measurements",
   "toolBarPriceListMetricPlaceHolder": "Filter by metrics",
+  "totalCost": "Total cost",
   "typeaheadAriaClear": "Clear button and input",
   "unitTooltips": "{units, select, byte_ms {{value} Byte-ms} cluster_month {cluster-month} core_hours {{value} core-hours} gb {{value} GB} gb_hours {{value} GB-hours} gb_month {{value} GB-month} gb_ms {{value} GB-ms} gib {{value} GiB} gib_hours {{value} GiB-hours} gib_month {{value} GiB-month} gibibyte_month {{value} GiB-month} hour {{value} hours} hrs {{value} hours} ms {{value} milliseconds} pvc_month {PVC-month} tag_month {{value} tag-month} vm_hours {{value} VM-hours} other {{value}}}",
   "units": "{units, select, byte_ms {Byte-ms} cluster_month {cluster-month} core {core} core_hours {core-hours} gb {GB} gb_hours {GB-hours} gb_month {GB-month} gb_ms {GB-ms} gib {GiB} gib_hours {GiB-hours} gib_month {GiB-month} gibibyte_month {GiB-month} hour {hours} hrs {hours} ms {milliseconds} pvc_month {PVC-month} tag_month {tag-month} vm_hours {VM-hours} other {}}",
@@ -690,5 +693,6 @@
   "volumeTitle": "Volume",
   "workerUnallocated": "Worker unallocated",
   "workerUnallocatedDesc": "Distribute unused and non-reserved resource costs to projects",
+  "workloadCost": "Workload cost",
   "yes": "Yes"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "@unleash/proxy-client-react": "^5.0.0",
         "axios": "^1.8.4",
         "date-fns": "^4.1.0",
+        "echarts": "^5.6.0",
         "js-file-download": "^0.4.12",
         "lodash": "^4.17.21",
         "qs": "^6.14.0",
@@ -7082,6 +7083,22 @@
       "dependencies": {
         "safe-buffer": "^5.0.1"
       }
+    },
+    "node_modules/echarts": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/echarts/-/echarts-5.6.0.tgz",
+      "integrity": "sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "2.3.0",
+        "zrender": "5.6.1"
+      }
+    },
+    "node_modules/echarts/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     },
     "node_modules/ee-first": {
       "version": "1.1.1",
@@ -18319,6 +18336,21 @@
       "engines": {
         "node": ">=10"
       }
+    },
+    "node_modules/zrender": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/zrender/-/zrender-5.6.1.tgz",
+      "integrity": "sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tslib": "2.3.0"
+      }
+    },
+    "node_modules/zrender/node_modules/tslib": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
+      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==",
+      "license": "0BSD"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "@unleash/proxy-client-react": "^5.0.0",
     "axios": "^1.8.4",
     "date-fns": "^4.1.0",
+    "echarts": "^5.6.0",
     "js-file-download": "^0.4.12",
     "lodash": "^4.17.21",
     "qs": "^6.14.0",

--- a/src/components/featureToggle/featureToggle.tsx
+++ b/src/components/featureToggle/featureToggle.tsx
@@ -9,6 +9,7 @@ export const enum FeatureToggle {
   accountInfoEmptyState = 'cost-management.ui.account-info-empty-state', // https://issues.redhat.com/browse/COST-5335
   awsEc2Instances = 'cost-management.ui.aws-ec2-instances', // https://issues.redhat.com/browse/COST-4855
   chartSkeleton = 'cost-management.ui.chart-skeleton', // https://issues.redhat.com/browse/COST-5573
+  costBreakdownChart = 'cost-management.ui.cost-breakdown-chart', // https://issues.redhat.com/browse/COST-5852
   debug = 'cost-management.ui.debug',
   detailsDateRange = 'cost-management.ui.details-date-range', // https://issues.redhat.com/browse/COST-5563
   exports = 'cost-management.ui.exports', // Async exports https://issues.redhat.com/browse/COST-2223
@@ -38,6 +39,10 @@ export const useIsAwsEc2InstancesToggleEnabled = () => {
 
 export const useIsChartSkeletonToggleEnabled = () => {
   return useIsToggleEnabled(FeatureToggle.chartSkeleton);
+};
+
+export const useIsCostBreakdownChartToggleEnabled = () => {
+  return useIsToggleEnabled(FeatureToggle.costBreakdownChart);
 };
 
 export const useIsDebugToggleEnabled = () => {
@@ -81,6 +86,7 @@ export const useFeatureToggle = () => {
   const isAccountInfoEmptyStateToggleEnabled = useIsAccountInfoEmptyStateToggleEnabled();
   const isAwsEc2InstancesToggleEnabled = useIsAwsEc2InstancesToggleEnabled();
   const isChartSkeletonToggleEnabled = useIsChartSkeletonToggleEnabled();
+  const isCostBreakdownChartToggleEnabled = useIsCostBreakdownChartToggleEnabled();
   const isDebugToggleEnabled = useIsDebugToggleEnabled();
   const isDetailsDateRangeToggleEnabled = useIsDetailsDateRangeToggleEnabled();
   const isExportsToggleEnabled = useIsExportsToggleEnabled();
@@ -104,6 +110,7 @@ export const useFeatureToggle = () => {
         isAccountInfoEmptyStateToggleEnabled,
         isAwsEc2InstancesToggleEnabled,
         isChartSkeletonToggleEnabled,
+        isCostBreakdownChartToggleEnabled,
         isDebugToggleEnabled,
         isDetailsDateRangeToggleEnabled,
         isExportsToggleEnabled,
@@ -123,6 +130,7 @@ export const useFeatureToggle = () => {
     isAccountInfoEmptyStateToggleEnabled,
     isAwsEc2InstancesToggleEnabled,
     isChartSkeletonToggleEnabled,
+    isCostBreakdownChartToggleEnabled,
     isDebugToggleEnabled,
     isDetailsDateRangeToggleEnabled,
     isExportsToggleEnabled,

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -305,6 +305,11 @@ export default defineMessages({
     description: 'The day of the month',
     id: 'chartDayOfTheMonth',
   },
+  chartDestination: {
+    defaultMessage: 'Destination',
+    description: 'Destination',
+    id: 'chartDestination',
+  },
   chartLimitLabel: {
     defaultMessage: 'Limit ({dateRange})',
     description: 'Limit (Jan 1-31)',
@@ -344,6 +349,11 @@ export default defineMessages({
     defaultMessage: 'Requests ({month})',
     description: 'Requests (Jan)',
     id: 'chartRequestsTooltip',
+  },
+  chartSource: {
+    defaultMessage: 'Source',
+    description: 'Source',
+    id: 'chartSource',
   },
   chartSupplementaryCostLabel: {
     defaultMessage: 'Supplementary cost ({dateRange})',
@@ -4038,6 +4048,11 @@ export default defineMessages({
     description: 'Filter by metrics',
     id: 'toolBarPriceListMetricPlaceHolder',
   },
+  totalCost: {
+    defaultMessage: 'Total cost',
+    description: 'Total cost',
+    id: 'totalCost',
+  },
   typeaheadAriaClear: {
     defaultMessage: 'Clear button and input',
     description: 'Clear button and input',
@@ -4176,6 +4191,11 @@ export default defineMessages({
     defaultMessage: 'Distribute unused and non-reserved resource costs to projects',
     description: 'Distribute unused and non-reserved resource costs to projects',
     id: 'workerUnallocatedDesc',
+  },
+  workloadCost: {
+    defaultMessage: 'Workload cost',
+    description: 'Workload cost',
+    id: 'workloadCost',
   },
   yes: {
     defaultMessage: 'Yes',

--- a/src/routes/details/components/costBreakdownChart/costBreakdownChart.styles.ts
+++ b/src/routes/details/components/costBreakdownChart/costBreakdownChart.styles.ts
@@ -1,0 +1,8 @@
+import t_global_font_weight_body_bold_legacy from '@patternfly/react-tokens/dist/js/t_global_font_weight_body_bold_legacy';
+
+export const chartStyles = {
+  chartHeight: 400,
+  subTitle: {
+    fontWeight: t_global_font_weight_body_bold_legacy.value as any,
+  },
+};

--- a/src/routes/details/components/costBreakdownChart/costBreakdownChart.tsx
+++ b/src/routes/details/components/costBreakdownChart/costBreakdownChart.tsx
@@ -1,0 +1,429 @@
+import 'routes/components/charts/common/chart.scss';
+
+import { Charts, ThemeColor } from '@patternfly/react-charts/echarts';
+import { Switch } from '@patternfly/react-core';
+import type { Report } from 'api/reports/report';
+import { SankeyChart } from 'echarts/charts';
+import { TitleComponent, TooltipComponent } from 'echarts/components';
+import * as echarts from 'echarts/core';
+import { SVGRenderer } from 'echarts/renderers';
+import messages from 'locales/messages';
+import React from 'react';
+import type { WrappedComponentProps } from 'react-intl';
+import { injectIntl } from 'react-intl';
+import { ComputedReportItemValueType, getResizeObserver } from 'routes/components/charts/common';
+import { noop } from 'routes/utils/noop';
+import type { reportActions } from 'store/reports';
+import { formatCurrency } from 'utils/format';
+
+import { chartStyles } from './costBreakdownChart.styles';
+
+// Register required components
+echarts.use([SankeyChart, SVGRenderer, TitleComponent, TooltipComponent]);
+
+interface CostBreakdownChartOwnProps {
+  costDistribution?: string;
+  id?: string;
+  report?: Report;
+}
+
+interface CostBreakdownChartStateProps {
+  data?: any[];
+  isChecked?: boolean;
+  links?: any[];
+  units?: string;
+  width?: number;
+}
+
+interface CostBreakdownChartDispatchProps {
+  fetchReport?: typeof reportActions.fetchReport;
+}
+
+type CostBreakdownChartProps = CostBreakdownChartOwnProps &
+  CostBreakdownChartStateProps &
+  CostBreakdownChartDispatchProps &
+  WrappedComponentProps;
+
+class CostBreakdownChartBase extends React.Component<CostBreakdownChartProps, any> {
+  private containerRef = React.createRef<HTMLDivElement>();
+  private observer: any = noop;
+
+  public state: CostBreakdownChartStateProps = {
+    isChecked: false,
+    units: 'USD',
+    width: 0,
+  };
+
+  public componentDidMount() {
+    this.observer = getResizeObserver(this.containerRef?.current, this.handleResize);
+    this.initDatum();
+  }
+
+  public componentDidUpdate(prevProps: CostBreakdownChartProps, prevState: CostBreakdownChartStateProps) {
+    if (
+      prevProps.costDistribution !== this.props.costDistribution ||
+      prevProps.report !== this.props.report ||
+      prevState.isChecked !== this.state.isChecked
+    ) {
+      this.initDatum();
+    }
+  }
+
+  public componentWillUnmount() {
+    if (this.observer) {
+      this.observer();
+    }
+  }
+
+  private getSkeleton = () => {
+    const { id } = this.props;
+    const { width } = this.state;
+
+    const data = [
+      {
+        name: 'raw',
+      },
+      {
+        name: 'markup',
+      },
+      {
+        name: 'usage',
+      },
+      {
+        name: 'networkUnattributedDistributed',
+      },
+      {
+        name: 'platformDistributed',
+      },
+      {
+        name: 'storageUnattributedDistributed',
+      },
+      {
+        name: 'workerUnallocated',
+      },
+      {
+        name: 'workloadCost',
+      },
+      {
+        name: 'overheadCost',
+      },
+      {
+        name: 'totalCost',
+      },
+    ];
+
+    const links = [
+      {
+        source: 'markup',
+        target: 'workloadCost',
+        value: 10,
+      },
+      {
+        source: 'raw',
+        target: 'workloadCost',
+        value: 20,
+      },
+      {
+        source: 'usage',
+        target: 'workloadCost',
+        value: 30,
+      },
+      {
+        source: 'networkUnattributedDistributed',
+        target: 'overheadCost',
+        value: 10,
+      },
+      {
+        source: 'platformDistributed',
+        target: 'overheadCost',
+        value: 20,
+      },
+      {
+        source: 'storageUnattributedDistributed',
+        target: 'overheadCost',
+        value: 30,
+      },
+      {
+        source: 'workerUnallocated',
+        target: 'overheadCost',
+        value: 40,
+      },
+      {
+        source: 'workloadCost',
+        target: 'totalCost',
+        value: 60,
+      },
+      {
+        source: 'overheadCost',
+        target: 'totalCost',
+        value: 100,
+      },
+      {
+        source: 'totalCost',
+        value: 160,
+      },
+    ];
+
+    return (
+      <Charts
+        height={chartStyles.chartHeight}
+        id={`${id}-skeleton`}
+        option={{
+          series: [
+            {
+              bottom: 25,
+              data,
+              left: 25,
+              links,
+              right: 75,
+              top: 25,
+              type: 'sankey',
+            },
+          ],
+        }}
+        themeColor={ThemeColor.skeleton}
+        width={width}
+      />
+    );
+  };
+
+  private handleChange = (_event, checked: boolean) => {
+    this.setState({ isChecked: checked });
+  };
+
+  private handleResize = () => {
+    const { width } = this.state;
+    const { clientWidth = 0 } = this.containerRef?.current || {};
+
+    if (clientWidth !== width) {
+      this.setState({ width: clientWidth });
+    }
+  };
+
+  private initDatum = () => {
+    const { costDistribution, report, intl } = this.props;
+    const { isChecked } = this.state;
+
+    if (!report) {
+      return;
+    }
+
+    const hasMarkup = report?.meta?.total?.cost?.markup;
+    const hasNetworkUnattributedDistributed =
+      report?.meta?.total?.cost?.network_unattributed_distributed &&
+      costDistribution === ComputedReportItemValueType.distributed;
+    const hasPlatformDistributed =
+      report?.meta?.total?.cost?.platform_distributed && costDistribution === ComputedReportItemValueType.distributed;
+    const hasRaw = report?.meta?.total?.cost?.raw;
+    const hasStorageUnattributedDistributed =
+      report?.meta?.total?.cost?.storage_unattributed_distributed &&
+      costDistribution === ComputedReportItemValueType.distributed;
+    const hasUsage = report?.meta?.total?.cost?.usage;
+    const hasWorkerUnallocated =
+      report?.meta?.total?.cost?.worker_unallocated_distributed &&
+      costDistribution === ComputedReportItemValueType.distributed;
+    const hasCostTotal = report?.meta?.total?.cost?.[costDistribution];
+
+    const markupValue = hasMarkup ? report.meta.total.cost.markup.value : 0;
+    const networkUnattributedDistributedValue =
+      hasNetworkUnattributedDistributed && report.meta.total.cost.network_unattributed_distributed.value > 0
+        ? report.meta.total.cost.network_unattributed_distributed.value
+        : 0;
+    const platformDistributedValue =
+      hasPlatformDistributed && report.meta.total.cost.platform_distributed.value > 0
+        ? report.meta.total.cost.platform_distributed.value
+        : 0;
+    const rawValue = hasRaw ? report.meta.total.cost.raw.value : 0;
+    const storageUnattributedDistributedValue =
+      hasStorageUnattributedDistributed && report.meta.total.cost.storage_unattributed_distributed.value > 0
+        ? report.meta.total.cost.storage_unattributed_distributed.value
+        : 0;
+    const totalCostValue = hasCostTotal ? report.meta.total.cost[costDistribution].value : 0;
+    const workerUnallocatedValue =
+      hasWorkerUnallocated && report.meta.total.cost.worker_unallocated_distributed.value > 0
+        ? report.meta.total.cost.worker_unallocated_distributed.value
+        : 0;
+    const usageValue = hasUsage ? report.meta.total.cost.usage.value : 0;
+
+    const markupLabel = intl.formatMessage(messages.markupTitle);
+    const networkUnattributedDistributedLabel = intl.formatMessage(messages.networkUnattributedDistributed);
+    const overheadCostLabel = intl.formatMessage(messages.costDistributionLabel);
+    const platformDistributedLabel = intl.formatMessage(messages.platformDistributed);
+    const rawLabel = intl.formatMessage(messages.rawCostTitle);
+    const storageUnattributedDistributedLabel = intl.formatMessage(messages.storageUnattributedDistributed);
+    const totalCostLabel = intl.formatMessage(messages.totalCost);
+    const usageLabel = intl.formatMessage(messages.usageCostTitle);
+    const workerUnallocatedLabel = intl.formatMessage(messages.workerUnallocated);
+    const workloadCostLabel = intl.formatMessage(messages.workloadCost);
+
+    const units = hasCostTotal ? report.meta.total.cost[costDistribution].units : 'USD';
+
+    const data = [
+      {
+        name: rawLabel,
+      },
+      {
+        name: markupLabel,
+      },
+      {
+        name: usageLabel,
+      },
+      {
+        name: networkUnattributedDistributedLabel,
+      },
+      {
+        name: platformDistributedLabel,
+      },
+      {
+        name: storageUnattributedDistributedLabel,
+      },
+      {
+        name: workerUnallocatedLabel,
+      },
+      {
+        name: workloadCostLabel,
+      },
+      {
+        name: overheadCostLabel,
+      },
+      {
+        name: totalCostLabel,
+      },
+    ];
+
+    const minNodeHeight = isChecked ? totalCostValue / data.length : 0;
+    const getMinNodeHeight = value => (minNodeHeight > value ? minNodeHeight : 0);
+
+    const links = [
+      {
+        source: markupLabel,
+        target: workloadCostLabel,
+        value: markupValue + getMinNodeHeight(markupValue),
+        _value: markupValue,
+      },
+      {
+        source: rawLabel,
+        target: workloadCostLabel,
+        value: rawValue + getMinNodeHeight(rawValue),
+        _value: rawValue,
+      },
+      {
+        source: usageLabel,
+        target: workloadCostLabel,
+        value: usageValue + getMinNodeHeight(usageValue),
+        _value: usageValue,
+      },
+      {
+        source: networkUnattributedDistributedLabel,
+        target: overheadCostLabel,
+        value: networkUnattributedDistributedValue + getMinNodeHeight(networkUnattributedDistributedValue),
+        _value: networkUnattributedDistributedValue,
+      },
+      {
+        source: platformDistributedLabel,
+        target: overheadCostLabel,
+        value: platformDistributedValue + getMinNodeHeight(platformDistributedValue),
+        _value: platformDistributedValue,
+      },
+      {
+        source: storageUnattributedDistributedLabel,
+        target: overheadCostLabel,
+        value: storageUnattributedDistributedValue + getMinNodeHeight(storageUnattributedDistributedValue),
+        _value: storageUnattributedDistributedValue,
+      },
+      {
+        source: workerUnallocatedLabel,
+        target: overheadCostLabel,
+        value: workerUnallocatedValue + getMinNodeHeight(workerUnallocatedValue),
+        _value: workerUnallocatedValue,
+      },
+      {
+        source: workloadCostLabel,
+        target: totalCostLabel,
+        value:
+          markupValue +
+          rawValue +
+          usageValue +
+          getMinNodeHeight(markupValue) +
+          getMinNodeHeight(rawValue) +
+          getMinNodeHeight(usageValue),
+        _value: markupValue + rawValue + usageValue,
+      },
+      {
+        source: overheadCostLabel,
+        target: totalCostLabel,
+        value:
+          networkUnattributedDistributedValue +
+          platformDistributedValue +
+          storageUnattributedDistributedValue +
+          workerUnallocatedValue +
+          getMinNodeHeight(networkUnattributedDistributedValue) +
+          getMinNodeHeight(platformDistributedValue) +
+          getMinNodeHeight(storageUnattributedDistributedValue) +
+          getMinNodeHeight(workerUnallocatedValue),
+        _value:
+          networkUnattributedDistributedValue +
+          platformDistributedValue +
+          storageUnattributedDistributedValue +
+          workerUnallocatedValue,
+      },
+      {
+        source: totalCostLabel,
+        value: totalCostValue,
+        _value: totalCostValue,
+      },
+    ];
+    this.setState({ data, links, units });
+  };
+
+  public render() {
+    const { id, intl } = this.props;
+    const { data, isChecked, links, units, width } = this.state;
+
+    const isSkeleton = !(data && links);
+
+    return (
+      <div className="chartOverride" ref={this.containerRef}>
+        <Switch label="Toggle minimum node height" isChecked={isChecked} onChange={this.handleChange} />
+        <div style={{ height: chartStyles.chartHeight }}>
+          {isSkeleton ? (
+            this.getSkeleton()
+          ) : (
+            <Charts
+              height={chartStyles.chartHeight}
+              id={id}
+              option={{
+                series: [
+                  {
+                    bottom: 25,
+                    data,
+                    layoutIterations: 0,
+                    left: 25,
+                    links,
+                    right: 75,
+                    top: 25,
+                    type: 'sankey',
+                  },
+                ],
+                tooltip: {
+                  destinationLabel: intl.formatMessage(messages.chartDestination),
+                  sourceLabel: intl.formatMessage(messages.chartSource),
+                  valueFormatter: value => {
+                    const link = links.find(item => item.value === value);
+                    return `&nbsp;${formatCurrency(link._value, units)}`;
+                  },
+                },
+              }}
+              themeColor={ThemeColor.green}
+              width={width}
+            />
+          )}
+        </div>
+      </div>
+    );
+  }
+}
+
+const CostBreakdownChart = injectIntl(CostBreakdownChartBase);
+
+export default CostBreakdownChart;

--- a/src/routes/details/components/costBreakdownChart/index.ts
+++ b/src/routes/details/components/costBreakdownChart/index.ts
@@ -1,0 +1,1 @@
+export { default as CostBreakdownChart } from './costBreakdownChart';

--- a/src/routes/details/components/costOverview/costOverviewBase.tsx
+++ b/src/routes/details/components/costOverview/costOverviewBase.tsx
@@ -21,6 +21,7 @@ import React from 'react';
 import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
 import { Cluster } from 'routes/components/cluster';
+import { CostBreakdownChart } from 'routes/details/components/costBreakdownChart';
 import { CostChart } from 'routes/details/components/costChart';
 import { OverheadCostChart } from 'routes/details/components/overheadCostChart';
 import { PvcChart } from 'routes/details/components/pvcChart';
@@ -43,6 +44,7 @@ interface CostOverviewOwnProps {
 }
 
 export interface CostOverviewStateProps {
+  isCostBreakdownChartToggleEnabled?: boolean;
   selectWidgets?: Record<number, any>;
   title?: string;
   widgets: number[];
@@ -80,6 +82,61 @@ class CostOverviewsBase extends React.Component<CostOverviewProps, any> {
     } else {
       return PLACEHOLDER;
     }
+  };
+
+  // Returns cost breakdown chart
+  private getCostBreakdownChart = (widget: CostOverviewWidget) => {
+    const { costDistribution, report, intl } = this.props;
+
+    return (
+      <Card>
+        <CardTitle>
+          <Title headingLevel="h2" size={TitleSizes.lg}>
+            {intl.formatMessage(messages.costBreakdownTitle)}
+            <Popover
+              aria-label={intl.formatMessage(messages.costBreakdownAriaLabel)}
+              enableFlip
+              bodyContent={
+                <>
+                  <p style={styles.infoTitle}>{intl.formatMessage(messages.markupTitle)}</p>
+                  <p>{intl.formatMessage(messages.markupDesc)}</p>
+                  <br />
+                  <p style={styles.infoTitle}>{intl.formatMessage(messages.networkUnattributedDistributed)}</p>
+                  <p>{intl.formatMessage(messages.networkUnattributedDistributedDesc)}</p>
+                  <br />
+                  <p style={styles.infoTitle}>{intl.formatMessage(messages.platformDistributed)}</p>
+                  <p>{intl.formatMessage(messages.platformDesc)}</p>
+                  <br />
+                  <p style={styles.infoTitle}>{intl.formatMessage(messages.rawCostTitle)}</p>
+                  <p>{intl.formatMessage(messages.rawCostDesc)}</p>
+                  <br />
+                  <p style={styles.infoTitle}>{intl.formatMessage(messages.storageUnattributedDistributed)}</p>
+                  <p>{intl.formatMessage(messages.storageUnattributedDistributedDesc)}</p>
+                  <br />
+                  <p style={styles.infoTitle}>{intl.formatMessage(messages.usageCostTitle)}</p>
+                  <p>{intl.formatMessage(messages.usageCostDesc)}</p>
+                  <br />
+                  <p style={styles.infoTitle}>{intl.formatMessage(messages.workerUnallocated)}</p>
+                  <p>{intl.formatMessage(messages.workerUnallocatedDesc)}</p>
+                  <br />
+                  <a href={intl.formatMessage(messages.docsCostModelTerminology)} rel="noreferrer" target="_blank">
+                    {intl.formatMessage(messages.learnMore)}
+                  </a>
+                  <a href={intl.formatMessage(messages.docsCostModelTerminology)} rel="noreferrer" target="_blank">
+                    {intl.formatMessage(messages.learnMore)}
+                  </a>
+                </>
+              }
+            >
+              <Button icon={<OutlinedQuestionCircleIcon style={styles.info} />} variant={ButtonVariant.plain}></Button>
+            </Popover>
+          </Title>
+        </CardTitle>
+        <CardBody>
+          <CostBreakdownChart costDistribution={costDistribution} id={widget.chartName} report={report} />
+        </CardBody>
+      </Card>
+    );
   };
 
   // Returns cost breakdown chart
@@ -122,10 +179,8 @@ class CostOverviewsBase extends React.Component<CostOverviewProps, any> {
     );
   };
 
-  // Returns cost distribution chart
-  // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-  // @ts-ignore
-  private getCostDistributionChart = (widget: CostOverviewWidget) => {
+  // Returns cost overhead chart
+  private getCostOverheadChart = (widget: CostOverviewWidget) => {
     const { costDistribution, intl, report } = this.props;
 
     if (!costDistribution) {
@@ -353,13 +408,17 @@ class CostOverviewsBase extends React.Component<CostOverviewProps, any> {
 
   // Returns rendered widget based on type
   private renderWidget(widget: CostOverviewWidget) {
+    const { isCostBreakdownChartToggleEnabled } = this.props;
+
     switch (widget.type) {
       case CostOverviewWidgetType.cluster:
         return this.getClusterCard(widget);
       case CostOverviewWidgetType.cost:
-        return this.getCostChart(widget);
+        return !isCostBreakdownChartToggleEnabled ? this.getCostChart(widget) : null;
+      case CostOverviewWidgetType.costBreakdown:
+        return isCostBreakdownChartToggleEnabled ? this.getCostBreakdownChart(widget) : null;
       case CostOverviewWidgetType.costDistribution:
-        return this.getCostDistributionChart(widget);
+        return !isCostBreakdownChartToggleEnabled ? this.getCostOverheadChart(widget) : null;
       case CostOverviewWidgetType.cpuUsage:
         return this.getCpuUsageChart(widget);
       case CostOverviewWidgetType.memoryUsage:

--- a/src/routes/details/ocpBreakdown/costOverview.tsx
+++ b/src/routes/details/ocpBreakdown/costOverview.tsx
@@ -3,6 +3,7 @@ import type { CostOverviewStateProps } from 'routes/details/components/costOverv
 import { CostOverviewBase } from 'routes/details/components/costOverview';
 import { ocpCostOverviewSelectors } from 'store/breakdown/costOverview/ocpCostOverview';
 import { createMapStateToProps } from 'store/common';
+import { selectIsCostBreakdownChartToggleEnabled } from 'store/featureToggle/featureToggleSelectors';
 
 interface OcpCostOverviewOwnProps {
   title?: string;
@@ -10,6 +11,7 @@ interface OcpCostOverviewOwnProps {
 
 const mapStateToProps = createMapStateToProps<OcpCostOverviewOwnProps, CostOverviewStateProps>((state, { title }) => {
   return {
+    isCostBreakdownChartToggleEnabled: selectIsCostBreakdownChartToggleEnabled(state),
     selectWidgets: ocpCostOverviewSelectors.selectWidgets(state),
     widgets: ocpCostOverviewSelectors.selectCurrentWidgets(state),
     title,

--- a/src/store/breakdown/costOverview/common/costOverviewCommon.ts
+++ b/src/store/breakdown/costOverview/common/costOverviewCommon.ts
@@ -3,6 +3,7 @@ import type { ReportPathsType, ReportType } from 'api/reports/report';
 export const enum CostOverviewWidgetType {
   cluster = 'cluster', // This type displays clusters associated with a project
   cost = 'cost', // This type displays a cost breakdown as a pie chart
+  costBreakdown = 'costBreakdown', // This type displays a cost breakdown as a sankey chart
   costDistribution = 'costDistribution', // This type displays cost distribution as a pie chart
   cpuUsage = 'cpuUsage', // This type displays cpu usage as a bullet chart
   memoryUsage = 'memoryUsage', // This type displays memory usage as a bullet chart

--- a/src/store/breakdown/costOverview/ocpCostOverview/ocpCostOverview.test.ts
+++ b/src/store/breakdown/costOverview/ocpCostOverview/ocpCostOverview.test.ts
@@ -8,6 +8,7 @@ import { ocpCostOverviewReducer } from './ocpCostOverviewReducer';
 import * as selectors from './ocpCostOverviewSelectors';
 import {
   clusterWidget,
+  costBreakdownWidget,
   costDistributionWidget,
   costWidget,
   cpuUsageWidget,
@@ -32,6 +33,7 @@ test('default state', () => {
   const store = createOcpCostOverviewStore();
   const state = store.getState();
   expect(selectors.selectCurrentWidgets(state)).toEqual([
+    costBreakdownWidget.id,
     costWidget.id,
     costDistributionWidget.id,
     projectSummaryWidget.id,

--- a/src/store/breakdown/costOverview/ocpCostOverview/ocpCostOverviewReducer.ts
+++ b/src/store/breakdown/costOverview/ocpCostOverview/ocpCostOverviewReducer.ts
@@ -2,6 +2,7 @@ import type { CostOverviewWidget } from 'store/breakdown/costOverview/common/cos
 
 import {
   clusterWidget,
+  costBreakdownWidget,
   costDistributionWidget,
   costWidget,
   cpuUsageWidget,
@@ -19,6 +20,7 @@ export type OcpCostOverviewState = Readonly<{
 
 export const defaultState: OcpCostOverviewState = {
   currentWidgets: [
+    costBreakdownWidget.id,
     costWidget.id,
     costDistributionWidget.id,
     projectSummaryWidget.id,
@@ -30,6 +32,7 @@ export const defaultState: OcpCostOverviewState = {
     volumeUsageWidget.id,
   ],
   widgets: {
+    [costBreakdownWidget.id]: costBreakdownWidget,
     [costWidget.id]: costWidget,
     [costDistributionWidget.id]: costDistributionWidget,
     [projectSummaryWidget.id]: projectSummaryWidget,

--- a/src/store/breakdown/costOverview/ocpCostOverview/ocpCostOverviewWidgets.ts
+++ b/src/store/breakdown/costOverview/ocpCostOverview/ocpCostOverviewWidgets.ts
@@ -25,6 +25,14 @@ export const costWidget: CostOverviewWidget = {
   type: CostOverviewWidgetType.cost,
 };
 
+export const costBreakdownWidget: CostOverviewWidget = {
+  chartName: 'costBreakdownWidget',
+  id: getId(),
+  reportPathsType: ReportPathsType.ocp,
+  reportType: ReportType.cost,
+  type: CostOverviewWidgetType.costBreakdown,
+};
+
 export const costDistributionWidget: CostOverviewWidget = {
   chartName: 'ocpCostDistributionWidget',
   id: getId(),

--- a/src/store/featureToggle/__snapshots__/featureToggle.test.ts.snap
+++ b/src/store/featureToggle/__snapshots__/featureToggle.test.ts.snap
@@ -7,6 +7,7 @@ exports[`default state 1`] = `
   "isAccountInfoEmptyStateToggleEnabled": false,
   "isAwsEc2InstancesToggleEnabled": false,
   "isChartSkeletonToggleEnabled": false,
+  "isCostBreakdownChartToggleEnabled": false,
   "isDebugToggleEnabled": false,
   "isDetailsDateRangeToggleEnabled": false,
   "isExportsToggleEnabled": false,

--- a/src/store/featureToggle/featureToggleActions.ts
+++ b/src/store/featureToggle/featureToggleActions.ts
@@ -5,6 +5,7 @@ export interface FeatureToggleActionMeta {
   isAccountInfoEmptyStateToggleEnabled?: boolean;
   isAwsEc2InstancesToggleEnabled?: boolean;
   isChartSkeletonToggleEnabled?: boolean;
+  isCostBreakdownChartToggleEnabled?: boolean;
   isDebugToggleEnabled?: boolean;
   isDetailsDateRangeToggleEnabled?: boolean;
   isExportsToggleEnabled?: boolean;

--- a/src/store/featureToggle/featureToggleReducer.ts
+++ b/src/store/featureToggle/featureToggleReducer.ts
@@ -12,6 +12,7 @@ export type FeatureToggleState = Readonly<{
   isAccountInfoEmptyStateToggleEnabled: boolean;
   isAwsEc2InstancesToggleEnabled: boolean;
   isChartSkeletonToggleEnabled: boolean;
+  isCostBreakdownChartToggleEnabled: boolean;
   isDebugToggleEnabled: boolean;
   isDetailsDateRangeToggleEnabled: boolean;
   isExportsToggleEnabled: boolean;
@@ -28,6 +29,7 @@ export const defaultState: FeatureToggleState = {
   isAccountInfoEmptyStateToggleEnabled: false,
   isAwsEc2InstancesToggleEnabled: false,
   isChartSkeletonToggleEnabled: false,
+  isCostBreakdownChartToggleEnabled: false,
   isDebugToggleEnabled: false,
   isDetailsDateRangeToggleEnabled: false,
   isExportsToggleEnabled: false,
@@ -50,6 +52,7 @@ export function FeatureToggleReducer(state = defaultState, action: FeatureToggle
         isAccountInfoEmptyStateToggleEnabled: action.payload.isAccountInfoEmptyStateToggleEnabled,
         isAwsEc2InstancesToggleEnabled: action.payload.isAwsEc2InstancesToggleEnabled,
         isChartSkeletonToggleEnabled: action.payload.isChartSkeletonToggleEnabled,
+        isCostBreakdownChartToggleEnabled: action.payload.isCostBreakdownChartToggleEnabled,
         isDebugToggleEnabled: action.payload.isDebugToggleEnabled,
         isDetailsDateRangeToggleEnabled: action.payload.isDetailsDateRangeToggleEnabled,
         isExportsToggleEnabled: action.payload.isExportsToggleEnabled,

--- a/src/store/featureToggle/featureToggleSelectors.ts
+++ b/src/store/featureToggle/featureToggleSelectors.ts
@@ -14,6 +14,8 @@ export const selectIsAwsEc2InstancesToggleEnabled = (state: RootState) =>
   selectFeatureToggleState(state).isAwsEc2InstancesToggleEnabled;
 export const selectIsChartSkeletonToggleEnabled = (state: RootState) =>
   selectFeatureToggleState(state).isChartSkeletonToggleEnabled;
+export const selectIsCostBreakdownChartToggleEnabled = (state: RootState) =>
+  selectFeatureToggleState(state).isCostBreakdownChartToggleEnabled;
 export const selectIsDebugToggleEnabled = (state: RootState) => selectFeatureToggleState(state).isDebugToggleEnabled;
 export const selectIsDetailsDateRangeToggleEnabled = (state: RootState) =>
   selectFeatureToggleState(state).isDetailsDateRangeToggleEnabled;


### PR DESCRIPTION
Created a Sankey chart to replace the two pie charts in the OCP breakdown page.

https://issues.redhat.com/browse/COST-5852

To test:

1. Log in as cost-demo
2. Ensure you're in "preview" mode
3. Navigate to OCP details page
4. Click on any project
5. See default Sankey chart -- some node values will be zero
6. Use the mouse to hover and show tooltips -- note the zero values
7. Click on the "Overhead cost" menu and select "Don't distribute overhead costs"
8. See how Sankey chart changes dynamically
9. Click on the "Toggle minimum node height" switch -- this is a workaround for zero values
10. Sankey nodes should now have a min height, even for zero values
11. Click on the "Overhead cost" menu and select "Don't distribute overhead costs"
12. See how the Sankey chart changes with the min node height enabled.