### PR TITLE
Extra tests

### DIFF
--- a/src/utils/format.extra.test.ts
+++ b/src/utils/format.extra.test.ts
@@ -1,0 +1,54 @@
+import * as f from './format';
+
+describe('utils/format (additional)', () => {
+  test.each([
+    { value: 1234567, units: 'USD' },
+    { value: 1234, units: 'USD' },
+  ])('formatCurrencyAbbreviation %#', ({ value, units }) => {
+    const out = f.formatCurrencyAbbreviation(value, units);
+    expect(typeof out).toBe('string');
+    expect(out.length).toBeGreaterThan(0);
+  });
+
+  test.each([
+    { value: '1,234.56', expected: true },
+    { value: '1,234', expected: true },
+    { value: 'abc', expected: false },
+  ])('isCurrencyFormatValid %#', ({ value, expected }) => {
+    expect(f.isCurrencyFormatValid(value)).toBe(expected);
+  });
+
+  test.each([
+    { value: '12.34', expected: true },
+    { value: '100', expected: true },
+    { value: 'abc', expected: false },
+  ])('isPercentageFormatValid %#', ({ value, expected }) => {
+    expect(f.isPercentageFormatValid(value)).toBe(expected);
+  });
+
+  test.each([
+    { value: '1,234.56', expected: '1234.56' },
+    { value: '$1,234.56', expected: '$1234.56' },
+  ])('unFormat %#', ({ value, expected }) => {
+    const out = f.unFormat(value);
+    expect(out).toBe(expected);
+  });
+
+  test.each([
+    { units: 'USD', expected: undefined },
+    { units: 'GB', expected: 'gb' },
+    { units: 'requests', expected: undefined },
+    { units: 'GB-mo', expected: 'gb_month' },
+  ])('unitsLookupKey %#', ({ units, expected }) => {
+    const key = f.unitsLookupKey(units);
+    expect(key).toBe(expected);
+  });
+
+  test.each([
+    { v: 0.1234 },
+    { v: 1.234 },
+  ])('formatPercentage variants %#', ({ v }) => {
+    const out = f.formatPercentage(v as any, {} as any);
+    expect(typeof out).toBe('string');
+  });
+}); 

--- a/src/utils/paths.test.ts
+++ b/src/utils/paths.test.ts
@@ -1,0 +1,47 @@
+import { routes } from 'routes'
+import { formatPath, getReleasePath, usePathname } from './paths'
+import { useLocation } from 'react-router-dom'
+
+// 1) single top‐level mock
+jest.mock('react-router-dom', () => ({
+  __esModule: true,
+  useLocation: jest.fn(),
+}))
+const mockUseLocation = useLocation as jest.MockedFunction<typeof useLocation>
+
+describe('utils/paths', () => {
+  const setWindowPathname = (pathname: string) => {
+    window.history.replaceState({}, '', pathname)
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  test('formatPath without release prefix', () => {
+    expect(formatPath(routes.overview.path)).toBe('/openshift/cost-management')
+    expect(formatPath(routes.costModel.basePath))
+      .toBe(`/openshift/cost-management${routes.costModel.basePath}`)
+  })
+
+  test.each([
+    { pathname: '/beta/openshift/cost-management', expected: '/beta' },
+    { pathname: '/preview/openshift/cost-management', expected: '/preview' },
+    { pathname: '/openshift/cost-management', expected: '' },
+  ])('getReleasePath for $pathname', ({ pathname, expected }) => {
+    setWindowPathname(pathname)
+    expect(getReleasePath()).toBe(expected)
+  })
+
+  test('formatPath with release prefix', () => {
+    setWindowPathname('/beta/openshift/cost-management')
+    expect(formatPath(routes.costModel.basePath, true).startsWith('/beta')).toBe(true)
+  })
+
+  test('usePathname collapses cost model UUID path', () => {
+    const base = formatPath(routes.costModel.basePath)
+    setWindowPathname(`${base}/123`)
+    mockUseLocation.mockReturnValue({ pathname: `${base}/123` })
+    expect(usePathname()).toBe(base)
+  })
+})


### PR DESCRIPTION
Extra tests

## Summary by Sourcery

Add comprehensive unit tests for path utility functions to validate release prefix handling and dynamic segment collapsing

Tests:
- Verify formatPath behavior with and without release path prefixes
- Parameterize getReleasePath for beta, preview, and default routes
- Confirm usePathname collapses dynamic cost model ID segments