### PR TITLE
Cannot select a tag key when using typeahead

### DIFF
--- a/src/routes/components/selectWrapper/selectTypeaheadWrapper.tsx
+++ b/src/routes/components/selectWrapper/selectTypeaheadWrapper.tsx
@@ -72,11 +72,6 @@ const SelectTypeaheadWrapper: React.FC<SelectTypeaheadWrapperProps> = ({
     );
   };
 
-  const handleOnBlur = () => {
-    setInputValue(selection ? selection.toString() : '');
-    setFilterValue('');
-  };
-
   const handleOnClear = () => {
     setInputValue('');
     setFilterValue('');
@@ -85,8 +80,8 @@ const SelectTypeaheadWrapper: React.FC<SelectTypeaheadWrapperProps> = ({
   };
 
   const handleOnToggleClick = () => {
+    // Don't clear filter value upon focus
     setIsOpen(!isOpen);
-    setFilterValue('');
   };
 
   const handleOnSelect = (_evt, value) => {
@@ -167,7 +162,6 @@ const SelectTypeaheadWrapper: React.FC<SelectTypeaheadWrapperProps> = ({
       <TextInputGroup isPlain>
         <TextInputGroupMain
           value={inputValue}
-          onBlur={handleOnBlur}
           onClick={handleOnToggleClick}
           onChange={handleOnTextInputChange}
           onKeyDown={handleOnInputKeyDown}


### PR DESCRIPTION
https://issues.redhat.com/browse/COST-6410

## Summary by Sourcery

Prevent the typeahead filter and input from clearing on blur and toggle click to enable selecting tag keys

Bug Fixes:
- Allow selecting a tag key by removing the blur handler that reset the input and filter values
- Retain the current filter value when toggling the dropdown instead of clearing it

Enhancements:
- Remove the unused handleOnBlur function from the SelectTypeaheadWrapper component