### PR TITLE
Show operator version for OCP only

### DIFF
--- a/src/routes/settings/costModels/costModel/addSourceStep.tsx
+++ b/src/routes/settings/costModels/costModel/addSourceStep.tsx
@@ -17,6 +17,7 @@ import { sourcesActions, sourcesSelectors } from 'store/sourceSettings';
 
 import { AssignSourcesToolbar } from './assignSourcesModalToolbar';
 import { styles } from './costModelInfo.styles';
+import { getSourceType } from './utils/sourceType';
 
 interface AddSourcesStepOwnProps extends WrappedComponentProps {
   checked: { [uuid: string]: { selected: boolean; meta: Provider } };
@@ -91,6 +92,8 @@ class AddSourcesStepBase extends React.Component<AddSourcesStepProps, AddSources
       });
     };
 
+    const source_type = getSourceType(costModel.source_type) ?? '';
+
     const sources = this.props.providers.map(providerData => {
       const isSelected = this.props.checked[providerData.uuid] ? this.props.checked[providerData.uuid].selected : false;
       const provCostModels =
@@ -102,24 +105,18 @@ class AddSourcesStepBase extends React.Component<AddSourcesStepProps, AddSources
         providerData.cost_models.find(cm => cm.name === costModel.name) === undefined;
       const cellName = <div key={providerData.uuid}>{providerData.name}</div>;
 
+      const cells = [cellName, provCostModels || ''];
+      if (source_type === 'OCP') {
+        cells.splice(1, 0, getOperatorStatus(providerData.additional_context?.operator_update_available));
+      }
+
       return {
         isAssigned,
-        cells: [
-          cellName,
-          getOperatorStatus(providerData.additional_context?.operator_update_available),
-          provCostModels || '',
-        ],
+        cells,
         selected: isSelected,
       };
     });
 
-    const sourceTypeMap = {
-      'OpenShift Container Platform': 'OCP',
-      'Microsoft Azure': 'Azure',
-      'Amazon Web Services': 'AWS',
-    };
-
-    const source_type = sourceTypeMap[costModel.source_type];
     return (
       <>
         <AssignSourcesToolbar
@@ -190,7 +187,7 @@ class AddSourcesStepBase extends React.Component<AddSourcesStepProps, AddSources
                   }}
                 ></Th>
                 <Th>{intl.formatMessage(messages.names, { count: 1 })}</Th>
-                <Th>{intl.formatMessage(messages.operatorVersion)}</Th>
+                {source_type === 'OCP' && <Th>{intl.formatMessage(messages.operatorVersion)}</Th>}
                 <Th>{intl.formatMessage(messages.costModelsWizardSourceTableCostModel)}</Th>
               </Tr>
             </Thead>

--- a/src/routes/settings/costModels/costModel/sourcesTable.tsx
+++ b/src/routes/settings/costModels/costModel/sourcesTable.tsx
@@ -18,6 +18,7 @@ import { rbacSelectors } from 'store/rbac';
 
 interface SourcesTableOwnProps {
   showDeleteDialog: (rowId: number) => void;
+  showOperatorVersion?: boolean;
 }
 
 interface SourcesTableStateProps {
@@ -28,7 +29,14 @@ interface SourcesTableStateProps {
 
 type SourcesTableProps = SourcesTableOwnProps & SourcesTableStateProps & WrappedComponentProps;
 
-const SourcesTable: React.FC<SourcesTableProps> = ({ canWrite, costModels, intl, providers, showDeleteDialog }) => {
+const SourcesTable: React.FC<SourcesTableProps> = ({
+  canWrite,
+  costModels,
+  intl,
+  providers,
+  showDeleteDialog,
+  showOperatorVersion,
+}) => {
   const rows: (IRow | string[])[] = costModels.length > 0 ? costModels[0].sources : [];
 
   return (
@@ -40,7 +48,7 @@ const SourcesTable: React.FC<SourcesTableProps> = ({ canWrite, costModels, intl,
       <Thead>
         <Tr>
           <Th>{intl.formatMessage(messages.names, { count: 1 })}</Th>
-          <Th>{intl.formatMessage(messages.operatorVersion)}</Th>
+          {showOperatorVersion && <Th>{intl.formatMessage(messages.operatorVersion)}</Th>}
           <Th>{intl.formatMessage(messages.lastProcessed)}</Th>
         </Tr>
       </Thead>
@@ -48,11 +56,13 @@ const SourcesTable: React.FC<SourcesTableProps> = ({ canWrite, costModels, intl,
         {rows.map((row: any, rowIndex) => (
           <Tr key={rowIndex}>
             <Td>{row.name}</Td>
-            <Td>
-              {getOperatorStatus(
-                providers?.data?.find(p => p.uuid === row.uuid)?.additional_context?.operator_update_available
-              )}
-            </Td>
+            {showOperatorVersion && (
+              <Td>
+                {getOperatorStatus(
+                  providers?.data?.find(p => p.uuid === row.uuid)?.additional_context?.operator_update_available
+                )}
+              </Td>
+            )}
             <Td>
               {intl.formatDate(row.last_processed, {
                 day: 'numeric',

--- a/src/routes/settings/costModels/costModel/table.tsx
+++ b/src/routes/settings/costModels/costModel/table.tsx
@@ -14,6 +14,7 @@ import { rbacSelectors } from 'store/rbac';
 
 import { SourcesToolbar } from './sourcesToolbar';
 import { styles } from './table.styles';
+import { getSourceType } from './utils/sourceType';
 
 interface TableBaseProps extends WrappedComponentProps {
   isWritePermission: boolean;
@@ -113,6 +114,7 @@ class TableBase extends React.Component<TableBaseProps, TableBaseState> {
             showDeleteDialog={(rowId: number) => {
               this.props.onDelete(res[rowId]);
             }}
+            showOperatorVersion={getSourceType(current.source_type) === 'OCP'}
           />
         )}
         {rows.length === 0 && (

--- a/src/routes/settings/costModels/costModel/utils/sourceType.ts
+++ b/src/routes/settings/costModels/costModel/utils/sourceType.ts
@@ -1,0 +1,18 @@
+export const getSourceType = (sourceType: string) => {
+  let result;
+  switch (sourceType) {
+    case 'Amazon Web Services':
+      result = 'AWS';
+      break;
+    case 'Google Cloud Platform':
+      result = 'GCP';
+      break;
+    case 'Microsoft Azure':
+      result = 'Azure';
+      break;
+    case 'OpenShift Container Platform':
+      result = 'OCP';
+      break;
+  }
+  return result;
+};


### PR DESCRIPTION
Show operator version for OCP only

## Summary by Sourcery

Show the operator version column exclusively for OCP in various tables by extracting source type mapping into a shared utility and simplifying column rendering logic

Enhancements:
- Display the operator version column conditionally only for OCP providers in the provider status table
- Introduce getSourceType utility to map provider source types to codes
- Use getSourceType to conditionally show operator version column in cost model sources and add-source-step tables
- Refactor table column and cell construction by removing hidden flags and filtering logic