### PR TITLE
Create hooks for common code

### DIFF
--- a/src/routes/components/export/exportSubmit.tsx
+++ b/src/routes/components/export/exportSubmit.tsx
@@ -20,7 +20,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { exportActions, exportSelectors } from 'store/export';
 import { FeatureToggleSelectors } from 'store/featureToggle';
 import { getToday } from 'utils/dates';
-import type { NotificationComponentProps } from 'utils/notification';
+import type { Notification, NotificationComponentProps } from 'utils/notification';
 import { withNotification } from 'utils/notification';
 import { orgUnitIdKey, tagPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
@@ -51,7 +51,7 @@ interface ExportSubmitStateProps {
   endDate: string;
   exportError: AxiosError;
   exportFetchStatus?: FetchStatus;
-  exportFetchNotification?: any;
+  exportFetchNotification?: Notification;
   exportQueryString: string;
   exportReport: Export;
   isExportsToggleEnabled?: boolean;

--- a/src/routes/details/components/actions/actions.tsx
+++ b/src/routes/details/components/actions/actions.tsx
@@ -12,7 +12,7 @@ import type { ComputedReportItem } from 'routes/utils/computedReport/getComputed
 import { createMapStateToProps, FetchStatus } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
 import { uiActions } from 'store/ui';
-import type { NotificationComponentProps } from 'utils/notification';
+import type { Notification, NotificationComponentProps } from 'utils/notification';
 import { withNotification } from 'utils/notification';
 import { tagPrefix } from 'utils/props';
 import type { RouterComponentProps } from 'utils/router';
@@ -34,7 +34,7 @@ interface DetailsActionsOwnProps extends NotificationComponentProps, RouterCompo
 
 interface DetailsActionsStateProps {
   redirectError: AxiosError;
-  redirectNotification?: any;
+  redirectNotification?: Notification;
   redirectStatus: FetchStatus;
 }
 
@@ -44,7 +44,7 @@ interface DetailsActionsDispatchProps {
 }
 
 interface DetailsActionsState {
-  currentNotification?: any;
+  currentNotification?: Notification;
   isExportModalOpen?: boolean;
 }
 

--- a/src/routes/settings/calculations/calculations.tsx
+++ b/src/routes/settings/calculations/calculations.tsx
@@ -1,19 +1,16 @@
 import { Card, CardBody, Title, TitleSizes, Tooltip } from '@patternfly/react-core';
-import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import { AccountSettingsType } from 'api/accountSettings';
-import type { AxiosError } from 'axios';
 import messages from 'locales/messages';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useIntl } from 'react-intl';
-import { useDispatch, useSelector } from 'react-redux';
+import { useDispatch } from 'react-redux';
 import type { AnyAction } from 'redux';
 import type { ThunkDispatch } from 'redux-thunk';
 import { CostType } from 'routes/components/costType';
 import { Currency } from 'routes/components/currency';
+import { useAccountSettingsUpdate } from 'routes/settings/utils/hooks';
 import type { RootState } from 'store';
-import { accountSettingsActions, accountSettingsSelectors } from 'store/accountSettings';
-import { FetchStatus } from 'store/common';
-import { resetStatus } from 'store/settings/settingsActions';
+import { accountSettingsActions } from 'store/accountSettings';
 import { getAccountCostType, getAccountCurrency } from 'utils/sessionStorage';
 
 import { styles } from './calculations.styles';
@@ -23,12 +20,7 @@ interface CalculationsPropsOwnProps {
 }
 
 export interface CalculationsStateProps {
-  costTypeAccountSettingsUpdateError: AxiosError;
-  costTypeAccountSettingsUpdateNotification?: any;
-  costTypeAccountSettingsUpdateStatus: FetchStatus;
-  currencyAccountSettingsUpdateError: AxiosError;
-  currencyAccountSettingsUpdateNotification?: any;
-  currencyAccountSettingsUpdateStatus: FetchStatus;
+  // TBD...
 }
 
 type CalculationsProps = CalculationsPropsOwnProps;
@@ -37,18 +29,10 @@ const Calculations: React.FC<CalculationsProps> = ({ canWrite }) => {
   const [costType, setCostType] = useState(getAccountCostType());
   const [currency, setCurrency] = useState(getAccountCurrency());
 
-  const addNotification = useAddNotification();
   const dispatch: ThunkDispatch<RootState, any, AnyAction> = useDispatch();
   const intl = useIntl();
 
-  const {
-    costTypeAccountSettingsUpdateError,
-    costTypeAccountSettingsUpdateNotification,
-    costTypeAccountSettingsUpdateStatus,
-    currencyAccountSettingsUpdateError,
-    currencyAccountSettingsUpdateNotification,
-    currencyAccountSettingsUpdateStatus,
-  } = useMapToProps();
+  useMapToProps(setCostType, setCurrency);
 
   const getCostType = () => {
     return (
@@ -114,40 +98,6 @@ const Calculations: React.FC<CalculationsProps> = ({ canWrite }) => {
     );
   };
 
-  useEffect(() => {
-    if (
-      costTypeAccountSettingsUpdateNotification &&
-      (costTypeAccountSettingsUpdateStatus === FetchStatus.complete || costTypeAccountSettingsUpdateError)
-    ) {
-      if (!costTypeAccountSettingsUpdateError) {
-        setCostType(getAccountCostType());
-      }
-      addNotification(costTypeAccountSettingsUpdateNotification);
-      dispatch(resetStatus());
-    }
-  }, [
-    costTypeAccountSettingsUpdateError,
-    costTypeAccountSettingsUpdateNotification,
-    costTypeAccountSettingsUpdateStatus,
-  ]);
-
-  useEffect(() => {
-    if (
-      currencyAccountSettingsUpdateNotification &&
-      (currencyAccountSettingsUpdateStatus === FetchStatus.complete || currencyAccountSettingsUpdateError)
-    ) {
-      if (!currencyAccountSettingsUpdateError) {
-        setCurrency(getAccountCurrency());
-      }
-      addNotification(currencyAccountSettingsUpdateNotification);
-      dispatch(resetStatus());
-    }
-  }, [
-    currencyAccountSettingsUpdateError,
-    currencyAccountSettingsUpdateNotification,
-    currencyAccountSettingsUpdateStatus,
-  ]);
-
   return (
     <Card>
       <CardBody>
@@ -158,34 +108,21 @@ const Calculations: React.FC<CalculationsProps> = ({ canWrite }) => {
   );
 };
 
-const useMapToProps = (): CalculationsStateProps => {
-  const costTypeAccountSettingsUpdateError = useSelector((state: RootState) =>
-    accountSettingsSelectors.selectAccountSettingsUpdateError(state, AccountSettingsType.costType)
-  );
-  const costTypeAccountSettingsUpdateNotification = useSelector((state: RootState) =>
-    accountSettingsSelectors.selectAccountSettingsUpdateNotification(state, AccountSettingsType.costType)
-  );
-  const costTypeAccountSettingsUpdateStatus = useSelector((state: RootState) =>
-    accountSettingsSelectors.selectAccountSettingsUpdateStatus(state, AccountSettingsType.costType)
-  );
+const useMapToProps = (setCostType, setCurrency): CalculationsStateProps => {
+  useAccountSettingsUpdate({
+    getSessionValue: getAccountCostType,
+    type: AccountSettingsType.costType,
+    setState: setCostType,
+  });
 
-  const currencyAccountSettingsUpdateError = useSelector((state: RootState) =>
-    accountSettingsSelectors.selectAccountSettingsUpdateError(state, AccountSettingsType.currency)
-  );
-  const currencyAccountSettingsUpdateNotification = useSelector((state: RootState) =>
-    accountSettingsSelectors.selectAccountSettingsUpdateNotification(state, AccountSettingsType.currency)
-  );
-  const currencyAccountSettingsUpdateStatus = useSelector((state: RootState) =>
-    accountSettingsSelectors.selectAccountSettingsUpdateStatus(state, AccountSettingsType.currency)
-  );
+  useAccountSettingsUpdate({
+    getSessionValue: getAccountCurrency,
+    type: AccountSettingsType.currency,
+    setState: setCurrency,
+  });
 
   return {
-    costTypeAccountSettingsUpdateError,
-    costTypeAccountSettingsUpdateNotification,
-    costTypeAccountSettingsUpdateStatus,
-    currencyAccountSettingsUpdateError,
-    currencyAccountSettingsUpdateNotification,
-    currencyAccountSettingsUpdateStatus,
+    // TBD...
   };
 };
 

--- a/src/routes/settings/costCategory/costCategory.tsx
+++ b/src/routes/settings/costCategory/costCategory.tsx
@@ -1,5 +1,4 @@
 import { Card, CardBody, Pagination, PaginationVariant } from '@patternfly/react-core';
-import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import type { Query } from 'api/queries/query';
 import { getQuery } from 'api/queries/query';
 import type { Settings } from 'api/settings';
@@ -14,11 +13,11 @@ import type { AnyAction } from 'redux';
 import type { ThunkDispatch } from 'redux-thunk';
 import { NotAvailable } from 'routes/components/page/notAvailable';
 import { LoadingState } from 'routes/components/state/loadingState';
+import { useSettingsUpdate } from 'routes/settings/utils/hooks';
 import * as queryUtils from 'routes/utils/query';
 import type { RootState } from 'store';
 import { FetchStatus } from 'store/common';
 import { settingsActions, settingsSelectors } from 'store/settings';
-import { resetStatus } from 'store/settings/settingsActions';
 import { useStateCallback } from 'utils/hooks';
 
 import { styles } from './costCategory.styles';
@@ -245,7 +244,6 @@ const CostCategory: React.FC<CostCategoryProps> = ({ canWrite }) => {
 
 const useMapToProps = ({ query }: CostCategoryMapProps): CostCategoryStateProps => {
   const dispatch: ThunkDispatch<RootState, any, AnyAction> = useDispatch();
-  const addNotification = useAddNotification();
 
   const settingsQuery = {
     filter_by: query.filter_by,
@@ -264,25 +262,13 @@ const useMapToProps = ({ query }: CostCategoryMapProps): CostCategoryStateProps 
     settingsSelectors.selectSettingsError(state, SettingsType.costCategories, settingsQueryString)
   );
 
-  const settingsUpdateDisableError = useSelector((state: RootState) =>
-    settingsSelectors.selectSettingsUpdateError(state, SettingsType.costCategoriesDisable)
-  );
-  const settingsUpdateDisableNotification = useSelector((state: RootState) =>
-    settingsSelectors.selectSettingsUpdateNotification(state, SettingsType.costCategoriesDisable)
-  );
-  const settingsUpdateDisableStatus = useSelector((state: RootState) =>
-    settingsSelectors.selectSettingsUpdateStatus(state, SettingsType.costCategoriesDisable)
-  );
+  const { status: settingsUpdateDisableStatus } = useSettingsUpdate({
+    type: SettingsType.costCategoriesDisable,
+  });
 
-  const settingsUpdateEnableError = useSelector((state: RootState) =>
-    settingsSelectors.selectSettingsUpdateError(state, SettingsType.costCategoriesEnable)
-  );
-  const settingsUpdateEnableNotification = useSelector((state: RootState) =>
-    settingsSelectors.selectSettingsUpdateNotification(state, SettingsType.costCategoriesEnable)
-  );
-  const settingsUpdateEnableStatus = useSelector((state: RootState) =>
-    settingsSelectors.selectSettingsUpdateStatus(state, SettingsType.costCategoriesEnable)
-  );
+  const { status: settingsUpdateEnableStatus } = useSettingsUpdate({
+    type: SettingsType.costCategoriesEnable,
+  });
 
   useEffect(() => {
     if (
@@ -294,26 +280,6 @@ const useMapToProps = ({ query }: CostCategoryMapProps): CostCategoryStateProps 
       dispatch(settingsActions.fetchSettings(SettingsType.costCategories, settingsQueryString));
     }
   }, [query, settingsUpdateDisableStatus, settingsUpdateEnableStatus]);
-
-  useEffect(() => {
-    if (
-      settingsUpdateEnableNotification &&
-      (settingsUpdateEnableStatus === FetchStatus.complete || settingsUpdateDisableError)
-    ) {
-      addNotification(settingsUpdateEnableNotification);
-      dispatch(resetStatus());
-    }
-  }, [settingsUpdateEnableNotification, settingsUpdateEnableStatus, settingsUpdateDisableError]);
-
-  useEffect(() => {
-    if (
-      settingsUpdateDisableNotification &&
-      (settingsUpdateDisableStatus === FetchStatus.complete || settingsUpdateEnableError)
-    ) {
-      addNotification(settingsUpdateDisableNotification);
-      dispatch(resetStatus());
-    }
-  }, [settingsUpdateDisableNotification, settingsUpdateDisableStatus, settingsUpdateEnableError]);
 
   return {
     settings,

--- a/src/routes/settings/costModels/costModel/costModelInfo.tsx
+++ b/src/routes/settings/costModels/costModel/costModelInfo.tsx
@@ -28,7 +28,7 @@ import { createMapStateToProps, FetchStatus } from 'store/common';
 import { costModelsActions, costModelsSelectors } from 'store/costModels';
 import { metricsActions, metricsSelectors } from 'store/metrics';
 import { rbacActions, rbacSelectors } from 'store/rbac';
-import type { NotificationComponentProps } from 'utils/notification';
+import type { Notification, NotificationComponentProps } from 'utils/notification';
 import { withNotification } from 'utils/notification';
 import type { RouterComponentProps } from 'utils/router';
 import { withRouter } from 'utils/router';
@@ -46,8 +46,8 @@ interface CostModelInfoOwnProps {
   markup: { value: string };
   metricsError: AxiosError;
   metricsStatus: FetchStatus;
-  rbacError: Error;
-  rbacNotification?: any;
+  rbacError: AxiosError;
+  rbacNotification?: Notification;
   rbacStatus: FetchStatus;
 }
 
@@ -68,9 +68,11 @@ class CostModelInfo extends React.Component<CostModelInfoProps, CostModelInfoSta
   }
 
   public componentDidMount() {
-    this.props.fetchRbac();
-    this.props.fetchMetrics();
-    this.props.fetchCostModels(`uuid=${this.props.router.params.uuid}`);
+    const { fetchCostModels, fetchMetrics, fetchRbac } = this.props;
+
+    fetchRbac();
+    fetchMetrics();
+    fetchCostModels(`uuid=${this.props.router.params.uuid}`);
   }
 
   public componentDidUpdate(prevProps: CostModelInfoProps) {

--- a/src/routes/settings/platformProjects/platformProjects.tsx
+++ b/src/routes/settings/platformProjects/platformProjects.tsx
@@ -1,5 +1,4 @@
 import { Card, CardBody, Pagination, PaginationVariant } from '@patternfly/react-core';
-import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import type { Query } from 'api/queries/query';
 import { getQuery } from 'api/queries/query';
 import type { Settings } from 'api/settings';
@@ -14,11 +13,11 @@ import type { AnyAction } from 'redux';
 import type { ThunkDispatch } from 'redux-thunk';
 import { NotAvailable } from 'routes/components/page/notAvailable';
 import { LoadingState } from 'routes/components/state/loadingState';
+import { useSettingsUpdate } from 'routes/settings/utils/hooks';
 import * as queryUtils from 'routes/utils/query';
 import type { RootState } from 'store';
 import { FetchStatus } from 'store/common';
 import { settingsActions, settingsSelectors } from 'store/settings';
-import { resetStatus } from 'store/settings/settingsActions';
 import { useStateCallback } from 'utils/hooks';
 
 import { styles } from './platformProjects.styles';
@@ -250,7 +249,6 @@ const PlatformProjects: React.FC<PlatformProjectsProps> = ({ canWrite }) => {
 
 const useMapToProps = ({ query }: PlatformProjectsMapProps): PlatformProjectsStateProps => {
   const dispatch: ThunkDispatch<RootState, any, AnyAction> = useDispatch();
-  const addNotification = useAddNotification();
 
   const settingsQuery = {
     filter_by: query.filter_by,
@@ -269,25 +267,13 @@ const useMapToProps = ({ query }: PlatformProjectsMapProps): PlatformProjectsSta
     settingsSelectors.selectSettingsError(state, SettingsType.platformProjects, settingsQueryString)
   );
 
-  const settingsUpdateDisableError = useSelector((state: RootState) =>
-    settingsSelectors.selectSettingsUpdateError(state, SettingsType.platformProjectsAdd)
-  );
-  const settingsUpdateDisableNotification = useSelector((state: RootState) =>
-    settingsSelectors.selectSettingsUpdateNotification(state, SettingsType.platformProjectsAdd)
-  );
-  const settingsUpdateDisableStatus = useSelector((state: RootState) =>
-    settingsSelectors.selectSettingsUpdateStatus(state, SettingsType.platformProjectsAdd)
-  );
+  const { status: settingsUpdateDisableStatus } = useSettingsUpdate({
+    type: SettingsType.platformProjectsAdd,
+  });
 
-  const settingsUpdateEnableError = useSelector((state: RootState) =>
-    settingsSelectors.selectSettingsUpdateError(state, SettingsType.platformProjectsRemove)
-  );
-  const settingsUpdateEnableNotification = useSelector((state: RootState) =>
-    settingsSelectors.selectSettingsUpdateNotification(state, SettingsType.platformProjectsRemove)
-  );
-  const settingsUpdateEnableStatus = useSelector((state: RootState) =>
-    settingsSelectors.selectSettingsUpdateStatus(state, SettingsType.platformProjectsRemove)
-  );
+  const { status: settingsUpdateEnableStatus } = useSettingsUpdate({
+    type: SettingsType.platformProjectsRemove,
+  });
 
   useEffect(() => {
     if (
@@ -299,26 +285,6 @@ const useMapToProps = ({ query }: PlatformProjectsMapProps): PlatformProjectsSta
       dispatch(settingsActions.fetchSettings(SettingsType.platformProjects, settingsQueryString));
     }
   }, [query, settingsUpdateDisableStatus, settingsUpdateEnableStatus]);
-
-  useEffect(() => {
-    if (
-      settingsUpdateEnableNotification &&
-      (settingsUpdateEnableStatus === FetchStatus.complete || settingsUpdateDisableError)
-    ) {
-      addNotification(settingsUpdateEnableNotification);
-      dispatch(resetStatus());
-    }
-  }, [settingsUpdateEnableNotification, settingsUpdateEnableStatus, settingsUpdateDisableError]);
-
-  useEffect(() => {
-    if (
-      settingsUpdateDisableNotification &&
-      (settingsUpdateDisableStatus === FetchStatus.complete || settingsUpdateEnableError)
-    ) {
-      addNotification(settingsUpdateDisableNotification);
-      dispatch(resetStatus());
-    }
-  }, [settingsUpdateDisableNotification, settingsUpdateDisableStatus, settingsUpdateEnableError]);
 
   return {
     settings,

--- a/src/routes/settings/tagLabels/tags/tags.tsx
+++ b/src/routes/settings/tagLabels/tags/tags.tsx
@@ -1,6 +1,5 @@
 import Unavailable from '@patternfly/react-component-groups/dist/esm/UnavailableContent';
 import { Pagination, PaginationVariant } from '@patternfly/react-core';
-import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import type { Query } from 'api/queries/query';
 import { getQuery } from 'api/queries/query';
 import type { Settings, SettingsData } from 'api/settings';
@@ -13,11 +12,11 @@ import { useDispatch, useSelector } from 'react-redux';
 import type { AnyAction } from 'redux';
 import type { ThunkDispatch } from 'redux-thunk';
 import { LoadingState } from 'routes/components/state/loadingState';
+import { useSettingsUpdate } from 'routes/settings/utils/hooks';
 import * as queryUtils from 'routes/utils/query';
 import type { RootState } from 'store';
 import { FetchStatus } from 'store/common';
 import { settingsActions, settingsSelectors } from 'store/settings';
-import { resetStatus } from 'store/settings/settingsActions';
 import { useStateCallback } from 'utils/hooks';
 
 import { styles } from './tags.styles';
@@ -249,7 +248,6 @@ const Tags: React.FC<TagsProps> = ({ canWrite }) => {
 
 const useMapToProps = ({ query }: TagsMapProps): TagsStateProps => {
   const dispatch: ThunkDispatch<RootState, any, AnyAction> = useDispatch();
-  const addNotification = useAddNotification();
 
   const settingsQuery = {
     filter_by: query.filter_by,
@@ -268,25 +266,13 @@ const useMapToProps = ({ query }: TagsMapProps): TagsStateProps => {
     settingsSelectors.selectSettingsError(state, SettingsType.tags, settingsQueryString)
   );
 
-  const settingsUpdateDisableError = useSelector((state: RootState) =>
-    settingsSelectors.selectSettingsUpdateError(state, SettingsType.tagsDisable)
-  );
-  const settingsUpdateDisableStatus = useSelector((state: RootState) =>
-    settingsSelectors.selectSettingsUpdateStatus(state, SettingsType.tagsDisable)
-  );
-  const settingsUpdateDisableNotification = useSelector((state: RootState) =>
-    settingsSelectors.selectSettingsUpdateNotification(state, SettingsType.tagsDisable)
-  );
+  const { status: settingsUpdateDisableStatus } = useSettingsUpdate({
+    type: SettingsType.tagsDisable,
+  });
 
-  const settingsUpdateEnableError = useSelector((state: RootState) =>
-    settingsSelectors.selectSettingsUpdateError(state, SettingsType.tagsEnable)
-  );
-  const settingsUpdateEnableNotification = useSelector((state: RootState) =>
-    settingsSelectors.selectSettingsUpdateNotification(state, SettingsType.tagsEnable)
-  );
-  const settingsUpdateEnableStatus = useSelector((state: RootState) =>
-    settingsSelectors.selectSettingsUpdateStatus(state, SettingsType.tagsEnable)
-  );
+  const { status: settingsUpdateEnableStatus } = useSettingsUpdate({
+    type: SettingsType.tagsEnable,
+  });
 
   useEffect(() => {
     if (
@@ -298,26 +284,6 @@ const useMapToProps = ({ query }: TagsMapProps): TagsStateProps => {
       dispatch(settingsActions.fetchSettings(SettingsType.tags, settingsQueryString));
     }
   }, [query, settingsUpdateDisableStatus, settingsUpdateEnableStatus]);
-
-  useEffect(() => {
-    if (
-      settingsUpdateEnableNotification &&
-      (settingsUpdateEnableStatus === FetchStatus.complete || settingsUpdateDisableError)
-    ) {
-      addNotification(settingsUpdateEnableNotification);
-      dispatch(resetStatus());
-    }
-  }, [settingsUpdateEnableNotification, settingsUpdateEnableStatus, settingsUpdateDisableError]);
-
-  useEffect(() => {
-    if (
-      settingsUpdateDisableNotification &&
-      (settingsUpdateDisableStatus === FetchStatus.complete || settingsUpdateEnableError)
-    ) {
-      addNotification(settingsUpdateDisableNotification);
-      dispatch(resetStatus());
-    }
-  }, [settingsUpdateDisableNotification, settingsUpdateDisableStatus, settingsUpdateEnableError]);
 
   return {
     settings,

--- a/src/routes/settings/utils/hooks.ts
+++ b/src/routes/settings/utils/hooks.ts
@@ -1,0 +1,84 @@
+import { useAddNotification } from '@redhat-cloud-services/frontend-components-notifications/hooks';
+import type { AccountSettingsType } from 'api/accountSettings';
+import type { SettingsType } from 'api/settings';
+import type { AxiosError } from 'axios';
+import { useEffect } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import type { AnyAction } from 'redux';
+import type { ThunkDispatch } from 'redux-thunk';
+import type { RootState } from 'store';
+import { accountSettingsSelectors } from 'store/accountSettings';
+import { FetchStatus } from 'store/common';
+import { settingsSelectors } from 'store/settings';
+import { resetStatus } from 'store/settings/settingsActions';
+
+interface AccountSettingsUpdateProps<T> {
+  type: AccountSettingsType;
+  getSessionValue: () => T;
+  setState: (v: T) => void;
+}
+
+interface SettingsUpdateProps {
+  type: SettingsType;
+}
+
+interface SettingsNotificationProps {
+  error: AxiosError;
+  notification: Notification;
+  status: FetchStatus;
+}
+
+export const useAccountSettingsUpdate = <T>({
+  type,
+  getSessionValue,
+  setState,
+}: AccountSettingsUpdateProps<T>): SettingsNotificationProps => {
+  const dispatch = useDispatch<ThunkDispatch<RootState, any, AnyAction>>();
+  const addNotification = useAddNotification();
+
+  const error = useSelector((state: RootState) =>
+    accountSettingsSelectors.selectAccountSettingsUpdateError(state, type)
+  ) as AxiosError | undefined;
+  const notification = useSelector((state: RootState) =>
+    accountSettingsSelectors.selectAccountSettingsUpdateNotification(state, type)
+  );
+  const status = useSelector((state: RootState) =>
+    accountSettingsSelectors.selectAccountSettingsUpdateStatus(state, type)
+  );
+
+  useEffect(() => {
+    if (status === FetchStatus.complete) {
+      if (!error) {
+        setState(getSessionValue());
+      }
+      if (notification) {
+        addNotification(notification as any);
+        dispatch(resetStatus());
+      }
+    }
+  }, [addNotification, dispatch, error, getSessionValue, notification, setState, status]);
+
+  return { error, notification, status };
+};
+
+export const useSettingsUpdate = ({ type }: SettingsUpdateProps): SettingsNotificationProps => {
+  const dispatch = useDispatch<ThunkDispatch<RootState, any, AnyAction>>();
+  const addNotification = useAddNotification();
+
+  const error = useSelector((state: RootState) => settingsSelectors.selectSettingsUpdateError(state, type)) as
+    | AxiosError
+    | undefined;
+  const notification = useSelector((state: RootState) =>
+    settingsSelectors.selectSettingsUpdateNotification(state, type)
+  );
+  const status = useSelector((state: RootState) => settingsSelectors.selectSettingsUpdateStatus(state, type));
+
+  useEffect(() => {
+    if (status === FetchStatus.complete && notification) {
+      addNotification(notification as any);
+      dispatch(resetStatus());
+    }
+  }, [addNotification, dispatch, error, notification, status]);
+
+  return { error, notification, status };
+};

--- a/src/store/rbac/reducer.ts
+++ b/src/store/rbac/reducer.ts
@@ -1,4 +1,5 @@
 import type { RBAC } from 'api/rbac';
+import type { AxiosError } from 'axios';
 import { FetchStatus } from 'store/common';
 import { resetState } from 'store/ui/uiActions';
 import type { ActionType } from 'typesafe-actions';
@@ -9,7 +10,7 @@ import { fetchRbacFailure, fetchRbacRequest, fetchRbacSuccess } from './actions'
 export const stateKey = 'RBAC';
 
 interface LoadingState {
-  error: Error;
+  error: AxiosError;
   notification?: any;
   status: FetchStatus;
 }

--- a/src/utils/notification.tsx
+++ b/src/utils/notification.tsx
@@ -1,3 +1,4 @@
+import type { AlertProps } from '@patternfly/react-core';
 import {
   useAddNotification,
   useClearNotifications,
@@ -5,6 +6,14 @@ import {
   useRemoveNotification,
 } from '@redhat-cloud-services/frontend-components-notifications/hooks';
 import React from 'react';
+
+export interface Notification {
+  description?: string;
+  dismissable?: boolean;
+  id?: string;
+  title: string;
+  variant: AlertProps['variant'];
+}
 
 export interface NotificationProps {
   addNotification: any;


### PR DESCRIPTION
https://issues.redhat.com/browse/COST-6288

## Summary by Sourcery

Refactor common settings update and notification logic into reusable hooks and apply them across multiple settings components

New Features:
- Introduce useAccountSettingsUpdate hook to encapsulate account settings update, state synchronization, and notifications
- Introduce useSettingsUpdate hook to handle generic settings updates and notifications
- Define a reusable Notification interface for typed notifications

Enhancements:
- Replace repeated selectors and useEffect notification logic in Calculations, CostCategory, PlatformProjects, Tags, and DetailsActions with the new hooks
- Remove redundant useAddNotification imports and manual mapToProps implementations
- Update state and prop types to use AxiosError and Notification where applicable
- Reorder CostModelInfo lifecycle fetch calls to use destructured props