### PR TITLE
Expandable tables should have Tbody elements

### DIFF
--- a/src/appEntry.tsx
+++ b/src/appEntry.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 // Todo: Uncomment for use with non-shared PatternFly packages
-import '@patternfly/patternfly/patternfly.css';
+// import '@patternfly/patternfly/patternfly.css';
 import '@patternfly/patternfly/patternfly-addons.css';
 import './styles/global.css';
 

--- a/src/routes/components/dataTable/expandableTable.tsx
+++ b/src/routes/components/dataTable/expandableTable.tsx
@@ -127,8 +127,8 @@ class ExpandableTable extends React.Component<ExpandableTableProps, ExpandableTa
               ))}
             </Tr>
           </Thead>
-          <Tbody>
-            {isLoading ? (
+          {isLoading ? (
+            <Tbody>
               <Tr>
                 <Td colSpan={100}>
                   <Bullseye>
@@ -138,11 +138,13 @@ class ExpandableTable extends React.Component<ExpandableTableProps, ExpandableTa
                   </Bullseye>
                 </Td>
               </Tr>
-            ) : (
-              rows.map((row, rowIndex) => {
-                const isExpanded = isAllExpanded || expandedRows.has(row?.item);
-                return (
-                  <React.Fragment key={`fragment-${rowIndex}`}>
+            </Tbody>
+          ) : (
+            rows.map((row, rowIndex) => {
+              const isExpanded = isAllExpanded || expandedRows.has(row?.item);
+              return (
+                <React.Fragment key={`fragment-${rowIndex}`}>
+                  <Tbody>
                     <Tr key={`row-${rowIndex}`} style={isExpanded ? styles.expandableRowBorder : undefined}>
                       {row.cells.map((item, cellIndex) =>
                         cellIndex === 0 ? (
@@ -190,11 +192,11 @@ class ExpandableTable extends React.Component<ExpandableTableProps, ExpandableTa
                         )}
                       </Tr>
                     ))}
-                  </React.Fragment>
-                );
-              })
-            )}
-          </Tbody>
+                  </Tbody>
+                </React.Fragment>
+              );
+            })
+          )}
         </Table>
         {rows.length === 0 && <div style={styles.emptyState}>{this.getEmptyState()}</div>}
       </>


### PR DESCRIPTION
PatternFly expects a Tbody element to surround each expandable Tr and its children

https://issues.redhat.com/browse/COST-6581

## Summary by Sourcery

Wrap each expandable row group and the loading placeholder in Tbody elements to conform to PatternFly’s table structure requirements.

Bug Fixes:
- Enclose the loading state row in its own Tbody element.
- Wrap each data row (and its expanded children) in a separate Tbody element.