### PR TITLE
Filtering by cluster/account alias is case-sensitive

### DIFF
--- a/src/routes/components/resourceTypeahead/resourceFetch.tsx
+++ b/src/routes/components/resourceTypeahead/resourceFetch.tsx
@@ -63,7 +63,7 @@ const ResourceFetch: React.FC<ResourceFetchProps> = ({
     if (resource && resource.data && resource.data.length > 0 && resourceFetchStatus !== FetchStatus.inProgress) {
       options = resource.data.map(item => {
         // The resource API typically returns just a value, but account_alias, cluster_alias, and instance_name may be preferred keys.
-        const value = item[resourceKey]?.includes(search) ? item[resourceKey] : item.value;
+        const value = item[resourceKey]?.toLowerCase().includes(search.toLowerCase()) ? item[resourceKey] : item.value;
         return {
           key: value,
           name: value,


### PR DESCRIPTION
Filtering by cluster/account alias is case-sensitive

https://issues.redhat.com/browse/COST-6505

## Summary by Sourcery

Bug Fixes:
- Make resource alias filtering case-insensitive by comparing lowercase values