### PR TITLE
UI filtering not sufficient

### DIFF
--- a/src/routes/details/components/historicalData/historicalDataCostChart.tsx
+++ b/src/routes/details/components/historicalData/historicalDataCostChart.tsx
@@ -171,7 +171,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
         ...(queryState?.exclude && queryState.exclude),
       },
       group_by: {
-        ...(groupBy && { [groupBy]: groupByValue }),
+        ...(groupBy && { [groupBy]: '*' }),
       },
     };
 
@@ -188,7 +188,8 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
       filter_by: {
         ...baseQuery.filter_by,
         // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
-        ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }), // Used by the "Platform" project
+        ...(groupBy && groupByValue !== '*' && { [`exact:${groupBy}`]: groupByValue }), // Add exact: filter -- see https://issues.redhat.com/browse/COST-6659
+        ...(groupBy && groupByValue !== '*' && groupByValue === 'Platform' && { [groupBy]: undefined }), // Required for the "Platform" project
       },
     };
 
@@ -214,7 +215,8 @@ const mapStateToProps = createMapStateToProps<HistoricalDataCostChartOwnProps, H
       filter_by: {
         ...baseQuery.filter_by,
         // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
-        ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }), // Used by the "Platform" project
+        ...(groupBy && groupByValue !== '*' && { [`exact:${groupBy}`]: groupByValue }), // Add exact: filter -- see https://issues.redhat.com/browse/COST-6659
+        ...(groupBy && groupByValue !== '*' && groupByValue === 'Platform' && { [groupBy]: undefined }), // Used by the "Platform" project
       },
     };
 

--- a/src/routes/details/components/historicalData/historicalDataUsageChart.tsx
+++ b/src/routes/details/components/historicalData/historicalDataUsageChart.tsx
@@ -151,7 +151,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
       },
       group_by: {
         ...(groupByOrgValue && !useFilter && { [orgUnitIdKey]: groupByOrgValue }),
-        ...(groupBy && !groupByOrgValue && { [groupBy]: groupByValue }),
+        ...(groupBy && !groupByOrgValue && { [groupBy]: '*' }),
       },
     };
 
@@ -166,7 +166,8 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
       filter_by: {
         ...baseQuery.filter_by,
         // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
-        ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }), // Used by the "Platform" project
+        ...(groupBy && groupByValue !== '*' && { [`exact:${groupBy}`]: groupByValue }), // Add exact: filter -- see https://issues.redhat.com/browse/COST-6659
+        ...(groupBy && groupByValue !== '*' && groupByValue === 'Platform' && { [groupBy]: undefined }), // Required for the "Platform" project
       },
     };
 
@@ -190,7 +191,8 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
       filter_by: {
         ...baseQuery.filter_by,
         // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
-        ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }), // Used by the "Platform" project
+        ...(groupBy && groupByValue !== '*' && { [`exact:${groupBy}`]: groupByValue }), // Add exact: filter -- see https://issues.redhat.com/browse/COST-6659
+        ...(groupBy && groupByValue !== '*' && groupByValue === 'Platform' && { [groupBy]: undefined }), // Used by the "Platform" project
       },
     };
 

--- a/src/routes/details/components/historicalData/historicalDataVolumeChart.tsx
+++ b/src/routes/details/components/historicalData/historicalDataVolumeChart.tsx
@@ -163,7 +163,8 @@ const mapStateToProps = createMapStateToProps<HistoricalDataVolumeChartOwnProps,
       filter_by: {
         ...baseQuery.filter_by,
         // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
-        ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }), // Used by the "Platform" project
+        ...(groupBy && groupByValue !== '*' && { [`exact:${groupBy}`]: groupByValue }), // Add exact: filter -- see https://issues.redhat.com/browse/COST-6659
+        ...(groupBy && groupByValue !== '*' && groupByValue === 'Platform' && { [groupBy]: undefined }), // Required for the "Platform" project
       },
     };
 
@@ -187,7 +188,8 @@ const mapStateToProps = createMapStateToProps<HistoricalDataVolumeChartOwnProps,
       filter_by: {
         ...baseQuery.filter_by,
         // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
-        ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }), // Used by the "Platform" project
+        ...(groupBy && groupByValue !== '*' && { [`exact:${groupBy}`]: groupByValue }), // Add exact: filter -- see https://issues.redhat.com/browse/COST-6659
+        // ...(groupBy && groupByValue !== '*' && groupByValue === 'Platform' && { [groupBy]: undefined }), // Used by the "Platform" project
       },
     };
 

--- a/src/routes/details/components/pvcChart/modal/pvcContent.tsx
+++ b/src/routes/details/components/pvcChart/modal/pvcContent.tsx
@@ -194,7 +194,8 @@ const useMapToProps = ({ query }: PvcContentMapProps): PvcContentStateProps => {
       ...(queryState?.filter_by && queryState.filter_by),
       ...(queryFromRoute?.isPlatformCosts && { category: platformCategoryKey }),
       // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
-      ...(groupBy && groupByValue !== '*' && { [groupBy]: groupByValue }), // Note: We're not inserting PVC information for the Platform project
+      // Add exact: filter -- see https://issues.redhat.com/browse/COST-6659
+      ...(groupBy && groupByValue !== '*' && { [`exact:${groupBy}`]: groupByValue }), // Note: We're not inserting PVC information for the 'Platform' project
       ...query.filter_by,
     },
     exclude: {

--- a/src/routes/details/components/pvcChart/pvcChart.tsx
+++ b/src/routes/details/components/pvcChart/pvcChart.tsx
@@ -384,7 +384,7 @@ const mapStateToProps = createMapStateToProps<PvcChartOwnProps, PvcChartStatePro
         ...(queryState?.filter_by && queryState.filter_by),
         ...(queryFromRoute?.isPlatformCosts && { category: platformCategoryKey }),
         // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
-        ...(groupBy && groupByValue !== '*' && { [groupBy]: groupByValue }), // Note: We're not inserting PVC information for the Platform project
+        ...(groupBy && groupByValue !== '*' && { [`exact:${groupBy}`]: groupByValue }), // Note: We're not inserting PVC information for the 'Platform' project
       },
       exclude: {
         ...(queryState?.exclude && queryState.exclude),

--- a/src/routes/details/components/summary/summaryCard.tsx
+++ b/src/routes/details/components/summary/summaryCard.tsx
@@ -250,14 +250,14 @@ const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps
         ...(queryState?.filter_by && queryState.filter_by),
         ...(queryFromRoute?.isPlatformCosts && { category: platformCategoryKey }),
         ...(queryFromRoute?.filter?.account && { [`${logicalAndPrefix}account`]: queryFromRoute.filter.account }),
-        // Related to https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
-        ...(groupBy && groupByValue !== '*' && { [groupBy]: groupByValue }), // group bys must appear in filter to show costs by region, account, etc
         // Workaround for https://issues.redhat.com/browse/COST-1189
         ...(queryState?.filter_by &&
           queryState.filter_by[orgUnitIdKey] && {
             [`${logicalOrPrefix}${orgUnitIdKey}`]: queryState.filter_by[orgUnitIdKey],
             [orgUnitIdKey]: undefined,
           }),
+        // Related to https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+        ...(groupBy && groupByValue !== '*' && { [`exact:${groupBy}`]: groupByValue }), // group bys must appear in filter to show costs by region, account, etc
       },
       exclude: {
         ...(queryState?.exclude && queryState.exclude),

--- a/src/routes/details/components/usageChart/usageChart.tsx
+++ b/src/routes/details/components/usageChart/usageChart.tsx
@@ -483,13 +483,14 @@ const mapStateToProps = createMapStateToProps<UsageChartOwnProps, UsageChartStat
         ...(queryState?.filter_by && queryState.filter_by),
         ...(queryFromRoute?.isPlatformCosts && { category: platformCategoryKey }),
         // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
-        ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }), // Used by the "Platform" project
+        ...(groupBy && groupByValue !== '*' && { [`exact:${groupBy}`]: groupByValue }), // Add exact: filter -- see https://issues.redhat.com/browse/COST-6659
+        ...(groupBy && groupByValue !== '*' && groupByValue === 'Platform' && { [groupBy]: undefined }), // Required for the "Platform" project
       },
       exclude: {
         ...(queryState?.exclude && queryState.exclude),
       },
       group_by: {
-        ...(groupBy && { [groupBy]: groupByValue }),
+        ...(groupBy && { [groupBy]: '*' }),
       },
     };
 

--- a/src/routes/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/routes/details/ocpBreakdown/ocpBreakdown.tsx
@@ -68,13 +68,14 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, BreakdownSta
       ...(queryState?.filter_by && queryState.filter_by),
       ...(queryFromRoute?.isPlatformCosts && { category: platformCategoryKey }),
       // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
-      ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }), // Used by the "Platform" project
+      ...(groupBy && groupByValue !== '*' && { [`exact:${groupBy}`]: groupByValue }), // Add exact: filter -- see https://issues.redhat.com/browse/COST-6659
+      ...(groupBy && groupByValue !== '*' && groupByValue === 'Platform' && { [groupBy]: undefined }), // Required for the "Platform" project
     },
     exclude: {
       ...(queryState?.exclude && queryState.exclude),
     },
     group_by: {
-      ...(groupBy && { [groupBy]: groupByValue }),
+      ...(groupBy && { [groupBy]: '*' }),
     },
   };
 

--- a/src/routes/details/ocpBreakdown/virtualization/virtualization.tsx
+++ b/src/routes/details/ocpBreakdown/virtualization/virtualization.tsx
@@ -371,13 +371,13 @@ const useMapToProps = ({ costType, currency, query }): VirtualizationStateProps 
       resolution: 'monthly',
       time_scope_units: 'month',
       time_scope_value: timeScopeValue,
-      [groupBy]: groupByValue,
     },
     filter_by: {
       // Add filters here to apply logical OR/AND
       ...(queryState?.filter_by && queryState.filter_by),
       ...(queryFromRoute?.filter?.account && { [`${logicalAndPrefix}account`]: queryFromRoute.filter.account }),
       ...(query.filter_by && query.filter_by),
+      ...(groupBy && groupByValue !== '*' && { [`exact:${groupBy}`]: groupByValue }), // Add exact: filter -- see https://issues.redhat.com/browse/COST-6659
     },
     exclude: {
       ...(queryState?.exclude && queryState.exclude),


### PR DESCRIPTION
Added `exact:` to filters applied in the OCP breakdown page. Note that the tags API is not currently supported.

https://issues.redhat.com/browse/COST-6659

## Summary by Sourcery

Use exact filters for group-by parameters and unify group-by behavior across multiple detail page charts and components.

Enhancements:
- Apply `exact:` prefix to groupBy filters in historical cost, usage, volume, summary, PVC, and OCP breakdown charts to enable precise filtering
- Use wildcard `*` for the `group_by` parameter instead of explicit values across charts to maintain grouping behavior
- Preserve the special-case omission of standard filters when `groupByValue` is 'Platform'