### PR TITLE
Replace bundleSegments with navigationSegments

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -18,10 +18,8 @@ objects:
           description: 'Understand and track costs for your OpenShift clusters and workloads.'
           alt_title:
             - 'Cost Management'
-      bundleSegments:
+      navigationSegments:
         - segmentId: 'cost-management'
-          bundleId: 'openshift'
-          position: 100
           navItems:
             - id: 'cost-management.nav'
               title: 'Cost Management'
@@ -36,7 +34,7 @@ objects:
                   href: '/openshift/cost-management/systems'
                   permissions:
                     - method: 'featureFlag'
-                      args: ["cost-management.ui.systems", true]
+                      args: [ "cost-management.ui.systems", true ]
                 - id: 'cost-management.optimizations'
                   title: 'Optimizations'
                   href: '/openshift/cost-management/optimizations'


### PR DESCRIPTION
Since Cost Management is nested in OPC nav, we must use navigationSegments instead of bundleSegments

https://issues.redhat.com/browse/COST-6157

## Summary by Sourcery

Deployment:
- Replace bundleSegments with navigationSegments in deploy/frontend.yaml and remove bundleId and position fields.