### PR TITLE
Refactor `exact:` filter to work with tags

### DIFF
--- a/src/routes/details/components/breakdown/breakdownHeader.tsx
+++ b/src/routes/details/components/breakdown/breakdownHeader.tsx
@@ -100,10 +100,13 @@ class BreakdownHeader extends React.Component<BreakdownHeaderProps, any> {
   };
 
   private hasFilterBy = () => {
-    const { router } = this.props;
+    const { groupBy, router } = this.props;
     const exclude = router.location.state?.details?.exclude;
     const filterBy = router.location.state?.details?.filter_by;
-    return (exclude && Object.keys(exclude).length > 0) || (filterBy && Object.keys(filterBy).length > 0);
+    return (
+      (exclude && Object.keys(exclude).filter(key => key !== groupBy).length > 0) ||
+      (filterBy && Object.keys(filterBy).filter(key => key !== groupBy).length > 0)
+    );
   };
 
   private getFilterChips = () => {

--- a/src/routes/details/components/historicalData/historicalDataNetworkChart.tsx
+++ b/src/routes/details/components/historicalData/historicalDataNetworkChart.tsx
@@ -10,7 +10,7 @@ import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { DatumType, transformReport } from 'routes/components/charts/common/chartDatum';
 import { HistoricalUsageChart } from 'routes/components/charts/historicalUsageChart';
-import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'routes/utils/groupBy';
+import { getGroupById, getGroupByOrgValue, getGroupByTagKey, getGroupByValue } from 'routes/utils/groupBy';
 import { getQueryState } from 'routes/utils/queryState';
 import { skeletonWidth } from 'routes/utils/skeleton';
 import { createMapStateToProps, FetchStatus } from 'store/common';
@@ -143,6 +143,9 @@ const mapStateToProps = createMapStateToProps<HistoricalDataNetworkChartOwnProps
     const groupByOrgValue = getGroupByOrgValue(queryFromRoute);
     const groupBy = getGroupById(queryFromRoute);
     const groupByValue = getGroupByValue(queryFromRoute);
+    const groupByTagKey = getGroupByTagKey(queryFromRoute);
+
+    const isFilterByExact = groupBy && groupByValue !== '*' && !groupByTagKey;
 
     // instance-types and storage APIs must filter org units
     const useFilter = reportType === ReportType.instanceType || reportType === ReportType.storage;
@@ -167,7 +170,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataNetworkChartOwnProps
       },
       group_by: {
         ...(groupByOrgValue && !useFilter && { [orgUnitIdKey]: groupByOrgValue }),
-        ...(groupBy && !groupByOrgValue && { [groupBy]: groupByValue }),
+        ...(groupBy && !groupByOrgValue && { [groupBy]: isFilterByExact ? '*' : groupByValue }),
       },
     };
 
@@ -182,7 +185,10 @@ const mapStateToProps = createMapStateToProps<HistoricalDataNetworkChartOwnProps
       filter_by: {
         ...baseQuery.filter_by,
         // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
-        ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }), // Used by the "Platform" project
+        ...(isFilterByExact && {
+          [groupBy]: undefined, // Replace with "exact:" filter below -- see https://issues.redhat.com/browse/COST-6659
+          [`exact:${groupBy}`]: groupByValue,
+        }),
       },
     };
 
@@ -206,7 +212,10 @@ const mapStateToProps = createMapStateToProps<HistoricalDataNetworkChartOwnProps
       filter_by: {
         ...baseQuery.filter_by,
         // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
-        ...(groupBy && groupByValue !== '*' && { [groupBy]: undefined }), // Used by the "Platform" project
+        ...(isFilterByExact && {
+          [groupBy]: undefined, // Replace with "exact:" filter below -- see https://issues.redhat.com/browse/COST-6659
+          [`exact:${groupBy}`]: groupByValue,
+        }),
       },
     };
 

--- a/src/routes/details/components/historicalData/historicalDataUsageChart.tsx
+++ b/src/routes/details/components/historicalData/historicalDataUsageChart.tsx
@@ -10,7 +10,7 @@ import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 import { DatumType, transformReport } from 'routes/components/charts/common/chartDatum';
 import { HistoricalUsageChart } from 'routes/components/charts/historicalUsageChart';
-import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'routes/utils/groupBy';
+import { getGroupById, getGroupByOrgValue, getGroupByTagKey, getGroupByValue } from 'routes/utils/groupBy';
 import { getQueryState } from 'routes/utils/queryState';
 import { skeletonWidth } from 'routes/utils/skeleton';
 import { createMapStateToProps, FetchStatus } from 'store/common';
@@ -128,6 +128,9 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
     const groupByOrgValue = getGroupByOrgValue(queryFromRoute);
     const groupBy = getGroupById(queryFromRoute);
     const groupByValue = getGroupByValue(queryFromRoute);
+    const groupByTagKey = getGroupByTagKey(queryFromRoute);
+
+    const isFilterByExact = groupBy && groupByValue !== '*' && !groupByTagKey;
 
     // instance-types and storage APIs must filter org units
     const useFilter = reportType === ReportType.instanceType || reportType === ReportType.storage;
@@ -151,7 +154,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
       },
       group_by: {
         ...(groupByOrgValue && !useFilter && { [orgUnitIdKey]: groupByOrgValue }),
-        ...(groupBy && !groupByOrgValue && { [groupBy]: '*' }),
+        ...(groupBy && !groupByOrgValue && { [groupBy]: isFilterByExact ? '*' : groupByValue }),
       },
     };
 
@@ -166,8 +169,10 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
       filter_by: {
         ...baseQuery.filter_by,
         // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
-        ...(groupBy && groupByValue !== '*' && { [`exact:${groupBy}`]: groupByValue }), // Add exact: filter -- see https://issues.redhat.com/browse/COST-6659
-        ...(groupBy && groupByValue !== '*' && groupByValue === 'Platform' && { [groupBy]: undefined }), // Required for the "Platform" project
+        ...(isFilterByExact && {
+          [groupBy]: undefined, // Replace with "exact:" filter below -- see https://issues.redhat.com/browse/COST-6659
+          [`exact:${groupBy}`]: groupByValue,
+        }),
       },
     };
 
@@ -191,8 +196,10 @@ const mapStateToProps = createMapStateToProps<HistoricalDataUsageChartOwnProps, 
       filter_by: {
         ...baseQuery.filter_by,
         // Omit filters associated with the current group_by -- see https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
-        ...(groupBy && groupByValue !== '*' && { [`exact:${groupBy}`]: groupByValue }), // Add exact: filter -- see https://issues.redhat.com/browse/COST-6659
-        ...(groupBy && groupByValue !== '*' && groupByValue === 'Platform' && { [groupBy]: undefined }), // Used by the "Platform" project
+        ...(isFilterByExact && {
+          [groupBy]: undefined, // Replace with "exact:" filter below -- see https://issues.redhat.com/browse/COST-6659
+          [`exact:${groupBy}`]: groupByValue,
+        }),
       },
     };
 

--- a/src/routes/details/ocpDetails/detailsTable.tsx
+++ b/src/routes/details/ocpDetails/detailsTable.tsx
@@ -218,7 +218,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
       const supplementaryCost = this.getSupplementaryCost(item, index);
       const InfrastructureCost = this.getInfrastructureCost(item, index);
       const isDefaultProject = item.classification === classificationDefault;
-      const isPlatformProject = item.classification === classificationPlatform;
+      const isPlatformCosts = item.classification === classificationPlatform;
       const isUnallocatedProject = item.classification === classificationUnallocated;
       const isUnattributedCosts = item.classification === classificationUnattributed;
       const isOverheadCosts =
@@ -241,7 +241,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
             basePath,
             description: item.id,
             id: item.id,
-            isPlatformProject,
+            isPlatformCosts,
             groupBy,
             title: label.toString(), // Convert IDs if applicable
           })}
@@ -306,7 +306,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
           },
           {
             hidden: !isGroupByProject,
-            value: !isPlatformProject && !isDisabled && (
+            value: !isPlatformCosts && !isDisabled && (
               <AsyncComponent
                 scope="costManagementMfe"
                 appName="cost-management-mfe"
@@ -316,7 +316,7 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
                   basePath,
                   description: item.id,
                   id: item.id,
-                  isPlatformProject,
+                  isPlatformCosts,
                   groupBy,
                   isOptimizationsTab: true,
                   title: label.toString(), // Convert IDs if applicable

--- a/src/routes/utils/paths.ts
+++ b/src/routes/utils/paths.ts
@@ -6,7 +6,7 @@ export const getBreakdownPath = ({
   description,
   groupBy,
   id,
-  isPlatformProject,
+  isPlatformCosts,
   isOptimizationsPath,
   isOptimizationsTab,
   title,
@@ -15,7 +15,7 @@ export const getBreakdownPath = ({
   description?: string; // Used to display a description in the breakdown header
   groupBy: string | number;
   id: string | number; // group_by[account]=<id> param in the breakdown page
-  isPlatformProject?: boolean;
+  isPlatformCosts?: boolean;
   isOptimizationsPath?: boolean;
   isOptimizationsTab?: boolean;
   title: string | number; // Used to display a title in the breakdown header
@@ -27,11 +27,11 @@ export const getBreakdownPath = ({
     optimizationsTab: isOptimizationsTab ? true : undefined, // Clear query params
     ...(groupBy && {
       group_by: {
-        [groupBy]: isPlatformProject ? '*' : id, // Use ID here -- see https://github.com/project-koku/koku-ui/pull/2821
+        [groupBy]: isPlatformCosts ? '*' : id, // Use ID here -- see https://github.com/project-koku/koku-ui/pull/2821
       },
     }),
     id,
-    isPlatformCosts: isPlatformProject ? true : undefined,
+    isPlatformCosts: isPlatformCosts ? true : undefined,
   };
   return `${basePath}?${getQueryRoute(newQuery)}`;
 };


### PR DESCRIPTION
Omit `exact:` filter for group_by tags

https://issues.redhat.com/browse/COST-6659

## Summary by Sourcery

Refactor exact filter logic to respect tag-based groupings and unify filter application across components; remove platform-specific special-casing; rename isPlatformProject to isPlatformCosts; update breakdown header filter detection.

Enhancements:
- Introduce isFilterByExact (excluding tag-based groupings) to standardize 'exact:' filter usage and wildcard grouping across multiple chart and data components, replacing ad-hoc platform special cases
- Rename isPlatformProject to isPlatformCosts across details table components and path utilities for consistent naming
- Update breakdown header to ignore the active groupBy key when determining the presence of filters