### PR TITLE
Deployment commit for prod-stable

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -2071,6 +2071,12 @@
         "value": "Create tag mapping"
       }
     ],
+    "credit": [
+      {
+        "type": 0,
+        "value": "Credit"
+      }
+    ],
     "currency": [
       {
         "type": 0,

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -198,6 +198,7 @@
   "createCostModelTitle": "Create a cost model",
   "createRate": "Create rate",
   "createTagMapping": "Create tag mapping",
+  "credit": "Credit",
   "currency": "Currency",
   "currencyAbbreviations": "{symbol, select, billion {{value} B} million {{value} M} quadrillion {{value} q} thousand {{value} K} trillion {{value} t} other {}}",
   "currencyCalcuationsTitle": "Currency and calculations",

--- a/src/api/reports/report.ts
+++ b/src/api/reports/report.ts
@@ -13,6 +13,7 @@ export interface ReportUsageValue extends ReportValue {
 }
 
 export interface ReportItemValue {
+  credit?: ReportValue;
   distributed?: ReportValue;
   markup?: ReportValue;
   network_unattributed_distributed?: ReportValue;

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -1078,6 +1078,11 @@ export default defineMessages({
     description: 'Create tag mapping',
     id: 'createTagMapping',
   },
+  credit: {
+    defaultMessage: 'Credit',
+    description: 'Credit',
+    id: 'credit',
+  },
   currency: {
     defaultMessage: 'Currency',
     description: 'Currency',

--- a/src/routes/details/components/costBreakdownChart/costBreakdownChart.tsx
+++ b/src/routes/details/components/costBreakdownChart/costBreakdownChart.tsx
@@ -231,34 +231,29 @@ class CostBreakdownChartBase extends React.Component<CostBreakdownChartProps, an
       return;
     }
 
-    const hasMarkup = report?.meta?.total?.cost?.markup;
-    const hasNetworkUnattributedDistributed =
-      report?.meta?.total?.cost?.network_unattributed_distributed &&
-      costDistribution === ComputedReportItemValueType.distributed;
-    const hasPlatformDistributed =
-      report?.meta?.total?.cost?.platform_distributed && costDistribution === ComputedReportItemValueType.distributed;
-    const hasRaw = report?.meta?.total?.cost?.raw;
-    const hasStorageUnattributedDistributed =
-      report?.meta?.total?.cost?.storage_unattributed_distributed &&
-      costDistribution === ComputedReportItemValueType.distributed;
-    const hasUsage = report?.meta?.total?.cost?.usage;
-    const hasWorkerUnallocated =
-      report?.meta?.total?.cost?.worker_unallocated_distributed &&
-      costDistribution === ComputedReportItemValueType.distributed;
+    const isDistributed = costDistribution === ComputedReportItemValueType.distributed;
+    const hasCredit = report?.meta?.total?.cost?.credit !== undefined;
 
-    const markupValue = hasMarkup ? report.meta.total.cost.markup.value : 0;
-    const networkUnattributedDistributedValue = hasNetworkUnattributedDistributed
-      ? report.meta.total.cost.network_unattributed_distributed.value
-      : 0;
-    const platformDistributedValue = hasPlatformDistributed ? report.meta.total.cost.platform_distributed.value : 0;
-    const rawValue = hasRaw ? report.meta.total.cost.raw.value : 0;
-    const storageUnattributedDistributedValue = hasStorageUnattributedDistributed
-      ? report.meta.total.cost.storage_unattributed_distributed.value
-      : 0;
-    const workerUnallocatedValue = hasWorkerUnallocated
-      ? report.meta.total.cost.worker_unallocated_distributed.value
-      : 0;
-    const usageValue = hasUsage ? report.meta.total.cost.usage.value : 0;
+    const creditValue = hasCredit ? report.meta.total.cost.credit.value : 0;
+    const markupValue = report?.meta?.total?.cost?.markup ? report.meta.total.cost.markup.value : 0;
+    const networkUnattributedDistributedValue =
+      report?.meta?.total?.cost?.network_unattributed_distributed && isDistributed
+        ? report.meta.total.cost.network_unattributed_distributed.value
+        : 0;
+    const platformDistributedValue =
+      report?.meta?.total?.cost?.platform_distributed && isDistributed
+        ? report.meta.total.cost.platform_distributed.value
+        : 0;
+    const rawValue = report?.meta?.total?.cost?.raw ? report.meta.total.cost.raw.value : 0;
+    const storageUnattributedDistributedValue =
+      report?.meta?.total?.cost?.storage_unattributed_distributed && isDistributed
+        ? report.meta.total.cost.storage_unattributed_distributed.value
+        : 0;
+    const workerUnallocatedValue =
+      report?.meta?.total?.cost?.worker_unallocated_distributed && isDistributed
+        ? report.meta.total.cost.worker_unallocated_distributed.value
+        : 0;
+    const usageValue = report?.meta?.total?.cost?.usage ? report.meta.total.cost.usage.value : 0;
 
     // Only add positive values for Sankey node heights
     const overheadCostValue =
@@ -274,10 +269,11 @@ class CostBreakdownChartBase extends React.Component<CostBreakdownChartProps, an
       workerUnallocatedValue;
 
     // Only add positive values for Sankey node heights
-    const workloadCostValue = Math.abs(markupValue) + Math.abs(rawValue) + Math.abs(usageValue);
+    const workloadCostValue = Math.abs(markupValue) + Math.abs(rawValue) + Math.abs(usageValue) + Math.abs(creditValue);
     // Actual value shown for labels and tooltips
-    const _workloadCostValue = markupValue + rawValue + usageValue;
+    const _workloadCostValue = markupValue + rawValue + usageValue + creditValue;
 
+    const creditLabel = intl.formatMessage(messages.credit);
     const markupLabel = intl.formatMessage(messages.markupTitle);
     const networkUnattributedDistributedLabel = intl.formatMessage(messages.networkUnattributedDistributed);
     const overheadCostLabel = intl.formatMessage(messages.costDistributionLabel);
@@ -325,20 +321,38 @@ class CostBreakdownChartBase extends React.Component<CostBreakdownChartProps, an
             name: totalCostLabel,
           },
         ]
-      : [
-          {
-            name: rawLabel,
-          },
-          {
-            name: markupLabel,
-          },
-          {
-            name: usageLabel,
-          },
-          {
-            name: totalCostLabel,
-          },
-        ];
+      : hasCredit
+        ? [
+            {
+              name: creditLabel,
+            },
+            {
+              name: rawLabel,
+            },
+            {
+              name: markupLabel,
+            },
+            {
+              name: usageLabel,
+            },
+            {
+              name: totalCostLabel,
+            },
+          ]
+        : [
+            {
+              name: rawLabel,
+            },
+            {
+              name: markupLabel,
+            },
+            {
+              name: usageLabel,
+            },
+            {
+              name: totalCostLabel,
+            },
+          ];
 
     const links = costDistribution
       ? [
@@ -402,31 +416,63 @@ class CostBreakdownChartBase extends React.Component<CostBreakdownChartProps, an
             _value: _overheadCostValue + _workloadCostValue,
           },
         ]
-      : [
-          {
-            source: rawLabel,
-            target: totalCostLabel,
-            value: Math.abs(rawValue),
-            _value: rawValue,
-          },
-          {
-            source: markupLabel,
-            target: totalCostLabel,
-            value: Math.abs(markupValue),
-            _value: markupValue,
-          },
-          {
-            source: usageLabel,
-            target: totalCostLabel,
-            value: Math.abs(usageValue),
-            _value: usageValue,
-          },
-          {
-            source: totalCostLabel,
-            value: workloadCostValue,
-            _value: _workloadCostValue,
-          },
-        ];
+      : hasCredit
+        ? [
+            {
+              source: creditLabel,
+              target: totalCostLabel,
+              value: Math.abs(creditValue),
+              _value: creditValue,
+            },
+            {
+              source: rawLabel,
+              target: totalCostLabel,
+              value: Math.abs(rawValue),
+              _value: rawValue,
+            },
+            {
+              source: markupLabel,
+              target: totalCostLabel,
+              value: Math.abs(markupValue),
+              _value: markupValue,
+            },
+            {
+              source: usageLabel,
+              target: totalCostLabel,
+              value: Math.abs(usageValue),
+              _value: usageValue,
+            },
+            {
+              source: totalCostLabel,
+              value: workloadCostValue,
+              _value: _workloadCostValue,
+            },
+          ]
+        : [
+            {
+              source: rawLabel,
+              target: totalCostLabel,
+              value: Math.abs(rawValue),
+              _value: rawValue,
+            },
+            {
+              source: markupLabel,
+              target: totalCostLabel,
+              value: Math.abs(markupValue),
+              _value: markupValue,
+            },
+            {
+              source: usageLabel,
+              target: totalCostLabel,
+              value: Math.abs(usageValue),
+              _value: usageValue,
+            },
+            {
+              source: totalCostLabel,
+              value: workloadCostValue,
+              _value: _workloadCostValue,
+            },
+          ];
 
     this.setState({ data, links, units });
   };


### PR DESCRIPTION
Merged main branch to prod-stable.

Use latest commit to update namespace `ref` in app-interface repo. Don't use merge commit, SHAs must be unique when images are created for each branch.

## Summary by Sourcery

Update cost breakdown chart to support credit cost reporting

New Features:
- Add support for displaying credit costs in the cost breakdown chart and report data structure

Enhancements:
- Refactor cost calculation logic to handle optional credit costs
- Improve flexibility of cost reporting by adding credit as a potential cost component