### PR TITLE
 Omit the "Enter rate by tag" feature for "Virtual Machine" options

### DIFF
--- a/src/routes/settings/costModels/components/rateForm/rateForm.tsx
+++ b/src/routes/settings/costModels/components/rateForm/rateForm.tsx
@@ -185,7 +185,7 @@ const RateFormBase: React.FC<RateFormProps> = ({ currencyUnits, intl = defaultIn
                 onChange={() => setCalculation('Supplementary')}
               />
             </FormGroup>
-            {metric !== 'Cluster' ? (
+            {metric !== 'Cluster' && metric !== 'Virtual Machine' ? (
               <Switch
                 aria-label={intl.formatMessage(messages.costModelsEnterTagRate)}
                 label={intl.formatMessage(messages.costModelsEnterTagRate)}


### PR DESCRIPTION
For the cost model wizard price list step, omit the "Enter rate by tag" feature for "Virtual Machine" options

https://issues.redhat.com/browse/COST-5987