### PR TITLE
Select Optimizations tab in Cypress federated module test

### DIFF
--- a/apps/koku-ui-onprem/cypress/e2e/integration/navigation/federatedModules.cy.ts
+++ b/apps/koku-ui-onprem/cypress/e2e/integration/navigation/federatedModules.cy.ts
@@ -59,6 +59,11 @@ describe('Federated Modules', () => {
 
       // Title is owned by OptimizationsDetailsTitle (parent), not OptimizationsDetails
       cy.get('h1').should('contain.text', 'Optimizations');
+
+      // On-prem HCCM defaults enable the efficiency toggle, so the page lands on the
+      // Efficiency tab (activeTabKey === 0). Open Optimizations to assert table rows.
+      cy.contains('[role="tab"]', /^Optimizations$/).click();
+
       // Federated OptimizationsDetails table row (avoid sortable header buttons —
       // PatternFly pf-v6-c-table__button is often not Cypress-"visible")
       cy.contains('api-server').should('be.visible');


### PR DESCRIPTION
## Summary
- Follow-up to #5441 / jkilzi's review: with efficiency enabled by default on-prem after #5437, `/optimizations` lands on the Efficiency tab
- Click the Optimizations tab before asserting federated table row content (`api-server`)

## Test plan
- [ ] Cypress E2E on this PR passes (`navigation/federatedModules.cy.ts`)
- [ ] Confirm Optimizations federated content assertion still finds `api-server` after tab click


Made with [Cursor](https://cursor.com)