### PR TITLE
Add cost checks

### DIFF
--- a/src/routes/details/components/summary/modal/summaryContent.tsx
+++ b/src/routes/details/components/summary/modal/summaryContent.tsx
@@ -95,7 +95,7 @@ class SummaryContentBase extends React.Component<SummaryContentProps, any> {
                   label={_item.label ? _item.label.toString() : ''}
                   totalValue={report.meta.total.cost[reportItemValue].value}
                   units={report.meta.total.cost[reportItemValue].units}
-                  value={_item.cost[reportItemValue].value}
+                  value={_item.cost[reportItemValue]?.value}
                 />
               ))
             }

--- a/src/routes/details/components/summary/summaryCard.tsx
+++ b/src/routes/details/components/summary/summaryCard.tsx
@@ -117,7 +117,7 @@ class SummaryBase extends React.Component<SummaryProps, SummaryState> {
               label={reportItem.label ? reportItem.label.toString() : undefined}
               totalValue={report.meta.total.cost[reportItemValue].value}
               units={report.meta.total.cost[reportItemValue].units}
-              value={reportItem.cost[reportItemValue].value}
+              value={reportItem.cost[reportItemValue]?.value}
             />
           ))
         }

--- a/src/routes/details/ocpBreakdown/ocpBreakdown.tsx
+++ b/src/routes/details/ocpBreakdown/ocpBreakdown.tsx
@@ -80,6 +80,12 @@ const mapStateToProps = createMapStateToProps<OcpBreakdownOwnProps, BreakdownSta
     group_by: {
       ...(groupBy && { [groupBy]: isFilterByExact ? '*' : groupByValue }),
     },
+    // Todo: Uncomment to omit group_by in breakdown page
+    // ...(!isFilterByExact && {
+    //   group_by: {
+    //     ...(groupBy && { [groupBy]: groupByValue }),
+    //   },
+    // }),
   };
 
   const reportQueryString = getQuery(reportQuery);

--- a/src/routes/details/ocpDetails/detailsTable.tsx
+++ b/src/routes/details/ocpDetails/detailsTable.tsx
@@ -391,10 +391,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
       report?.meta?.total?.cost && report.meta.total.cost[reportItemValue]
         ? report.meta.total.cost[reportItemValue].value
         : 0;
-    const percentValue = cost === 0 ? cost.toFixed(2) : ((item.supplementary.total.value / cost) * 100).toFixed(2);
+    const percentValue = cost === 0 ? cost.toFixed(2) : ((item.supplementary?.total?.value / cost) * 100).toFixed(2);
     return (
       <>
-        {formatCurrency(item.supplementary.total.value, item.supplementary.total.units)}
+        {formatCurrency(item.supplementary?.total?.value, item.supplementary?.total?.units)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {intl.formatMessage(messages.percentOfCost, { value: percentValue })}
         </div>
@@ -410,10 +410,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
       report?.meta?.total?.cost && report.meta.total.cost[reportItemValue]
         ? report.meta.total.cost[reportItemValue].value
         : 0;
-    const percentValue = cost === 0 ? cost.toFixed(2) : ((item.infrastructure.total.value / cost) * 100).toFixed(2);
+    const percentValue = cost === 0 ? cost.toFixed(2) : ((item.infrastructure?.total?.value / cost) * 100).toFixed(2);
     return (
       <>
-        {formatCurrency(item.infrastructure.total.value, item.infrastructure.total.units)}
+        {formatCurrency(item.infrastructure?.total?.value, item.infrastructure?.total?.units)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {intl.formatMessage(messages.percentOfCost, { value: percentValue })}
         </div>
@@ -426,8 +426,8 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
 
     const reportItemValue = costDistribution ? costDistribution : ComputedReportItemValueType.total;
     const value = formatCurrency(
-      Math.abs(item.cost[reportItemValue].value - item.delta_value),
-      item.cost[reportItemValue].units
+      Math.abs(item.cost[reportItemValue]?.value - item.delta_value),
+      item.cost[reportItemValue]?.units
     );
     const percentage = item.delta_percent !== null ? formatPercentage(Math.abs(item.delta_percent)) : 0;
 
@@ -488,10 +488,10 @@ class DetailsTableBase extends React.Component<DetailsTableProps, DetailsTableSt
       report?.meta?.total?.cost && report.meta.total.cost[reportItemValue]
         ? report.meta.total.cost[reportItemValue].value
         : 0;
-    const percentValue = cost === 0 ? cost.toFixed(2) : ((item.cost[reportItemValue].value / cost) * 100).toFixed(2);
+    const percentValue = cost === 0 ? cost.toFixed(2) : ((item.cost[reportItemValue]?.value / cost) * 100)?.toFixed(2);
     return (
       <>
-        {formatCurrency(item.cost[reportItemValue].value, item.cost[reportItemValue].units)}
+        {formatCurrency(item.cost[reportItemValue]?.value, item.cost[reportItemValue]?.units)}
         <div style={styles.infoDescription} key={`total-cost-${index}`}>
           {intl.formatMessage(messages.percentOfCost, { value: percentValue })}
         </div>

--- a/src/routes/utils/computedReport/getComputedReportItems.ts
+++ b/src/routes/utils/computedReport/getComputedReportItems.ts
@@ -262,6 +262,9 @@ export function getUnsortedComputedReportItems<R extends Report, T extends Repor
   isDateMap = false,
   isGroupBy = true,
   report,
+
+  // Todo: Uncomment to omit group_by in breakdown page
+  // isGroupBy = report?.data?.find(data => data.hasOwnProperty(`values`)) === undefined,
 }: ComputedReportItemsParams<R, T>) {
   if (!report) {
     return [];


### PR DESCRIPTION
Add checks to ensure costs are not undefined

## Summary by Sourcery

Add safety checks for undefined cost properties across report detail components and include commented placeholders for future breakdown grouping behavior

Enhancements:
- Use optional chaining for cost, supplementary, and infrastructure fields to prevent undefined errors in DetailsTable, SummaryContent, and SummaryCard components
- Include commented TODO sections in mapStateToProps and getComputedReportItems for potential group_by omission in breakdown pages