### PR TITLE
feat(token-refresher): extract token refresher into reusable library package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ report.*.json
 .vscode/
 .swc/
 .dccache
+docs

--- a/apps/koku-ui-onprem/README.md
+++ b/apps/koku-ui-onprem/README.md
@@ -30,7 +30,7 @@ export API_PROXY_URL=<backend_url>
 export API_TOKEN=<auth_token_for_backend>
 ```
 
-For example, you can point on-prem application to SaaS backend:
+### Pointing to the SaaS (console.redhat.com) backend
 
 Download [ocm CLI](https://console.redhat.com/openshift/downloads)
 
@@ -39,6 +39,28 @@ ocm login --use-auth-code
 export API_PROXY_URL=https://console.redhat.com/api/cost-management/v1
 export API_TOKEN=$(ocm token)
 ```
+
+### Pointing to an on-prem backend deployed on an OpenShift cluster
+
+If you have a cost-onprem Helm chart deployment running on an OpenShift cluster,
+log in with `oc` and source the helper script to auto-discover all required
+environment variables:
+
+```
+oc login -s <cluster_api_url> -u <username> --password <password>
+source scripts/setup-onprem-env.sh
+```
+
+This sets `API_PROXY_URL` and `API_TOKEN` from the cluster's
+`CostManagementMetricsConfig` CR and Keycloak auth secret.
+
+It also exports `KEYCLOAK_TOKEN_URL`, `KEYCLOAK_CLIENT_ID`, and
+`KEYCLOAK_CLIENT_SECRET`, which enable **automatic token renewal** in the
+dev server. Without these variables the proxy uses the static `API_TOKEN`
+(which expires after a few minutes); with them, the proxy refreshes the
+token in the background before it expires.
+
+### Starting the dev server
 
 From the root of the repo, run
 ```

--- a/apps/koku-ui-onprem/package.json
+++ b/apps/koku-ui-onprem/package.json
@@ -46,6 +46,7 @@
     "typesafe-actions": "^5.1.0"
   },
   "devDependencies": {
+    "@koku-ui/token-refresher": "*",
     "@types/node": "^25.3.3",
     "css-minimizer-webpack-plugin": "^7.0.4",
     "cypress": "^15.11.0",

--- a/apps/koku-ui-onprem/webpack.config.ts
+++ b/apps/koku-ui-onprem/webpack.config.ts
@@ -1,3 +1,4 @@
+import { createDevServerProxy, createKeycloakFetcher, TokenRefresher } from '@koku-ui/token-refresher';
 import CssMinimizerPlugin from 'css-minimizer-webpack-plugin';
 import HtmlWebpackPlugin from 'html-webpack-plugin';
 import MiniCssExtractPlugin from 'mini-css-extract-plugin';
@@ -8,6 +9,42 @@ import { container } from 'webpack';
 import type { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
 
 const NODE_ENV = (process.env.NODE_ENV || 'development') as Configuration['mode'];
+
+let refresher: TokenRefresher | undefined;
+
+if (NODE_ENV !== 'production' && !process.env.CI) {
+  if (!process.env.API_PROXY_URL) {
+    throw new Error(
+      '[koku-ui-onprem] Missing required env var: API_PROXY_URL\n' +
+        'Set it to the backend URL, e.g. https://koku-api.example.com:8000'
+    );
+  }
+
+  const hasKeycloak =
+    process.env.KEYCLOAK_TOKEN_URL && process.env.KEYCLOAK_CLIENT_ID && process.env.KEYCLOAK_CLIENT_SECRET;
+
+  if (!hasKeycloak && !process.env.API_TOKEN) {
+    throw new Error(
+      '[koku-ui-onprem] No authentication configured for the dev proxy.\n' +
+        'Provide one of:\n' +
+        '  1. KEYCLOAK_TOKEN_URL + KEYCLOAK_CLIENT_ID + KEYCLOAK_CLIENT_SECRET  (auto-refresh)\n' +
+        '  2. API_TOKEN  (static bearer token)\n' +
+        'See apps/koku-ui-onprem/README.md for details.'
+    );
+  }
+
+  if (hasKeycloak) {
+    refresher = new TokenRefresher({
+      fetchToken: createKeycloakFetcher({
+        tokenUrl: process.env.KEYCLOAK_TOKEN_URL!,
+        clientId: process.env.KEYCLOAK_CLIENT_ID!,
+        clientSecret: process.env.KEYCLOAK_CLIENT_SECRET!,
+      }),
+      fallbackToken: process.env.API_TOKEN,
+    });
+    refresher.start();
+  }
+}
 
 const config: Configuration & {
   devServer?: WebpackDevServerConfiguration;
@@ -38,16 +75,23 @@ const config: Configuration & {
       overlay: true,
     },
     proxy: [
-      {
-        context: ['/api/cost-management/v1'],
-        target: process.env.API_PROXY_URL,
-        changeOrigin: true,
-        secure: false,
-        pathRewrite: { '^/api/cost-management/v1': '' },
-        headers: {
-          Authorization: `Bearer ${process.env.API_TOKEN}`,
-        },
-      },
+      refresher
+        ? createDevServerProxy(refresher, {
+            context: ['/api/cost-management/v1'],
+            target: process.env.API_PROXY_URL!,
+            pathRewrite: { '^/api/cost-management/v1': '' },
+            secure: false,
+          })
+        : {
+            context: ['/api/cost-management/v1'],
+            target: process.env.API_PROXY_URL,
+            changeOrigin: true,
+            secure: false,
+            pathRewrite: { '^/api/cost-management/v1': '' },
+            headers: {
+              Authorization: `Bearer ${process.env.API_TOKEN}`,
+            },
+          },
     ],
   },
   module: {

--- a/libs/token-refresher/README.md
+++ b/libs/token-refresher/README.md
@@ -1,0 +1,139 @@
+# @koku-ui/token-refresher
+
+Dev-only JWT token refresher for webpack-dev-server proxy configurations. Keeps
+an OAuth2 access token fresh in the background so that `devServer.proxy` requests
+are always authenticated — no manual token copy-paste, no fixed-interval polling.
+
+## Architecture
+
+Three layers, each usable independently:
+
+```mermaid
+graph LR
+  A[TokenRefresher] -->|delegates to| B["fetchToken()"]
+  B --> C[createKeycloakFetcher]
+  A -->|consumed by| D[createDevServerProxy]
+  D -->|produces| E["devServer.proxy config"]
+  E -->|injects| F["Authorization: Bearer &lt;token&gt;"]
+```
+
+| Layer | Responsibility |
+|-------|----------------|
+| **`TokenRefresher`** | Generic cache + adaptive scheduling. Reads JWT `exp`, computes next refresh, serves stale tokens while revalidating. |
+| **`createKeycloakFetcher`** | Keycloak `client_credentials` grant via the Fetch API. Returns a `() => Promise<string>` plugged into `TokenRefresher`. |
+| **`createDevServerProxy`** | Builds a complete `devServer.proxy[]` entry with `onProxyReq` wired to inject the bearer token. |
+
+## Token lifecycle
+
+```mermaid
+sequenceDiagram
+  participant WP as webpack-dev-server
+  participant TR as TokenRefresher
+  participant KC as Keycloak
+
+  WP->>TR: start()
+  TR->>KC: POST /token (client_credentials)
+  KC-->>TR: { access_token, exp }
+  TR->>TR: cache token, schedule refresh at exp − buffer
+
+  Note over TR: Time passes...
+
+  TR->>KC: POST /token (scheduled refresh)
+  KC-->>TR: { access_token, exp }
+  TR->>TR: update cache, reschedule
+
+  WP->>TR: proxy request → get token
+  TR-->>WP: cached token (immediate, non-blocking)
+  WP->>WP: setHeader("Authorization", "Bearer <token>")
+```
+
+## Usage
+
+```typescript
+import {
+  TokenRefresher,
+  createKeycloakFetcher,
+  createDevServerProxy,
+} from '@koku-ui/token-refresher';
+
+const refresher = new TokenRefresher({
+  fetchToken: createKeycloakFetcher({
+    tokenUrl: process.env.KEYCLOAK_TOKEN_URL,
+    clientId: process.env.KEYCLOAK_CLIENT_ID,
+    clientSecret: process.env.KEYCLOAK_CLIENT_SECRET,
+  }),
+  fallbackToken: process.env.API_TOKEN,
+});
+refresher.start();
+
+// In webpack config:
+const config = {
+  devServer: {
+    proxy: [
+      createDevServerProxy(refresher, {
+        context: ['/api/cost-management/v1'],
+        target: process.env.API_PROXY_URL,
+        pathRewrite: { '^/api/cost-management/v1': '' },
+      }),
+    ],
+  },
+};
+```
+
+## API reference
+
+### `TokenRefresher`
+
+```typescript
+new TokenRefresher(options: TokenRefresherOptions)
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `fetchToken` | `() => Promise<string>` | *required* | Async function that returns a JWT string. |
+| `fallbackToken` | `string` | `''` | Static token used before the first fetch completes. |
+| `refreshBufferSec` | `number` | `60` | Seconds before `exp` to trigger the next refresh. |
+| `logger` | `(msg: string) => void` | `console.log` | Log sink for refresh/error messages. |
+
+**Methods:** `start()`, `stop()`, `get token: string`
+
+### `createKeycloakFetcher`
+
+```typescript
+createKeycloakFetcher(options: KeycloakFetcherOptions): () => Promise<string>
+```
+
+| Option | Type | Description |
+|--------|------|-------------|
+| `tokenUrl` | `string` | Full Keycloak token endpoint URL. |
+| `clientId` | `string` | OAuth2 client ID. |
+| `clientSecret` | `string` | OAuth2 client secret. |
+
+For self-signed certificates, set `NODE_TLS_REJECT_UNAUTHORIZED=0` in your environment.
+
+### `createDevServerProxy`
+
+```typescript
+createDevServerProxy(refresher: TokenRefresher, options: DevServerProxyOptions): WebpackDevServer.ProxyConfigArrayItem
+```
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `context` | `string \| string[]` | *required* | URL paths to proxy. |
+| `target` | `string` | *required* | Backend URL. |
+| `pathRewrite` | `Record<string, string>` | — | Path rewrite rules. |
+| `changeOrigin` | `boolean` | `true` | Change `Host` header to target. |
+| `secure` | `boolean` | `true` | Verify target TLS certificate. |
+
+## Running tests
+
+```bash
+npm test -w @koku-ui/token-refresher
+```
+
+Or directly:
+
+```bash
+cd libs/token-refresher
+node --experimental-strip-types --experimental-test-module-mocks --test 'test/**/*.test.ts'
+```

--- a/libs/token-refresher/package.json
+++ b/libs/token-refresher/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "@koku-ui/token-refresher",
+  "version": "0.0.1",
+  "description": "Dev-only JWT token refresher for webpack-dev-server proxy configurations",
+  "repository": "https://github.com/project-koku/koku-ui.git",
+  "author": "Red Hat",
+  "license": "Apache-2.0",
+  "private": true,
+  "files": ["dist", "src"],
+  "main": "src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "build": "tsc --build tsconfig.build.json",
+    "clean": "rimraf dist",
+    "lint": "npm-run-all lint:*",
+    "lint:ts": "eslint src",
+    "lint:ts:fix": "eslint src --fix",
+    "test": "node --experimental-strip-types --experimental-test-module-mocks --test 'test/**/*.test.ts'"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "typescript": "^5.9.3",
+    "webpack-dev-server": "^5.2.3"
+  }
+}

--- a/libs/token-refresher/src/TokenRefresher.ts
+++ b/libs/token-refresher/src/TokenRefresher.ts
@@ -1,0 +1,134 @@
+const DEFAULT_BUFFER_SEC = 60;
+const FALLBACK_TTL_SEC = 300;
+
+// From Node.js docs: "When delay is larger than 2147483647 or less than 1, the delay will be set to 1."
+const MAX_TIMEOUT_MS = 2_147_483_647;
+
+export interface TokenRefresherOptions {
+  fetchToken: () => Promise<string>;
+  fallbackToken?: string;
+  refreshBufferSec?: number;
+  logger?: (msg: string) => void;
+}
+
+interface CachedToken {
+  value: string;
+  exp: number;
+}
+
+function parseJwtExp(token: string): number {
+  try {
+    const payload = token.split('.')[1];
+    if (!payload) {
+      return 0;
+    }
+    const padded = payload + '='.repeat((4 - (payload.length % 4)) % 4);
+    const decoded = JSON.parse(Buffer.from(padded, 'base64url').toString());
+    return typeof decoded.exp === 'number' ? decoded.exp : 0;
+  } catch {
+    return 0;
+  }
+}
+
+export class TokenRefresher {
+  private fetchToken: () => Promise<string>;
+  private fallbackToken: string;
+  private bufferSec: number;
+  private log: (msg: string) => void;
+
+  private cache: CachedToken | null = null;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private refreshPromise: Promise<string> | null = null;
+  private started = false;
+
+  constructor(options: TokenRefresherOptions) {
+    this.fetchToken = options.fetchToken;
+    this.fallbackToken = options.fallbackToken ?? '';
+    this.bufferSec = options.refreshBufferSec ?? DEFAULT_BUFFER_SEC;
+    // eslint-disable-next-line no-console
+    this.log = options.logger ?? console.log;
+  }
+
+  get token(): string {
+    if (this.cache && !this.isExpiringSoon()) {
+      return this.cache.value;
+    }
+    this.triggerRefresh();
+    return this.cache?.value ?? this.fallbackToken;
+  }
+
+  start(): void {
+    if (this.started) {
+      return;
+    }
+    this.started = true;
+
+    if (this.fallbackToken) {
+      const exp = parseJwtExp(this.fallbackToken);
+      if (exp > 0) {
+        this.cache = { value: this.fallbackToken, exp };
+      }
+    }
+
+    this.triggerRefresh();
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+    this.cache = null;
+    this.refreshPromise = null;
+    this.started = false;
+  }
+
+  private isExpiringSoon(): boolean {
+    if (!this.cache) {
+      return true;
+    }
+    return Math.floor(Date.now() / 1000) >= this.cache.exp - this.bufferSec;
+  }
+
+  private triggerRefresh(): void {
+    if (this.refreshPromise) {
+      return;
+    }
+
+    this.refreshPromise = this.fetchToken()
+      .then(token => {
+        const exp = parseJwtExp(token);
+        const effectiveExp = exp > 0 ? exp : Math.floor(Date.now() / 1000) + FALLBACK_TTL_SEC;
+        this.cache = { value: token, exp: effectiveExp };
+
+        const ttl = effectiveExp - Math.floor(Date.now() / 1000);
+        this.log(`[token-refresher] Token refreshed, expires in ${ttl}s`);
+
+        this.scheduleNext(effectiveExp);
+        return token;
+      })
+      .catch(err => {
+        this.log(`[token-refresher] Refresh failed: ${(err as Error).message}`);
+        this.scheduleRetry();
+        return this.cache?.value ?? this.fallbackToken;
+      })
+      .finally(() => {
+        this.refreshPromise = null;
+      });
+  }
+
+  private scheduleNext(exp: number): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+    const delay = Math.min(Math.max((exp - this.bufferSec - Math.floor(Date.now() / 1000)) * 1000, 0), MAX_TIMEOUT_MS);
+    this.timer = setTimeout(() => this.triggerRefresh(), delay);
+  }
+
+  private scheduleRetry(): void {
+    if (this.timer) {
+      clearTimeout(this.timer);
+    }
+    this.timer = setTimeout(() => this.triggerRefresh(), 30_000);
+  }
+}

--- a/libs/token-refresher/src/devServerProxy.ts
+++ b/libs/token-refresher/src/devServerProxy.ts
@@ -1,0 +1,32 @@
+import type WebpackDevServer from 'webpack-dev-server';
+
+import type { TokenRefresher } from './TokenRefresher';
+
+export interface DevServerProxyOptions {
+  context: string | string[];
+  target: string;
+  pathRewrite?: Record<string, string>;
+  changeOrigin?: boolean;
+  secure?: boolean;
+}
+
+export function createDevServerProxy(
+  refresher: TokenRefresher,
+  options: DevServerProxyOptions
+): WebpackDevServer.ProxyConfigArrayItem {
+  const { context, target, pathRewrite, changeOrigin = true, secure = true } = options;
+
+  return {
+    context,
+    target,
+    changeOrigin,
+    secure,
+    ...(pathRewrite && { pathRewrite }),
+    onProxyReq: proxyReq => {
+      const tok = refresher.token;
+      if (tok) {
+        proxyReq.setHeader('Authorization', `Bearer ${tok}`);
+      }
+    },
+  };
+}

--- a/libs/token-refresher/src/index.ts
+++ b/libs/token-refresher/src/index.ts
@@ -1,0 +1,6 @@
+export { TokenRefresher } from './TokenRefresher';
+export type { TokenRefresherOptions } from './TokenRefresher';
+export { createKeycloakFetcher } from './keycloak';
+export type { KeycloakFetcherOptions } from './keycloak';
+export { createDevServerProxy } from './devServerProxy';
+export type { DevServerProxyOptions } from './devServerProxy';

--- a/libs/token-refresher/src/keycloak.ts
+++ b/libs/token-refresher/src/keycloak.ts
@@ -1,0 +1,34 @@
+export interface KeycloakFetcherOptions {
+  tokenUrl: string;
+  clientId: string;
+  clientSecret: string;
+}
+
+export function createKeycloakFetcher(options: KeycloakFetcherOptions): () => Promise<string> {
+  const { tokenUrl, clientId, clientSecret } = options;
+
+  return async () => {
+    const body = new URLSearchParams({
+      grant_type: 'client_credentials',
+      client_id: clientId,
+      client_secret: clientSecret,
+    });
+
+    const res = await fetch(tokenUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Keycloak token request failed: ${res.status} ${text}`);
+    }
+
+    const json = await res.json();
+    if (!json.access_token) {
+      throw new Error('No access_token in Keycloak response');
+    }
+    return json.access_token;
+  };
+}

--- a/libs/token-refresher/test/TokenRefresher.test.ts
+++ b/libs/token-refresher/test/TokenRefresher.test.ts
@@ -1,0 +1,182 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it, mock } from 'node:test';
+import { TokenRefresher } from '../src/TokenRefresher.ts';
+
+function fakeJwt(exp: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ exp })).toString('base64url');
+  return `${header}.${payload}.sig`;
+}
+
+function nowSec(): number {
+  return Math.floor(Date.now() / 1000);
+}
+
+describe('TokenRefresher', () => {
+  let refresher: TokenRefresher;
+
+  afterEach(() => {
+    refresher?.stop();
+  });
+
+  describe('constructor and token getter', () => {
+    it('returns empty string when no fallback and not started', () => {
+      refresher = new TokenRefresher({ fetchToken: () => Promise.resolve('') });
+      assert.equal(refresher.token, '');
+    });
+
+    it('returns fallbackToken when not started', () => {
+      refresher = new TokenRefresher({
+        fetchToken: () => Promise.resolve(''),
+        fallbackToken: 'static-fallback',
+      });
+      assert.equal(refresher.token, 'static-fallback');
+    });
+  });
+
+  describe('start()', () => {
+    it('fetches a token immediately on start', async () => {
+      const exp = nowSec() + 300;
+      const jwt = fakeJwt(exp);
+      const fetchToken = mock.fn(() => Promise.resolve(jwt));
+
+      refresher = new TokenRefresher({ fetchToken });
+      refresher.start();
+      await new Promise(r => setTimeout(r, 50));
+
+      assert.equal(refresher.token, jwt);
+      assert.equal(fetchToken.mock.callCount(), 1);
+    });
+
+    it('is idempotent — calling twice does not double-fetch', async () => {
+      const exp = nowSec() + 300;
+      const fetchToken = mock.fn(() => Promise.resolve(fakeJwt(exp)));
+
+      refresher = new TokenRefresher({ fetchToken });
+      refresher.start();
+      refresher.start();
+      await new Promise(r => setTimeout(r, 50));
+
+      assert.equal(fetchToken.mock.callCount(), 1);
+    });
+
+    it('seeds cache from fallbackToken JWT on start', async () => {
+      const exp = nowSec() + 300;
+      const fallback = fakeJwt(exp);
+      const freshJwt = fakeJwt(exp + 600);
+      const fetchToken = mock.fn(() => Promise.resolve(freshJwt));
+
+      refresher = new TokenRefresher({ fetchToken, fallbackToken: fallback });
+      refresher.start();
+
+      // Synchronously, before fetch resolves, should return fallback
+      assert.equal(refresher.token, fallback);
+    });
+  });
+
+  describe('adaptive scheduling', () => {
+    it('schedules refresh based on JWT exp, not fixed interval', async () => {
+      const exp = nowSec() + 3; // expires in 3 seconds
+      const fetchToken = mock.fn(() => Promise.resolve(fakeJwt(exp)));
+
+      refresher = new TokenRefresher({
+        fetchToken,
+        refreshBufferSec: 1, // refresh 1s before expiry = at T+2s
+      });
+      refresher.start();
+      await new Promise(r => setTimeout(r, 50));
+      assert.equal(fetchToken.mock.callCount(), 1);
+
+      // At T+1s — should NOT have refreshed yet
+      await new Promise(r => setTimeout(r, 1000));
+      assert.equal(fetchToken.mock.callCount(), 1);
+
+      // At T+2.5s — should have refreshed (scheduled at exp-buffer = T+2s)
+      const exp2 = nowSec() + 300;
+      fetchToken.mock.mockImplementation(() => Promise.resolve(fakeJwt(exp2)));
+      await new Promise(r => setTimeout(r, 1500));
+      assert.equal(fetchToken.mock.callCount(), 2);
+    });
+  });
+
+  describe('stale-while-revalidate', () => {
+    it('returns stale token while refresh is in-flight', async () => {
+      const exp = nowSec() + 2;
+      const staleJwt = fakeJwt(exp);
+      let resolveSecond: (v: string) => void;
+      const secondFetch = new Promise<string>(r => { resolveSecond = r; });
+      let callCount = 0;
+
+      refresher = new TokenRefresher({
+        fetchToken: () => {
+          callCount++;
+          if (callCount === 1) return Promise.resolve(staleJwt);
+          return secondFetch;
+        },
+        refreshBufferSec: 1,
+      });
+      refresher.start();
+      await new Promise(r => setTimeout(r, 50));
+
+      // Wait until refresh triggers but don't resolve it
+      await new Promise(r => setTimeout(r, 1500));
+      assert.equal(refresher.token, staleJwt); // stale
+
+      // Resolve second fetch
+      const freshJwt = fakeJwt(nowSec() + 600);
+      resolveSecond!(freshJwt);
+      await new Promise(r => setTimeout(r, 50));
+      assert.equal(refresher.token, freshJwt);
+    });
+  });
+
+  describe('error handling', () => {
+    it('keeps stale token when refresh fails', async () => {
+      const exp = nowSec() + 2;
+      const staleJwt = fakeJwt(exp);
+      let callCount = 0;
+
+      refresher = new TokenRefresher({
+        fetchToken: () => {
+          callCount++;
+          if (callCount === 1) return Promise.resolve(staleJwt);
+          return Promise.reject(new Error('network error'));
+        },
+        refreshBufferSec: 1,
+        logger: () => {}, // suppress test output
+      });
+      refresher.start();
+      await new Promise(r => setTimeout(r, 50));
+
+      // Wait for failed refresh
+      await new Promise(r => setTimeout(r, 1500));
+      assert.equal(refresher.token, staleJwt);
+    });
+
+    it('falls back to fallbackToken when initial fetch fails', async () => {
+      refresher = new TokenRefresher({
+        fetchToken: () => Promise.reject(new Error('fail')),
+        fallbackToken: 'my-fallback',
+        logger: () => {},
+      });
+      refresher.start();
+      await new Promise(r => setTimeout(r, 50));
+
+      assert.equal(refresher.token, 'my-fallback');
+    });
+  });
+
+  describe('stop()', () => {
+    it('clears scheduled refresh and resets state', async () => {
+      const exp = nowSec() + 300;
+      const fetchToken = mock.fn(() => Promise.resolve(fakeJwt(exp)));
+
+      refresher = new TokenRefresher({ fetchToken });
+      refresher.start();
+      await new Promise(r => setTimeout(r, 50));
+      refresher.stop();
+
+      assert.equal(refresher.token, '');
+    });
+  });
+});

--- a/libs/token-refresher/test/keycloak.test.ts
+++ b/libs/token-refresher/test/keycloak.test.ts
@@ -1,0 +1,100 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it, mock } from 'node:test';
+import { createKeycloakFetcher } from '../src/keycloak.ts';
+
+function fakeJwt(exp: number): string {
+  const header = Buffer.from(JSON.stringify({ alg: 'none' })).toString('base64url');
+  const payload = Buffer.from(JSON.stringify({ exp })).toString('base64url');
+  return `${header}.${payload}.sig`;
+}
+
+const originalFetch = globalThis.fetch;
+const fetchMock = mock.fn<typeof globalThis.fetch>();
+
+describe('createKeycloakFetcher', () => {
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    fetchMock.mock.resetCalls();
+  });
+
+  function mockFetchResponse(body: unknown, status = 200) {
+    globalThis.fetch = fetchMock;
+    fetchMock.mock.mockImplementation(() =>
+      Promise.resolve(new Response(JSON.stringify(body), { status }))
+    );
+  }
+
+  it('returns a function', () => {
+    const fetcher = createKeycloakFetcher({
+      tokenUrl: 'https://kc.example.com/realms/test/protocol/openid-connect/token',
+      clientId: 'test-client',
+      clientSecret: 'test-secret',
+    });
+    assert.equal(typeof fetcher, 'function');
+  });
+
+  it('fetches a token via client_credentials grant', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 300;
+    const jwt = fakeJwt(exp);
+    mockFetchResponse({ access_token: jwt });
+
+    const fetcher = createKeycloakFetcher({
+      tokenUrl: 'https://kc.example.com/realms/test/protocol/openid-connect/token',
+      clientId: 'test-client',
+      clientSecret: 'test-secret',
+    });
+
+    const token = await fetcher();
+    assert.equal(token, jwt);
+  });
+
+  it('sends correct URL, method, and form body', async () => {
+    const exp = Math.floor(Date.now() / 1000) + 300;
+    mockFetchResponse({ access_token: fakeJwt(exp) });
+
+    const fetcher = createKeycloakFetcher({
+      tokenUrl: 'https://kc.example.com:8443/realms/test/protocol/openid-connect/token',
+      clientId: 'cid',
+      clientSecret: 'csec',
+    });
+    await fetcher();
+
+    assert.equal(fetchMock.mock.callCount(), 1);
+    const [url, init] = fetchMock.mock.calls[0].arguments;
+    assert.equal(url, 'https://kc.example.com:8443/realms/test/protocol/openid-connect/token');
+    assert.equal(init?.method, 'POST');
+    assert.equal(init?.headers?.['Content-Type' as keyof HeadersInit], 'application/x-www-form-urlencoded');
+
+    const bodyParams = new URLSearchParams(init?.body as string);
+    assert.equal(bodyParams.get('grant_type'), 'client_credentials');
+    assert.equal(bodyParams.get('client_id'), 'cid');
+    assert.equal(bodyParams.get('client_secret'), 'csec');
+  });
+
+  it('rejects when Keycloak returns HTTP error', async () => {
+    globalThis.fetch = fetchMock;
+    fetchMock.mock.mockImplementation(() =>
+      Promise.resolve(new Response('Unauthorized', { status: 401 }))
+    );
+
+    const fetcher = createKeycloakFetcher({
+      tokenUrl: 'https://kc.example.com/realms/test/protocol/openid-connect/token',
+      clientId: 'cid',
+      clientSecret: 'csec',
+    });
+
+    await assert.rejects(fetcher(), /token request failed.*401/);
+  });
+
+  it('rejects when response has no access_token', async () => {
+    mockFetchResponse({ error: 'no token' });
+
+    const fetcher = createKeycloakFetcher({
+      tokenUrl: 'https://kc.example.com/realms/test/protocol/openid-connect/token',
+      clientId: 'cid',
+      clientSecret: 'csec',
+    });
+
+    await assert.rejects(fetcher(), /No access_token/);
+  });
+});

--- a/libs/token-refresher/tsconfig.build.json
+++ b/libs/token-refresher/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "allowImportingTsExtensions": false,
+    "noEmit": false
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/libs/token-refresher/tsconfig.json
+++ b/libs/token-refresher/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": ".",
+    "outDir": "dist",
+    "lib": ["es2020"],
+    "strict": true,
+    "declaration": true,
+    "declarationMap": true,
+    "allowImportingTsExtensions": true,
+    "noEmit": true
+  },
+  "include": ["src/**/*.ts", "test/**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -278,7 +278,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -301,8 +300,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "apps/koku-ui-hccm/node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -337,6 +335,7 @@
         "typesafe-actions": "^5.1.0"
       },
       "devDependencies": {
+        "@koku-ui/token-refresher": "*",
         "@types/node": "^25.3.3",
         "css-minimizer-webpack-plugin": "^7.0.4",
         "cypress": "^15.11.0",
@@ -391,8 +390,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "apps/koku-ui-onprem/node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -622,7 +620,6 @@
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.2.0.tgz",
       "integrity": "sha512-ROY9fvHhwOD9ySfrF0wmvu//bKCQ6AeZZq1nJNtbDC+kk5DuSuNX/n6YWYF/SYy7bSba4D4FSz8DJeKY/S/r+g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.6",
         "use-sync-external-store": "^1.4.0"
@@ -645,8 +642,7 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
       "integrity": "sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "apps/koku-ui-ros/node_modules/redux-thunk": {
       "version": "3.1.0",
@@ -672,6 +668,33 @@
       "devDependencies": {
         "typescript": "^5.9.3"
       }
+    },
+    "libs/token-refresher": {
+      "name": "@koku-ui/token-refresher",
+      "version": "0.0.1",
+      "license": "Apache-2.0",
+      "devDependencies": {
+        "@types/node": "^22.0.0",
+        "typescript": "^5.9.3",
+        "webpack-dev-server": "^5.2.3"
+      }
+    },
+    "libs/token-refresher/node_modules/@types/node": {
+      "version": "22.19.13",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.19.13.tgz",
+      "integrity": "sha512-akNQMv0wW5uyRpD2v2IEyRSZiR+BeGuoB6L310EgGObO44HSMNT8z1xzio28V8qOrgYaopIDNA18YgdXd+qTiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "libs/token-refresher/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "libs/ui-lib": {
       "name": "@koku-ui/ui-lib",
@@ -746,7 +769,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1353,7 +1375,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -1377,7 +1398,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1448,6 +1468,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/accessibility/-/accessibility-3.1.1.tgz",
       "integrity": "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -1476,6 +1497,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/modifiers/-/modifiers-9.0.0.tgz",
       "integrity": "sha512-ybiLc66qRGuZoC20wdSSG6pDXFikui/dCNGthxv4Ndy8ylErY0N3KVxY2bgo7AWwIbxDmXDg3ylAFmnrjcbVvw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
@@ -1490,6 +1512,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/sortable/-/sortable-10.0.0.tgz",
       "integrity": "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@dnd-kit/utilities": "^3.2.2",
         "tslib": "^2.0.0"
@@ -1504,6 +1527,7 @@
       "resolved": "https://registry.npmjs.org/@dnd-kit/utilities/-/utilities-3.2.2.tgz",
       "integrity": "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -3237,6 +3261,10 @@
       "resolved": "libs/onprem-cloud-deps",
       "link": true
     },
+    "node_modules/@koku-ui/token-refresher": {
+      "resolved": "libs/token-refresher",
+      "link": true
+    },
     "node_modules/@koku-ui/ui-lib": {
       "resolved": "libs/ui-lib",
       "link": true
@@ -3511,7 +3539,6 @@
       "resolved": "https://registry.npmjs.org/@patternfly/react-core/-/react-core-6.4.1.tgz",
       "integrity": "sha512-EUSV76Eifkt4R3q2JIaiB6/FHeQqOCttK1DQMXNoOCNa3ODkZ7H+KlMdminufMDfRzhwAgTVihZ62K9PFfc8Vg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@patternfly/react-icons": "^6.4.0",
         "@patternfly/react-styles": "^6.4.0",
@@ -3550,7 +3577,6 @@
       "resolved": "https://registry.npmjs.org/@patternfly/react-icons/-/react-icons-6.4.0.tgz",
       "integrity": "sha512-SPjzatm73NUYv/BL6A/cjRA5sFQ15NkiyPAcT8gmklI7HY+ptd6/eg49uBDFmxTQcSwbb5ISW/R6wwCQBY2M+Q==",
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "react": "^17 || ^18 || ^19",
         "react-dom": "^17 || ^18 || ^19"
@@ -3567,7 +3593,6 @@
       "resolved": "https://registry.npmjs.org/@patternfly/react-table/-/react-table-6.4.1.tgz",
       "integrity": "sha512-dceS5X1I5gmhRfEf6gsLIdFhrQd5hY+SWRIYzEvI19rrdN9VwCVWg+bhSsNv05pQnGs8uOlzYVBI25p7PJtFeA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@patternfly/react-core": "^6.4.1",
         "@patternfly/react-icons": "^6.4.0",
@@ -3585,8 +3610,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@patternfly/react-tokens/-/react-tokens-6.4.0.tgz",
       "integrity": "sha512-iZthBoXSGQ/+PfGTdPFJVulaJZI3rwE+7A/whOXPGp3Jyq3k6X52pr1+5nlO6WHasbZ9FyeZGqXf4fazUZNjbw==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/@peculiar/asn1-cms": {
       "version": "2.6.0",
@@ -4606,7 +4630,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@swc/counter": "^0.1.3",
         "@swc/types": "^0.1.25"
@@ -4822,7 +4845,6 @@
       "integrity": "sha512-eyokjOwYd0Q8RnMHri+8/FS1HIrIUKK/sRrFp8c1dThUOfNeCWbLmBP1P5VsKdvmkd25JaH+OKYwEYiAYg9YAA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/create-cache-key-function": "^30.0.0",
         "@swc/counter": "^0.1.3",
@@ -4979,7 +5001,8 @@
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -5143,7 +5166,6 @@
       "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/estree": "*",
         "@types/json-schema": "*"
@@ -5428,7 +5450,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.27.tgz",
       "integrity": "sha512-cisd7gxkzjBKU2GgdYrTdtQx1SORymWyaAFhaxQPK9bYO9ot3Y5OikQRvY0VYQtvwjeQnizCINJAenh/V7MK2w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -5440,7 +5461,6 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
@@ -5672,7 +5692,6 @@
       "integrity": "sha512-klQbnPAAiGYFyI02+znpBRLyjL4/BrBd0nyWkdC0s/6xFLkXYQ8OoRrSkqacS1ddVxf/LDyODIKbQ5TgKAf/Fg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.56.1",
         "@typescript-eslint/types": "8.56.1",
@@ -6455,7 +6474,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -6532,7 +6550,6 @@
       "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -7483,7 +7500,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -9419,7 +9435,8 @@
       "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
       "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dom-converter": {
       "version": "0.2.0",
@@ -9652,7 +9669,6 @@
       "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "ansi-colors": "^4.1.1",
         "strip-ansi": "^6.0.1"
@@ -9922,7 +9938,6 @@
       "integrity": "sha512-uYixubwmqJZH+KLVYIVKY1JQt7tysXhtj21WSvjcSmU5SVNzMus1bgLe+pAt816yQ8opKfheVVoPLqvVMGejYw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -13218,7 +13233,6 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -15388,7 +15402,6 @@
       "integrity": "sha512-Cvc9WUhxSMEo4McES3P7oK3QaXldCfNWp7pl2NNeiIFlCoLr3kfq9kb1fxftiwk1FLV7CvpvDfonxtzUDeSOPg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "cssstyle": "^4.2.1",
         "data-urls": "^5.0.0",
@@ -16029,8 +16042,7 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/lodash-es": {
       "version": "4.17.23",
@@ -16151,6 +16163,7 @@
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -17582,7 +17595,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -18130,7 +18142,6 @@
       "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -18184,6 +18195,7 @@
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -18199,6 +18211,7 @@
       "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -18211,7 +18224,8 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/process": {
       "version": "0.11.10",
@@ -18235,7 +18249,6 @@
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -18383,7 +18396,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -18396,7 +18408,6 @@
       "resolved": "https://registry.npmjs.org/react-content-loader/-/react-content-loader-6.2.1.tgz",
       "integrity": "sha512-6ONbFX+Hi3SHuP66JB8CPvJn372pj+qwltJV0J8z/8MFrq98I1cbFdZuhDWeQXu3CFxiiDTXJn7DFxx2ZvrO7g==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -18415,7 +18426,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -18506,7 +18516,6 @@
       "integrity": "sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18531,7 +18540,6 @@
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
       "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.23.2",
         "react-router": "6.30.3"
@@ -18651,7 +18659,6 @@
       "integrity": "sha512-LAUYz4lc+Do8/g7aeRa8JkyDErK6ekstQaqWQrNRW//MY1TvCEpMtpTWvlQ+FPbWCx+Xixu/6SHt5N0HR+SB4w==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.9.2"
       }
@@ -18801,7 +18808,8 @@
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/resize-observer-polyfill/-/resize-observer-polyfill-1.5.1.tgz",
       "integrity": "sha512-LwZrotdHOo12nQuZlHEmtuXdqGoOD0OhaxopaNFxWzInpEgaLWoVuAMbTzixuosCx2nEG58ngzW3vxdWoxIgdg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/resolve": {
       "version": "2.0.0-next.5",
@@ -19349,7 +19357,6 @@
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -20738,7 +20745,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
       "integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tiny-warning": {
       "version": "1.0.3",
@@ -20918,7 +20926,6 @@
       "integrity": "sha512-fSpWtOO/1AjSNQguk43hb/JCo16oJDnMJf3CdEGNkqsEX3t0KX96xvyX1D7PfLCpVoKu4MfVrqUkFyblYoY4lA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "bs-logger": "^0.2.6",
         "fast-json-stable-stringify": "^2.1.0",
@@ -21088,8 +21095,7 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "license": "0BSD",
-      "peer": true
+      "license": "0BSD"
     },
     "node_modules/tsyringe": {
       "version": "4.10.0",
@@ -21360,6 +21366,7 @@
       "resolved": "https://registry.npmjs.org/unleash-proxy-client/-/unleash-proxy-client-3.7.8.tgz",
       "integrity": "sha512-VX0jDcOporeVb1nh4+HGpEZIwcwHl/HP/7cyZxQq3umffN0hx44Tw1u4nmdopmm9s7Hb2BES0pFCIntr/lh3vQ==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "tiny-emitter": "^2.1.0",
         "uuid": "^9.0.1"
@@ -21374,6 +21381,7 @@
         "https://github.com/sponsors/ctavan"
       ],
       "license": "MIT",
+      "peer": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -21651,7 +21659,6 @@
       "resolved": "https://registry.npmjs.org/victory-area/-/victory-area-37.3.6.tgz",
       "integrity": "sha512-wVC8LKrZJLiSySNuJLRCB449qZTsPiRyzLlNoJwe21y+XA/a2HJbmJSeywmo8P153aX8viKe1H8ygDsTFXQhHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6",
@@ -21669,7 +21676,6 @@
       "resolved": "https://registry.npmjs.org/victory-axis/-/victory-axis-37.3.6.tgz",
       "integrity": "sha512-Vi0dZvgmXmnCdoqc49WckeG5cMXnl7FTtqVhXu9JweA9cgCnkZabBd5mRvAjblb3Lo4j0HZCSPKHYWUPW70qZg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6"
@@ -21686,7 +21692,6 @@
       "resolved": "https://registry.npmjs.org/victory-bar/-/victory-bar-37.3.6.tgz",
       "integrity": "sha512-jdATFRWL1LUW/yEpKWx/aId2BiU2o1pPF9+Kh1TFISBduJoI4ZqvZD90H1QK4f/z50PikqiqiDECaKoKM1jfOQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6",
@@ -21704,7 +21709,6 @@
       "resolved": "https://registry.npmjs.org/victory-box-plot/-/victory-box-plot-37.3.6.tgz",
       "integrity": "sha512-GOucnD63h14ScBuISC/nd1GBTEx6gIZfLE+0P0gyeH1poBKq0trTTvpQDvAMuGR8zICfEETG3ltmUMCwRrFyUg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6",
@@ -21789,7 +21793,6 @@
       "resolved": "https://registry.npmjs.org/victory-chart/-/victory-chart-37.3.6.tgz",
       "integrity": "sha512-IkPo/W4AJ7bPu902TGER09OseR9ODm+FQAKfOBw4JsdEhZZ7BiG9zgd/25+x0r5EsTLu81CYGQVkBa+ZazcOlA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
@@ -21810,7 +21813,6 @@
       "resolved": "https://registry.npmjs.org/victory-core/-/victory-core-37.3.6.tgz",
       "integrity": "sha512-aFgO6KokxPbUCPznZP5UPhOdI22pMuwDXKDt6eoQOnkVim66Ia+K95TQar2nwVKGYV5j26aKVf/n9blwphGJRw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.21",
         "react-fast-compare": "^3.2.0",
@@ -21828,7 +21830,6 @@
       "resolved": "https://registry.npmjs.org/victory-create-container/-/victory-create-container-37.3.6.tgz",
       "integrity": "sha512-Uf5bFQvqUsXCjqpvBW4LhrdrHkM6dBqxYgub6FCsBb86f84xZQ3vY7jFkg/JfvF0oGKMoWXYYrYLC1sk+fcWVA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-brush-container": "37.3.6",
@@ -21850,7 +21851,6 @@
       "resolved": "https://registry.npmjs.org/victory-cursor-container/-/victory-cursor-container-37.3.6.tgz",
       "integrity": "sha512-+Oiw57d5nE+iq8As8RvepknzmNtKq1Gsc50u1X3IRd4jXtX8zqZrgXGlVZ+BP/tkLsWnGYVjKulwKBf2oaEUuw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6"
@@ -21883,7 +21883,6 @@
       "resolved": "https://registry.npmjs.org/victory-group/-/victory-group-37.3.6.tgz",
       "integrity": "sha512-kgy/Azl5BxwlJAV0KDPGypv35TMrOD1J2ZxnJW2Wyyq+e8i0GGBIv5MoBzou64BRsDlS9V0CYRIjnkHgrBpB5w==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
@@ -21921,7 +21920,6 @@
       "resolved": "https://registry.npmjs.org/victory-legend/-/victory-legend-37.3.6.tgz",
       "integrity": "sha512-vRRrhj3/ENqKVLdaBMzEmR83N6BOjox1bthYT1eJjN2H5SIK35bxn30IkiV/Pz3y627EqZe4TAWaxc0jiJlCiA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6"
@@ -21938,7 +21936,6 @@
       "resolved": "https://registry.npmjs.org/victory-line/-/victory-line-37.3.6.tgz",
       "integrity": "sha512-Ke817uf/qFbN9jU7Dba7CrcHXYO5wAZuKKnyeHJmLDeQeFST0773xejnIuC+dBgZipjFr4KIbSd+VcUafFNE1g==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6",
@@ -21956,7 +21953,6 @@
       "resolved": "https://registry.npmjs.org/victory-pie/-/victory-pie-37.3.6.tgz",
       "integrity": "sha512-tvdgAZ/HQWlo3KDDe0XAVbizHuaNMbgkkiF7zfA7Ww+3bHSs+0P9dsDtK2xP365D8gBCOv8pWmuzvKRhzNbqeA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6",
@@ -21990,7 +21986,6 @@
       "resolved": "https://registry.npmjs.org/victory-scatter/-/victory-scatter-37.3.6.tgz",
       "integrity": "sha512-fp95zMTPXgW1cmTowzDXhn+KxePMVDrzU0lotsHQMdBV7eB+ioXdu9hORlx4VHmMYg2ihsGwRTF+VAZ7rGxphA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6"
@@ -22041,7 +22036,6 @@
       "resolved": "https://registry.npmjs.org/victory-stack/-/victory-stack-37.3.6.tgz",
       "integrity": "sha512-ldod04RdqGJGH5p5eWXCofdTkbhZqIp3iwW7NpxSbMDLs8zPQIVvDFVtuJgMwQiC5vnIpbhMmxVeFbr8m64ZKA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "react-fast-compare": "^3.2.0",
@@ -22060,7 +22054,6 @@
       "resolved": "https://registry.npmjs.org/victory-tooltip/-/victory-tooltip-37.3.6.tgz",
       "integrity": "sha512-vqaJS9noauOqDDBBAV9Ln9duOY/i17h1DCfCPAqhwPFyvFbwKvAub9zPTeYWAm/14VvWX5O/0yekFCVbcC7hjg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6"
@@ -22116,7 +22109,6 @@
       "resolved": "https://registry.npmjs.org/victory-voronoi-container/-/victory-voronoi-container-37.3.6.tgz",
       "integrity": "sha512-qAAG0rMuK7A4EoJ4cyUk5wNdOW+HuCXNKPOko+hYK6wWOYXJvFhiglYyA85a695YyAXECc6JyJS/crm4IOEFag==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "delaunay-find": "0.0.6",
         "lodash": "^4.17.19",
@@ -22136,7 +22128,6 @@
       "resolved": "https://registry.npmjs.org/victory-zoom-container/-/victory-zoom-container-37.3.6.tgz",
       "integrity": "sha512-AGL+k20mI44OL5b0VgIxlmnNSefIoFmbbim5NraPmIxbtns9qQW/56ivIncJcYomBungIx99gUpsEpcQaMNHgQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "lodash": "^4.17.19",
         "victory-core": "37.3.6"
@@ -22241,7 +22232,6 @@
       "integrity": "sha512-gX/dMkRQc7QOMzgTe6KsYFM7DxeIONQSui1s0n/0xht36HvrgbxtM1xBlgx596NbpHuQU8P7QpKwrZYwUX48nw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.7",
         "@types/estree": "^1.0.8",
@@ -22291,7 +22281,6 @@
       "integrity": "sha512-pIDJHIEI9LR0yxHXQ+Qh95k2EvXpWzZ5l+d+jIo+RdSm9MiHfzazIxwwni/p7+x4eJZuvG1AJwgC4TNQ7NRgsg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@discoveryjs/json-ext": "^0.5.0",
         "@webpack-cli/configtest": "^2.1.1",
@@ -23057,7 +23046,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "release:all": "node scripts/release-all.js",
     "start:hccm": "npm run -w @koku-ui/koku-ui-hccm start",
     "start:ros": "npm run -w @koku-ui/koku-ui-ros start",
-    "start:onprem": "concurrently -k --names \"HOST,HCCM,ROS\" --prefix-colors \"yellow,cyan,magenta\" \"npm run -w @koku-ui/koku-ui-onprem start\" \"npm run -w @koku-ui/koku-ui-hccm start:onprem\" \"npm run -w @koku-ui/koku-ui-ros start:onprem\""
+    "start:onprem": "concurrently -k --names \"HOST,HCCM,ROS\" --prefix-colors \"yellow,cyan,magenta\" \"npm run -w @koku-ui/koku-ui-onprem start\" \"npm run -w @koku-ui/koku-ui-hccm start:onprem\" \"npm run -w @koku-ui/koku-ui-ros start:onprem\"",
+    "start:onprem:dev": ". scripts/setup-onprem-env.sh; npm run start:onprem"
   },
   "scripts-info": {
     "check:dependencies": "Checks for outdated dependencies in each workspace",

--- a/scripts/setup-onprem-env.sh
+++ b/scripts/setup-onprem-env.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Discovers Keycloak and Koku API configuration from the OpenShift cluster
+# and exports environment variables for the on-prem UI dev server.
+#
+# Prerequisites: logged into the cluster via `oc login`
+#
+# Usage:
+#   source scripts/setup-onprem-env.sh            # auto-detect everything
+#   source scripts/setup-onprem-env.sh my-ns      # specify the operator namespace
+#
+# Then run:
+#   npm run start:onprem
+
+set -euo pipefail
+
+_fail() { echo "Error: $1" >&2; return 1 2>/dev/null || exit 1; }
+
+# ---------------------------------------------------------------------------
+# Locate the CostManagementMetricsConfig CR
+# ---------------------------------------------------------------------------
+
+echo "Looking for CostManagementMetricsConfig CR..."
+
+CMC_LINE=$(kubectl get costmanagementmetricsconfig -A --no-headers -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name' 2>/dev/null | head -1)
+
+[[ -z "$CMC_LINE" ]] && _fail "no CostManagementMetricsConfig found on this cluster"
+
+CMC_NS=$(echo "$CMC_LINE" | awk '{print $1}')
+CMC_NAME=$(echo "$CMC_LINE" | awk '{print $2}')
+
+echo "  Found: $CMC_NAME in namespace $CMC_NS"
+
+# ---------------------------------------------------------------------------
+# Extract values from the CR spec via jsonpath
+# ---------------------------------------------------------------------------
+
+API_URL=$(kubectl get costmanagementmetricsconfig "$CMC_NAME" -n "$CMC_NS" \
+  -o jsonpath='{.spec.api_url}')
+TOKEN_URL=$(kubectl get costmanagementmetricsconfig "$CMC_NAME" -n "$CMC_NS" \
+  -o jsonpath='{.spec.authentication.token_url}')
+SECRET_NAME=$(kubectl get costmanagementmetricsconfig "$CMC_NAME" -n "$CMC_NS" \
+  -o jsonpath='{.spec.authentication.secret_name}')
+SOURCES_PATH=$(kubectl get costmanagementmetricsconfig "$CMC_NAME" -n "$CMC_NS" \
+  -o jsonpath='{.spec.source.sources_path}')
+SOURCES_PATH="${SOURCES_PATH:-/api/cost-management/v1/}"
+
+[[ -z "$API_URL" ]]    && _fail "spec.api_url is empty in $CMC_NAME"
+[[ -z "$TOKEN_URL" ]]  && _fail "spec.authentication.token_url is empty in $CMC_NAME"
+[[ -z "$SECRET_NAME" ]] && _fail "spec.authentication.secret_name is empty in $CMC_NAME"
+
+# ---------------------------------------------------------------------------
+# Read client credentials from the auth secret
+# ---------------------------------------------------------------------------
+
+echo "  Reading secret: $SECRET_NAME"
+
+CLIENT_ID=$(kubectl get secret "$SECRET_NAME" -n "$CMC_NS" -o jsonpath='{.data.client_id}' | base64 -d)
+CLIENT_SECRET=$(kubectl get secret "$SECRET_NAME" -n "$CMC_NS" -o jsonpath='{.data.client_secret}' | base64 -d)
+
+[[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]] && _fail "could not read client_id/client_secret from secret $SECRET_NAME"
+
+# ---------------------------------------------------------------------------
+# Build API_PROXY_URL
+# ---------------------------------------------------------------------------
+
+API_URL_CLEAN="${API_URL%/}"
+SOURCES_PATH_CLEAN="${SOURCES_PATH#/}"
+PROXY_URL="${API_URL_CLEAN}/${SOURCES_PATH_CLEAN%/}"
+
+# ---------------------------------------------------------------------------
+# Fetch an initial token to validate connectivity
+# ---------------------------------------------------------------------------
+
+echo "  Validating Keycloak connectivity..."
+
+# -k is needed because dev/lab clusters typically use self-signed certificates
+ACCESS_TOKEN=$(curl -sk -X POST "$TOKEN_URL" \
+  -d "grant_type=client_credentials" \
+  -d "client_id=$CLIENT_ID" \
+  -d "client_secret=$CLIENT_SECRET" \
+  | jq -r '.access_token // empty' 2>/dev/null) || true
+
+if [[ -z "$ACCESS_TOKEN" ]]; then
+  echo "  Warning: could not obtain a token from Keycloak." >&2
+  echo "  Token URL: $TOKEN_URL" >&2
+  echo "  The dev server will start but API calls will fail until a token is available." >&2
+else
+  TOKEN_EXP=$(node -e "
+    const token = process.argv[1];
+    try {
+      const payload = Buffer.from(token.split('.')[1], 'base64url').toString();
+      const exp = JSON.parse(payload).exp;
+      console.log(new Date(exp * 1000).toTimeString().slice(0, 8));
+    } catch { console.log('unknown'); }
+  " "$ACCESS_TOKEN" 2>/dev/null) || true
+  echo "  Token obtained (expires at ${TOKEN_EXP:-unknown})"
+fi
+
+# ---------------------------------------------------------------------------
+# Export
+# ---------------------------------------------------------------------------
+
+export API_PROXY_URL="$PROXY_URL"
+export API_TOKEN="$ACCESS_TOKEN"
+export KEYCLOAK_TOKEN_URL="$TOKEN_URL"
+export KEYCLOAK_CLIENT_ID="$CLIENT_ID"
+export KEYCLOAK_CLIENT_SECRET="$CLIENT_SECRET"
+
+echo ""
+echo "Environment configured:"
+echo "  API_PROXY_URL        = $API_PROXY_URL"
+echo "  KEYCLOAK_TOKEN_URL   = $KEYCLOAK_TOKEN_URL"
+echo "  KEYCLOAK_CLIENT_ID   = $KEYCLOAK_CLIENT_ID"
+echo "  KEYCLOAK_CLIENT_SECRET = ${KEYCLOAK_CLIENT_SECRET:0:4}****"
+echo "  API_TOKEN            = ${ACCESS_TOKEN:0:20}..."
+echo ""
+echo "Run:  npm run start:onprem"


### PR DESCRIPTION
## Summary

- Extracts the inline Keycloak token refresher from the `koku-ui-onprem` webpack config into a new `@koku-ui/token-refresher` workspace package under `libs/token-refresher/`
- Three-layer design: `TokenRefresher` class (adaptive JWT scheduling + stale-while-revalidate), `createKeycloakFetcher` (Keycloak client_credentials grant via Fetch API), and `createDevServerProxy` (webpack-dev-server proxy config builder)
- Adds `scripts/setup-onprem-env.sh` to auto-discover Keycloak and API configuration from an OpenShift cluster
- Wires up `koku-ui-onprem` webpack config to use the library with fail-fast validation for missing environment variables
- Includes full unit test suite (15 tests) using Node test runner (`node --test`)

## Motivation

Previously, developers had to manually refresh API tokens every few minutes when working against an on-prem backend. The token refresher automatically renews tokens in the background before they expire, using adaptive scheduling derived from the JWT `exp` claim.

## Key files

| Path | Description |
|---|---|
| `libs/token-refresher/src/TokenRefresher.ts` | Core class — cache, adaptive scheduling, stale-while-revalidate |
| `libs/token-refresher/src/keycloak.ts` | `createKeycloakFetcher` — Keycloak client_credentials grant |
| `libs/token-refresher/src/devServerProxy.ts` | `createDevServerProxy` — webpack proxy config builder |
| `libs/token-refresher/test/` | Unit tests (15 tests, ~6s) |
| `apps/koku-ui-onprem/webpack.config.ts` | Integration — uses the library for proxy auth |
| `scripts/setup-onprem-env.sh` | Cluster env discovery helper |

## Test plan

- [x] `node --experimental-strip-types --experimental-test-module-mocks --test 'test/**/*.test.ts'` — 15/15 pass
- [x] `tsc --noEmit` — no type errors (both IDE and build tsconfigs)
- [x] ESLint — no lint errors
- [x] Dev server starts successfully with `npm run start:onprem`
- [x] Token auto-refresh confirmed working against live OpenShift cluster (Keycloak 5-min tokens)
- [x] Proxy correctly injects `Authorization: Bearer <token>` header on API requests


Made with [Cursor](https://cursor.com)