### PR TITLE
Renamed namespace metric as project

### DIFF
--- a/locales/data.json
+++ b/locales/data.json
@@ -10366,14 +10366,6 @@
               }
             ]
           },
-          "namespace": {
-            "value": [
-              {
-                "type": 0,
-                "value": "Namespace"
-              }
-            ]
-          },
           "node": {
             "value": [
               {
@@ -10390,6 +10382,14 @@
               {
                 "type": 0,
                 "value": "Persistent volume claims"
+              }
+            ]
+          },
+          "project": {
+            "value": [
+              {
+                "type": 0,
+                "value": "Project"
               }
             ]
           },

--- a/locales/translations.json
+++ b/locales/translations.json
@@ -405,7 +405,7 @@
   "memoryTitle": "Memory",
   "metric": "Metric",
   "metricPlaceholder": "Filter by metrics",
-  "metricValues": "{value, select, cpu {CPU} cluster {Cluster} memory {Memory} namespace {Namespace} node {Node} persistent_volume_claims {Persistent volume claims} storage {Storage} virtual_machine {Virtual machine}other {}}",
+  "metricValues": "{value, select, cpu {CPU} cluster {Cluster} memory {Memory} project {Project} node {Node} persistent_volume_claims {Persistent volume claims} storage {Storage} virtual_machine {Virtual machine}other {}}",
   "metricsOperatorVersion": "Cost management operator version",
   "monthOverMonthChange": "Month over month change",
   "moreOptions": "More options",

--- a/src/locales/messages.ts
+++ b/src/locales/messages.ts
@@ -2591,7 +2591,7 @@ export default defineMessages({
       'cpu {CPU} ' +
       'cluster {Cluster} ' +
       'memory {Memory} ' +
-      'namespace {Namespace} ' +
+      'project {Project} ' +
       'node {Node} ' +
       'persistent_volume_claims {Persistent volume claims} ' +
       'storage {Storage} ' +

--- a/src/routes/settings/costModels/components/__snapshots__/rateTable.test.tsx.snap
+++ b/src/routes/settings/costModels/components/__snapshots__/rateTable.test.tsx.snap
@@ -6,25 +6,25 @@ exports[`rate-table sort by metric & measurement 1`] = `
     class="pf-v6-c-table__td"
     tabindex="-1"
   >
-    {value, select, cpu {CPU} cluster {Cluster} memory {Memory} namespace {Namespace} node {Node} persistent_volume_claims {Persistent volume claims} storage {Storage} virtual_machine {Virtual machine}other {}}{"value":"Node"}
+    {value, select, cpu {CPU} cluster {Cluster} memory {Memory} project {Project} node {Node} persistent_volume_claims {Persistent volume claims} storage {Storage} virtual_machine {Virtual machine}other {}}{"value":"Node"}
   </td>,
   <td
     class="pf-v6-c-table__td"
     tabindex="-1"
   >
-    {value, select, cpu {CPU} cluster {Cluster} memory {Memory} namespace {Namespace} node {Node} persistent_volume_claims {Persistent volume claims} storage {Storage} virtual_machine {Virtual machine}other {}}{"value":"CPU"}
+    {value, select, cpu {CPU} cluster {Cluster} memory {Memory} project {Project} node {Node} persistent_volume_claims {Persistent volume claims} storage {Storage} virtual_machine {Virtual machine}other {}}{"value":"CPU"}
   </td>,
   <td
     class="pf-v6-c-table__td"
     tabindex="-1"
   >
-    {value, select, cpu {CPU} cluster {Cluster} memory {Memory} namespace {Namespace} node {Node} persistent_volume_claims {Persistent volume claims} storage {Storage} virtual_machine {Virtual machine}other {}}{"value":"CPU"}
+    {value, select, cpu {CPU} cluster {Cluster} memory {Memory} project {Project} node {Node} persistent_volume_claims {Persistent volume claims} storage {Storage} virtual_machine {Virtual machine}other {}}{"value":"CPU"}
   </td>,
   <td
     class="pf-v6-c-table__td"
     tabindex="-1"
   >
-    {value, select, cpu {CPU} cluster {Cluster} memory {Memory} namespace {Namespace} node {Node} persistent_volume_claims {Persistent volume claims} storage {Storage} virtual_machine {Virtual machine}other {}}{"value":"CPU"}
+    {value, select, cpu {CPU} cluster {Cluster} memory {Memory} project {Project} node {Node} persistent_volume_claims {Persistent volume claims} storage {Storage} virtual_machine {Virtual machine}other {}}{"value":"CPU"}
   </td>,
 ]
 `;

--- a/src/routes/settings/costModels/components/rateForm/rateForm.tsx
+++ b/src/routes/settings/costModels/components/rateForm/rateForm.tsx
@@ -185,7 +185,7 @@ const RateFormBase: React.FC<RateFormProps> = ({ currencyUnits, intl = defaultIn
                 aria-label={intl.formatMessage(messages.costModelsEnterTagRate)}
                 label={intl.formatMessage(messages.costModelsEnterTagRate)}
                 isChecked={rateKind === 'tagging'}
-                isDisabled={metric.toLowerCase() === 'namespace'}
+                isDisabled={metric.toLowerCase() === 'project'}
                 onChange={toggleTaggingRate}
               />
             ) : null}

--- a/src/routes/settings/costModels/components/rateForm/useRateForm.tsx
+++ b/src/routes/settings/costModels/components/rateForm/useRateForm.tsx
@@ -308,7 +308,7 @@ export function useRateData(metricsHash: MetricHash, rate: Rate = undefined, tie
         value,
         defaultCalculation: getDefaultCalculation(metricsHash, value),
       });
-      if (value.toLowerCase() === 'namespace') {
+      if (value.toLowerCase() === 'project') {
         dispatch({ type: 'RESET_RATE_KIND_TAGGING' });
       }
     },


### PR DESCRIPTION
Renamed namespace metric as project

https://issues.redhat.com/browse/COST-6445

## Summary by Sourcery

Rename metric 'namespace' to 'project' across the UI, logic, translations, and tests.

Enhancements:
- Update resource type label from 'namespace' to 'project' in locale messages
- Disable the tagging rate option for the project metric
- Reset tagging rate state when switching to the project metric
- Refresh translation files and test snapshots to reflect the rename