### PR TITLE
Show operator version for OCP only

### DIFF
--- a/src/routes/details/components/providerStatus/providerTable.tsx
+++ b/src/routes/details/components/providerStatus/providerTable.tsx
@@ -1,5 +1,6 @@
 import { Button, ButtonVariant } from '@patternfly/react-core';
-import type { Provider, ProviderType } from 'api/providers';
+import type { Provider } from 'api/providers';
+import { ProviderType } from 'api/providers';
 import messages from 'locales/messages';
 import React, { useEffect, useState } from 'react';
 import { useIntl } from 'react-intl';
@@ -36,6 +37,7 @@ const ProviderTable: React.FC<ProviderTableProps> = ({ onClick, providers, provi
         name: intl.formatMessage(messages.integration),
       },
       {
+        hidden: providerType !== ProviderType.ocp,
         name: intl.formatMessage(messages.operatorVersion),
       },
       {
@@ -55,7 +57,10 @@ const ProviderTable: React.FC<ProviderTableProps> = ({ onClick, providers, provi
       newRows.push({
         cells: [
           { value: <SourceLink provider={item} showLabel={false} /> },
-          { value: getOperatorStatus(item.additional_context?.operator_update_available) },
+          {
+            hidden: providerType !== ProviderType.ocp,
+            value: getOperatorStatus(item.additional_context?.operator_update_available),
+          },
           { value: <OverallStatus isLastUpdated providerId={item.id} providerType={providerType} /> },
           {
             value: <OverallStatus isStatusMsg providerId={item.id} providerType={providerType} />,
@@ -74,8 +79,14 @@ const ProviderTable: React.FC<ProviderTableProps> = ({ onClick, providers, provi
       });
     });
 
-    setColumns(newColumns);
-    setRows(newRows);
+    const filteredColumns = (newColumns as any[]).filter(column => !column.hidden);
+    const filteredRows = newRows.map(({ ...row }) => {
+      row.cells = row.cells.filter(cell => !cell.hidden);
+      return row;
+    });
+
+    setColumns(filteredColumns);
+    setRows(filteredRows);
   };
 
   useEffect(() => {

--- a/src/routes/settings/costModels/costModelWizard/sourcesTable.tsx
+++ b/src/routes/settings/costModels/costModelWizard/sourcesTable.tsx
@@ -21,6 +21,7 @@ import { getOperatorStatus } from 'routes/utils/operatorStatus';
 
 import { AssignSourcesToolbar } from './assignSourcesToolbar';
 import { CostModelContext } from './context';
+import { styles } from './wizard.styles';
 
 const SourcesTable: React.FC<WrappedComponentProps> = ({ intl }) => {
   return (
@@ -97,14 +98,12 @@ const SourcesTable: React.FC<WrappedComponentProps> = ({ intl }) => {
                 >
                   <Thead>
                     <Tr>
-                      {[
-                        '',
-                        intl.formatMessage(messages.names, { count: 1 }),
-                        intl.formatMessage(messages.operatorVersion),
-                        intl.formatMessage(messages.costModelsWizardSourceTableCostModel),
-                      ].map((c, i) => (
-                        <Th key={i}>{c}</Th>
-                      ))}
+                      <Th />
+                      <Th>{intl.formatMessage(messages.names, { count: 1 })}</Th>
+                      {sourceType === 'OCP' && <Th>{intl.formatMessage(messages.operatorVersion)}</Th>}
+                      <Th style={sourceType === 'OCP' ? styles.costModelAssigned : undefined}>
+                        {intl.formatMessage(messages.costModelsWizardSourceTableCostModel)}
+                      </Th>
                     </Tr>
                   </Thead>
                   <Tbody>
@@ -139,7 +138,7 @@ const SourcesTable: React.FC<WrappedComponentProps> = ({ intl }) => {
                         <Td>
                           <Truncate maxCharsDisplayed={35} content={row.name} />
                         </Td>
-                        <Td>{getOperatorStatus(row.updateAvailable)}</Td>
+                        {sourceType === 'OCP' && <Td>{getOperatorStatus(row.updateAvailable)}</Td>}
                         <Td>
                           <Truncate maxCharsDisplayed={35} content={row.costmodel ? row.costmodel : ''} />
                         </Td>

--- a/src/routes/settings/costModels/costModelWizard/wizard.styles.ts
+++ b/src/routes/settings/costModels/costModelWizard/wizard.styles.ts
@@ -15,4 +15,7 @@ export const styles = {
     display: 'inline-block',
     marginRight: '1em',
   },
+  costModelAssigned: {
+    minWidth: '125px',
+  },
 } as { [className: string]: React.CSSProperties };


### PR DESCRIPTION
Show operator version for OCP only. This does not apply to AWS, Azure, etc.

https://issues.redhat.com/browse/COST-6854

## Summary by Sourcery

Restrict the operator version display to OpenShift sources and providers, filter out hidden columns/cells in the provider status table, and adjust the cost model column styling in the wizard.

Enhancements:
- Limit the operator version column and cells in source and provider tables to OCP only and hide them for other provider types
- Filter out columns and cells marked hidden in the provider status table before setting rows and columns
- Add a minimum width style to the cost model column in the wizard