### PR TITLE
Scope notification and status resets

### DIFF
--- a/apps/koku-ui-hccm/src/routes/settings/priceLists/utils/hooks.test.tsx
+++ b/apps/koku-ui-hccm/src/routes/settings/priceLists/utils/hooks.test.tsx
@@ -75,12 +75,25 @@ describe('priceList hooks', () => {
       combineReducers({ [priceListStateKey]: frozenReducer }),
       applyMiddleware(thunk)
     );
+    const dispatchSpy = jest.spyOn(store, 'dispatch');
 
     renderHook(() => usePriceListAddNotification(true), {
       wrapper: wrapperFor(store),
     });
 
     await waitFor(() => expect(addNotification).toHaveBeenCalled());
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'priceList/notifications/reset',
+        payload: { fetchId: fid },
+      })
+    );
+    expect(dispatchSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'priceList/status/reset',
+        payload: { fetchId: fid },
+      })
+    );
   });
 
   test('usePriceListDuplicate does not call onDuplicate when duplicate fails', async () => {

--- a/apps/koku-ui-hccm/src/routes/settings/priceLists/utils/hooks.ts
+++ b/apps/koku-ui-hccm/src/routes/settings/priceLists/utils/hooks.ts
@@ -9,6 +9,7 @@ import type { ThunkDispatch } from 'redux-thunk';
 import type { RootState } from 'store';
 import { FetchStatus } from 'store/common';
 import { priceListActions, priceListSelectors } from 'store/priceLists';
+import { getFetchId } from 'store/priceLists/priceListCommon';
 import type { Notification } from 'utils/notification';
 
 interface NotificationProps {
@@ -16,6 +17,7 @@ interface NotificationProps {
   isNotificationEnabled?: boolean;
   notification: Notification;
   status: FetchStatus;
+  type: PriceListType;
 }
 
 export function usePriceListDuplicate(priceList: PriceListData, onUpdateSuccess?: () => void) {
@@ -103,7 +105,7 @@ export function usePriceListEnabledToggle(priceList: PriceListData, onDeprecate?
 
 // Notifications
 
-const useNotification = ({ error, isNotificationEnabled = true, notification, status }: NotificationProps) => {
+const useNotification = ({ error, isNotificationEnabled = true, notification, status, type }: NotificationProps) => {
   const dispatch = useDispatch<ThunkDispatch<RootState, any, AnyAction>>();
   const addNotification = useAddNotification();
 
@@ -112,10 +114,11 @@ const useNotification = ({ error, isNotificationEnabled = true, notification, st
       if (isNotificationEnabled) {
         addNotification(notification as any);
       }
-      dispatch(priceListActions.resetNotifications());
-      dispatch(priceListActions.resetStatus());
+      const fetchId = getFetchId(type);
+      dispatch(priceListActions.resetNotifications({ fetchId }));
+      dispatch(priceListActions.resetStatus({ fetchId }));
     }
-  }, [addNotification, dispatch, error, isNotificationEnabled, notification, status]);
+  }, [addNotification, dispatch, error, isNotificationEnabled, notification, status, type]);
 };
 
 export const usePriceListAddNotification = (isNotificationEnabled: boolean) => {
@@ -129,7 +132,7 @@ export const usePriceListAddNotification = (isNotificationEnabled: boolean) => {
     priceListSelectors.selectPriceListFetchStatus(state, PriceListType.priceListAdd, undefined)
   );
 
-  useNotification({ error, isNotificationEnabled, notification, status });
+  useNotification({ error, isNotificationEnabled, notification, status, type: PriceListType.priceListAdd });
 };
 
 export const usePriceListDuplicateNotification = (isNotificationEnabled: boolean) => {
@@ -143,7 +146,7 @@ export const usePriceListDuplicateNotification = (isNotificationEnabled: boolean
     priceListSelectors.selectPriceListFetchStatus(state, PriceListType.priceListDuplicate, undefined)
   );
 
-  useNotification({ error, isNotificationEnabled, notification, status });
+  useNotification({ error, isNotificationEnabled, notification, status, type: PriceListType.priceListDuplicate });
 };
 
 export const usePriceListRemoveNotification = (isNotificationEnabled: boolean) => {
@@ -157,7 +160,7 @@ export const usePriceListRemoveNotification = (isNotificationEnabled: boolean) =
     priceListSelectors.selectPriceListFetchStatus(state, PriceListType.priceListRemove, undefined)
   );
 
-  useNotification({ error, isNotificationEnabled, notification, status });
+  useNotification({ error, isNotificationEnabled, notification, status, type: PriceListType.priceListRemove });
 };
 
 export const usePriceListUpdateNotification = (isNotificationEnabled: boolean) => {
@@ -171,7 +174,7 @@ export const usePriceListUpdateNotification = (isNotificationEnabled: boolean) =
     priceListSelectors.selectPriceListFetchStatus(state, PriceListType.priceListUpdate, undefined)
   );
 
-  useNotification({ error, isNotificationEnabled, notification, status });
+  useNotification({ error, isNotificationEnabled, notification, status, type: PriceListType.priceListUpdate });
 };
 
 export const usePriceListNotifications = (isNotificationEnabled = true) => {

--- a/apps/koku-ui-hccm/src/routes/settings/tagLabels/tagMapping/components/parentTagMapping/parentTagMapping.tsx
+++ b/apps/koku-ui-hccm/src/routes/settings/tagLabels/tagMapping/components/parentTagMapping/parentTagMapping.tsx
@@ -24,6 +24,7 @@ import { ParentTags } from 'routes/settings/tagLabels/tagMapping/components/pare
 import type { RootState } from 'store';
 import { FetchStatus } from 'store/common';
 import { settingsActions, settingsSelectors } from 'store/settings';
+import { getFetchId } from 'store/settings/settingsCommon';
 
 import { styles } from './parentTagMapping.styles';
 import { ParentTagMappingEmptyState } from './parentTagMappingEmptyState';
@@ -249,9 +250,9 @@ const ParentTagMapping: React.FC<ParentTagMappingProps> = ({
   // Clear error state if tags changed
   useEffect(() => {
     if (settingsError) {
-      dispatch(settingsActions.resetStatus());
+      dispatch(settingsActions.resetStatus({ fetchId: getFetchId(SettingsType.tagsMappingsChildAdd) }));
     }
-  }, [childTags, parentTags]);
+  }, [childTags, dispatch, parentTags, settingsError]);
 
   return (
     <>

--- a/apps/koku-ui-hccm/src/routes/settings/utils/hooks.ts
+++ b/apps/koku-ui-hccm/src/routes/settings/utils/hooks.ts
@@ -11,6 +11,7 @@ import { accountSettingsActions, accountSettingsSelectors } from 'store/accountS
 import { getFetchId as getAccountSettingsFetchId } from 'store/accountSettings/accountSettingsCommon';
 import { FetchStatus } from 'store/common';
 import { settingsActions, settingsSelectors } from 'store/settings';
+import { getFetchId as getSettingsFetchId } from 'store/settings/settingsCommon';
 
 interface AccountSettingsUpdateProps<T> {
   type: AccountSettingsType;
@@ -68,8 +69,9 @@ export const useSettingsNotifications = ({ type }: SettingsUpdateProps) => {
   useEffect(() => {
     if (status === FetchStatus.complete && notification) {
       addNotification(notification as any);
-      dispatch(settingsActions.resetNotifications());
-      dispatch(settingsActions.resetStatus());
+      const fetchId = getSettingsFetchId(type);
+      dispatch(settingsActions.resetNotifications({ fetchId }));
+      dispatch(settingsActions.resetStatus({ fetchId }));
     }
-  }, [addNotification, dispatch, error, notification, status]);
+  }, [addNotification, dispatch, error, notification, status, type]);
 };

--- a/apps/koku-ui-hccm/src/store/priceLists/priceList.store.test.ts
+++ b/apps/koku-ui-hccm/src/store/priceLists/priceList.store.test.ts
@@ -8,6 +8,8 @@ import {
   fetchPriceListFailure,
   fetchPriceListRequest,
   fetchPriceListSuccess,
+  resetNotifications,
+  resetStatus,
   updatePriceList,
   updatePriceListFailure,
   updatePriceListRequest,
@@ -43,6 +45,24 @@ describe('priceList store', () => {
     expect(state.errors.size).toBe(0);
     expect(state.notification?.size).toBe(0);
     expect(state.status.size).toBe(0);
+  });
+
+  test('scoped resetNotifications/resetStatus only clear the given fetchId', () => {
+    const listFid = getFetchId(PriceListType.priceList, 'limit=10');
+    const addFid = getFetchId(PriceListType.priceListAdd);
+    let state: any = emptySlice();
+    state.status.set(listFid, FetchStatus.complete);
+    state.status.set(addFid, FetchStatus.complete);
+    state.notification.set(listFid, { t: 'list' });
+    state.notification.set(addFid, { t: 'add' });
+
+    state = priceListReducer(state, resetNotifications({ fetchId: addFid }));
+    expect(state.notification.get(addFid)).toBeUndefined();
+    expect(state.notification.get(listFid)).toEqual({ t: 'list' });
+
+    state = priceListReducer(state, resetStatus({ fetchId: addFid }));
+    expect(state.status.get(addFid)).toBeUndefined();
+    expect(state.status.get(listFid)).toBe(FetchStatus.complete);
   });
 
   test('fetch request, success, and failure update maps', () => {

--- a/apps/koku-ui-hccm/src/store/priceLists/priceListActions.ts
+++ b/apps/koku-ui-hccm/src/store/priceLists/priceListActions.ts
@@ -19,8 +19,8 @@ interface PriceListActionMeta {
 
 // Reset notification and status
 
-export const resetNotifications = createAction('priceList/notifications/reset')();
-export const resetStatus = createAction('priceList/status/reset')();
+export const resetNotifications = createAction('priceList/notifications/reset')<{ fetchId: string }>();
+export const resetStatus = createAction('priceList/status/reset')<{ fetchId: string }>();
 
 // Fetch price list
 

--- a/apps/koku-ui-hccm/src/store/priceLists/priceListReducer.ts
+++ b/apps/koku-ui-hccm/src/store/priceLists/priceListReducer.ts
@@ -52,19 +52,23 @@ export function priceListReducer(state = defaultState, action: PriceListAction):
       state = defaultState;
       return state;
 
-    case getType(resetNotifications):
-      state = {
+    case getType(resetNotifications): {
+      const notification = new Map(state.notification);
+      notification.delete(action.payload.fetchId);
+      return {
         ...state,
-        notification: new Map(),
+        notification,
       };
-      return state;
+    }
 
-    case getType(resetStatus):
-      state = {
+    case getType(resetStatus): {
+      const status = new Map(state.status);
+      status.delete(action.payload.fetchId);
+      return {
         ...state,
-        status: new Map(),
+        status,
       };
-      return state;
+    }
 
     case getType(fetchPriceListRequest):
       return {

--- a/apps/koku-ui-hccm/src/store/settings/settings.test.ts
+++ b/apps/koku-ui-hccm/src/store/settings/settings.test.ts
@@ -6,6 +6,7 @@ import {
 	fetchSettingsFailure,
 	fetchSettingsRequest,
 	fetchSettingsSuccess,
+	resetNotifications,
 	resetStatus,
 	updateSettings,
 	updateSettingsFailure,
@@ -40,10 +41,27 @@ describe('settings store', () => {
 		expect(state).toEqual(defaultState);
 	});
 
-	test('resetStatus clears status map', () => {
-		let state = settingsReducer(undefined as any, fetchSettingsRequest({ fetchId: 'a' } as any));
-		state = settingsReducer(state, resetStatus());
-		expect(state.status?.size).toBe(0);
+	test('scoped resetNotifications/resetStatus only clear the given fetchId', () => {
+		const tagsFid = getFetchId(SettingsType.tags, 'q=1');
+		const enableFid = getFetchId(SettingsType.tagsEnable);
+		let state = settingsReducer(undefined as any, fetchSettingsRequest({ fetchId: tagsFid } as any));
+		state = settingsReducer(state, updateSettingsRequest({ fetchId: enableFid } as any));
+		state = settingsReducer(
+			state,
+			updateSettingsSuccess({} as any, { fetchId: enableFid, notification: { title: 'enabled' } } as any)
+		);
+		state = settingsReducer(
+			state,
+			fetchSettingsSuccess({ data: [] } as any, { fetchId: tagsFid } as any)
+		);
+
+		state = settingsReducer(state, resetNotifications({ fetchId: enableFid }));
+		expect(state.notification?.get(enableFid)).toBeUndefined();
+		expect(state.status?.get(tagsFid)).toBe(FetchStatus.complete);
+
+		state = settingsReducer(state, resetStatus({ fetchId: enableFid }));
+		expect(state.status?.get(enableFid)).toBeUndefined();
+		expect(state.status?.get(tagsFid)).toBe(FetchStatus.complete);
 	});
 
 	test('request/success/failure reducer branches', () => {

--- a/apps/koku-ui-hccm/src/store/settings/settingsActions.ts
+++ b/apps/koku-ui-hccm/src/store/settings/settingsActions.ts
@@ -28,8 +28,8 @@ export const updateSettingsSuccess = createAction('settings/update/success')<
 >();
 export const updateSettingsFailure = createAction('settings/update/failure')<AxiosError, SettingsActionMeta>();
 
-export const resetNotifications = createAction('settings/notification/reset')();
-export const resetStatus = createAction('settings/status/reset')();
+export const resetNotifications = createAction('settings/notification/reset')<{ fetchId: string }>();
+export const resetStatus = createAction('settings/status/reset')<{ fetchId: string }>();
 
 export function fetchSettings(settingsType: SettingsType, settingsQueryString: string): ThunkAction {
   return (dispatch, getState) => {

--- a/apps/koku-ui-hccm/src/store/settings/settingsReducer.ts
+++ b/apps/koku-ui-hccm/src/store/settings/settingsReducer.ts
@@ -48,19 +48,23 @@ export function settingsReducer(state = defaultState, action: SettingsAction): S
       state = defaultState;
       return state;
 
-    case getType(resetNotifications):
-      state = {
+    case getType(resetNotifications): {
+      const notification = new Map(state.notification);
+      notification.delete(action.payload.fetchId);
+      return {
         ...state,
-        notification: new Map(),
+        notification,
       };
-      return state;
+    }
 
-    case getType(resetStatus):
-      state = {
+    case getType(resetStatus): {
+      const status = new Map(state.status);
+      status.delete(action.payload.fetchId);
+      return {
         ...state,
-        status: new Map(),
+        status,
       };
-      return state;
+    }
 
     case getType(fetchSettingsFailure):
       return {


### PR DESCRIPTION
Scope notification and status resets by fetch ID

## Summary by Sourcery

Scope settings and price list notification/status resets to individual fetch IDs instead of clearing global maps.

Bug Fixes:
- Ensure resetting notifications or status only affects the targeted fetchId for settings and price list operations.

Enhancements:
- Update hooks and components to compute fetch IDs and dispatch scoped reset actions for settings and price list flows.
- Adjust reducers to remove notification and status entries by fetchId rather than reinitializing the entire maps.

Tests:
- Add and update unit and hook tests to verify scoped reset behavior and dispatched actions for specific fetch IDs.