### PR TITLE
Fix namespace query restore to avoid duplicate API requests

### DIFF
--- a/apps/koku-ui-ros/src/routes/optimizations/optimizationsDetails/optimizationsDetails.tsx
+++ b/apps/koku-ui-ros/src/routes/optimizations/optimizationsDetails/optimizationsDetails.tsx
@@ -1,7 +1,7 @@
 import { Card, CardBody, PageSection } from '@patternfly/react-core';
 import { RosNamespace } from 'api/ros/ros';
 import { useIsNamespaceToggleEnabled } from 'components/featureToggle';
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import { useLocation } from 'react-router-dom';
 import { OptimizationsContainersTable, OptimizationsProjectsTable } from 'routes/optimizations/optimizationsTable';
 import { OptimizationsTable } from 'routes/optimizations/optimizationsTable';
@@ -49,11 +49,7 @@ const OptimizationsDetails: React.FC<OptimizationsDetailsProps> = ({
     namespace: queryState?.namespace ?? (isNamespaceToggleEnabled ? RosNamespace.projects : RosNamespace.containers),
     optimizationType: queryState?.optimizationType ?? OptimizationType.performance,
   });
-  const [resetTableQuery, setResetTableQuery] = useState(false);
-
-  useEffect(() => {
-    setResetTableQuery(false);
-  }, [query.namespace]);
+  const [isInitialLoad, setIsInitialLoad] = useState(true);
 
   // Handlers
 
@@ -62,7 +58,7 @@ const OptimizationsDetails: React.FC<OptimizationsDetailsProps> = ({
   };
 
   const handleOnNamespaceSelect = (value: RosNamespace) => {
-    setResetTableQuery(value !== query.namespace);
+    setIsInitialLoad(false);
     setQuery({ ...query, namespace: value });
   };
 
@@ -98,7 +94,7 @@ const OptimizationsDetails: React.FC<OptimizationsDetailsProps> = ({
                   optimizationType={query?.optimizationType}
                   query={query}
                   queryStateName={queryStateName}
-                  resetQuery={resetTableQuery}
+                  restoreState={isInitialLoad}
                 />
               ) : (
                 <OptimizationsProjectsTable
@@ -110,7 +106,7 @@ const OptimizationsDetails: React.FC<OptimizationsDetailsProps> = ({
                   optimizationType={query?.optimizationType}
                   query={query}
                   queryStateName={queryStateName}
-                  resetQuery={resetTableQuery}
+                  restoreState={isInitialLoad}
                 />
               )
             ) : (

--- a/apps/koku-ui-ros/src/routes/optimizations/optimizationsTable/optimizationsContainersTable/optimizationsContainersTable.tsx
+++ b/apps/koku-ui-ros/src/routes/optimizations/optimizationsTable/optimizationsContainersTable/optimizationsContainersTable.tsx
@@ -41,7 +41,7 @@ interface OptimizationsContainersTableOwnProps {
   project?: string; // Project name to filter by
   query?: RosDetailsQuery;
   queryStateName: string; // Name used to store query state
-  resetQuery?: boolean; // Reset table query when namespace changes
+  restoreState?: boolean; // Restore table query from link state on initial page load
 }
 
 export interface OptimizationsContainersTableStateProps {
@@ -83,14 +83,19 @@ const OptimizationsContainersTable: React.FC<OptimizationsContainersTableProps> 
   project,
   query: parentQueryState,
   queryStateName,
-  resetQuery,
+  restoreState,
 }) => {
   const intl = useIntl();
   const location = useLocation();
 
   const [newLinkState, setNewLinkState] = useState();
   const queryState = getQueryState(location, queryStateName);
-  const [query, setQuery] = useState({ ...baseQuery, ...(queryState && queryState?.containers) });
+  const [query, setQuery] = useState(() => {
+    if (restoreState === false) {
+      return { ...baseQuery };
+    }
+    return { ...baseQuery, ...queryState?.containers };
+  });
   const { report, reportError, reportFetchStatus } = useMapToProps({
     project,
     query,
@@ -219,13 +224,6 @@ const OptimizationsContainersTable: React.FC<OptimizationsContainersTableProps> 
       })
     );
   }, [parentQueryState, query]);
-
-  // Reset query state when switching between projects and containers
-  useEffect(() => {
-    if (resetQuery) {
-      setQuery({ ...baseQuery });
-    }
-  }, [resetQuery]);
 
   // Render
 

--- a/apps/koku-ui-ros/src/routes/optimizations/optimizationsTable/optimizationsProjectsTable/optimizationsProjectsDataTable.tsx
+++ b/apps/koku-ui-ros/src/routes/optimizations/optimizationsTable/optimizationsProjectsTable/optimizationsProjectsDataTable.tsx
@@ -167,7 +167,6 @@ const OptimizationsProjectsDataTable: React.FC<OptimizationsProjectTableProps> =
 
     report?.data?.forEach(item => {
       const cluster = item.cluster_alias ?? item.cluster_uuid ?? '';
-      const container = item.container ?? '';
       const lastReported = getTimeFromNow(item.last_reported);
       const project = item.project ?? '';
       const showWarningIcon = hasNotificationsWarning(item?.recommendations, true);
@@ -177,7 +176,7 @@ const OptimizationsProjectsDataTable: React.FC<OptimizationsProjectTableProps> =
         breadcrumbLabel,
         breadcrumbPath,
         id: item.id,
-        title: container,
+        title: project,
       });
 
       const hasRecommendations =
@@ -217,7 +216,6 @@ const OptimizationsProjectsDataTable: React.FC<OptimizationsProjectTableProps> =
           { value: lastReported, style: styles.lastItem },
         ],
         optimization: {
-          container: item.container,
           id: item.id,
           project,
         },

--- a/apps/koku-ui-ros/src/routes/optimizations/optimizationsTable/optimizationsProjectsTable/optimizationsProjectsTable.tsx
+++ b/apps/koku-ui-ros/src/routes/optimizations/optimizationsTable/optimizationsProjectsTable/optimizationsProjectsTable.tsx
@@ -44,7 +44,7 @@ interface OptimizationsProjectsTableOwnProps {
   project?: string; // Project name to filter by for OCP breakdown
   query?: RosDetailsQuery;
   queryStateName: string; // Name used to store query state
-  resetQuery?: boolean; // Reset table query when namespace changes
+  restoreState?: boolean; // Restore table query from link state on initial page load
 }
 
 export interface OptimizationsProjectsTableStateProps {
@@ -87,14 +87,19 @@ const OptimizationsProjectsTable: React.FC<OptimizationsProjectsTableProps> = ({
   project,
   query: parentQueryState,
   queryStateName,
-  resetQuery,
+  restoreState,
 }) => {
   const intl = useIntl();
   const location = useLocation();
 
   const [newLinkState, setNewLinkState] = useState();
   const queryState = getQueryState(location, queryStateName);
-  const [query, setQuery] = useState({ ...baseQuery, ...(queryState && queryState?.projects) });
+  const [query, setQuery] = useState(() => {
+    if (restoreState === false) {
+      return { ...baseQuery };
+    }
+    return { ...baseQuery, ...queryState?.projects };
+  });
   const { report, reportError, reportFetchStatus } = useMapToProps({
     project,
     query,
@@ -221,13 +226,6 @@ const OptimizationsProjectsTable: React.FC<OptimizationsProjectsTableProps> = ({
       })
     );
   }, [parentQueryState, query]);
-
-  // Reset query state when switching between projects and containers
-  useEffect(() => {
-    if (resetQuery) {
-      setQuery({ ...baseQuery });
-    }
-  }, [resetQuery]);
 
   // Render
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,6 @@
         "jest-transform-stub": "^2.0.0",
         "npm-check-updates": "^22.2.9",
         "npm-run-all2": "^9.0.2",
-        "pac-proxy-agent": "^9.1.0",
         "prettier": "^3.9.3",
         "rimraf": "^6.1.3",
         "swc_mut_cjs_exports": "^10.7.0",

--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "jest-transform-stub": "^2.0.0",
     "npm-check-updates": "^22.2.9",
     "npm-run-all2": "^9.0.2",
-    "pac-proxy-agent": "^9.1.0",
     "prettier": "^3.9.3",
     "rimraf": "^6.1.3",
     "swc_mut_cjs_exports": "^10.7.0",


### PR DESCRIPTION
## Summary
- Replace the synchronized `resetQuery`/`useEffect` pattern with `restoreState` and lazy `useState` initialization so namespace tab switches clear filters without triggering duplicate API requests.
- Preserve saved table query state when navigating back to the optimizations page on initial load.
- Remove redundant `pac-proxy-agent` from the root `package.json` (it remains in `apps/koku-ui-onprem`).

## Test plan
- [ ] Navigate to optimizations details with saved filters and confirm query state is restored on initial load
- [ ] Switch between projects and containers namespaces and confirm filters reset to defaults with a single API request
- [ ] Verify OCP breakdown tables still restore saved query state when `restoreState` is not passed
- [ ] Confirm on-prem webpack dev server still resolves `pac-proxy-agent` from the onprem workspace package


Made with [Cursor](https://cursor.com)