### PR TITLE
Update ci/build workflow to run for main branch only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - main
-      - stage-onprem
   push:
     branches:
       - main


### PR DESCRIPTION
Update ci/build workflow to run for main branch only to unblock PRs for stage-onprem branch.

From Cursor:
`PR #5243 uses main as its head branch (syncing main → stage-onprem). When [PR #5257](https://github.com/project-koku/koku-ui/pull/5257) was merged into main, that push triggered a second CI run on the same commit (b9952ca).`