### PR TITLE
Add Azure and GCP filters to overview compute card

### DIFF
--- a/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
+++ b/src/store/dashboard/ocpCloudDashboard/ocpCloudDashboardWidgets.ts
@@ -65,7 +65,10 @@ export const computeWidget: DashboardWidget = {
     usageKey: messages.usage,
   },
   filter: {
-    service: 'AmazonEC2',
+    service:
+      'AmazonEC2,' + // AWS
+      'Virtual Machines,' + // Azure
+      'Compute Engine', // GCP
   },
   trend: {
     computedReportItem: ComputedReportItemType.usage,


### PR DESCRIPTION
Add Azure and GCP filters to overview compute card

New API request
`api/cost-management/v1/reports/openshift/infrastructures/all/instance-types/?currency=USD&filter[resolution]=daily&filter[service]=AmazonEC2,Virtual%20Machines,Compute%20Engine&filter[time_scope_units]=month&filter[time_scope_value]=-1`

https://issues.redhat.com/browse/COST-6457

## Summary by Sourcery

New Features:
- Include Azure 'Virtual Machines' and GCP 'Compute Engine' services in the compute widget filter