### PR TITLE
Truncate long text in cost models wizard

### DIFF
--- a/src/routes/settings/costModels/costModelWizard/sourcesTable.tsx
+++ b/src/routes/settings/costModels/costModelWizard/sourcesTable.tsx
@@ -8,6 +8,7 @@ import {
   Title,
   TitleSizes,
   Tooltip,
+  Truncate,
 } from '@patternfly/react-core';
 import { Table, TableVariant, Tbody, Td, Th, Thead, Tr } from '@patternfly/react-table';
 import messages from 'locales/messages';
@@ -135,7 +136,9 @@ const SourcesTable: React.FC<WrappedComponentProps> = ({ intl }) => {
                             />
                           )}
                         </Td>
-                        <Td>{row.name} </Td>
+                        <Td>
+                          <Truncate maxCharsDisplayed={35} content={row.name} />
+                        </Td>
                         <td>
                           {row.updateAvailable === true && (
                             <Tooltip content={intl.formatMessage(messages.newOperatorAvailable)}>
@@ -150,7 +153,9 @@ const SourcesTable: React.FC<WrappedComponentProps> = ({ intl }) => {
                             </Label>
                           )}
                         </td>
-                        <Td>{row.costmodel ? row.costmodel : ''}</Td>
+                        <Td>
+                          <Truncate maxCharsDisplayed={35} content={row.costmodel ? row.costmodel : ''} />
+                        </Td>
                       </Tr>
                     ))}
                   </Tbody>


### PR DESCRIPTION
Truncate long text in cost models wizard

https://issues.redhat.com/browse/COST-6853

<img width="1127" height="768" alt="Screenshot 2025-09-29 at 8 52 47 AM" src="https://github.com/user-attachments/assets/5e4602f5-c664-44a8-a921-f0eb2fee3bb3" />

## Summary by Sourcery

Use Truncate component to limit the length of source and cost model names in the sources table within the cost models wizard.

Enhancements:
- Truncate source name column content to 35 characters.
- Truncate cost model column content to 35 characters.