### PR TITLE
"No data" alert should appear outside details card

### DIFF
--- a/src/routes/details/awsDetails/awsDetails.tsx
+++ b/src/routes/details/awsDetails/awsDetails.tsx
@@ -434,17 +434,17 @@ class AwsDetails extends React.Component<AwsDetailsProps, AwsDetailsState> {
           />
         </PageSection>
         <PageSection>
+          {!isCurrentMonthData && (
+            <Alert
+              isInline
+              style={styles.alert}
+              title={intl.formatMessage(messages.noCurrentData, {
+                dateRange: getSinceDateRangeString(),
+              })}
+              variant="info"
+            />
+          )}
           <Card>
-            {!isCurrentMonthData && (
-              <Alert
-                isInline
-                style={styles.alert}
-                title={intl.formatMessage(messages.noCurrentData, {
-                  dateRange: getSinceDateRangeString(),
-                })}
-                variant="info"
-              />
-            )}
             <CardBody>
               {this.getToolbar(computedItems)}
               {this.getExportModal(computedItems)}

--- a/src/routes/details/azureDetails/azureDetails.tsx
+++ b/src/routes/details/azureDetails/azureDetails.tsx
@@ -391,17 +391,17 @@ class AzureDetails extends React.Component<AzureDetailsProps, AzureDetailsState>
           />
         </PageSection>
         <PageSection>
+          {!isCurrentMonthData && (
+            <Alert
+              isInline
+              style={styles.alert}
+              title={intl.formatMessage(messages.noCurrentData, {
+                dateRange: getSinceDateRangeString(),
+              })}
+              variant="info"
+            />
+          )}
           <Card>
-            {!isCurrentMonthData && (
-              <Alert
-                isInline
-                style={styles.alert}
-                title={intl.formatMessage(messages.noCurrentData, {
-                  dateRange: getSinceDateRangeString(),
-                })}
-                variant="info"
-              />
-            )}
             <CardBody>
               {this.getToolbar(computedItems)}
               {this.getExportModal(computedItems)}

--- a/src/routes/details/gcpDetails/gcpDetails.tsx
+++ b/src/routes/details/gcpDetails/gcpDetails.tsx
@@ -390,17 +390,17 @@ class GcpDetails extends React.Component<GcpDetailsProps, GcpDetailsState> {
           />
         </PageSection>
         <PageSection>
+          {!isCurrentMonthData && (
+            <Alert
+              isInline
+              style={styles.alert}
+              title={intl.formatMessage(messages.noCurrentData, {
+                dateRange: getSinceDateRangeString(),
+              })}
+              variant="info"
+            />
+          )}
           <Card>
-            {!isCurrentMonthData && (
-              <Alert
-                isInline
-                style={styles.alert}
-                title={intl.formatMessage(messages.noCurrentData, {
-                  dateRange: getSinceDateRangeString(),
-                })}
-                variant="info"
-              />
-            )}
             <CardBody>
               {this.getToolbar(computedItems)}
               {this.getExportModal(computedItems)}

--- a/src/routes/explorer/explorer.tsx
+++ b/src/routes/explorer/explorer.tsx
@@ -538,17 +538,17 @@ class Explorer extends React.Component<ExplorerProps, ExplorerState> {
           ) : (
             <Grid hasGutter>
               <GridItem sm={12}>
+                {!isCurrentMonthData && !isDateRangeSelected && dateRangeType === DateRangeType.previousMonth && (
+                  <Alert
+                    isInline
+                    style={styles.alert}
+                    title={intl.formatMessage(messages.noCurrentData, {
+                      dateRange: getSinceDateRangeString(),
+                    })}
+                    variant="info"
+                  />
+                )}
                 <Card>
-                  {!isCurrentMonthData && !isDateRangeSelected && dateRangeType === DateRangeType.previousMonth && (
-                    <Alert
-                      isInline
-                      style={styles.alert}
-                      title={intl.formatMessage(messages.noCurrentData, {
-                        dateRange: getSinceDateRangeString(),
-                      })}
-                      variant="info"
-                    />
-                  )}
                   <CardBody>
                     <ExplorerChart
                       costDistribution={costDistribution}


### PR DESCRIPTION
The "No data" alert should appear outside details card.

https://issues.redhat.com/browse/COST-6867

<img width="1419" height="561" alt="outside card" src="https://github.com/user-attachments/assets/50673b0f-e574-42aa-83f7-0c0f65a22b5d" />
