### PR TITLE
Migrate frontend-components-notifications to v6.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@patternfly/react-table": "6.2.0",
         "@patternfly/react-tokens": "6.2.0",
         "@redhat-cloud-services/frontend-components": "^6.0.7",
-        "@redhat-cloud-services/frontend-components-notifications": "^5.0.7",
+        "@redhat-cloud-services/frontend-components-notifications": "^6.0.0",
         "@redhat-cloud-services/frontend-components-translations": "^4.0.4",
         "@redhat-cloud-services/frontend-components-utilities": "^6.0.5",
         "@redhat-cloud-services/rbac-client": "^4.0.1",
@@ -2329,23 +2329,19 @@
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-notifications": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-5.0.7.tgz",
-      "integrity": "sha512-CCkioaXuz/gCK4qbBOIEle14C2EM1Qj77uyEnD0m0zpF68VRAT1xDIUO6eWFpWGTbSpklLy/Iz+5iGcSDIBxuw==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/frontend-components-notifications/-/frontend-components-notifications-6.0.0.tgz",
+      "integrity": "sha512-FMNOAaTQz48R2D1wRjS0bb9/cMnyu++mweSDpWQ8vFRzvsgoOJXxNNOI6+bJpN6FOgP637rI7tiquWd2QLv+Aw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@redhat-cloud-services/frontend-components": "^6.0.0",
-        "@redhat-cloud-services/frontend-components-utilities": "^6.0.0",
-        "redux-promise-middleware": "6.1.3"
+        "@redhat-cloud-services/frontend-components-utilities": "^6.0.0"
       },
       "peerDependencies": {
         "@patternfly/react-core": "^6.0.0",
         "@patternfly/react-icons": "^6.0.0",
-        "prop-types": "^15.6.2",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0",
-        "react-redux": "^7.2.9 || ^8.0.0 || ^9.0.0",
-        "redux": ">=4.2.0"
+        "react-dom": "^18.2.0"
       }
     },
     "node_modules/@redhat-cloud-services/frontend-components-translations": {
@@ -14233,15 +14229,6 @@
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
       "license": "MIT"
-    },
-    "node_modules/redux-promise-middleware": {
-      "version": "6.1.3",
-      "resolved": "https://registry.npmjs.org/redux-promise-middleware/-/redux-promise-middleware-6.1.3.tgz",
-      "integrity": "sha512-B/Hi5Ct5d9y5d/KG0f6MZUXKA0nrQh5583mHCx13HY3Avte8KfpoRH/TB5QT6k/FcjT6JCxjv7jedymidy2A1A==",
-      "license": "MIT",
-      "peerDependencies": {
-        "redux": "^2.0.0 || ^3.0.0 || ^4.0.0"
-      }
     },
     "node_modules/redux-thunk": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@patternfly/react-table": "6.2.0",
     "@patternfly/react-tokens": "6.2.0",
     "@redhat-cloud-services/frontend-components": "^6.0.7",
-    "@redhat-cloud-services/frontend-components-notifications": "^5.0.7",
+    "@redhat-cloud-services/frontend-components-notifications": "^6.0.0",
     "@redhat-cloud-services/frontend-components-translations": "^4.0.4",
     "@redhat-cloud-services/frontend-components-utilities": "^6.0.5",
     "@redhat-cloud-services/rbac-client": "^4.0.1",

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -1,9 +1,8 @@
 import './app.scss';
 
 import { useChrome } from '@redhat-cloud-services/frontend-components/useChrome';
-import NotificationsPortal from '@redhat-cloud-services/frontend-components-notifications/NotificationPortal';
-import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
-import { getRegistry } from '@redhat-cloud-services/frontend-components-utilities/Registry';
+import NotificationsProvider from '@redhat-cloud-services/frontend-components-notifications/NotificationsProvider';
+import { createStore } from '@redhat-cloud-services/frontend-components-notifications/state';
 import React, { useEffect, useLayoutEffect } from 'react';
 import { invalidateSession } from 'utils/sessionStorage';
 
@@ -13,11 +12,9 @@ import { Routes } from './routes';
 
 const App = () => {
   const { updateDocumentTitle } = useChrome();
+  const store = createStore();
 
   useEffect(() => {
-    const registry = getRegistry();
-    registry.register({ notifications: notificationsReducer as any });
-
     // You can use directly the name of your app
     updateDocumentTitle(pkg.insights.appname);
   }, []);
@@ -37,8 +34,9 @@ const App = () => {
 
   return (
     <div>
-      <NotificationsPortal />
-      <Routes />
+      <NotificationsProvider store={store}>
+        <Routes />
+      </NotificationsProvider>
     </div>
   );
 };

--- a/src/routes/details/ocpDetails/detailsTable.tsx
+++ b/src/routes/details/ocpDetails/detailsTable.tsx
@@ -231,7 +231,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
       const desc = item?.id !== item.label ? <div style={styles.infoDescription}>{item.id}</div> : null;
       const isDisabled = label === `${noPrefix}${groupBy}` || label === `${noPrefix}${groupByTagKey}`;
       const isLinkDisabled = isDisabled || isUnallocatedProject || isUnattributedCosts;
-      const actions = this.getActions(item, isDisabled);
+      const actions = this.getActions(item, index, isDisabled);
 
       const name = isLinkDisabled ? (
         (label as any)
@@ -364,7 +364,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
     });
   };
 
-  private getActions = (item: ComputedReportItem, isDisabled) => {
+  private getActions = (item: ComputedReportItem, index: number, isDisabled: boolean) => {
     const { groupBy, reportQueryString, timeScopeValue } = this.props;
 
     return (
@@ -377,6 +377,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
         reportQueryString={reportQueryString}
         reportType={ReportType.cost}
         showPriceListOption={groupBy === 'cluster'}
+        showRedirectNotification={index === 0}
         timeScopeValue={timeScopeValue}
       />
     );

--- a/src/routes/settings/calculations/calculations.tsx
+++ b/src/routes/settings/calculations/calculations.tsx
@@ -1,5 +1,7 @@
 import { Card, CardBody, Title, TitleSizes, Tooltip } from '@patternfly/react-core';
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import { AccountSettingsType } from 'api/accountSettings';
+import type { AxiosError } from 'axios';
 import messages from 'locales/messages';
 import React, { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
@@ -10,7 +12,8 @@ import { CostType } from 'routes/components/costType';
 import { Currency } from 'routes/components/currency';
 import type { RootState } from 'store';
 import { accountSettingsActions, accountSettingsSelectors } from 'store/accountSettings';
-import type { FetchStatus } from 'store/common';
+import { FetchStatus } from 'store/common';
+import { resetStatus } from 'store/settings/settingsActions';
 import { getAccountCostType, getAccountCurrency } from 'utils/sessionStorage';
 
 import { styles } from './calculations.styles';
@@ -20,7 +23,11 @@ interface CalculationsPropsOwnProps {
 }
 
 export interface CalculationsStateProps {
+  costTypeAccountSettingsUpdateError: AxiosError;
+  costTypeAccountSettingsUpdateNotification?: any;
   costTypeAccountSettingsUpdateStatus: FetchStatus;
+  currencyAccountSettingsUpdateError: AxiosError;
+  currencyAccountSettingsUpdateNotification?: any;
   currencyAccountSettingsUpdateStatus: FetchStatus;
 }
 
@@ -28,12 +35,20 @@ type CalculationsProps = CalculationsPropsOwnProps;
 
 const Calculations: React.FC<CalculationsProps> = ({ canWrite }) => {
   const [costType, setCostType] = useState(getAccountCostType());
-  const [currency, setCurrency] = useState(getAccountCostType());
+  const [currency, setCurrency] = useState(getAccountCurrency());
 
+  const addNotification = useAddNotification();
   const dispatch: ThunkDispatch<RootState, any, AnyAction> = useDispatch();
   const intl = useIntl();
 
-  const { costTypeAccountSettingsUpdateStatus, currencyAccountSettingsUpdateStatus } = useMapToProps();
+  const {
+    costTypeAccountSettingsUpdateError,
+    costTypeAccountSettingsUpdateNotification,
+    costTypeAccountSettingsUpdateStatus,
+    currencyAccountSettingsUpdateError,
+    currencyAccountSettingsUpdateNotification,
+    currencyAccountSettingsUpdateStatus,
+  } = useMapToProps();
 
   const getCostType = () => {
     return (
@@ -100,9 +115,38 @@ const Calculations: React.FC<CalculationsProps> = ({ canWrite }) => {
   };
 
   useEffect(() => {
-    setCostType(getAccountCostType());
-    setCurrency(getAccountCurrency());
-  }, [costTypeAccountSettingsUpdateStatus, currencyAccountSettingsUpdateStatus]);
+    if (
+      costTypeAccountSettingsUpdateNotification &&
+      (costTypeAccountSettingsUpdateStatus === FetchStatus.complete || costTypeAccountSettingsUpdateError)
+    ) {
+      if (!costTypeAccountSettingsUpdateError) {
+        setCostType(getAccountCostType());
+      }
+      addNotification(costTypeAccountSettingsUpdateNotification);
+      dispatch(resetStatus());
+    }
+  }, [
+    costTypeAccountSettingsUpdateError,
+    costTypeAccountSettingsUpdateNotification,
+    costTypeAccountSettingsUpdateStatus,
+  ]);
+
+  useEffect(() => {
+    if (
+      currencyAccountSettingsUpdateNotification &&
+      (currencyAccountSettingsUpdateStatus === FetchStatus.complete || currencyAccountSettingsUpdateError)
+    ) {
+      if (!currencyAccountSettingsUpdateError) {
+        setCurrency(getAccountCurrency());
+      }
+      addNotification(currencyAccountSettingsUpdateNotification);
+      dispatch(resetStatus());
+    }
+  }, [
+    currencyAccountSettingsUpdateError,
+    currencyAccountSettingsUpdateNotification,
+    currencyAccountSettingsUpdateStatus,
+  ]);
 
   return (
     <Card>
@@ -115,15 +159,32 @@ const Calculations: React.FC<CalculationsProps> = ({ canWrite }) => {
 };
 
 const useMapToProps = (): CalculationsStateProps => {
+  const costTypeAccountSettingsUpdateError = useSelector((state: RootState) =>
+    accountSettingsSelectors.selectAccountSettingsUpdateError(state, AccountSettingsType.costType)
+  );
+  const costTypeAccountSettingsUpdateNotification = useSelector((state: RootState) =>
+    accountSettingsSelectors.selectAccountSettingsUpdateNotification(state, AccountSettingsType.costType)
+  );
   const costTypeAccountSettingsUpdateStatus = useSelector((state: RootState) =>
     accountSettingsSelectors.selectAccountSettingsUpdateStatus(state, AccountSettingsType.costType)
+  );
+
+  const currencyAccountSettingsUpdateError = useSelector((state: RootState) =>
+    accountSettingsSelectors.selectAccountSettingsUpdateError(state, AccountSettingsType.currency)
+  );
+  const currencyAccountSettingsUpdateNotification = useSelector((state: RootState) =>
+    accountSettingsSelectors.selectAccountSettingsUpdateNotification(state, AccountSettingsType.currency)
   );
   const currencyAccountSettingsUpdateStatus = useSelector((state: RootState) =>
     accountSettingsSelectors.selectAccountSettingsUpdateStatus(state, AccountSettingsType.currency)
   );
 
   return {
+    costTypeAccountSettingsUpdateError,
+    costTypeAccountSettingsUpdateNotification,
     costTypeAccountSettingsUpdateStatus,
+    currencyAccountSettingsUpdateError,
+    currencyAccountSettingsUpdateNotification,
     currencyAccountSettingsUpdateStatus,
   };
 };

--- a/src/routes/settings/costModels/costModel/costModelInfo.tsx
+++ b/src/routes/settings/costModels/costModel/costModelInfo.tsx
@@ -28,6 +28,8 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
 import { metricsActions, metricsSelectors } from 'store/metrics';
 import { rbacActions, rbacSelectors } from 'store/rbac';
+import type { NotificationComponentProps } from 'utils/notification';
+import { withNotification } from 'utils/notification';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
 
@@ -38,17 +40,21 @@ interface CostModelInfoOwnProps {
   costModelStatus: FetchStatus;
   costModelError: AxiosError;
   distribution: { value: string };
-  fetchMetrics: typeof metricsActions.fetchMetrics;
-  markup: { value: string };
-  metricsStatus: FetchStatus;
-  metricsError: AxiosError;
-  fetchRbac: typeof rbacActions.fetchRbac;
-  rbacStatus: FetchStatus;
-  rbacError: Error;
   fetchCostModels: typeof costModelsActions.fetchCostModels;
+  fetchMetrics: typeof metricsActions.fetchMetrics;
+  fetchRbac: typeof rbacActions.fetchRbac;
+  markup: { value: string };
+  metricsError: AxiosError;
+  metricsStatus: FetchStatus;
+  rbacError: Error;
+  rbacNotification?: any;
+  rbacStatus: FetchStatus;
 }
 
-type CostModelInfoProps = CostModelInfoOwnProps & RouterComponentProps & WrappedComponentProps;
+type CostModelInfoProps = CostModelInfoOwnProps &
+  NotificationComponentProps &
+  RouterComponentProps &
+  WrappedComponentProps;
 
 interface CostModelInfoState {
   tabIndex: number;
@@ -65,6 +71,22 @@ class CostModelInfo extends React.Component<CostModelInfoProps, CostModelInfoSta
     this.props.fetchRbac();
     this.props.fetchMetrics();
     this.props.fetchCostModels(`uuid=${this.props.router.params.uuid}`);
+  }
+
+  public componentDidUpdate(prevProps: CostModelInfoProps) {
+    const { notification, rbacError, rbacNotification, rbacStatus } = this.props;
+
+    if (
+      rbacNotification &&
+      rbacNotification !== null &&
+      rbacError &&
+      rbacError !== null &&
+      rbacError !== prevProps.rbacError &&
+      rbacStatus !== prevProps.rbacStatus &&
+      rbacStatus === FetchStatus.complete
+    ) {
+      notification.addNotification(rbacNotification);
+    }
   }
 
   public render() {
@@ -167,27 +189,30 @@ class CostModelInfo extends React.Component<CostModelInfoProps, CostModelInfoSta
 }
 
 export default injectIntl(
-  withRouter(
-    connect(
-      createMapStateToProps(store => {
-        return {
-          costModels: costModelsSelectors.costModels(store),
-          costModelError: costModelsSelectors.error(store),
-          costModelStatus: costModelsSelectors.status(store),
-          metricsHash: metricsSelectors.metrics(store),
-          maxRate: metricsSelectors.maxRate(store),
-          costTypes: metricsSelectors.costTypes(store),
-          metricsError: metricsSelectors.metricsState(store).error,
-          metricsStatus: metricsSelectors.status(store),
-          rbacError: rbacSelectors.selectRbacState(store).error,
-          rbacStatus: rbacSelectors.selectRbacState(store).status,
-        };
-      }),
-      {
-        fetchMetrics: metricsActions.fetchMetrics,
-        fetchRbac: rbacActions.fetchRbac,
-        fetchCostModels: costModelsActions.fetchCostModels,
-      }
-    )(CostModelInfo)
+  withNotification(
+    withRouter(
+      connect(
+        createMapStateToProps(state => {
+          return {
+            costModels: costModelsSelectors.costModels(state),
+            costModelError: costModelsSelectors.error(state),
+            costModelStatus: costModelsSelectors.status(state),
+            costTypes: metricsSelectors.costTypes(state),
+            maxRate: metricsSelectors.maxRate(state),
+            metricsError: metricsSelectors.metricsState(state).error,
+            metricsHash: metricsSelectors.metrics(state),
+            metricsStatus: metricsSelectors.status(state),
+            rbacError: rbacSelectors.selectRbacState(state).error,
+            rbacNotification: rbacSelectors.selectRbacState(state).notification,
+            rbacStatus: rbacSelectors.selectRbacState(state).status,
+          };
+        }),
+        {
+          fetchMetrics: metricsActions.fetchMetrics,
+          fetchRbac: rbacActions.fetchRbac,
+          fetchCostModels: costModelsActions.fetchCostModels,
+        }
+      )(CostModelInfo)
+    )
   )
 );

--- a/src/routes/settings/tagLabels/tags/tags.tsx
+++ b/src/routes/settings/tagLabels/tags/tags.tsx
@@ -1,5 +1,6 @@
 import Unavailable from '@patternfly/react-component-groups/dist/esm/UnavailableContent';
 import { Pagination, PaginationVariant } from '@patternfly/react-core';
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import type { Query } from 'api/queries/query';
 import { getQuery } from 'api/queries/query';
 import type { Settings, SettingsData } from 'api/settings';
@@ -16,6 +17,7 @@ import * as queryUtils from 'routes/utils/query';
 import type { RootState } from 'store';
 import { FetchStatus } from 'store/common';
 import { settingsActions, settingsSelectors } from 'store/settings';
+import { resetStatus } from 'store/settings/settingsActions';
 import { useStateCallback } from 'utils/hooks';
 
 import { styles } from './tags.styles';
@@ -247,6 +249,7 @@ const Tags: React.FC<TagsProps> = ({ canWrite }) => {
 
 const useMapToProps = ({ query }: TagsMapProps): TagsStateProps => {
   const dispatch: ThunkDispatch<RootState, any, AnyAction> = useDispatch();
+  const addNotification = useAddNotification();
 
   const settingsQuery = {
     filter_by: query.filter_by,
@@ -265,8 +268,21 @@ const useMapToProps = ({ query }: TagsMapProps): TagsStateProps => {
     settingsSelectors.selectSettingsError(state, SettingsType.tags, settingsQueryString)
   );
 
+  const settingsUpdateDisableError = useSelector((state: RootState) =>
+    settingsSelectors.selectSettingsUpdateError(state, SettingsType.tagsDisable)
+  );
   const settingsUpdateDisableStatus = useSelector((state: RootState) =>
     settingsSelectors.selectSettingsUpdateStatus(state, SettingsType.tagsDisable)
+  );
+  const settingsUpdateDisableNotification = useSelector((state: RootState) =>
+    settingsSelectors.selectSettingsUpdateNotification(state, SettingsType.tagsDisable)
+  );
+
+  const settingsUpdateEnableError = useSelector((state: RootState) =>
+    settingsSelectors.selectSettingsUpdateError(state, SettingsType.tagsEnable)
+  );
+  const settingsUpdateEnableNotification = useSelector((state: RootState) =>
+    settingsSelectors.selectSettingsUpdateNotification(state, SettingsType.tagsEnable)
   );
   const settingsUpdateEnableStatus = useSelector((state: RootState) =>
     settingsSelectors.selectSettingsUpdateStatus(state, SettingsType.tagsEnable)
@@ -282,6 +298,26 @@ const useMapToProps = ({ query }: TagsMapProps): TagsStateProps => {
       dispatch(settingsActions.fetchSettings(SettingsType.tags, settingsQueryString));
     }
   }, [query, settingsUpdateDisableStatus, settingsUpdateEnableStatus]);
+
+  useEffect(() => {
+    if (
+      settingsUpdateEnableNotification &&
+      (settingsUpdateEnableStatus === FetchStatus.complete || settingsUpdateDisableError)
+    ) {
+      addNotification(settingsUpdateEnableNotification);
+      dispatch(resetStatus());
+    }
+  }, [settingsUpdateEnableNotification, settingsUpdateEnableStatus, settingsUpdateDisableError]);
+
+  useEffect(() => {
+    if (
+      settingsUpdateDisableNotification &&
+      (settingsUpdateDisableStatus === FetchStatus.complete || settingsUpdateEnableError)
+    ) {
+      addNotification(settingsUpdateDisableNotification);
+      dispatch(resetStatus());
+    }
+  }, [settingsUpdateDisableNotification, settingsUpdateDisableStatus, settingsUpdateEnableError]);
 
   return {
     settings,

--- a/src/store/accountSettings/__snapshots__/accountSettings.test.ts.snap
+++ b/src/store/accountSettings/__snapshots__/accountSettings.test.ts.snap
@@ -4,6 +4,7 @@ exports[`default state 1`] = `
 {
   "byId": Map {},
   "errors": Map {},
+  "notification": Map {},
   "status": Map {},
 }
 `;

--- a/src/store/accountSettings/accountSettingsActions.ts
+++ b/src/store/accountSettings/accountSettingsActions.ts
@@ -1,5 +1,4 @@
 import { AlertVariant } from '@patternfly/react-core';
-import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import type { AccountSettings, AccountSettingsPayload, AccountSettingsType } from 'api/accountSettings';
 import {
   fetchAccountSettings as apiFetchAccountSettings,
@@ -25,6 +24,7 @@ interface AccountSettingsActionMeta {
   costType?: string;
   currency?: string;
   fetchId: string;
+  notification?: any;
 }
 
 export const fetchAccountSettingsRequest = createAction('settings/fetch/request')<AccountSettingsActionMeta>();
@@ -93,24 +93,28 @@ export function updateAccountSettings(settingsType: AccountSettingsType, payload
 
     return apiUpdateAccountSettings(settingsType, payload)
       .then(res => {
-        dispatch(updateAccountSettingsSuccess(res, meta));
         dispatch(
-          addNotification({
-            title: intl.formatMessage(messages.settingsSuccessTitle),
-            description: intl.formatMessage(messages.settingsSuccessDesc),
-            variant: AlertVariant.success,
-            dismissable: true,
+          updateAccountSettingsSuccess(res, {
+            ...meta,
+            notification: {
+              description: intl.formatMessage(messages.settingsSuccessDesc),
+              dismissable: true,
+              title: intl.formatMessage(messages.settingsSuccessTitle),
+              variant: AlertVariant.success,
+            },
           })
         );
       })
       .catch(err => {
-        dispatch(updateAccountSettingsFailure(err, meta));
         dispatch(
-          addNotification({
-            title: intl.formatMessage(messages.settingsErrorTitle),
-            description: intl.formatMessage(messages.settingsErrorDesc),
-            variant: AlertVariant.danger,
-            dismissable: true,
+          updateAccountSettingsFailure(err, {
+            ...meta,
+            notification: {
+              description: intl.formatMessage(messages.settingsErrorDesc),
+              dismissable: true,
+              title: intl.formatMessage(messages.settingsErrorTitle),
+              variant: AlertVariant.danger,
+            },
           })
         );
       });

--- a/src/store/accountSettings/accountSettingsReducer.ts
+++ b/src/store/accountSettings/accountSettingsReducer.ts
@@ -25,12 +25,14 @@ import {
 export type AccountSettingsState = Readonly<{
   byId: Map<string, AccountSettings>;
   errors?: Map<string, AxiosError>;
+  notification?: Map<string, any>;
   status?: Map<string, FetchStatus>;
 }>;
 
 export const defaultState: AccountSettingsState = {
   byId: new Map(),
   errors: new Map(),
+  notification: new Map(),
   status: new Map(),
 };
 
@@ -81,8 +83,9 @@ export function accountSettingsReducer(state = defaultState, action: AccountSett
     case getType(updateAccountSettingsFailure):
       return {
         ...state,
-        status: new Map(state.status).set(action.meta.fetchId, FetchStatus.complete),
         errors: new Map(state.errors).set(action.meta.fetchId, action.payload),
+        notification: new Map(state.notification).set(action.meta.fetchId, action.meta.notification),
+        status: new Map(state.status).set(action.meta.fetchId, FetchStatus.complete),
       };
     case getType(updateAccountSettingsRequest):
       return {
@@ -100,8 +103,9 @@ export function accountSettingsReducer(state = defaultState, action: AccountSett
       }
       return {
         ...state,
-        status: new Map(state.status).set(action.meta.fetchId, FetchStatus.complete),
         errors: new Map(state.errors).set(action.meta.fetchId, null),
+        notification: new Map(state.notification).set(action.meta.fetchId, action.meta.notification),
+        status: new Map(state.status).set(action.meta.fetchId, FetchStatus.complete),
       };
     default:
       return state;

--- a/src/store/accountSettings/accountSettingsSelectors.ts
+++ b/src/store/accountSettings/accountSettingsSelectors.ts
@@ -8,14 +8,17 @@ export const selectAccountSettingsState = (state: RootState) => state[accountSet
 export const selectAccountSettings = (state: RootState, accountSettingsType: AccountSettingsType) =>
   selectAccountSettingsState(state).byId.get(getFetchId(accountSettingsType));
 
-export const selectAccountSettingsStatus = (state: RootState, accountSettingsType: AccountSettingsType) =>
-  selectAccountSettingsState(state)?.status.get(getFetchId(accountSettingsType));
-
 export const selectAccountSettingsError = (state: RootState, accountSettingsType: AccountSettingsType) =>
   selectAccountSettingsState(state)?.errors.get(getFetchId(accountSettingsType));
 
-export const selectAccountSettingsUpdateStatus = (state: RootState, accountSettingsType: AccountSettingsType) =>
+export const selectAccountSettingsStatus = (state: RootState, accountSettingsType: AccountSettingsType) =>
   selectAccountSettingsState(state)?.status.get(getFetchId(accountSettingsType));
 
 export const selectAccountSettingsUpdateError = (state: RootState, accountSettingsType: AccountSettingsType) =>
   selectAccountSettingsState(state)?.errors.get(getFetchId(accountSettingsType));
+
+export const selectAccountSettingsUpdateNotification = (state: RootState, accountSettingsType: AccountSettingsType) =>
+  selectAccountSettingsState(state)?.notification?.get(getFetchId(accountSettingsType));
+
+export const selectAccountSettingsUpdateStatus = (state: RootState, accountSettingsType: AccountSettingsType) =>
+  selectAccountSettingsState(state)?.status.get(getFetchId(accountSettingsType));

--- a/src/store/costModels/__snapshots__/store.test.ts.snap
+++ b/src/store/costModels/__snapshots__/store.test.ts.snap
@@ -26,6 +26,11 @@ exports[`default state 1`] = `
       "updateMarkup": false,
       "updateRate": false,
     },
+    "redirect": {
+      "error": null,
+      "notification": null,
+      "status": 0,
+    },
     "status": 0,
     "update": {
       "current": null,

--- a/src/store/costModels/reducer.ts
+++ b/src/store/costModels/reducer.ts
@@ -11,6 +11,9 @@ import {
   fetchCostModelsFailure,
   fetchCostModelsRequest,
   fetchCostModelsSuccess,
+  redirectFailure,
+  redirectRequest,
+  redirectSuccess,
   resetCostModel,
   selectCostModel,
   setCostModelDialog,
@@ -52,6 +55,11 @@ export type CostModelsState = Readonly<{
     error: AxiosError;
     status: FetchStatus;
   };
+  redirect: {
+    error: AxiosError;
+    notification?: any;
+    status: FetchStatus;
+  };
 }>;
 
 export const defaultState: CostModelsState = {
@@ -84,6 +92,11 @@ export const defaultState: CostModelsState = {
     error: null,
     status: FetchStatus.none,
   },
+  redirect: {
+    error: null,
+    notification: null,
+    status: FetchStatus.none,
+  },
 };
 
 export type CostModelsAction = ActionType<
@@ -96,10 +109,13 @@ export type CostModelsAction = ActionType<
   | typeof fetchCostModelsFailure
   | typeof fetchCostModelsRequest
   | typeof fetchCostModelsSuccess
-  | typeof updateFilterToolbar
+  | typeof redirectFailure
+  | typeof redirectRequest
+  | typeof redirectSuccess
+  | typeof resetCostModel
   | typeof setCostModelDialog
   | typeof selectCostModel
-  | typeof resetCostModel
+  | typeof updateFilterToolbar
 >;
 
 export const reducer = (state: CostModelsState = defaultState, action: CostModelsAction): CostModelsState => {
@@ -162,8 +178,8 @@ export const reducer = (state: CostModelsState = defaultState, action: CostModel
     case getType(fetchCostModelsFailure):
       return {
         ...state,
-        status: FetchStatus.complete,
         error: action.payload,
+        status: FetchStatus.complete,
       };
     case getType(deleteCostModelsRequest):
       return {
@@ -203,6 +219,33 @@ export const reducer = (state: CostModelsState = defaultState, action: CostModel
           [action.payload.name]: action.payload.isOpen,
         },
         dialogData: action.payload.meta,
+      };
+    case getType(redirectFailure):
+      return {
+        ...state,
+        redirect: {
+          error: action.payload,
+          notification: action.meta.notification,
+          status: FetchStatus.complete,
+        },
+      };
+    case getType(redirectRequest):
+      return {
+        ...state,
+        redirect: {
+          error: null,
+          notification: null,
+          status: FetchStatus.inProgress,
+        },
+      };
+    case getType(redirectSuccess):
+      return {
+        ...state,
+        redirect: {
+          error: null,
+          notification: null,
+          status: FetchStatus.complete,
+        },
       };
     default:
       return state;

--- a/src/store/costModels/selectors.ts
+++ b/src/store/costModels/selectors.ts
@@ -50,6 +50,10 @@ export const status = (state: RootState) => costModelsState(state).status;
 
 export const error = (state: RootState) => costModelsState(state).error;
 
+export const redirectError = (state: RootState) => costModelsState(state).redirect?.error;
+export const redirectNotification = (state: RootState) => costModelsState(state).redirect?.notification;
+export const redirectStatus = (state: RootState) => costModelsState(state).redirect?.status;
+
 export const stateName = (state: RootState) => {
   const costStatus = status(state);
   const costError = error(state);

--- a/src/store/export/__snapshots__/export.test.ts.snap
+++ b/src/store/export/__snapshots__/export.test.ts.snap
@@ -5,5 +5,6 @@ exports[`default state 1`] = `
   "byId": Map {},
   "errors": Map {},
   "fetchStatus": Map {},
+  "notification": Map {},
 }
 `;

--- a/src/store/export/exportReducer.ts
+++ b/src/store/export/exportReducer.ts
@@ -13,14 +13,16 @@ export interface CachedExport extends Export {
 
 export type ExportState = Readonly<{
   byId: Map<string, CachedExport>;
-  fetchStatus: Map<string, FetchStatus>;
   errors: Map<string, AxiosError>;
+  fetchStatus: Map<string, FetchStatus>;
+  notification: Map<string, any>;
 }>;
 
 const defaultState: ExportState = {
   byId: new Map(),
-  fetchStatus: new Map(),
   errors: new Map(),
+  fetchStatus: new Map(),
+  notification: new Map(),
 };
 
 export type ExportAction = ActionType<
@@ -42,19 +44,21 @@ export function exportReducer(state = defaultState, action: ExportAction): Expor
     case getType(fetchExportSuccess):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
         byId: new Map(state.byId).set(action.meta.fetchId, {
           data: action.payload as any,
           timeRequested: Date.now(),
         }),
         errors: new Map(state.errors).set(action.meta.fetchId, null),
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        notification: new Map(state.notification).set(action.meta.fetchId, action.meta.notification),
       };
 
     case getType(fetchExportFailure):
       return {
         ...state,
-        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
         errors: new Map(state.errors).set(action.meta.fetchId, action.payload),
+        fetchStatus: new Map(state.fetchStatus).set(action.meta.fetchId, FetchStatus.complete),
+        notification: new Map(state.notification).set(action.meta.fetchId, action.meta.notification),
       };
     default:
       return state;

--- a/src/store/export/exportSelectors.ts
+++ b/src/store/export/exportSelectors.ts
@@ -12,16 +12,23 @@ export const selectExport = (
   reportQueryString: string
 ) => selectExportState(state).byId.get(getFetchId(reportPathsType, reportType, reportQueryString));
 
-export const selectExportFetchStatus = (
-  state: RootState,
-  reportPathsType: ReportPathsType,
-  reportType: ReportType,
-  reportQueryString: string
-) => selectExportState(state).fetchStatus.get(getFetchId(reportPathsType, reportType, reportQueryString));
-
 export const selectExportError = (
   state: RootState,
   reportPathsType: ReportPathsType,
   reportType: ReportType,
   reportQueryString: string
 ) => selectExportState(state).errors.get(getFetchId(reportPathsType, reportType, reportQueryString));
+
+export const selectExportFetchNotification = (
+  state: RootState,
+  reportPathsType: ReportPathsType,
+  reportType: ReportType,
+  reportQueryString: string
+) => selectExportState(state).notification?.get(getFetchId(reportPathsType, reportType, reportQueryString));
+
+export const selectExportFetchStatus = (
+  state: RootState,
+  reportPathsType: ReportPathsType,
+  reportType: ReportType,
+  reportQueryString: string
+) => selectExportState(state).fetchStatus.get(getFetchId(reportPathsType, reportType, reportQueryString));

--- a/src/store/rbac/actions.ts
+++ b/src/store/rbac/actions.ts
@@ -1,17 +1,19 @@
 import { AlertVariant } from '@patternfly/react-core';
-import { addNotification } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import type { RBAC } from 'api/rbac';
 import { getRBAC } from 'api/rbac';
+import type { AxiosError } from 'axios';
 import { intl } from 'components/i18n';
 import messages from 'locales/messages';
 import type { Dispatch } from 'redux';
-import { createAsyncAction } from 'typesafe-actions';
+import { createAction } from 'typesafe-actions';
 
-export const {
-  request: fetchRbacRequest,
-  success: fetchRbacSuccess,
-  failure: fetchRbacFailure,
-} = createAsyncAction('fetch/RBAC/request', 'fetch/RBAC/success', 'fetch/RBAC/failure')<void, RBAC, Error>();
+interface RbacActionMeta {
+  notification?: any;
+}
+
+export const fetchRbacRequest = createAction('settings/RBAC/request')<void>();
+export const fetchRbacSuccess = createAction('settings/RBAC/success')<RBAC>();
+export const fetchRbacFailure = createAction('settings/RBAC/failure')<AxiosError, RbacActionMeta>();
 
 export const fetchRbac = (): any => {
   return (dispatch: Dispatch) => {
@@ -22,14 +24,15 @@ export const fetchRbac = (): any => {
       })
       .catch(err => {
         dispatch(
-          addNotification({
-            title: intl.formatMessage(messages.rbacErrorTitle),
-            description: intl.formatMessage(messages.rbacErrorDesc),
-            variant: AlertVariant.danger,
-            dismissable: true,
+          fetchRbacFailure(err, {
+            notification: {
+              description: intl.formatMessage(messages.rbacErrorDesc),
+              dismissable: true,
+              title: intl.formatMessage(messages.rbacErrorTitle),
+              variant: AlertVariant.danger,
+            },
           })
         );
-        dispatch(fetchRbacFailure(err));
       });
   };
 };

--- a/src/store/rbac/reducer.ts
+++ b/src/store/rbac/reducer.ts
@@ -9,17 +9,19 @@ import { fetchRbacFailure, fetchRbacRequest, fetchRbacSuccess } from './actions'
 export const stateKey = 'RBAC';
 
 interface LoadingState {
-  status: FetchStatus;
   error: Error;
+  notification?: any;
+  status: FetchStatus;
 }
 
 export type RbacState = Readonly<LoadingState & RBAC>;
 
 export const defaultState: RbacState = {
+  error: null,
   isOrgAdmin: false,
+  notification: undefined,
   permissions: null,
   status: FetchStatus.none,
-  error: null,
 };
 
 export type RbacAction = ActionType<
@@ -39,14 +41,15 @@ export const reducer = (state: RbacState = defaultState, action: RbacAction): Rb
     case getType(fetchRbacSuccess):
       return {
         ...action.payload,
-        status: FetchStatus.complete,
         error: null,
+        status: FetchStatus.complete,
       };
     case getType(fetchRbacFailure):
       return {
         ...state,
-        status: FetchStatus.complete,
         error: action.payload,
+        notification: action.meta.notification,
+        status: FetchStatus.complete,
       };
     default:
       return state;

--- a/src/store/rbac/selectors.ts
+++ b/src/store/rbac/selectors.ts
@@ -8,6 +8,8 @@ export const selectRbacStatus = (state: RootState) => selectRbacState(state).sta
 
 export const selectRbacError = (state: RootState) => selectRbacState(state).error;
 
+export const selectRbacNotification = (state: RootState) => selectRbacState(state).notification;
+
 export const isCostModelWritePermission = (state: RootState) => {
   const { isOrgAdmin, permissions } = selectRbacState(state);
   if (isOrgAdmin === true) {

--- a/src/store/rootReducer.ts
+++ b/src/store/rootReducer.ts
@@ -1,4 +1,3 @@
-import { notificationsReducer } from '@redhat-cloud-services/frontend-components-notifications/redux';
 import { combineReducers } from 'redux';
 import { accountSettingsReducer, accountSettingsStateKey } from 'store/accountSettings';
 import { awsCostOverviewReducer, awsCostOverviewStateKey } from 'store/breakdown/costOverview/awsCostOverview';
@@ -75,5 +74,4 @@ export const rootReducer = combineReducers({
   [tagStateKey]: tagReducer,
   [uiStateKey]: uiReducer,
   [userAccessStateKey]: userAccessReducer,
-  notifications: notificationsReducer,
 });

--- a/src/store/settings/settingsReducer.ts
+++ b/src/store/settings/settingsReducer.ts
@@ -11,12 +11,14 @@ import { fetchSettingsFailure, fetchSettingsRequest, fetchSettingsSuccess } from
 export type SettingsState = Readonly<{
   byId: Map<string, Settings>;
   errors?: Map<string, AxiosError>;
+  notification?: Map<string, any>;
   status?: Map<string, FetchStatus>;
 }>;
 
 export const defaultState: SettingsState = {
   byId: new Map(),
   errors: new Map(),
+  notification: new Map(),
   status: new Map(),
 };
 
@@ -67,8 +69,9 @@ export function settingsReducer(state = defaultState, action: SettingsAction): S
     case getType(updateSettingsFailure):
       return {
         ...state,
-        status: new Map(state.status).set(action.meta.fetchId, FetchStatus.complete),
         errors: new Map(state.errors).set(action.meta.fetchId, action.payload),
+        notification: new Map(state.notification).set(action.meta.fetchId, action.meta.notification),
+        status: new Map(state.status).set(action.meta.fetchId, FetchStatus.complete),
       };
     case getType(updateSettingsRequest):
       return {
@@ -78,8 +81,9 @@ export function settingsReducer(state = defaultState, action: SettingsAction): S
     case getType(updateSettingsSuccess):
       return {
         ...state,
-        status: new Map(state.status).set(action.meta.fetchId, FetchStatus.complete),
         errors: new Map(state.errors).set(action.meta.fetchId, null),
+        notification: new Map(state.notification).set(action.meta.fetchId, action.meta.notification),
+        status: new Map(state.status).set(action.meta.fetchId, FetchStatus.complete),
       };
     default:
       return state;

--- a/src/store/settings/settingsSelectors.ts
+++ b/src/store/settings/settingsSelectors.ts
@@ -18,5 +18,8 @@ export const selectSettingsError = (state: RootState, settingsType: SettingsType
 export const selectSettingsUpdateStatus = (state: RootState, settingsType: SettingsType) =>
   selectSettingsState(state)?.status.get(getFetchId(settingsType));
 
+export const selectSettingsUpdateNotification = (state: RootState, settingsType: SettingsType) =>
+  selectSettingsState(state)?.notification?.get(getFetchId(settingsType));
+
 export const selectSettingsUpdateError = (state: RootState, settingsType: SettingsType) =>
   selectSettingsState(state)?.errors.get(getFetchId(settingsType));

--- a/src/store/store.ts
+++ b/src/store/store.ts
@@ -1,4 +1,3 @@
-import { notificationsMiddleware } from '@redhat-cloud-services/frontend-components-notifications/notificationsMiddleware';
 import { configureStore as createStore } from '@reduxjs/toolkit';
 import { axiosInstance } from 'api';
 
@@ -13,7 +12,7 @@ export const middleware = getDefaultMiddleware =>
       ignoreActions: true,
       ignoreState: true,
     },
-  }).concat(notificationsMiddleware());
+  });
 
 export function configureStore(initialState: Partial<RootState>) {
   const store = createStore({

--- a/src/utils/notification.tsx
+++ b/src/utils/notification.tsx
@@ -1,0 +1,33 @@
+import {
+  useAddNotification,
+  useClearNotifications,
+  useNotifications,
+  useRemoveNotification,
+} from '@redhat-cloud-services/frontend-components-notifications/hooks';
+import React from 'react';
+
+export interface NotificationProps {
+  addNotification: any;
+  clearNotifications: any;
+  notifications: any;
+  removeNotification: any;
+}
+
+export interface NotificationComponentProps {
+  notification: NotificationProps;
+}
+
+// See https://github.com/RedHatInsights/frontend-components/blob/master/packages/notifications/doc/notifications.md
+export const withNotification = Component => {
+  function ComponentNotificationProp(props) {
+    const addNotification = useAddNotification();
+    const clearNotifications = useClearNotifications();
+    const notifications = useNotifications();
+    const removeNotification = useRemoveNotification();
+    return (
+      <Component {...props} notification={{ addNotification, clearNotifications, notifications, removeNotification }} />
+    );
+  }
+
+  return ComponentNotificationProp;
+};


### PR DESCRIPTION
https://issues.redhat.com/browse/COST-6288

## Summary by Sourcery

Migrate notification integration to the v6 hook-based API and refactor components, actions, reducers, and the store to support notification metadata across the app.

New Features:
- Introduce a withNotification HOC and NotificationComponentProps to inject notification hooks into components
- Enable notification metadata in async action creators for cost models, exports, settings, account settings, and RBAC

Enhancements:
- Refactor components (CostModelInfo, Calculations, ExportSubmit, DetailsActions, and various settings pages) to use useAddNotification and withNotification instead of the legacy Redux notifications
- Extend reducers and selectors to store and retrieve notification objects from action metadata for export, account settings, settings, cost models, and RBAC
- Remove the notifications reducer and middleware from the Redux store and wrap the app with NotificationsProvider in App.tsx

Build:
- Bump @redhat-cloud-services/frontend-components-notifications to v6.0.0 in package.json