### PR TITLE
OCP cluster details storage breakdown chart not ordered

### DIFF
--- a/src/routes/details/components/summary/summaryCard.tsx
+++ b/src/routes/details/components/summary/summaryCard.tsx
@@ -265,6 +265,9 @@ const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps
       group_by: {
         ...(reportGroupBy && { [reportGroupBy]: '*' }), // Group by all accounts, regions, etc.
       },
+      order_by: {
+        cost: 'desc', // Volumes API uses implicit ordering on usage instead of cost -- see https://issues.redhat.com/browse/COST-6560
+      },
       ...(costDistribution === ComputedReportItemValueType.distributed && {
         order_by: {
           distributed_cost: 'desc',


### PR DESCRIPTION
Adds order_by parameter for volumes API, which uses implicit ordering on usage instead of cost

https://issues.redhat.com/browse/COST-6560

![Screenshot 2025-07-07 at 9 51 05 AM](https://github.com/user-attachments/assets/f266f2fb-7c51-40f8-a5c7-e9e2d13b4497)

## Summary by Sourcery

Bug Fixes:
- Explicitly order volumes API results by cost (desc) to fix incorrect default usage ordering in the OCP storage breakdown chart.