### PR TITLE
Added test coverage to src/api directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "stats": "npm run build:prod --profile --json > stats.json",
     "test": "jest --no-cache",
     "test:clean": "jest --clearCache",
+    "test:coverage": "jest --coverage",
     "test:update": "npm run test:clean && jest --updateSnapshot",
     "translations": "npm-run-all translations:extract translations:compile translations:compile:ast translations:datafile",
     "translations:test": "npm-run-all translations:extract translations:compile translations:compile:ast 'translations:syncTranslations --locale fr' 'translations:syncTranslations --locale de' translations:datafile",

--- a/src/api/api.__mocks__.ts
+++ b/src/api/api.__mocks__.ts
@@ -1,0 +1,3 @@
+// Re-export the axios mock to satisfy imports of axiosInstance in some tests
+import mockAxios from 'axios';
+export default mockAxios as any;

--- a/src/api/api.test.ts
+++ b/src/api/api.test.ts
@@ -1,0 +1,56 @@
+import mockAxios from 'axios';
+
+describe('api axiosInstance', () => {
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+  });
+
+  const mockAxiosModule = () => {
+    const interceptors = { request: { use: jest.fn() } };
+    const instance = { get: jest.fn(), interceptors } as any;
+    const create = jest.fn(() => instance);
+    jest.doMock('axios', () => ({ __esModule: true, default: { create } }));
+    return { instance, create };
+  };
+
+  const loadModule = () => {
+    const state: any = {};
+    jest.isolateModules(() => {
+      const { instance, create } = mockAxiosModule();
+      const exported = require('./api');
+      state.axiosInstance = exported.default as any;
+      state.instance = instance;
+      state.create = create;
+    });
+    return state as { axiosInstance: any; instance: any; create: jest.Mock };
+  };
+
+  test('registers request interceptor', () => {
+    const { instance } = loadModule();
+    expect(instance.interceptors.request.use).toHaveBeenCalledTimes(1);
+    const interceptor = (instance.interceptors.request.use as jest.Mock).mock.calls[0][0];
+    expect(typeof interceptor).toBe('function');
+  });
+
+  test('authInterceptor preserves headers', () => {
+    const { instance } = loadModule();
+    const interceptor = (instance.interceptors.request.use as jest.Mock).mock.calls[0][0];
+    const config = { headers: { Foo: 'Bar' } } as any;
+    const result = interceptor(config);
+    expect(result).toEqual({ ...config, headers: { Foo: 'Bar' } });
+  });
+
+  test('authInterceptor handles missing headers', () => {
+    const { instance } = loadModule();
+    const interceptor = (instance.interceptors.request.use as jest.Mock).mock.calls[0][0];
+    const result = interceptor({} as any);
+    expect(result.headers).toEqual({});
+  });
+
+  test('proxies get calls to axios instance', () => {
+    const { axiosInstance, instance } = loadModule();
+    axiosInstance.get('/test');
+    expect(instance.get).toHaveBeenCalledWith('/test');
+  });
+}); 

--- a/src/api/apiDev.test.ts
+++ b/src/api/apiDev.test.ts
@@ -1,0 +1,67 @@
+// Top-level axios mock with shared state
+let mockAxiosInstance: any = {
+  get: jest.fn(),
+  interceptors: { request: { use: jest.fn() } },
+};
+let mockCreate = jest.fn(() => mockAxiosInstance);
+
+jest.mock('axios', () => ({ __esModule: true, default: { create: (...args: unknown[]) => (mockCreate as any)(...args) } }));
+
+function setInsightsMock({ token }: { token?: string | null } = {}) {
+  (window as any).insights = {
+    chrome: {
+      auth: {
+        getToken: () => (token === undefined ? null : Promise.resolve(token)),
+      },
+    },
+  };
+}
+
+describe('apiDev axiosInstance', () => {
+  const loadModule = () => {
+    const state: any = {};
+    jest.isolateModules(() => {
+      // Re-require module under test to invoke axios.create and register interceptor
+      const exported = require('./apiDev');
+      state.axiosInstance = exported.default as any;
+    });
+    return state as { axiosInstance: any };
+  };
+
+  beforeEach(() => {
+    jest.resetModules();
+    jest.clearAllMocks();
+    // Fresh axios instance each test
+    mockAxiosInstance = { get: jest.fn(), interceptors: { request: { use: jest.fn() } } };
+    mockCreate = jest.fn(() => mockAxiosInstance);
+  });
+
+  test('registers request interceptor', () => {
+    loadModule();
+    expect(mockAxiosInstance.interceptors.request.use).toHaveBeenCalled();
+  });
+
+  test('devAuthInterceptor returns undefined when no promise (mock env)', async () => {
+    setInsightsMock({ token: undefined });
+    loadModule();
+    const interceptor = (mockAxiosInstance.interceptors.request.use as jest.Mock).mock.calls[0][0];
+    const result = interceptor({ headers: { Foo: 'Bar' } } as any);
+    expect(result).toBeUndefined();
+  });
+
+  test('devAuthInterceptor resolves with Authorization header when token provided', async () => {
+    setInsightsMock({ token: 'abc123' });
+    loadModule();
+    const interceptor = (mockAxiosInstance.interceptors.request.use as jest.Mock).mock.calls[0][0];
+    const result = await interceptor({ headers: { Foo: 'Bar' } } as any);
+    expect(result.headers.Authorization).toEqual('Bearer abc123');
+    expect(result.headers.Accept).toEqual('application/json');
+    expect(result.headers.Foo).toEqual('Bar');
+  });
+
+  test('devAxiosInstance proxies get', () => {
+    const { axiosInstance } = loadModule();
+    axiosInstance.get('/ping');
+    expect(mockAxiosInstance.get).toHaveBeenCalledWith('/ping');
+  });
+}); 


### PR DESCRIPTION
Added test coverage to src/api directory via Cursor AI.

## Summary by Sourcery

Add Jest coverage support and initial unit tests for the src/api directory

Build:
- Add npm script 'test:coverage' to run Jest with coverage

Tests:
- Add 'src/api/apiDev.test.ts' to cover axios instance creation, request interceptors, token injection, and get proxying
- Add 'src/api/api.__mocks__.ts' to mock axios imports for testing
- Add 'src/api/api.test.ts' as initial test suite for the main API module