### PR TITLE
Historical charts should omit request and limit legends

### DIFF
--- a/src/routes/components/charts/historicalUsageChart/historicalUsageChart.test.tsx
+++ b/src/routes/components/charts/historicalUsageChart/historicalUsageChart.test.tsx
@@ -24,6 +24,8 @@ const props: HistoricalUsageChartProps = {
   name: 'exampleUsageChart',
   previousRequestData,
   previousUsageData,
+  showLimit: true,
+  showRequest: true,
   title: 'Usage Title',
 };
 
@@ -31,6 +33,7 @@ test('reports are formatted to datums', () => {
   render(<HistoricalUsageChart {...props} />);
   /* eslint-disable-next-line testing-library/no-node-access */
   expect(screen.getByText(props.title).parentElement).toMatchSnapshot();
+  console.log(`***** ${screen.getAllByText(/no data/i).length}`);
   expect(screen.getAllByText(/no data/i).length).toBe(4);
 });
 

--- a/src/routes/components/charts/historicalUsageChart/historicalUsageChart.tsx
+++ b/src/routes/components/charts/historicalUsageChart/historicalUsageChart.tsx
@@ -54,6 +54,7 @@ interface HistoricalUsageChartOwnProps {
   requestLabelNoDataKey?: MessageDescriptor;
   requestTooltipKey?: MessageDescriptor;
   showLimit?: boolean;
+  showRequest?: boolean;
   title?: string;
   usageLabelKey?: MessageDescriptor;
   usageLabelNoDataKey?: MessageDescriptor;
@@ -123,7 +124,8 @@ class HistoricalUsageChartBase extends React.Component<HistoricalUsageChartProps
       previousLimitData,
       previousRequestData,
       previousUsageData,
-      showLimit = true,
+      showLimit,
+      showRequest,
     } = this.props;
 
     // Show all legends, regardless of length -- https://github.com/project-koku/koku-ui/issues/248
@@ -165,43 +167,47 @@ class HistoricalUsageChartBase extends React.Component<HistoricalUsageChartProps
           },
         },
       },
-      {
-        childName: 'previousRequest',
-        data: previousRequestData,
-        legendItem: {
-          name: getUsageRangeString(previousRequestData, requestLabelKey, true, true, 1, requestLabelNoDataKey),
-          symbol: {
-            fill: chartStyles.previousColorScale[1],
-            type: 'dash',
-          },
-          tooltip: getUsageRangeTooltip(previousRequestData, requestTooltipKey, false, false, 1),
-        },
-        style: {
-          data: {
-            ...chartStyles.previousRequestData,
-            stroke: chartStyles.previousColorScale[1],
-          },
-        },
-      },
-      {
-        childName: 'currentRequest',
-        data: currentRequestData,
-        legendItem: {
-          name: getUsageRangeString(currentRequestData, requestLabelKey, true, false, 0, requestLabelNoDataKey),
-          symbol: {
-            fill: chartStyles.currentColorScale[1],
-            type: 'dash',
-          },
-          tooltip: getUsageRangeTooltip(currentRequestData, requestTooltipKey, false, false),
-        },
-        style: {
-          data: {
-            ...chartStyles.currentRequestData,
-            stroke: chartStyles.currentColorScale[1],
-          },
-        },
-      },
     ];
+    if (showRequest) {
+      series.push(
+        {
+          childName: 'previousRequest',
+          data: previousRequestData,
+          legendItem: {
+            name: getUsageRangeString(previousRequestData, requestLabelKey, true, true, 1, requestLabelNoDataKey),
+            symbol: {
+              fill: chartStyles.previousColorScale[1],
+              type: 'dash',
+            },
+            tooltip: getUsageRangeTooltip(previousRequestData, requestTooltipKey, false, false, 1),
+          },
+          style: {
+            data: {
+              ...chartStyles.previousRequestData,
+              stroke: chartStyles.previousColorScale[1],
+            },
+          },
+        },
+        {
+          childName: 'currentRequest',
+          data: currentRequestData,
+          legendItem: {
+            name: getUsageRangeString(currentRequestData, requestLabelKey, true, false, 0, requestLabelNoDataKey),
+            symbol: {
+              fill: chartStyles.currentColorScale[1],
+              type: 'dash',
+            },
+            tooltip: getUsageRangeTooltip(currentRequestData, requestTooltipKey, false, false),
+          },
+          style: {
+            data: {
+              ...chartStyles.currentRequestData,
+              stroke: chartStyles.currentColorScale[1],
+            },
+          },
+        }
+      );
+    }
     if (showLimit) {
       series.push(
         {

--- a/src/routes/details/components/historicalData/historicalDataBase.tsx
+++ b/src/routes/details/components/historicalData/historicalDataBase.tsx
@@ -94,6 +94,8 @@ class HistoricalDatasBase extends React.Component<HistoricalDataProps, any> {
               chartName={widget.chartName}
               reportPathsType={widget.reportPathsType}
               reportType={widget.reportType}
+              showLimit={widget.showLimit}
+              showRequest={widget.showRequest}
               timeScopeValue={timeScopeValue}
             />
           </CardBody>
@@ -131,6 +133,8 @@ class HistoricalDatasBase extends React.Component<HistoricalDataProps, any> {
               chartName={widget.chartName}
               reportPathsType={widget.reportPathsType}
               reportType={widget.reportType}
+              showLimit={widget.showLimit}
+              showRequest={widget.showRequest}
               timeScopeValue={timeScopeValue}
             />
           </CardBody>
@@ -185,6 +189,8 @@ class HistoricalDatasBase extends React.Component<HistoricalDataProps, any> {
             chartName={widget.chartName}
             reportPathsType={widget.reportPathsType}
             reportType={widget.reportType}
+            showLimit={widget.showLimit}
+            showRequest={widget.showRequest}
             timeScopeValue={timeScopeValue}
           />
         </CardBody>

--- a/src/routes/details/components/historicalData/historicalDataNetworkChart.tsx
+++ b/src/routes/details/components/historicalData/historicalDataNetworkChart.tsx
@@ -26,6 +26,8 @@ interface HistoricalDataNetworkChartOwnProps extends RouterComponentProps, Wrapp
   chartName?: string;
   reportPathsType: ReportPathsType;
   reportType: ReportType;
+  showLimit?: boolean;
+  showRequest?: boolean;
   timeScopeValue?: number;
 }
 
@@ -77,8 +79,16 @@ class HistoricalDataNetworkChartBase extends React.Component<HistoricalDataNetwo
   };
 
   public render() {
-    const { chartName, currentReport, currentReportFetchStatus, previousReport, previousReportFetchStatus, intl } =
-      this.props;
+    const {
+      chartName,
+      currentReport,
+      currentReportFetchStatus,
+      previousReport,
+      previousReportFetchStatus,
+      intl,
+      showLimit,
+      showRequest,
+    } = this.props;
 
     // Current data
     const currentRequestData = transformReport(currentReport, DatumType.rolling, 'date', 'data_transfer_in', undefined);
@@ -121,7 +131,8 @@ class HistoricalDataNetworkChartBase extends React.Component<HistoricalDataNetwo
               requestLabelKey={messages.chartDataInLabel}
               requestLabelNoDataKey={messages.chartDataInLabelNoData}
               requestTooltipKey={messages.chartDataInTooltip}
-              showLimit={false}
+              showLimit={showLimit}
+              showRequest={showRequest}
               usageLabelKey={messages.chartDataOutLabel}
               usageLabelNoDataKey={messages.chartDataOutLabelNoData}
               usageTooltipKey={messages.chartDataOutTooltip}

--- a/src/routes/details/components/historicalData/historicalDataUsageChart.tsx
+++ b/src/routes/details/components/historicalData/historicalDataUsageChart.tsx
@@ -26,6 +26,8 @@ interface HistoricalDataUsageChartOwnProps extends RouterComponentProps, Wrapped
   chartName?: string;
   reportPathsType: ReportPathsType;
   reportType: ReportType;
+  showLimit?: boolean;
+  showRequest?: boolean;
   timeScopeValue?: number;
 }
 
@@ -77,8 +79,16 @@ class HistoricalDataUsageChartBase extends React.Component<HistoricalDataUsageCh
   };
 
   public render() {
-    const { chartName, currentReport, currentReportFetchStatus, previousReport, previousReportFetchStatus, intl } =
-      this.props;
+    const {
+      chartName,
+      currentReport,
+      currentReportFetchStatus,
+      previousReport,
+      previousReportFetchStatus,
+      intl,
+      showLimit,
+      showRequest,
+    } = this.props;
 
     // Current data
     const currentLimitData = transformReport(currentReport, DatumType.rolling, 'date', 'limit', 'total');
@@ -110,6 +120,8 @@ class HistoricalDataUsageChartBase extends React.Component<HistoricalDataUsageCh
               previousLimitData={previousLimitData}
               previousRequestData={previousRequestData}
               previousUsageData={previousUsageData}
+              showLimit={showLimit}
+              showRequest={showRequest}
               xAxisLabel={intl.formatMessage(messages.historicalChartDayOfMonthLabel)}
               yAxisLabel={intl.formatMessage(messages.units, { units: unitsLookupKey(usageUnits) })}
             />

--- a/src/routes/details/components/historicalData/historicalDataVolumeChart.tsx
+++ b/src/routes/details/components/historicalData/historicalDataVolumeChart.tsx
@@ -26,6 +26,8 @@ interface HistoricalDataVolumeChartOwnProps extends RouterComponentProps, Wrappe
   chartName?: string;
   reportPathsType: ReportPathsType;
   reportType: ReportType;
+  showLimit?: boolean;
+  showRequest?: boolean;
   timeScopeValue?: number;
 }
 
@@ -77,8 +79,16 @@ class HistoricalDataVolumeChartBase extends React.Component<HistoricalDataVolume
   };
 
   public render() {
-    const { chartName, currentReport, currentReportFetchStatus, previousReport, previousReportFetchStatus, intl } =
-      this.props;
+    const {
+      chartName,
+      currentReport,
+      currentReportFetchStatus,
+      previousReport,
+      previousReportFetchStatus,
+      intl,
+      showLimit,
+      showRequest,
+    } = this.props;
 
     // Current data
     const currentRequestData = transformReport(currentReport, DatumType.rolling, 'date', 'request', 'total');
@@ -106,7 +116,8 @@ class HistoricalDataVolumeChartBase extends React.Component<HistoricalDataVolume
               name={chartName}
               previousRequestData={previousRequestData}
               previousUsageData={previousUsageData}
-              showLimit={false}
+              showLimit={showLimit}
+              showRequest={showRequest}
               xAxisLabel={intl.formatMessage(messages.historicalChartDayOfMonthLabel)}
               yAxisLabel={intl.formatMessage(messages.units, { units: unitsLookupKey(usageUnits) })}
             />

--- a/src/store/breakdown/historicalData/common/historicalDataCommon.ts
+++ b/src/store/breakdown/historicalData/common/historicalDataCommon.ts
@@ -13,6 +13,8 @@ export interface HistoricalDataWidget {
   id: number;
   reportPathsType: ReportPathsType; // Report URL path
   reportType: ReportType; // Report type; cost, storage, etc.
+  showLimit?: boolean; // Show chart legend for limit data
+  showRequest?: boolean; // Show chart legend for request data
   showWidgetOnGroupBy?: string[]; // Show widget when group_by is matched
   type: HistoricalDataWidgetType;
 }

--- a/src/store/breakdown/historicalData/ocpHistoricalData/ocpHistoricalDataWidgets.ts
+++ b/src/store/breakdown/historicalData/ocpHistoricalData/ocpHistoricalDataWidgets.ts
@@ -7,6 +7,7 @@ import {
 let currrentId = 0;
 const getId = () => currrentId++;
 
+// Cost comparison
 export const costWidget: HistoricalDataWidget = {
   chartName: 'ocpCostChart',
   id: getId(),
@@ -15,36 +16,46 @@ export const costWidget: HistoricalDataWidget = {
   type: HistoricalDataWidgetType.cost,
 };
 
+// CPU usage, request, and limit comparison
 export const cpuUsageWidget: HistoricalDataWidget = {
   chartName: 'ocpCpuChart',
   id: getId(),
   reportPathsType: ReportPathsType.ocp,
   reportType: ReportType.cpu,
+  showLimit: true,
+  showRequest: true,
   type: HistoricalDataWidgetType.usage,
 };
 
+// Memory usage, request, and limit comparison
 export const memoryUsageWidget: HistoricalDataWidget = {
   chartName: 'ocpMemoryChart',
   id: getId(),
   reportPathsType: ReportPathsType.ocp,
   reportType: ReportType.memory,
+  showLimit: true,
+  showRequest: true,
   type: HistoricalDataWidgetType.usage,
 };
 
+// Network usage comparison (shown when grouped by cluster and node)
 export const networkUsageWidget: HistoricalDataWidget = {
   chartName: 'ocpNetworkChart',
   id: getId(),
   reportPathsType: ReportPathsType.ocp,
   reportType: ReportType.network,
+  showRequest: true, // Reusing request to show "Data in" legend
   showWidgetOnGroupBy: ['cluster', 'node'],
   type: HistoricalDataWidgetType.network,
 };
 
+// Storage usage comparison
 export const volumeUsageWidget: HistoricalDataWidget = {
   chartName: 'ocpVolumeChart',
   id: getId(),
   reportPathsType: ReportPathsType.ocp,
   reportType: ReportType.volume,
+  showRequest: true,
   showWidgetOnGroupBy: ['cluster', 'node', 'project'],
   type: HistoricalDataWidgetType.volume,
 };


### PR DESCRIPTION
Historical charts should omit request and limit legends for cloud providers

https://issues.redhat.com/browse/COST-6726

## Summary by Sourcery

Add showRequest and showLimit flags to historical usage, network, volume, and usage chart components and widget configurations to conditionally display request and limit legends for cloud providers

Enhancements:
- Introduce showRequest and showLimit props in chart components to toggle request and limit series
- Extend HistoricalDataWidget interface and default OCP widget settings with showRequest and showLimit flags
- Propagate the new flags through base and detail chart components to control legend rendering