### PR TITLE
Navigation test in stage env

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -28,7 +28,7 @@ objects:
               expandable: true
               routes:
                 - id: 'cost-management.overview'
-                  title: 'Overview'
+                  title: '0verview'
                   href: '/openshift/cost-management'
                   product: 'Red Hat Cost Management'
                 - id: 'cost-management.systems'


### PR DESCRIPTION
Navigation test in stage env. If we don't see an updated nav link, then it will confirm Consoledot is not using the local nav. Plan to change this back later, after testing is complete

## Summary by Sourcery

Chores:
- Change the 'cost-management.overview' route title from 'Overview' to '0verview' in the frontend deploy configuration