### PR TITLE
Add PatternFly's ExpandableRowContent component to expandable table

### DIFF
--- a/src/routes/components/dataTable/dataTable.styles.ts
+++ b/src/routes/components/dataTable/dataTable.styles.ts
@@ -27,6 +27,10 @@ export const styles = {
   expandableRowBorder: {
     border: 0,
   },
+  expandableRowContent: {
+    paddingBottom: 4,
+    paddingTop: 4,
+  },
   infoArrow: {
     position: 'relative',
   },

--- a/src/routes/components/dataTable/expandableTable.tsx
+++ b/src/routes/components/dataTable/expandableTable.tsx
@@ -3,7 +3,17 @@ import './dataTable.scss';
 import { Bullseye, EmptyState, EmptyStateBody, Spinner } from '@patternfly/react-core';
 import { CalculatorIcon } from '@patternfly/react-icons/dist/esm/icons/calculator-icon';
 import type { ThProps } from '@patternfly/react-table';
-import { SortByDirection, Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
+import {
+  ExpandableRowContent,
+  SortByDirection,
+  Table,
+  TableVariant,
+  Tbody,
+  Td,
+  Th,
+  Thead,
+  Tr,
+} from '@patternfly/react-table';
 import messages from 'locales/messages';
 import React from 'react';
 import type { WrappedComponentProps } from 'react-intl';
@@ -169,29 +179,31 @@ class ExpandableTable extends React.Component<ExpandableTableProps, ExpandableTa
                         )
                       )}
                     </Tr>
-                    {row?.children?.map((child, childIndex) => (
-                      <Tr
-                        isExpanded={isExpanded}
-                        key={`row-children-${childIndex}-${rowIndex}`}
-                        style={childIndex !== row.children.length - 1 ? styles.expandableRowBorder : undefined}
-                      >
-                        {child.cells.map((item, cellIndex) =>
-                          cellIndex === 0 ? (
-                            <Td key={`child-cell-${cellIndex}-${rowIndex}`} />
-                          ) : (
-                            <Td
-                              dataLabel={columns[cellIndex].name}
-                              key={`child-cell-${rowIndex}-${cellIndex}`}
-                              modifier="nowrap"
-                              isActionCell={isActionsCell && cellIndex === child.cells.length - 1}
-                              style={item.style}
-                            >
-                              {item.value}
-                            </Td>
-                          )
-                        )}
-                      </Tr>
-                    ))}
+                    {isExpanded &&
+                      row?.children?.map((child, childIndex) => (
+                        <Tr
+                          isExpanded={isExpanded}
+                          key={`row-children-${childIndex}-${rowIndex}`}
+                          style={childIndex !== row.children.length - 1 ? styles.expandableRowBorder : undefined}
+                        >
+                          {child.cells.map((item, cellIndex) =>
+                            cellIndex === 0 ? (
+                              <Td key={`child-cell-${cellIndex}-${rowIndex}`} noPadding />
+                            ) : (
+                              <Td
+                                dataLabel={columns[cellIndex].name}
+                                key={`child-cell-${rowIndex}-${cellIndex}`}
+                                modifier="nowrap"
+                                noPadding
+                                isActionCell={isActionsCell && cellIndex === child.cells.length - 1}
+                                style={{ ...styles.expandableRowContent, ...item.style }}
+                              >
+                                <ExpandableRowContent>{item.value}</ExpandableRowContent>
+                              </Td>
+                            )
+                          )}
+                        </Tr>
+                      ))}
                   </Tbody>
                 </React.Fragment>
               );

--- a/src/routes/settings/costModels/components/rateTable.tsx
+++ b/src/routes/settings/costModels/components/rateTable.tsx
@@ -163,7 +163,7 @@ const RateTableBase: React.FC<RateTableProps> = ({
                 </Td>
               )}
             </Tr>
-            {row.data.hasChildren && isExpanded && (
+            {isExpanded && row.data.hasChildren && (
               <Tr>
                 <Td colSpan={6}>
                   <ExpandableRowContent>

--- a/src/routes/settings/tagLabels/tagMapping/tagMapping.styles.ts
+++ b/src/routes/settings/tagLabels/tagMapping/tagMapping.styles.ts
@@ -12,10 +12,10 @@ export const styles = {
     paddingRight: t_global_spacer_2xl.value,
   },
   childSourceTypeColumn: {
-    paddingRight: t_global_spacer_sm.value,
+    paddingLeft: t_global_spacer_md.value,
   },
   childTagKeyColumn: {
-    paddingLeft: t_global_spacer_lg.value,
+    paddingLeft: t_global_spacer_md.value,
   },
   emptyStateContainer: {
     paddingTop: t_global_spacer_md.value,


### PR DESCRIPTION
Add PatternFly's ExpandableRowContent component to expandable table

https://issues.redhat.com/browse/COST-6581

## Summary by Sourcery

Integrate PatternFly’s ExpandableRowContent into expandable tables and normalize row padding and spacing across data and tag mapping components

Enhancements:
- Wrap child row cells in ExpandableRowContent with noPadding in expandableTable and rateTable for consistent expandable layout
- Introduce expandableRowContent style with vertical padding to support the new component
- Restrict rendering of expanded child rows to when isExpanded is true
- Standardize padding in tagMapping.styles by using t_global_spacer_md for child columns