### PR TITLE
Added `exact:` filter for tags API

### DIFF
--- a/src/routes/components/dataToolbar/costCategoryValue.tsx
+++ b/src/routes/components/dataToolbar/costCategoryValue.tsx
@@ -150,7 +150,7 @@ const mapStateToProps = createMapStateToProps<CostCategoryValueOwnProps, CostCat
 
     const groupByOrgValue = getGroupByOrgValue(queryFromRoute);
     const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(queryFromRoute);
-    const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(queryFromRoute);
+    const groupByValue = groupByOrgValue || getGroupByValue(queryFromRoute);
 
     // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
     const resourceQueryString = getQuery({

--- a/src/routes/components/dataToolbar/tagValue.tsx
+++ b/src/routes/components/dataToolbar/tagValue.tsx
@@ -176,7 +176,7 @@ const mapStateToProps = createMapStateToProps<TagValueOwnProps, TagValueStatePro
 
     const groupByOrgValue = getGroupByOrgValue(queryFromRoute);
     const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(queryFromRoute);
-    const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(queryFromRoute);
+    const groupByValue = groupByOrgValue || getGroupByValue(queryFromRoute);
 
     // Omitting key_only to share a single, cached request -- although the header doesn't need key values, the toolbar does
     const tagQueryString = getQuery({

--- a/src/routes/details/awsBreakdown/awsBreakdown.tsx
+++ b/src/routes/details/awsBreakdown/awsBreakdown.tsx
@@ -52,7 +52,7 @@ const mapStateToProps = createMapStateToProps<AwsBreakdownOwnProps, BreakdownSta
 
   const groupByOrgValue = getGroupByOrgValue(queryFromRoute);
   const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(queryFromRoute);
-  const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(queryFromRoute);
+  const groupByValue = groupByOrgValue || getGroupByValue(queryFromRoute);
 
   const costType = getCostType();
   const currency = getCurrency();

--- a/src/routes/details/components/historicalData/historicalDataTrendChart.tsx
+++ b/src/routes/details/components/historicalData/historicalDataTrendChart.tsx
@@ -159,7 +159,7 @@ const mapStateToProps = createMapStateToProps<HistoricalDataTrendChartOwnProps, 
 
     const groupByOrgValue = getGroupByOrgValue(queryFromRoute);
     const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(queryFromRoute);
-    const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(queryFromRoute);
+    const groupByValue = groupByOrgValue || getGroupByValue(queryFromRoute);
     const groupByTagKey = getGroupByTagKey(queryFromRoute);
 
     const isFilterByExact = groupBy && groupByValue !== '*' && !groupByTagKey;

--- a/src/routes/details/components/summary/modal/summaryContent.tsx
+++ b/src/routes/details/components/summary/modal/summaryContent.tsx
@@ -113,7 +113,7 @@ const mapStateToProps = createMapStateToProps<SummaryContentOwnProps, SummaryCon
 
     const groupByOrgValue = getGroupByOrgValue(queryFromRoute);
     const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(queryFromRoute);
-    const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(queryFromRoute);
+    const groupByValue = groupByOrgValue || getGroupByValue(queryFromRoute);
     const timeScopeValue = getTimeScopeValue(queryState);
 
     const reportQuery: Query = {

--- a/src/routes/details/components/summary/summaryCard.tsx
+++ b/src/routes/details/components/summary/summaryCard.tsx
@@ -232,7 +232,7 @@ const mapStateToProps = createMapStateToProps<SummaryOwnProps, SummaryStateProps
 
     const groupByOrgValue = getGroupByOrgValue(queryFromRoute);
     const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(queryFromRoute);
-    const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(queryFromRoute);
+    const groupByValue = groupByOrgValue || getGroupByValue(queryFromRoute);
     const groupByTagKey = getGroupByTagKey(queryFromRoute);
 
     const isFilterByExact = groupBy && groupByValue !== '*' && !groupByTagKey;

--- a/src/routes/details/components/tag/modal/tagModal.tsx
+++ b/src/routes/details/components/tag/modal/tagModal.tsx
@@ -8,7 +8,7 @@ import React from 'react';
 import type { WrappedComponentProps } from 'react-intl';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
-import { getGroupById, getGroupByOrgValue, getGroupByValue } from 'routes/utils/groupBy';
+import { getGroupById, getGroupByOrgValue, getGroupByTagKey, getGroupByValue } from 'routes/utils/groupBy';
 import { getQueryState } from 'routes/utils/queryState';
 import { getTimeScopeValue } from 'routes/utils/timeScope';
 import type { FetchStatus } from 'store/common';
@@ -122,7 +122,10 @@ const mapStateToProps = createMapStateToProps<TagModalOwnProps, TagModalStatePro
 
     const groupByOrgValue = getGroupByOrgValue(queryFromRoute);
     const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(queryFromRoute);
-    const groupByValue = groupByOrgValue ? groupByOrgValue : getGroupByValue(queryFromRoute);
+    const groupByValue = groupByOrgValue || getGroupByValue(queryFromRoute);
+    const groupByTagKey = getGroupByTagKey(queryFromRoute);
+
+    const isFilterByExact = groupBy && groupByValue !== '*' && !groupByTagKey;
     const timeScopeValue = getTimeScopeValue(queryState);
 
     // Prune unsupported tag params from filter_by, but don't reset queryState
@@ -153,7 +156,10 @@ const mapStateToProps = createMapStateToProps<TagModalOwnProps, TagModalStatePro
         ...(queryFromRoute?.isPlatformCosts && { category: platformCategoryKey }),
         ...(queryFromRoute?.filter?.account && { [`${logicalAndPrefix}account`]: queryFromRoute.filter.account }),
         // Related to https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
-        ...(groupBy && groupByValue !== '*' && groupBy.indexOf(tagPrefix) === -1 && { [groupBy]: groupByValue }), // Note: Cannot use group_by with tags
+        ...(isFilterByExact && {
+          [groupBy]: undefined, // Replace with "exact:" filter below -- see https://issues.redhat.com/browse/COST-6659
+          [`exact:${groupBy}`]: groupByValue,
+        }),
       },
     };
 

--- a/src/routes/details/ocpBreakdown/virtualization/virtualization.tsx
+++ b/src/routes/details/ocpBreakdown/virtualization/virtualization.tsx
@@ -3,6 +3,7 @@ import type { Query } from 'api/queries/query';
 import { getQuery } from 'api/queries/query';
 import type { Report } from 'api/reports/report';
 import { ReportPathsType, ReportType } from 'api/reports/report';
+import { TagPathsType } from 'api/tags/tag';
 import type { AxiosError } from 'axios';
 import messages from 'locales/messages';
 import { cloneDeep } from 'lodash';
@@ -86,6 +87,7 @@ const defaultColumnOptions: ColumnManagementModalOption[] = [
 
 const reportType = ReportType.virtualization;
 const reportPathsType = ReportPathsType.ocp;
+const tagPathsType = TagPathsType.ocp;
 
 const Virtualization: React.FC<VirtualizationProps> = ({ costDistribution, costType, currency }) => {
   const intl = useIntl();
@@ -211,6 +213,7 @@ const Virtualization: React.FC<VirtualizationProps> = ({ costDistribution, costT
         reportQueryString={reportQueryString}
         reportType={reportType}
         selectedItems={selectedItems}
+        tagPathsType={tagPathsType}
       />
     );
   };

--- a/src/routes/details/ocpBreakdown/virtualization/virtualizationTable.tsx
+++ b/src/routes/details/ocpBreakdown/virtualization/virtualizationTable.tsx
@@ -3,6 +3,7 @@ import 'routes/components/dataTable/dataTable.scss';
 import type { Query } from 'api/queries/query';
 import type { OcpReport, OcpReportItem } from 'api/reports/ocpReports';
 import type { Report } from 'api/reports/report';
+import type { TagPathsType } from 'api/tags/tag';
 import messages from 'locales/messages';
 import React, { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
@@ -37,6 +38,7 @@ interface VirtualizationTableOwnProps {
   reportQueryString: string;
   reportType: string;
   selectedItems?: ComputedReportItem[];
+  tagPathsType: TagPathsType;
 }
 
 type VirtualizationTableProps = VirtualizationTableOwnProps;
@@ -64,6 +66,7 @@ const VirtualizationTable: React.FC<VirtualizationTableProps> = ({
   reportQueryString,
   reportType,
   selectedItems,
+  tagPathsType,
 }) => {
   const intl = useIntl();
   const [columns, setColumns] = useState([]);
@@ -163,7 +166,7 @@ const VirtualizationTable: React.FC<VirtualizationTableProps> = ({
             value: <StorageLink storageData={item.storage} virtualMachine={item.vm_name} />,
           },
           {
-            value: <TagLink tagData={item.tags} virtualMachine={item.vm_name} />,
+            value: <TagLink tagData={item.tags} tagPathsType={tagPathsType} virtualMachine={item.vm_name} />,
           },
           {
             id: VirtualizationTableColumnIds.cpu,

--- a/src/routes/details/ocpBreakdown/virtualization/virtualizationToolbar.tsx
+++ b/src/routes/details/ocpBreakdown/virtualization/virtualizationToolbar.tsx
@@ -1,6 +1,6 @@
 import type { ToolbarLabelGroup } from '@patternfly/react-core';
 import type { AwsQuery } from 'api/queries/awsQuery';
-import { getQuery } from 'api/queries/query';
+import { getQuery, parseQuery, type Query } from 'api/queries/query';
 import { ResourcePathsType } from 'api/resources/resource';
 import type { Tag } from 'api/tags/tag';
 import { TagPathsType, TagType } from 'api/tags/tag';
@@ -13,12 +13,16 @@ import { DataToolbar } from 'routes/components/dataToolbar';
 import type { ComputedReportItem } from 'routes/utils/computedReport/getComputedReportItems';
 import { isEqual } from 'routes/utils/equal';
 import type { Filter } from 'routes/utils/filter';
+import { getGroupById, getGroupByOrgValue, getGroupByTagKey, getGroupByValue } from 'routes/utils/groupBy';
+import { getQueryState } from 'routes/utils/queryState';
 import type { FetchStatus } from 'store/common';
 import { createMapStateToProps } from 'store/common';
 import { tagActions, tagSelectors } from 'store/tags';
-import { tagKey } from 'utils/props';
+import { logicalAndPrefix, orgUnitIdKey, platformCategoryKey, tagKey, tagPrefix } from 'utils/props';
+import type { RouterComponentProps } from 'utils/router';
+import { withRouter } from 'utils/router';
 
-interface VirtualizationToolbarOwnProps {
+interface VirtualizationToolbarOwnProps extends RouterComponentProps {
   hideCluster?: boolean;
   hideNode?: boolean;
   hideProject?: boolean;
@@ -195,17 +199,56 @@ export class VirtualizationToolbarBase extends React.Component<VirtualizationToo
 }
 
 const mapStateToProps = createMapStateToProps<VirtualizationToolbarOwnProps, VirtualizationToolbarStateProps>(
-  (state, { timeScopeValue = -1 }) => {
-    // Note: Omitting key_only would help to share a single, cached request. Only the toolbar requires key values;
-    // however, for better server-side performance, we chose to use key_only here.
-    const tagQueryString = getQuery({
+  (state, { router, timeScopeValue = -1 }) => {
+    const queryFromRoute = parseQuery<Query>(router.location.search);
+    const queryState = getQueryState(router.location, 'details');
+
+    const groupByOrgValue = getGroupByOrgValue(queryFromRoute);
+    const groupBy = groupByOrgValue ? orgUnitIdKey : getGroupById(queryFromRoute);
+    const groupByValue = groupByOrgValue || getGroupByValue(queryFromRoute);
+    const groupByTagKey = getGroupByTagKey(queryFromRoute);
+
+    const isFilterByExact = groupBy && groupByValue !== '*' && !groupByTagKey;
+
+    // Prune unsupported tag params from filter_by, but don't reset queryState
+    const filterByParams = {
+      ...(queryState?.filter_by ? queryState.filter_by : {}),
+    };
+    for (const key of Object.keys(filterByParams)) {
+      // Omit unsupported query params
+      if (
+        key.indexOf('node') !== -1 ||
+        key.indexOf('region') !== -1 ||
+        key.indexOf('resource_location') !== -1 ||
+        key.indexOf('service') !== -1 ||
+        key.indexOf(tagPrefix) !== -1
+      ) {
+        delete filterByParams[key];
+      }
+    }
+
+    const tagQuery = {
       filter: {
         time_scope_value: timeScopeValue,
       },
+      filter_by: {
+        // Add filters here to apply logical OR/AND
+        ...filterByParams,
+        ...(queryFromRoute?.isPlatformCosts && { category: platformCategoryKey }),
+        ...(queryFromRoute?.filter?.account && { [`${logicalAndPrefix}account`]: queryFromRoute.filter.account }),
+        // Related to https://issues.redhat.com/browse/COST-1131 and https://issues.redhat.com/browse/COST-3642
+        ...(isFilterByExact && {
+          [groupBy]: undefined, // Replace with "exact:" filter below -- see https://issues.redhat.com/browse/COST-6659
+          [`exact:${groupBy}`]: groupByValue,
+        }),
+      },
+      // Note: Omitting key_only would help to share a single, cached request. Only the toolbar requires key values;
+      // however, for better server-side performance, we chose to use key_only here.
       key_only: true,
       limit: 1000,
-    });
+    };
 
+    const tagQueryString = getQuery(tagQuery);
     const tagReport = tagSelectors.selectTag(state, tagPathsType, tagType, tagQueryString);
     const tagReportFetchStatus = tagSelectors.selectTagFetchStatus(state, tagPathsType, tagType, tagQueryString);
 
@@ -221,7 +264,9 @@ const mapDispatchToProps: VirtualizationToolbarDispatchProps = {
   fetchTag: tagActions.fetchTag,
 };
 
-const VirtualizationToolbarConnect = connect(mapStateToProps, mapDispatchToProps)(VirtualizationToolbarBase);
+const VirtualizationToolbarConnect = withRouter(
+  connect(mapStateToProps, mapDispatchToProps)(VirtualizationToolbarBase)
+);
 const VirtualizationToolbar = injectIntl(VirtualizationToolbarConnect);
 
 export { VirtualizationToolbar };


### PR DESCRIPTION
Added `exact:` filter for tags API request in OCP breakdown page

https://issues.redhat.com/browse/COST-6659

## Summary by Sourcery

Add `exact:` filter support for tag API requests and enhance route-driven query parameter handling in OCP breakdown virtualization and tag components

New Features:
- Add `exact:` filter support for tag API requests when grouping by non-tag keys in virtualization toolbar, tag modal, and tag link

Enhancements:
- Use withRouter and query state parsing to derive tag queries from route parameters
- Prune unsupported `filter_by` parameters and apply logical AND filters for account and platform category
- Propagate `tagPathsType` prop through the virtualization table to the TagLink component