### PR TITLE
Migrate alt titles from chrome-services-backend

### DIFF
--- a/deploy/frontend.yaml
+++ b/deploy/frontend.yaml
@@ -25,7 +25,31 @@ objects:
           href: '/openshift/cost-management'
           description: 'Understand and track costs for your OpenShift clusters and workloads.'
           alt_title:
-            - 'Cost Management'
+            - 'cost management'
+            - 'overview'
+            - 'cost management overview'
+            - 'costmgmt'
+            - 'cost'
+            - 'finops'
+            - 'cost management for openshift'
+            - 'openshift cost'
+            - 'rhcm'
+            - 'finsights'
+            - 'finops'
+            - 'spend'
+            - 'distribute'
+            - 'cost model'
+            - 'money'
+            - 'bill'
+            - 'billing'
+            - 'financial'
+            - 'chargeback'
+            - 'showback'
+            - 'rate'
+            - 'save'
+            - 'savings'
+            - 'resource optimization'
+            - 'resources'
       navigationSegments:
         - segmentId: 'cost-management'
           navItems:
@@ -42,7 +66,7 @@ objects:
                   href: '/openshift/cost-management/systems'
                   permissions:
                     - method: 'featureFlag'
-                      args: [ "cost-management.ui.systems", true ]
+                      args: [ 'cost-management.ui.systems', true ]
                 - id: 'cost-management.optimizations'
                   title: 'Optimizations'
                   href: '/openshift/cost-management/optimizations'


### PR DESCRIPTION
Migrate alt titles from chrome-services-backend to searchEntries

## Summary by Sourcery

Migrate and enrich alt titles for the cost management frontend configuration and clean up YAML quoting style

Enhancements:
- Expand the alt_title list for the cost management entry with additional synonyms and keywords
- Standardize YAML quoting for the cost-management.ui.systems feature flag arguments