### PR TITLE
Fetch project name for OCP staging page

### DIFF
--- a/apps/koku-ui-ros/src/routes/optimizations/optimizationsTable/optimizationsContainersTable/optimizationsContainersTable.tsx
+++ b/apps/koku-ui-ros/src/routes/optimizations/optimizationsTable/optimizationsContainersTable/optimizationsContainersTable.tsx
@@ -343,7 +343,7 @@ const useMapToProps = ({
     if (!reportError && reportFetchStatus !== FetchStatus.inProgress) {
       dispatch(rosActions.fetchRosReport(reportPathsType, reportType, reportQueryString));
     }
-  }, [query]);
+  }, [project, query]);
 
   return {
     report,

--- a/apps/koku-ui-ros/src/routes/optimizations/optimizationsTable/optimizationsProjectsTable/optimizationsProjectsTable.tsx
+++ b/apps/koku-ui-ros/src/routes/optimizations/optimizationsTable/optimizationsProjectsTable/optimizationsProjectsTable.tsx
@@ -314,7 +314,7 @@ const useMapToProps = ({
     if (!reportError && reportFetchStatus !== FetchStatus.inProgress) {
       dispatch(rosActions.fetchRosReport(reportPathsType, reportType, reportQueryString));
     }
-  }, [query]);
+  }, [project, query]);
 
   return {
     report,

--- a/apps/koku-ui-ros/src/routes/staging/optimizations/ocpOptimizationsStaging.tsx
+++ b/apps/koku-ui-ros/src/routes/staging/optimizations/ocpOptimizationsStaging.tsx
@@ -1,24 +1,66 @@
 import { PageSection } from '@patternfly/react-core';
+import { getQuery } from 'api/queries/query';
+import type { RosReport } from 'api/ros/ros';
+import { RosPathsType, RosType } from 'api/ros/ros';
+import type { AxiosError } from 'axios';
 import messages from 'locales/messages';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useIntl } from 'react-intl';
+import { useDispatch, useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
+import type { AnyAction } from 'redux';
+import type { ThunkDispatch } from 'redux-thunk';
 import { routes } from 'routes';
+import { NotAvailable } from 'routes/components/page/notAvailable';
+import { NotConfigured } from 'routes/components/page/notConfigured';
+import { LoadingState } from 'routes/components/state/loadingState';
 import { OptimizationsOcpBreakdown } from 'routes/optimizations/optimizationsOcpBreakdown';
+import type { RootState } from 'store';
+import { FetchStatus } from 'store/common';
+import { rosActions, rosSelectors } from 'store/ros';
 import { formatPath } from 'utils/paths';
 
 interface OcpOptimizationsStagingOwnProps {
   // TBD...
 }
 
+export interface OptimizationsProjectsTableStateProps {
+  report: RosReport;
+  reportError: AxiosError;
+  reportFetchStatus: FetchStatus;
+}
+
 type OcpOptimizationsStagingProps = OcpOptimizationsStagingOwnProps;
+
+const reportPathsType = RosPathsType.recommendations;
+const reportType = RosType.namespace as any;
 
 const OcpOptimizationsStaging: React.FC<OcpOptimizationsStagingProps> = () => {
   const intl = useIntl();
   const location = useLocation();
 
-  // Test filters
-  const project = 'project-ros-A2';
+  const { report, reportError, reportFetchStatus } = useMapToProps();
+
+  const project = report?.data?.[0]?.project;
+
+  if (reportError) {
+    return <NotAvailable title={intl.formatMessage(messages.optimizations)} />;
+  }
+
+  if (reportFetchStatus === FetchStatus.inProgress) {
+    return (
+      <PageSection>
+        <LoadingState
+          body={intl.formatMessage(messages.optimizationsLoadingStateDesc)}
+          heading={intl.formatMessage(messages.optimizationsLoadingStateTitle)}
+        />
+      </PageSection>
+    );
+  }
+
+  if (reportFetchStatus === FetchStatus.complete && !project) {
+    return <NotConfigured />;
+  }
 
   return (
     <PageSection>
@@ -34,6 +76,38 @@ const OcpOptimizationsStaging: React.FC<OcpOptimizationsStagingProps> = () => {
       />
     </PageSection>
   );
+};
+
+// For API spec, see https://github.com/RedHatInsights/ros-ocp-backend/blob/main/openapi.json
+const useMapToProps = (): OptimizationsProjectsTableStateProps => {
+  const dispatch: ThunkDispatch<RootState, any, AnyAction> = useDispatch();
+
+  const reportQuery = {
+    // TBD...
+  };
+
+  const reportQueryString = getQuery(reportQuery);
+  const report = useSelector((state: RootState) =>
+    rosSelectors.selectRos(state, reportPathsType, reportType, reportQueryString)
+  );
+  const reportFetchStatus = useSelector((state: RootState) =>
+    rosSelectors.selectRosFetchStatus(state, reportPathsType, reportType, reportQueryString)
+  );
+  const reportError = useSelector((state: RootState) =>
+    rosSelectors.selectRosError(state, reportPathsType, reportType, reportQueryString)
+  );
+
+  useEffect(() => {
+    if (!reportError && reportFetchStatus !== FetchStatus.inProgress) {
+      dispatch(rosActions.fetchRosReport(reportPathsType, reportType, reportQueryString));
+    }
+  }, []);
+
+  return {
+    report,
+    reportError,
+    reportFetchStatus,
+  };
 };
 
 export default OcpOptimizationsStaging;


### PR DESCRIPTION
Fetch project name for OCP staging page. This ensures a valid project name for different users (cost-demo Vs test-ocp-new)