### PR TITLE
Remove workaround to hide tag based rates option

### DIFF
--- a/src/routes/settings/costModels/components/rateForm/rateForm.tsx
+++ b/src/routes/settings/costModels/components/rateForm/rateForm.tsx
@@ -185,7 +185,7 @@ const RateFormBase: React.FC<RateFormProps> = ({ currencyUnits, intl = defaultIn
                 onChange={() => setCalculation('Supplementary')}
               />
             </FormGroup>
-            {metric !== 'Cluster' && metric !== 'Virtual Machine' ? (
+            {metric !== 'Cluster' ? (
               <Switch
                 aria-label={intl.formatMessage(messages.costModelsEnterTagRate)}
                 label={intl.formatMessage(messages.costModelsEnterTagRate)}


### PR DESCRIPTION
Remove workaround to hide tag based rates option

https://issues.redhat.com/browse/COST-6170

## Summary by Sourcery

Enhancements:
- Simplified the condition for displaying tag-based rates option