### PR TITLE
feat(dev): auth-enabled dev mode with local oauth2-proxy

### DIFF
--- a/apps/koku-ui-onprem/README.md
+++ b/apps/koku-ui-onprem/README.md
@@ -51,8 +51,9 @@ oc login -s <cluster_api_url> -u <username> --password <password>
 source scripts/setup-onprem-env.sh
 ```
 
-This sets `API_PROXY_URL` and `API_TOKEN` from the cluster's
-`CostManagementMetricsConfig` CR and Keycloak auth secret.
+This sets `API_PROXY_URL` and `API_TOKEN` by auto-discovering cluster configuration.
+Discovery order: (1) `CostManagementMetricsConfig` CR if the CMMO operator is installed,
+(2) `cost-onprem` Helm chart resources (gateway route + keycloak-debug ConfigMap + Keycloak secret).
 
 It also exports `KEYCLOAK_TOKEN_URL`, `KEYCLOAK_CLIENT_ID`, and
 `KEYCLOAK_CLIENT_SECRET`, which enable **automatic token renewal** in the
@@ -67,19 +68,32 @@ From the root of the repo, run
 npm run start:onprem:dev
 ```
 
-`start:onprem:dev` sources `scripts/setup-onprem-env.sh` (requires `oc` login and a
-`CostManagementMetricsConfig` CR on the cluster), then starts the full on-prem stack.
+`start:onprem:dev` sources `scripts/setup-onprem-env.sh` (requires `oc` login; auto-discovers
+API URL and Keycloak credentials from cluster resources), then starts the full on-prem stack.
 All remotes share `libs/onprem-cloud-deps` (feat shims; Unleash stub uses lazy init to avoid HCCM TDZ).
 
-Equivalent manual flow:
+The dev server opens pre-authenticated (no login screen). Token refresh runs in the background.
+
+### Auth enabled dev-mode — login screen, real sessions & logout (start:onprem:auth)
+
+To test the login flow, session expiry, and the logout redirect, use the `start:onprem:auth` script:
 
 ```
-source scripts/setup-onprem-env.sh
-npm run start:onprem
+npm run start:onprem:auth
 ```
 
-This runs concurrent dev builds of the host, HCCM, ROS, Sources, and RBAC remotes.
-After the successful build, navigate to http://localhost:9001
+**Prerequisites** (in addition to `oc` login):
+- [Podman](https://podman.io/) or [Docker](https://www.docker.com/) with the daemon running.
+  No binary installation of `oauth2-proxy` is needed — it runs as a container.
+
+Then open **http://localhost:9002** (not 9001). You will be redirected to the Keycloak login page.
+
+For a detailed walkthrough of how the auth flow works, how the script reads its configuration from the cluster, and troubleshooting tips, see **[docs/auth-enabled-dev-mode.md](docs/auth-enabled-dev-mode.md)**.
+
+Optional port / namespace overrides:
+```
+ONPREM_AUTH_PORT=9002 ONPREM_UI_PORT=9001 npm run start:onprem:auth
+```
 
 ### RBAC IAM remote (FLPATH-4164)
 

--- a/apps/koku-ui-onprem/docs/auth-enabled-dev-mode.md
+++ b/apps/koku-ui-onprem/docs/auth-enabled-dev-mode.md
@@ -1,0 +1,153 @@
+# Auth-enabled dev mode (`start:onprem:auth`)
+
+> **TL;DR** — run `npm run start:onprem:auth`, open `http://localhost:9002`, and you get a real Keycloak login screen instead of a pre-authenticated session.
+
+---
+
+## Why does this mode exist?
+
+The default dev server (`start:onprem:dev`) is optimised for **speed**. It bypasses the login screen entirely: a background process silently fetches an API token using a service account and injects it into every outgoing request. This is great for everyday development, but it makes it impossible to:
+
+- See what the login page actually looks like to a real user.
+- Test what happens when a session expires and the user is redirected to log in again.
+- Verify the logout flow (`/logout` → Keycloak sign-out → back to the login page).
+
+`start:onprem:auth` adds a thin authentication layer in front of the dev server that mirrors exactly what happens in production.
+
+---
+
+## What is oauth2-proxy?
+
+[oauth2-proxy](https://oauth2-proxy.github.io/oauth2-proxy/) is a small reverse-proxy that handles the OAuth 2.0 / OIDC dance on behalf of your application. In production, it runs as a sidecar container next to the UI nginx container. Your browser never talks to the UI directly — it always goes through oauth2-proxy first.
+
+When you are not logged in, oauth2-proxy redirects your browser to Keycloak. After you log in, Keycloak sends an authorisation code back to oauth2-proxy, which exchanges it for tokens, sets an encrypted session cookie, and forwards your request to the real app — with an `Authorization: Bearer <token>` header already attached.
+
+---
+
+## How the two modes compare
+
+| | `start:onprem:dev` | `start:onprem:auth` |
+|---|---|---|
+| **Login screen** | ✗ skipped | ✔ real Keycloak page |
+| **Session / logout** | ✗ token never expires | ✔ real session, real logout |
+| **Port** | 9001 | 9002 |
+| **Auth mechanism** | `TokenRefresher` (service account) | oauth2-proxy (OIDC PKCE) |
+| **Extra prerequisite** | — | Podman or Docker |
+
+---
+
+## How it works, step by step
+
+```
+Your browser  ──────────────────────►  oauth2-proxy  (localhost:9002)
+                                             │
+                                  Not logged in?
+                                             │
+                                             ▼
+                                         Keycloak  (on-cluster)
+                                             │
+                              You enter your username & password
+                                             │
+                                             ▼
+                               Keycloak issues an auth code
+                                             │
+                                             ▼
+                                  oauth2-proxy exchanges the
+                                  code for an access token,
+                                  sets an encrypted cookie
+                                             │
+                                             ▼
+                oauth2-proxy forwards your request to webpack-dev-server
+                (localhost:9001) with  Authorization: Bearer <token>
+                                             │
+                                             ▼
+                          webpack-dev-server proxies API calls to
+                          the Envoy gateway on the cluster
+```
+
+### 1. You open `http://localhost:9002`
+
+Your browser hits the `oauth2-proxy` container running on your machine. If you are not logged in, it immediately redirects you to the Keycloak login page hosted on the cluster.
+
+### 2. You log in to Keycloak
+
+This is the same Keycloak instance that the cluster uses for real users. You enter your credentials exactly as a real user would.
+
+### 3. Keycloak redirects back to `oauth2-proxy`
+
+After a successful login, Keycloak sends your browser to `http://localhost:9002/oauth2/callback` with a short-lived authorisation code. `oauth2-proxy` exchanges this code for an access token (this is the **PKCE** flow — the code cannot be replayed even if intercepted).
+
+### 4. `oauth2-proxy` sets a session cookie and forwards the request
+
+`oauth2-proxy` stores your tokens in an encrypted session cookie and forwards your original request to the webpack dev server on `localhost:9001`, adding the `Authorization: Bearer <token>` header.
+
+### 5. webpack proxies API calls to the cluster
+
+webpack-dev-server is running in `OAUTH2_PROXY_MODE=true`. In this mode:
+- It does **not** start `TokenRefresher` (no background token fetching — `oauth2-proxy` handles that).
+- Its `/api/me` endpoint reads the `x-auth-request-preferred-username` and `x-forwarded-email` headers that `oauth2-proxy` injects, so the app shows your real username.
+- Its `/logout` endpoint redirects to `/oauth2/sign_out`, which tells `oauth2-proxy` to clear your session and send you back to the Keycloak logout page.
+
+### 6. Token refresh and logout
+
+`oauth2-proxy` silently refreshes your access token in the background (every ~4 minutes, matching the cluster configuration). When the token can no longer be refreshed — or when you click **Log out** — `oauth2-proxy` clears the session cookie and redirects you back to the Keycloak login page.
+
+---
+
+## Configuration the script reads from the cluster
+
+To ensure the local `oauth2-proxy` container behaves identically to the one running in production, `start-onprem-auth.mts` reads its configuration **directly from the cluster** at startup:
+
+| What | Where it comes from |
+|---|---|
+| `oauth2-proxy` image tag | `cost-onprem-ui` Deployment (container `oauth-proxy`) |
+| `oauth2-proxy` flags (`--provider`, `--oidc-issuer-url`, etc.) | Same Deployment's `args` list |
+| `cost-management-ui` client ID & secret | Secret `keycloak-client-secret-cost-management-ui` in the `keycloak` namespace |
+| Keycloak CA certificate | Secret `keycloak-ca-cert` in the `cost-onprem` namespace |
+| Cookie secret | Generated fresh each run (32 random bytes) |
+
+A few cluster-only flags are stripped (TLS cert paths, HTTPS address) and replaced with local equivalents (plain HTTP on `:9002`, upstream pointing to `localhost:9001`).
+
+---
+
+## Startup sequence
+
+When you run `npm run start:onprem:auth`:
+
+1. **`setup-onprem-env.sh`** runs first (same as `start:onprem:dev`) — it logs you into the cluster and sets `API_PROXY_URL`.
+2. **`start-onprem-auth.mts`** takes over:
+   - Detects your container runtime (`CONTAINER_RUNTIME` env var if set, otherwise Podman → Docker via PATH).
+   - Reads credentials and the CA certificate from the cluster.
+   - Starts **webpack** on `:9001` in the background with `OAUTH2_PROXY_MODE=true`.
+   - Polls `http://localhost:9001/` until webpack is ready.
+   - Starts the **`oauth2-proxy` container** on `:9002` in the foreground.
+3. When you press **Ctrl-C**: the container stops, webpack is killed, and the temporary CA cert file is deleted automatically.
+
+---
+
+## Environment overrides
+
+```bash
+# Change ports
+ONPREM_AUTH_PORT=9002 ONPREM_UI_PORT=9001 npm run start:onprem:auth
+
+# Use a non-default podman or docker binary path
+CONTAINER_RUNTIME=/opt/podman/bin/podman npm run start:onprem:auth
+
+# Override cluster namespaces
+COST_NAMESPACE=my-cost KEYCLOAK_NAMESPACE=my-keycloak npm run start:onprem:auth
+```
+
+---
+
+## Troubleshooting
+
+**"no container runtime found"** — install [Podman](https://podman.io/docs/installation) or [Docker Desktop](https://docs.docker.com/get-started/get-docker/). If either is installed at a non-standard path, set `CONTAINER_RUNTIME=/path/to/podman` (or `docker`).
+
+**"API_PROXY_URL is not set"** — you ran `node scripts/start-onprem-auth.mts` directly. Always use `npm run start:onprem:auth`, which sources `setup-onprem-env.sh` first.
+
+**"could not read oauth-proxy image from cost-onprem-ui"** — the `cost-onprem` Helm chart is not deployed on the cluster, or you are not logged in (`oc whoami` to check).
+
+**Keycloak shows "invalid redirect URI"** — the `cost-management-ui` Keycloak client on the cluster may not have `http://localhost:9002/oauth2/callback` in its allowed redirect URIs. Ask your cluster admin to add it, or open the Keycloak admin console and add it yourself.
+
+**Browser shows a blank page after login** — webpack may still be starting up. Wait a few seconds and reload.

--- a/apps/koku-ui-onprem/webpack.config.ts
+++ b/apps/koku-ui-onprem/webpack.config.ts
@@ -9,19 +9,39 @@ import type { Configuration } from 'webpack';
 import { container, DefinePlugin } from 'webpack';
 import type { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
 
-let setupMiddlewares: WebpackDevServerConfiguration['setupMiddlewares'] = undefined;
-let proxyHeaders: Record<string, string> | undefined = undefined;
+const isOauth2ProxyMode = process.env.OAUTH2_PROXY_MODE === 'true';
 
-if (process.env.API_TOKEN !== 'false') {
-  setupMiddlewares = (middlewares, devServer) => {
-    devServer.app?.get('/api/me', (_, res) => {
-      res.json({
-        username: 'dev-user',
-        email: 'dev@example.com',
-      });
-    });
-    return middlewares;
-  };
+let proxyHeaders: Record<string, string> | undefined;
+
+// Always register /api/me and /logout middlewares.
+// In oauth2-proxy mode /api/me reads real identity headers injected by oauth2-proxy,
+// mirroring the nginx $http_x_auth_request_preferred_username behaviour in production.
+// In headless mode the headers are absent and fixed dev-user stubs are returned.
+const setupMiddlewares: WebpackDevServerConfiguration['setupMiddlewares'] = (middlewares, devServer) => {
+  devServer.app?.get('/api/me', (req, res) => {
+    const username = isOauth2ProxyMode
+      ? ((req.headers['x-auth-request-preferred-username'] as string | undefined) ?? 'dev-user')
+      : 'dev-user';
+    const email = isOauth2ProxyMode
+      ? ((req.headers['x-forwarded-email'] as string | undefined) ?? 'dev@example.com')
+      : 'dev@example.com';
+    if (isOauth2ProxyMode && !req.headers['x-auth-request-preferred-username']) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        '[koku-ui-onprem] OAUTH2_PROXY_MODE=true but x-auth-request-preferred-username is missing' +
+          ' — oauth2-proxy may be misconfigured or the request bypassed the proxy'
+      );
+    }
+    res.json({ username, email });
+  });
+  // Mirrors nginx: `location = /logout { return 302 /oauth2/sign_out?rd=/oauth2/start; }`
+  devServer.app?.get('/logout', (_, res) => {
+    res.redirect('/oauth2/sign_out?rd=/oauth2/start');
+  });
+  return middlewares;
+};
+
+if (!isOauth2ProxyMode && process.env.API_TOKEN !== 'false') {
   proxyHeaders = {
     Authorization: `Bearer ${process.env.API_TOKEN}`,
   };
@@ -51,30 +71,33 @@ if (NODE_ENV !== 'production' && !process.env.CI) {
     );
   }
 
-  const hasKeycloak =
-    process.env.KEYCLOAK_TOKEN_URL && process.env.KEYCLOAK_CLIENT_ID && process.env.KEYCLOAK_CLIENT_SECRET;
+  if (!isOauth2ProxyMode) {
+    const hasKeycloak =
+      process.env.KEYCLOAK_TOKEN_URL && process.env.KEYCLOAK_CLIENT_ID && process.env.KEYCLOAK_CLIENT_SECRET;
 
-  // When running the UI with a local koku API, API_TOKEN is omitted
-  if (!hasKeycloak && !process.env.API_TOKEN) {
-    throw new Error(
-      '[koku-ui-onprem] No authentication configured for the dev proxy.\n' +
-        'Provide one of:\n' +
-        '  1. KEYCLOAK_TOKEN_URL + KEYCLOAK_CLIENT_ID + KEYCLOAK_CLIENT_SECRET  (auto-refresh)\n' +
-        '  2. API_TOKEN  (static bearer token)\n' +
-        'See apps/koku-ui-onprem/README.md for details.'
-    );
-  }
+    // When running the UI with a local koku API, API_TOKEN is omitted
+    if (!hasKeycloak && !process.env.API_TOKEN) {
+      throw new Error(
+        '[koku-ui-onprem] No authentication configured for the dev proxy.\n' +
+          'Provide one of:\n' +
+          '  1. KEYCLOAK_TOKEN_URL + KEYCLOAK_CLIENT_ID + KEYCLOAK_CLIENT_SECRET  (auto-refresh)\n' +
+          '  2. API_TOKEN  (static bearer token)\n' +
+          '  3. OAUTH2_PROXY_MODE=true  (oauth2-proxy handles auth)\n' +
+          'See apps/koku-ui-onprem/README.md for details.'
+      );
+    }
 
-  if (hasKeycloak) {
-    refresher = new TokenRefresher({
-      fetchToken: createKeycloakFetcher({
-        tokenUrl: process.env.KEYCLOAK_TOKEN_URL!,
-        clientId: process.env.KEYCLOAK_CLIENT_ID!,
-        clientSecret: process.env.KEYCLOAK_CLIENT_SECRET!,
-      }),
-      fallbackToken: process.env.API_TOKEN,
-    });
-    refresher.start();
+    if (hasKeycloak) {
+      refresher = new TokenRefresher({
+        fetchToken: createKeycloakFetcher({
+          tokenUrl: process.env.KEYCLOAK_TOKEN_URL!,
+          clientId: process.env.KEYCLOAK_CLIENT_ID!,
+          clientSecret: process.env.KEYCLOAK_CLIENT_SECRET!,
+        }),
+        fallbackToken: process.env.API_TOKEN,
+      });
+      refresher.start();
+    }
   }
 }
 
@@ -84,10 +107,13 @@ const config: Configuration & {
   mode: NODE_ENV,
   devtool: 'eval-source-map',
   devServer: {
-    host: 'localhost',
+    // In oauth2-proxy mode webpack must bind to all interfaces so the proxy
+    // container can reach it via host.containers.internal / host.docker.internal.
+    host: isOauth2ProxyMode ? '0.0.0.0' : 'localhost',
     port: 9001,
     historyApiFallback: true,
-    open: NODE_ENV !== 'production',
+    // In oauth2-proxy mode open the proxy port (9002) so the auth flow kicks in immediately.
+    open: isOauth2ProxyMode ? `http://localhost:${process.env.ONPREM_AUTH_PORT ?? '9002'}/` : true,
     static: [
       {
         directory: path.resolve(__dirname, 'dist'),
@@ -118,7 +144,7 @@ const config: Configuration & {
     },
     setupMiddlewares,
     proxy: [
-      refresher
+      refresher && !isOauth2ProxyMode
         ? createDevServerProxy(refresher, {
             context: ['/api/cost-management/v1'],
             target: process.env.API_PROXY_URL!,
@@ -131,11 +157,13 @@ const config: Configuration & {
             changeOrigin: true,
             secure: false,
             pathRewrite: { '^/api/cost-management/v1': '' },
+            // In oauth2-proxy mode proxyHeaders is undefined — the Authorization
+            // header injected by oauth2-proxy is forwarded as-is to the gateway.
             ...(proxyHeaders && { headers: proxyHeaders }),
           },
       ...(rbacProxyTarget
         ? [
-            refresher
+            refresher && !isOauth2ProxyMode
               ? createDevServerProxy(refresher, {
                   context: ['/api/rbac'],
                   target: rbacProxyTarget,

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "start:ros": "npm run -w @koku-ui/koku-ui-ros start",
     "start:onprem": "concurrently -k --names \"HOST,HCCM,ROS,SRCS,RBAC\" --prefix-colors \"yellow,cyan,magenta,green,blue\" \"npm run -w @koku-ui/koku-ui-onprem start\" \"npm run -w @koku-ui/koku-ui-hccm start:onprem\" \"npm run -w @koku-ui/koku-ui-ros start:onprem\" \"npm run -w @koku-ui/koku-ui-sources start:onprem\" \"npm run -w @koku-ui/rbac-ui-onprem start:onprem\"",
     "start:onprem:dev": ". scripts/setup-onprem-env.sh && npm run start:onprem",
+    "start:onprem:auth": ". scripts/setup-onprem-env.sh && scripts/start-onprem-auth.mts",
     "start:onprem:koku": "API_TOKEN=false API_PROXY_URL=http://localhost:8000/api/cost-management/v1 npm run start:onprem"
   },
   "scripts-info": {
@@ -43,6 +44,7 @@
     "start:ros": "Run ROS UI",
     "start:onprem": "Run onprem UI",
     "start:onprem:dev": "Runs onprem UI against a deployment made with the cost-onprem Helm chart",
+    "start:onprem:auth": "Use when you need to test the login screen, session expiry, or logout redirect. Runs the on-prem UI behind a local oauth2-proxy container (real OIDC PKCE flow) — requires Podman or Docker",
     "start:onprem:koku": "Run onprem UI with local Koku API"
   },
   "devDependencies": {

--- a/scripts/setup-onprem-env.sh
+++ b/scripts/setup-onprem-env.sh
@@ -4,9 +4,13 @@
 #
 # Prerequisites: `oc` CLI installed (will prompt for login if needed)
 #
+# Discovery order:
+#   1. CostManagementMetricsConfig CR (CMMO operator, if installed)
+#   2. cost-onprem Helm chart resources (route + keycloak-debug CM + keycloak secret)
+#
 # Usage:
 #   source scripts/setup-onprem-env.sh            # auto-detect everything
-#   source scripts/setup-onprem-env.sh my-ns      # specify the operator namespace
+#   source scripts/setup-onprem-env.sh my-ns      # override cost-onprem namespace
 #
 # Then run:
 #   npm run start:onprem
@@ -27,48 +31,80 @@ fi
 echo "Logged in as $(oc whoami) on $(oc whoami --show-server)"
 
 # ---------------------------------------------------------------------------
-# Locate the CostManagementMetricsConfig CR
+# Strategy 1: CostManagementMetricsConfig CR (CMMO operator)
 # ---------------------------------------------------------------------------
 
 echo "Looking for CostManagementMetricsConfig CR..."
 
-CMC_LINE=$(kubectl get costmanagementmetricsconfig -A --no-headers -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name' 2>/dev/null | head -1)
+CMC_LINE=$(kubectl get costmanagementmetricsconfig -A --no-headers \
+  -o custom-columns='NS:.metadata.namespace,NAME:.metadata.name' 2>/dev/null || true)
+CMC_LINE=$(echo "$CMC_LINE" | head -1 | xargs 2>/dev/null || true)
 
-[[ -z "$CMC_LINE" ]] && _fail "no CostManagementMetricsConfig found on this cluster"
+if [[ -n "$CMC_LINE" ]]; then
+  CMC_NS=$(echo "$CMC_LINE" | awk '{print $1}')
+  CMC_NAME=$(echo "$CMC_LINE" | awk '{print $2}')
+  echo "  Found: $CMC_NAME in namespace $CMC_NS"
 
-CMC_NS=$(echo "$CMC_LINE" | awk '{print $1}')
-CMC_NAME=$(echo "$CMC_LINE" | awk '{print $2}')
+  API_URL=$(kubectl get costmanagementmetricsconfig "$CMC_NAME" -n "$CMC_NS" \
+    -o jsonpath='{.spec.api_url}')
+  TOKEN_URL=$(kubectl get costmanagementmetricsconfig "$CMC_NAME" -n "$CMC_NS" \
+    -o jsonpath='{.spec.authentication.token_url}')
+  SECRET_NAME=$(kubectl get costmanagementmetricsconfig "$CMC_NAME" -n "$CMC_NS" \
+    -o jsonpath='{.spec.authentication.secret_name}')
+  SOURCES_PATH=$(kubectl get costmanagementmetricsconfig "$CMC_NAME" -n "$CMC_NS" \
+    -o jsonpath='{.spec.source.sources_path}')
+  SOURCES_PATH="${SOURCES_PATH:-/api/cost-management/v1/}"
 
-echo "  Found: $CMC_NAME in namespace $CMC_NS"
+  [[ -z "$API_URL" ]]     && _fail "spec.api_url is empty in $CMC_NAME"
+  [[ -z "$TOKEN_URL" ]]   && _fail "spec.authentication.token_url is empty in $CMC_NAME"
+  [[ -z "$SECRET_NAME" ]] && _fail "spec.authentication.secret_name is empty in $CMC_NAME"
 
-# ---------------------------------------------------------------------------
-# Extract values from the CR spec via jsonpath
-# ---------------------------------------------------------------------------
+  echo "  Reading secret: $SECRET_NAME"
+  CLIENT_ID=$(kubectl get secret "$SECRET_NAME" -n "$CMC_NS" \
+    -o jsonpath='{.data.client_id}' | base64 -d)
+  CLIENT_SECRET=$(kubectl get secret "$SECRET_NAME" -n "$CMC_NS" \
+    -o jsonpath='{.data.client_secret}' | base64 -d)
+  [[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]] && \
+    _fail "could not read client_id/client_secret from secret $SECRET_NAME"
 
-API_URL=$(kubectl get costmanagementmetricsconfig "$CMC_NAME" -n "$CMC_NS" \
-  -o jsonpath='{.spec.api_url}')
-TOKEN_URL=$(kubectl get costmanagementmetricsconfig "$CMC_NAME" -n "$CMC_NS" \
-  -o jsonpath='{.spec.authentication.token_url}')
-SECRET_NAME=$(kubectl get costmanagementmetricsconfig "$CMC_NAME" -n "$CMC_NS" \
-  -o jsonpath='{.spec.authentication.secret_name}')
-SOURCES_PATH=$(kubectl get costmanagementmetricsconfig "$CMC_NAME" -n "$CMC_NS" \
-  -o jsonpath='{.spec.source.sources_path}')
-SOURCES_PATH="${SOURCES_PATH:-/api/cost-management/v1/}"
+else
+  # ---------------------------------------------------------------------------
+  # Strategy 2: cost-onprem Helm chart resources (always present after chart install)
+  # ---------------------------------------------------------------------------
 
-[[ -z "$API_URL" ]]    && _fail "spec.api_url is empty in $CMC_NAME"
-[[ -z "$TOKEN_URL" ]]  && _fail "spec.authentication.token_url is empty in $CMC_NAME"
-[[ -z "$SECRET_NAME" ]] && _fail "spec.authentication.secret_name is empty in $CMC_NAME"
+  echo "  Not found — falling back to cost-onprem Helm chart resources"
+  HELM_NS="${1:-cost-onprem}"
 
-# ---------------------------------------------------------------------------
-# Read client credentials from the auth secret
-# ---------------------------------------------------------------------------
+  # API URL from the gateway route
+  ROUTE_HOST=$(oc get route cost-onprem-api -n "$HELM_NS" \
+    -o jsonpath='{.spec.host}' 2>/dev/null || true)
+  [[ -z "$ROUTE_HOST" ]] && _fail "route cost-onprem-api not found in namespace $HELM_NS"
+  API_URL="https://${ROUTE_HOST}"
+  SOURCES_PATH="/api/cost-management/v1/"
 
-echo "  Reading secret: $SECRET_NAME"
+  # Token URL from keycloak-debug configmap (written by the Helm chart)
+  KC_DEBUG_DATA=$(oc get cm cost-onprem-keycloak-debug -n "$HELM_NS" \
+    -o jsonpath='{.data.keycloak-detection-results\.yaml}' 2>/dev/null || true)
+  [[ -z "$KC_DEBUG_DATA" ]] && \
+    _fail "configmap cost-onprem-keycloak-debug not found in $HELM_NS"
 
-CLIENT_ID=$(kubectl get secret "$SECRET_NAME" -n "$CMC_NS" -o jsonpath='{.data.client_id}' | base64 -d)
-CLIENT_SECRET=$(kubectl get secret "$SECRET_NAME" -n "$CMC_NS" -o jsonpath='{.data.client_secret}' | base64 -d)
+  ISSUER_URL=$(echo "$KC_DEBUG_DATA" | grep 'issuer_url:' | awk '{print $2}' | tr -d '"\r')
+  [[ -z "$ISSUER_URL" ]] && _fail "issuer_url not found in cost-onprem-keycloak-debug"
+  TOKEN_URL="${ISSUER_URL}/protocol/openid-connect/token"
 
-[[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]] && _fail "could not read client_id/client_secret from secret $SECRET_NAME"
+  # Keycloak namespace and client credentials
+  KC_NS=$(echo "$KC_DEBUG_DATA" | grep 'keycloak_namespace:' | awk '{print $2}' | tr -d '"\r')
+  KC_NS="${KC_NS:-keycloak}"
+  SECRET_NAME="keycloak-client-secret-cost-management-operator"
+
+  echo "  Reading secret: $SECRET_NAME (ns: $KC_NS)"
+  CLIENT_ID=$(oc get secret "$SECRET_NAME" -n "$KC_NS" \
+    -o jsonpath='{.data.CLIENT_ID}' 2>/dev/null | base64 -d || true)
+  CLIENT_SECRET=$(oc get secret "$SECRET_NAME" -n "$KC_NS" \
+    -o jsonpath='{.data.CLIENT_SECRET}' 2>/dev/null | base64 -d || true)
+  [[ -z "$CLIENT_ID" || -z "$CLIENT_SECRET" ]] && \
+    _fail "could not read CLIENT_ID/CLIENT_SECRET from secret $SECRET_NAME in $KC_NS"
+fi
 
 # ---------------------------------------------------------------------------
 # Build API_PROXY_URL
@@ -119,10 +155,10 @@ export KEYCLOAK_CLIENT_SECRET="$CLIENT_SECRET"
 
 echo ""
 echo "Environment configured:"
-echo "  API_PROXY_URL        = $API_PROXY_URL"
-echo "  KEYCLOAK_TOKEN_URL   = $KEYCLOAK_TOKEN_URL"
-echo "  KEYCLOAK_CLIENT_ID   = $KEYCLOAK_CLIENT_ID"
+echo "  API_PROXY_URL          = $API_PROXY_URL"
+echo "  KEYCLOAK_TOKEN_URL     = $KEYCLOAK_TOKEN_URL"
+echo "  KEYCLOAK_CLIENT_ID     = $KEYCLOAK_CLIENT_ID"
 echo "  KEYCLOAK_CLIENT_SECRET = ${KEYCLOAK_CLIENT_SECRET:0:4}****"
-echo "  API_TOKEN            = ${ACCESS_TOKEN:0:20}..."
+echo "  API_TOKEN              = ${ACCESS_TOKEN:0:20}..."
 echo ""
 echo "Run:  npm run start:onprem"

--- a/scripts/start-onprem-auth.mts
+++ b/scripts/start-onprem-auth.mts
@@ -1,0 +1,712 @@
+#!/usr/bin/env -S node --experimental-strip-types --no-warnings=ExperimentalWarning
+
+/**
+ * start-onprem-auth.mts
+ *
+ * Starts the on-prem UI dev server behind a local oauth2-proxy container,
+ * replicating the production auth stack (login screen, real sessions, logout redirect).
+ *
+ * Prerequisites:
+ *   - Podman or Docker with daemon running
+ *   - Run via: npm run start:onprem:auth
+ *     (sources setup-onprem-env.sh first, which requires `oc` login)
+ *
+ * Optional environment overrides:
+ *   CONTAINER_RUNTIME     Path to podman or docker binary     (default: auto-detected via PATH)
+ *   ONPREM_AUTH_PORT      Port oauth2-proxy listens on        (default: 9002)
+ *   ONPREM_UI_PORT        Port webpack dev server listens on  (default: 9001)
+ *   KEYCLOAK_NAMESPACE    Namespace of Keycloak secrets       (default: keycloak)
+ *   COST_NAMESPACE        Namespace of cost-onprem resources  (default: cost-onprem)
+ */
+
+import { type ChildProcess, spawn as cpSpawn } from 'node:child_process';
+import { randomBytes } from 'node:crypto';
+import { rm, writeFile } from 'node:fs/promises';
+import https from 'node:https';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const isMain = process.argv[1] === fileURLToPath(import.meta.url);
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const AUTH_PORT = process.env.ONPREM_AUTH_PORT ?? '9002';
+const UI_PORT = process.env.ONPREM_UI_PORT ?? '9001';
+const KC_NS = process.env.KEYCLOAK_NAMESPACE ?? 'keycloak';
+const COST_NS = process.env.COST_NAMESPACE ?? 'cost-onprem';
+const LOCAL_REDIRECT_URI = `http://localhost:${AUTH_PORT}/oauth2/callback`;
+
+// ---------------------------------------------------------------------------
+// Logging — ANSI colours; stripped in non-TTY environments (CI pipes)
+// ---------------------------------------------------------------------------
+
+const tty = process.stdout.isTTY;
+
+const C = tty
+  ? {
+      reset: '\x1b[0m',
+      bold: '\x1b[1m',
+      dim: '\x1b[2m',
+      cyan: '\x1b[1;36m',
+      green: '\x1b[0;32m',
+      yellow: '\x1b[0;33m',
+      red: '\x1b[0;31m',
+    }
+  : { reset: '', bold: '', dim: '', cyan: '', green: '', yellow: '', red: '' };
+
+const log = {
+  step: (m: string) => process.stdout.write(`${C.cyan}▶ ${m}${C.reset}\n`),
+  info: (m: string) => process.stdout.write(`${C.green}  ✔ ${m}${C.reset}\n`),
+  dim: (m: string) => process.stdout.write(`${C.dim}  · ${m}${C.reset}\n`),
+  warn: (m: string) => process.stderr.write(`${C.yellow}  ⚠ ${m}${C.reset}\n`),
+  fail: (m: string): never => {
+    process.stderr.write(`${C.bold}${C.red}✖ Error: ${m}${C.reset}\n`);
+    throw new Error(m);
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Process helpers
+// ---------------------------------------------------------------------------
+
+/** Resolves after `ms` milliseconds. */
+const sleep = (ms: number): Promise<void> => new Promise(r => setTimeout(r, ms));
+
+interface StreamOpts {
+  nothrow?: boolean;
+  env?: NodeJS.ProcessEnv;
+}
+
+/**
+ * Tagged template helper that splits literal parts on whitespace into tokens
+ * while keeping each interpolated value as one atomic argument — safe even when
+ * values contain spaces (file paths, namespace names, etc.).
+ *
+ * Usage:
+ *   await shell`oc get secret ${secretName} -n ${KC_NS} -o jsonpath={.data.CLIENT_ID}`
+ *
+ * Runs the command and captures stdout. Both stdout and stderr are suppressed
+ * from the terminal. Rejects with an Error on non-zero exit.
+ */
+function shell(parts: TemplateStringsArray, ...values: string[]): Promise<string> {
+  const argv: string[] = [];
+  for (let i = 0; i < parts.length; i++) {
+    argv.push(...parts[i].trim().split(/\s+/).filter(Boolean));
+    if (i < values.length) {
+      argv.push(values[i]);
+    } // never split interpolated values
+  }
+  const [cmd, ...args] = argv;
+  return new Promise((resolve, reject) => {
+    const proc = cpSpawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    proc.stdout?.on('data', (d: Buffer) => {
+      stdout += d;
+    });
+    proc.stderr?.on('data', (d: Buffer) => {
+      stderr += d;
+    });
+    proc.on('error', reject);
+    proc.on('close', (code: number | null) => {
+      if (code !== 0) {
+        reject(new Error(`${cmd} exited with code ${code}: ${stderr.trim()}`));
+      } else {
+        resolve(stdout);
+      }
+    });
+  });
+}
+
+/**
+ * Runs a command in the foreground with all I/O inherited from the current
+ * process (output streams to the terminal). Returns the exit code.
+ * Pass nothrow: true to resolve instead of reject on non-zero exit.
+ */
+function stream(cmd: string, args: string[], { nothrow = false, env }: StreamOpts = {}): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const proc = cpSpawn(cmd, args, { stdio: 'inherit', env: env ?? process.env });
+    proc.on('error', reject);
+    proc.on('close', (code: number | null) => {
+      if (!nothrow && code !== 0) {
+        reject(new Error(`${cmd} exited with code ${code}`));
+      } else {
+        resolve(code ?? 0);
+      }
+    });
+  });
+}
+
+/**
+ * Starts a command in the background, streaming its I/O to the terminal.
+ * Returns the ChildProcess so callers can kill it and watch for exit.
+ */
+function background(cmd: string, args: string[], env?: NodeJS.ProcessEnv): ChildProcess {
+  return cpSpawn(cmd, args, { stdio: 'inherit', env: env ?? process.env });
+}
+
+/** Resolves to the full path of `name` if found in PATH, otherwise null. */
+async function findInPath(name: string): Promise<string | null> {
+  return shell`which ${name}`.then(s => s.trim() || null).catch(() => null);
+}
+
+/** Decodes a base64-encoded OpenShift secret field value to a UTF-8 string. */
+function fromBase64(b64: string): string {
+  return Buffer.from(b64.trim(), 'base64').toString('utf8');
+}
+
+/**
+ * Reads a single field from a named OpenShift secret, base64-decoding the value.
+ */
+async function readSecretField(secret: string, ns: string, field: string): Promise<string> {
+  const jsonpath = `jsonpath={.data.${field}}`;
+  return fromBase64(await shell`oc get secret ${secret} -n ${ns} -o ${jsonpath}`);
+}
+
+// ---------------------------------------------------------------------------
+// Mutable state — shared between step functions and cleanup
+// ---------------------------------------------------------------------------
+
+let containerRuntime = '';
+let kcCaCertFile = '';
+let webpackChild: ChildProcess | null = null;
+let cleaningUp = false;
+
+interface KcAdminContext {
+  baseUrl: string;
+  realm: string;
+  adminUser: string;
+  adminPass: string;
+  clientUuid: string;
+}
+let kcAdminCtx: KcAdminContext | null = null;
+let kcRedirectUriAdded = false;
+
+interface KcClient {
+  id: string;
+  clientId: string;
+  redirectUris?: string[];
+  [key: string]: unknown;
+}
+
+// ---------------------------------------------------------------------------
+// Step functions
+// ---------------------------------------------------------------------------
+
+interface RuntimeInfo {
+  runtime: string;
+  upstreamHost: string;
+  extraFlags: string[];
+}
+
+/**
+ * Resolves the container runtime binary. Honours `CONTAINER_RUNTIME` if set;
+ * otherwise probes PATH for `podman` then `docker`. Only `podman` and `docker`
+ * are supported — other runtimes use incompatible CLI flags. Returns the binary
+ * path, the correct hostname alias for the host machine from inside the
+ * container, and any extra `run` flags required by the runtime.
+ */
+async function detectContainerRuntime(): Promise<RuntimeInfo> {
+  log.step('Detecting container runtime');
+
+  const runtime =
+    process.env.CONTAINER_RUNTIME ??
+    (await findInPath('podman')) ??
+    (await findInPath('docker')) ??
+    log.fail('no container runtime found — install Podman or Docker, or set CONTAINER_RUNTIME=/path/to/podman');
+
+  const name = runtime.split('/').at(-1) ?? runtime;
+
+  if (name !== 'podman' && name !== 'docker') {
+    log.fail(
+      `unsupported container runtime: "${name}" — only podman and docker are supported. ` +
+        `Fix: unset CONTAINER_RUNTIME or point it to a podman/docker binary.`
+    );
+  }
+
+  log.info(`${name} (${runtime})`);
+
+  const isPodman = name === 'podman';
+  return {
+    runtime,
+    upstreamHost: isPodman ? 'host.containers.internal' : 'host.docker.internal',
+    // --add-host is a no-op on Docker for Mac/Windows; required on Docker for Linux
+    extraFlags: isPodman ? [] : ['--add-host=host.docker.internal:host-gateway'],
+  };
+}
+
+/**
+ * Guards against being invoked without the cluster env already sourced.
+ * `API_PROXY_URL` is exported by `setup-onprem-env.sh`; its absence means
+ * the script was called directly instead of through `npm run start:onprem:auth`.
+ */
+function validateClusterEnv(): void {
+  log.step('Validating cluster environment');
+  if (!process.env.API_PROXY_URL) {
+    log.fail('API_PROXY_URL is not set — run via "npm run start:onprem:auth" which sources setup-onprem-env.sh first');
+  }
+  log.info(`API_PROXY_URL: ${process.env.API_PROXY_URL}`);
+}
+
+interface ClientCredentials {
+  clientId: string;
+  clientSecret: string;
+}
+
+/**
+ * Reads the `CLIENT_ID` and `CLIENT_SECRET` for the `cost-management-ui`
+ * Keycloak client from the `keycloak-client-secret-cost-management-ui` secret
+ * in the Keycloak namespace. Values are base64-encoded in the secret.
+ */
+async function readUiClientCredentials(): Promise<ClientCredentials> {
+  log.step('Reading cost-management-ui client credentials');
+  const secret = 'keycloak-client-secret-cost-management-ui';
+
+  const clientId = await readSecretField(secret, KC_NS, 'CLIENT_ID');
+  const clientSecret = await readSecretField(secret, KC_NS, 'CLIENT_SECRET');
+
+  if (!clientId || !clientSecret) {
+    log.fail(`could not read credentials from ${secret} in ${KC_NS}`);
+  }
+
+  log.info(`secret ${secret} (ns: ${KC_NS})`);
+  return { clientId, clientSecret };
+}
+
+/**
+ * Fetches the Keycloak CA certificate from the `keycloak-ca-cert` secret in
+ * the cost-onprem namespace, writes it to a temp file (mode 0600), and returns
+ * the path. The file is removed during `cleanup()`.
+ */
+async function fetchKeycloakCaCert(): Promise<string> {
+  log.step('Fetching Keycloak CA certificate');
+
+  const b64 = (await shell`oc get secret keycloak-ca-cert -n ${COST_NS} -o jsonpath={.data.ca\\.crt}`).trim();
+  if (!b64) {
+    log.fail(`keycloak CA cert is empty — check secret keycloak-ca-cert in ${COST_NS}`);
+  }
+
+  const certPath = join(tmpdir(), `keycloak-ca-${Date.now()}.crt`);
+  await writeFile(certPath, Buffer.from(b64, 'base64'), { mode: 0o600 });
+
+  log.info(`saved to ${certPath}`);
+  return certPath;
+}
+
+/**
+ * Generates a cryptographically random 32-byte cookie secret encoded as
+ * base64url, suitable for the `--cookie-secret` flag of oauth2-proxy.
+ */
+function generateCookieSecret(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+interface ProxyConfig {
+  image: string;
+  args: string[];
+}
+
+/**
+ * Minimal HTTPS JSON helper for Keycloak admin API calls.
+ * Note: TLS verification is intentionally disabled — the Keycloak admin
+ * endpoint is served behind the cluster's ingress CA which may not be
+ * trusted by Node.js's bundled CA store, and obtaining it would add another
+ * `oc` round-trip. This is acceptable for a local dev script on your own cluster.
+ */
+async function kcFetch<T = unknown>(
+  url: string,
+  method: string,
+  token: string | null,
+  body?: string,
+  contentType = 'application/json'
+): Promise<T> {
+  const headers: Record<string, string> = { 'content-type': contentType };
+  if (token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+  if (body) {
+    headers['content-length'] = String(Buffer.byteLength(body));
+  }
+
+  return new Promise((resolve, reject) => {
+    const req = https.request(url, { method, headers, rejectUnauthorized: false }, res => {
+      let data = '';
+      res.on('data', (chunk: Buffer) => {
+        data += chunk;
+      });
+      res.on('end', () => {
+        if (res.statusCode && res.statusCode >= 400) {
+          reject(new Error(`HTTP ${res.statusCode} ${method} ${url}: ${data.slice(0, 300)}`));
+          return;
+        }
+        try {
+          resolve(data ? (JSON.parse(data) as T) : (null as T));
+        } catch (e) {
+          reject(new Error(`Failed to parse response from ${url}: ${e instanceof Error ? e.message : String(e)}`));
+        }
+      });
+    });
+    req.on('error', reject);
+    req.on('timeout', () => req.destroy(new Error(`Request to ${url} timed out`)));
+    req.setTimeout(10_000);
+    if (body) {
+      req.write(body);
+    }
+    req.end();
+  });
+}
+
+/**
+ * Parses the Keycloak base URL and realm name from a token URL of the form
+ * `https://<host>/realms/<realm>/protocol/openid-connect/token`.
+ */
+function parseKeycloakTokenUrl(tokenUrl: string): { baseUrl: string; realm: string } {
+  const match = tokenUrl.match(/^(https?:\/\/.+?)\/realms\/([^/]+)\//);
+  if (!match) {
+    throw new Error(`Cannot parse Keycloak base URL from: ${tokenUrl}`);
+  }
+  return { baseUrl: match[1], realm: match[2] };
+}
+
+/**
+ * Fetches a short-lived Keycloak admin token from the master realm using the
+ * `admin-cli` client and the provided credentials.
+ */
+async function getKeycloakAdminToken(baseUrl: string, adminUser: string, adminPass: string): Promise<string> {
+  const body =
+    `client_id=admin-cli&grant_type=password` +
+    `&username=${encodeURIComponent(adminUser)}&password=${encodeURIComponent(adminPass)}`;
+  const resp = await kcFetch<{ access_token: string }>(
+    `${baseUrl}/realms/master/protocol/openid-connect/token`,
+    'POST',
+    null,
+    body,
+    'application/x-www-form-urlencoded'
+  );
+  return resp.access_token;
+}
+
+/**
+ * Registers `http://localhost:<AUTH_PORT>/oauth2/callback` as a valid redirect
+ * URI on the `cost-management-ui` Keycloak client. Reads admin credentials from
+ * the `keycloak-initial-admin` secret. Sets `kcAdminCtx` and `kcRedirectUriAdded`
+ * so `cleanup()` can reverse the change. No-op if the URI is already registered.
+ */
+async function registerLocalRedirectUri(clientId: string): Promise<void> {
+  log.step('Registering localhost redirect URI with Keycloak');
+
+  const tokenUrl = process.env.KEYCLOAK_TOKEN_URL ?? '';
+  if (!tokenUrl) {
+    log.fail('KEYCLOAK_TOKEN_URL is not set — cannot register redirect URI');
+  }
+
+  const { baseUrl, realm } = parseKeycloakTokenUrl(tokenUrl);
+
+  const adminUser = await readSecretField('keycloak-initial-admin', KC_NS, 'username');
+  const adminPass = await readSecretField('keycloak-initial-admin', KC_NS, 'password');
+  if (!adminUser || !adminPass) {
+    log.fail('could not read keycloak-initial-admin credentials from namespace ' + KC_NS);
+  }
+
+  const adminToken = await getKeycloakAdminToken(baseUrl, adminUser, adminPass);
+
+  const clients = await kcFetch<KcClient[]>(
+    `${baseUrl}/admin/realms/${realm}/clients?clientId=${encodeURIComponent(clientId)}`,
+    'GET',
+    adminToken
+  );
+  if (!clients || !clients.length) {
+    log.fail(`Keycloak client '${clientId}' not found in realm '${realm}'`);
+  }
+
+  const client = clients[0];
+  kcAdminCtx = { baseUrl, realm, adminUser, adminPass, clientUuid: client.id };
+
+  if ((client.redirectUris ?? []).includes(LOCAL_REDIRECT_URI)) {
+    log.info('redirect URI already registered — no change needed');
+    return;
+  }
+
+  await kcFetch(
+    `${baseUrl}/admin/realms/${realm}/clients/${client.id}`,
+    'PUT',
+    adminToken,
+    JSON.stringify({ ...client, redirectUris: [...(client.redirectUris ?? []), LOCAL_REDIRECT_URI] })
+  );
+  kcRedirectUriAdded = true;
+  log.info(`added ${LOCAL_REDIRECT_URI}`);
+}
+
+/**
+ * Reverses `registerLocalRedirectUri` — removes the localhost callback URI from
+ * the Keycloak client. Re-authenticates with fresh admin credentials because
+ * the original token will have expired by the time cleanup runs.
+ */
+async function unregisterLocalRedirectUri(): Promise<void> {
+  if (!kcAdminCtx || !kcRedirectUriAdded) {
+    return;
+  }
+  const { baseUrl, realm, adminUser, adminPass, clientUuid } = kcAdminCtx;
+
+  const adminToken = await getKeycloakAdminToken(baseUrl, adminUser, adminPass);
+
+  const client = await kcFetch<KcClient>(`${baseUrl}/admin/realms/${realm}/clients/${clientUuid}`, 'GET', adminToken);
+  if (!client || !client.redirectUris) {
+    return;
+  }
+
+  const updated = client.redirectUris.filter(u => u !== LOCAL_REDIRECT_URI);
+  if (updated.length === client.redirectUris.length) {
+    return;
+  } // already gone
+
+  await kcFetch(
+    `${baseUrl}/admin/realms/${realm}/clients/${clientUuid}`,
+    'PUT',
+    adminToken,
+    JSON.stringify({ ...client, redirectUris: updated })
+  );
+  log.dim('localhost redirect URI removed from Keycloak client');
+}
+
+/**
+ * Reads the oauth2-proxy image and startup args from the live `cost-onprem-ui`
+ * Deployment on the cluster (single source of truth). Strips cluster-specific
+ * flags (TLS, upstream URL, redirect URL, etc.) and replaces them with local
+ * equivalents pointing at the webpack dev server and this machine's ports.
+ *
+ * @param upstreamHost - Hostname the container runtime uses to reach the host
+ *   machine (e.g. `host.containers.internal` for Podman).
+ */
+async function assembleProxyArgs(upstreamHost: string): Promise<ProxyConfig> {
+  log.step('Reading oauth2-proxy configuration from cluster Deployment');
+
+  const sel = '{.spec.template.spec.containers[?(@.name=="oauth-proxy")]';
+  const imageJsonpath = `jsonpath=${sel}.image}`;
+  const argsJsonpath = `jsonpath=${sel}.args}`;
+
+  const image = (await shell`oc get deployment cost-onprem-ui -n ${COST_NS} -o ${imageJsonpath}`).trim();
+  if (!image) {
+    log.fail(`could not read oauth-proxy image from cost-onprem-ui in ${COST_NS}`);
+  }
+
+  const argsJson = (await shell`oc get deployment cost-onprem-ui -n ${COST_NS} -o ${argsJsonpath}`).trim();
+  if (!argsJson) {
+    log.fail(`could not read oauth-proxy args from cost-onprem-ui in ${COST_NS}`);
+  }
+
+  // Strip cluster-specific flags; re-add with local overrides below
+  const STRIP = [
+    '--https-address',
+    '--tls-cert-file',
+    '--tls-key-file',
+    '--upstream',
+    '--redirect-url',
+    '--cookie-secure',
+    '--backend-logout-url',
+    '--pass-host-header',
+    '--provider-ca-file',
+  ];
+
+  const args = [
+    ...(JSON.parse(argsJson) as string[]).filter(a => !STRIP.some(p => a === p || a.startsWith(`${p}=`))),
+    `--http-address=0.0.0.0:${AUTH_PORT}`,
+    `--upstream=http://${upstreamHost}:${UI_PORT}`,
+    `--redirect-url=${LOCAL_REDIRECT_URI}`,
+    '--cookie-secure=false',
+    '--provider-ca-file=/etc/keycloak-ca.crt',
+  ];
+
+  log.info(`image:    ${image}`);
+  log.info(`upstream: http://${upstreamHost}:${UI_PORT}`);
+  log.info(`proxy:    http://localhost:${AUTH_PORT}`);
+  return { image, args };
+}
+
+/**
+ * Launches `npm run start:onprem` as a background process with
+ * `OAUTH2_PROXY_MODE=true` so webpack skips the `TokenRefresher` middleware
+ * and instead reads user identity from headers injected by oauth2-proxy.
+ * Polls `http://localhost:<UI_PORT>/` every 2 s (up to 120 s) before returning.
+ */
+async function startWebpack(): Promise<void> {
+  log.step(`Starting webpack dev server on :${UI_PORT} (OAUTH2_PROXY_MODE=true)`);
+
+  const env = { ...process.env, OAUTH2_PROXY_MODE: 'true' };
+  webpackChild = background('npm', ['run', 'start:onprem'], env);
+
+  webpackChild.on('close', (code: number | null) => {
+    if (!cleaningUp && code !== null && code !== 0) {
+      log.warn(`webpack exited unexpectedly (code ${code})`);
+      cleanup().then(() => process.exit(1));
+    }
+  });
+
+  log.dim('Waiting for webpack to be ready...');
+  for (let i = 0; i < 60; i++) {
+    try {
+      const controller = new AbortController();
+      const timeoutId = setTimeout(() => controller.abort(), 1500);
+      const res = await fetch(`http://localhost:${UI_PORT}/`, { signal: controller.signal });
+      clearTimeout(timeoutId);
+      if (res.status < 500) {
+        log.info(`ready after ${i * 2}s`);
+        return;
+      }
+    } catch {
+      // not ready yet — keep polling
+    }
+    await sleep(2000);
+  }
+  log.fail('webpack did not become ready within 120s');
+}
+
+/**
+ * Runs the oauth2-proxy container in the foreground (blocking until it exits
+ * or is stopped). Credentials are passed as bare `-e KEY` flags so that the
+ * actual values — set on `process.env` — never appear in `ps aux` output.
+ * Force-removes any container left over from a previous crashed run before
+ * starting (only when one is actually found, with a visible warning), so stale
+ * containers never block a restart.
+ *
+ * @param runtime    - Full path to the container runtime binary.
+ * @param image      - OCI image reference for oauth2-proxy.
+ * @param args       - Assembled oauth2-proxy CLI flags.
+ * @param extraFlags - Runtime-specific `run` flags (e.g. `--add-host` for Docker on Linux).
+ */
+async function startProxyContainer(
+  runtime: string,
+  image: string,
+  args: string[],
+  extraFlags: string[]
+): Promise<void> {
+  log.step(`Starting oauth2-proxy container on :${AUTH_PORT}`);
+  log.dim(`Open: http://localhost:${AUTH_PORT}`);
+
+  // Secrets are inherited via process.env; bare -e KEY flags (no value in CLI)
+  // prevent secrets from appearing in `ps aux` output
+  const containerArgs = [
+    'run',
+    '--rm',
+    '--name',
+    'cost-onprem-oauth2-proxy',
+    '-p',
+    `${AUTH_PORT}:${AUTH_PORT}`,
+    '-v',
+    `${kcCaCertFile}:/etc/keycloak-ca.crt:ro`,
+    '-e',
+    'OAUTH2_PROXY_CLIENT_ID',
+    '-e',
+    'OAUTH2_PROXY_CLIENT_SECRET',
+    '-e',
+    'OAUTH2_PROXY_COOKIE_SECRET',
+    ...extraFlags,
+    image,
+    ...args,
+  ];
+
+  // Only remove a stale container if one actually exists (running or stopped).
+  // This gives a visible warning when a crashed run left one behind.
+  const stale = (await shell`${runtime} ps -a --filter name=cost-onprem-oauth2-proxy --format {{.Names}}`).trim();
+  if (stale) {
+    log.warn('Found stale container from a previous run — removing it');
+    await stream(runtime, ['rm', '-f', 'cost-onprem-oauth2-proxy'], { nothrow: true }).catch(() => {});
+  }
+
+  const exitCode = await stream(runtime, containerArgs, { nothrow: true });
+  if (exitCode !== 0 && !cleaningUp) {
+    throw new Error(`oauth2-proxy container failed to start (exit code ${exitCode})`);
+  }
+}
+
+/**
+ * Idempotent teardown — safe to call multiple times via signal handlers and
+ * the `finally` block. Sends SIGTERM to webpack, gracefully stops the proxy
+ * container (SIGTERM → SIGKILL after 10 s; `--rm` handles removal), and
+ * removes the temporary CA cert file.
+ */
+async function cleanup(): Promise<void> {
+  if (cleaningUp) {
+    return;
+  }
+  cleaningUp = true;
+  process.stdout.write('\n');
+  log.step('Shutting down...');
+  if (webpackChild) {
+    webpackChild.kill('SIGTERM');
+  }
+  if (kcAdminCtx && kcRedirectUriAdded) {
+    await unregisterLocalRedirectUri().catch(e =>
+      log.warn(`could not remove localhost redirect URI: ${e instanceof Error ? e.message : String(e)}`)
+    );
+  }
+  if (containerRuntime) {
+    // `--rm` on the container means it is removed automatically when it exits,
+    // so `stop` (SIGTERM → SIGKILL) is all that is needed.
+    // Race against a 15s wall-clock timeout so a broken runtime can't block cleanup forever.
+    await Promise.race([
+      stream(containerRuntime, ['stop', '--time', '10', 'cost-onprem-oauth2-proxy'], { nothrow: true }).catch(() => {}),
+      sleep(15_000),
+    ]);
+  }
+  if (kcCaCertFile) {
+    await rm(kcCaCertFile, { force: true });
+  }
+  log.dim('Done.');
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  process.on('SIGINT', async () => {
+    await cleanup();
+    process.exit(0);
+  });
+  process.on('SIGTERM', async () => {
+    await cleanup();
+    process.exit(0);
+  });
+
+  try {
+    const { runtime, upstreamHost, extraFlags } = await detectContainerRuntime();
+    containerRuntime = runtime;
+
+    validateClusterEnv();
+
+    const { clientId, clientSecret } = await readUiClientCredentials();
+
+    kcCaCertFile = await fetchKeycloakCaCert();
+
+    await registerLocalRedirectUri(clientId);
+
+    const cookieSecret = generateCookieSecret();
+
+    const { image, args } = await assembleProxyArgs(upstreamHost);
+
+    // Set secrets on process.env — inherited by the container runtime subprocess.
+    // Combined with bare -e KEY flags (no value in CLI), they stay out of ps output.
+    process.env.OAUTH2_PROXY_CLIENT_ID = clientId;
+    process.env.OAUTH2_PROXY_CLIENT_SECRET = clientSecret;
+    process.env.OAUTH2_PROXY_COOKIE_SECRET = cookieSecret;
+
+    process.stdout.write('\n');
+    await startWebpack();
+
+    process.stdout.write('\n');
+    await startProxyContainer(runtime, image, args, extraFlags);
+  } finally {
+    await cleanup();
+  }
+}
+
+if (isMain) {
+  main().catch(e => {
+    process.stderr.write(`${C.bold}${C.red}✖ Error: ${e instanceof Error ? e.message : String(e)}${C.reset}\n`);
+    process.exit(1);
+  });
+}


### PR DESCRIPTION
## Why this is needed

The existing `npm run start:onprem:dev` mode bypasses authentication entirely:

- The app opens **already signed in** — there is no way to see or test the Keycloak login screen.
- The token never expires because `TokenRefresher` silently fetches and refreshes it every ~300 s.
- Auto-logout (session expiry redirect) cannot be tested.
- Multi-user scenarios (switch accounts, verify RBAC boundaries per user) are impossible without a real session.

### Historical context — `TokenRefresher` as a legacy workaround

`TokenRefresher` was introduced at a time when the on-prem app did **not support multi-tenancy**. There was a single service-account token used by every user, so the UI had to acquire and refresh it itself. Now that the app supports multiple authenticated users backed by Keycloak, this approach is no longer necessary for normal development — it just prevents testing the full auth flow.

## What this PR adds

### `npm run start:onprem:auth` — a new dev mode

A new script (`scripts/start-onprem-auth.mts`) starts a local `oauth2-proxy` container in front of the webpack dev server, closely replicating the production authentication stack:

```
browser → oauth2-proxy (localhost:9002) → webpack dev server (localhost:9001) → cluster API
```

At startup the script:

1. Detects the container runtime (Podman or Docker).
2. Validates the cluster environment sourced by `setup-onprem-env.sh`.
3. Reads `cost-management-ui` client credentials from the Keycloak namespace.
4. Fetches the Keycloak CA certificate and writes it to a temp file.
5. **Registers `http://localhost:9002/oauth2/callback`** as a valid redirect URI on the Keycloak client via the admin REST API (using credentials from `keycloak-initial-admin`).
6. Reads the `oauth2-proxy` image and flags directly from the live `cost-onprem-ui` Deployment (single source of truth — no duplicated config).
7. Starts webpack with `OAUTH2_PROXY_MODE=true`, which disables `TokenRefresher` and enables real-user identity from proxy headers.
8. Starts the `oauth2-proxy` container in the foreground.

On shutdown (`Ctrl-C` / `SIGTERM`) the script:
- Stops the container gracefully (`podman/docker stop`).
- Removes the localhost redirect URI from the Keycloak client, restoring the original config.
- Deletes the temporary CA cert file.

### Changes to `webpack.config.ts`

- `OAUTH2_PROXY_MODE=true` disables `TokenRefresher` middleware injection and proxy auth headers.
- `/api/me` reads `x-auth-request-preferred-username` / `x-forwarded-email` headers set by oauth2-proxy.
- `/logout` redirects to `/oauth2/sign_out?rd=/oauth2/start`.
- `devServer.host` is set to `0.0.0.0` in proxy mode so the container can reach webpack via `host.containers.internal`.
- `devServer.open` points to `http://localhost:9002` in proxy mode so the browser opens at the proxy, not the raw webpack port.

### Also: `setup-onprem-env.sh` fallback

Added a fallback discovery path for clusters where the `CostManagementMetricsConfig` CRD is not installed (CMMO not deployed). The script now falls back to reading the API URL, Keycloak token URL, and client credentials directly from the cost-onprem Helm chart resources (routes, ConfigMaps, secrets).

## Test plan

- [x] `npm run start:onprem:auth` starts without errors on a cluster with cost-onprem installed
- [x] Browser opens at `http://localhost:9002` and redirects to the Keycloak login page
- [x] Login completes and the app loads with the authenticated user's identity
- [x] Logout via the app redirects back to the Keycloak login page
- [x] On `Ctrl-C`, the container stops and the redirect URI is removed from the Keycloak client
- [x] `npm run start:onprem:dev` is unaffected (TokenRefresher still active in that mode)

Made with [Cursor](https://cursor.com)