### PR TITLE
OCP breakdown header missing filter chips

### DIFF
--- a/apps/koku-ui-hccm/src/routes/details/components/breakdown/breakdownBase.tsx
+++ b/apps/koku-ui-hccm/src/routes/details/components/breakdown/breakdownBase.tsx
@@ -358,6 +358,7 @@ class BreakdownBase extends React.Component<BreakdownProps, BreakdownState> {
             onCostTypeSelect={() => handleOnCostTypeSelect(query, router, router?.location?.state)}
             onCurrencySelect={() => handleOnCurrencySelect(query, router, router?.location?.state)}
             query={query}
+            queryStateName={queryStateName}
             report={report}
             showCostDistribution={showCostDistribution && !(optimizationsComponent && activeTabKey === 3)}
             showCostType={showCostType}


### PR DESCRIPTION
Fixed an issue where filter chips are missing from OCP breakdown header

https://redhat.atlassian.net/browse/COST-7367