### PR TITLE
Adjust padding for cost breakdown chart

### DIFF
--- a/src/routes/details/components/costBreakdownChart/costBreakdownChart.tsx
+++ b/src/routes/details/components/costBreakdownChart/costBreakdownChart.tsx
@@ -433,7 +433,7 @@ class CostBreakdownChartBase extends React.Component<CostBreakdownChartProps, an
               option={{
                 series: [
                   {
-                    bottom: 0,
+                    bottom: 20,
                     data,
                     label: {
                       formatter: params => {
@@ -452,7 +452,7 @@ class CostBreakdownChartBase extends React.Component<CostBreakdownChartProps, an
                     links,
                     left: 0,
                     nodeGap: 26,
-                    right: 70,
+                    right: 110,
                     top: 20,
                     type: 'sankey',
                   },


### PR DESCRIPTION
Adjust padding for cost breakdown chart -- cannot see "Usage cost" label

![Screenshot 2025-04-03 at 12 24 00 PM](https://github.com/user-attachments/assets/3358eec0-38fd-4cb6-8fc2-095d33ee39f7)

