### PR TITLE
When filtering on cluster name, cluster uuid is shown

### DIFF
--- a/src/routes/details/azureDetails/detailsToolbar.tsx
+++ b/src/routes/details/azureDetails/detailsToolbar.tsx
@@ -96,6 +96,7 @@ export class DetailsToolbarBase extends React.Component<DetailsToolbarProps, Det
       {
         name: intl.formatMessage(messages.filterByValues, { value: 'subscription_guid' }),
         key: 'subscription_guid',
+        resourceKey: 'account_alias',
       },
       { name: intl.formatMessage(messages.filterByValues, { value: 'service_name' }), key: 'service_name' },
       {

--- a/src/routes/explorer/explorerUtils.ts
+++ b/src/routes/explorer/explorerUtils.ts
@@ -59,8 +59,9 @@ export const groupByAwsOptions: {
 export const groupByAzureOptions: {
   label: string;
   value: ComputedAzureReportItemsParams['idKey'];
+  resourceKey?: string;
 }[] = [
-  { label: 'subscription_guid', value: 'subscription_guid' },
+  { label: 'subscription_guid', value: 'subscription_guid', resourceKey: 'account_alias' },
   { label: 'service_name', value: 'service_name' },
   { label: 'resource_location', value: 'resource_location' },
 ];
@@ -88,8 +89,9 @@ export const groupByGcpOcpOptions: {
 export const groupByOcpOptions: {
   label: string;
   value: ComputedOcpReportItemsParams['idKey'];
+  resourceKey?: string;
 }[] = [
-  { label: 'cluster', value: 'cluster' },
+  { label: 'cluster', value: 'cluster', resourceKey: 'cluster_alias' },
   { label: 'node', value: 'node' },
   { label: 'project', value: 'project' },
 ];


### PR DESCRIPTION
Different resource APIs use unique keys. Updated filters to look for `cluster_alias` for OCP and `account_alias` for Azure.

https://issues.redhat.com/browse/COST-6433

**OCP Cluster Example**
![Screenshot 2025-06-18 at 2 09 08 PM](https://github.com/user-attachments/assets/42189971-e788-4df5-baef-bf733d6d7dc6)



**Azure Account Example**
![Screenshot 2025-06-18 at 2 12 04 PM](https://github.com/user-attachments/assets/21ac3020-0600-4691-b5d2-37ac75a960cf)

