### PR TITLE
Efficiency tab breakdown links do not filter optimizations table

### DIFF
--- a/apps/koku-ui-hccm/src/routes/optimizations/optimizations.tsx
+++ b/apps/koku-ui-hccm/src/routes/optimizations/optimizations.tsx
@@ -45,12 +45,17 @@ const Optimizations: React.FC<OptimizationsProps> = () => {
     // Immediately update local state so the tab header responds without waiting
     // for the navigation round-trip.
     setActiveTabKey(tabIndex);
+    // Drop optimizationsDetailsState so filters are not restored when returning
+    // to the optimizations tab. Links that intentionally set filter_by (e.g.
+    // from the efficiency table) still navigate via Link, not this handler.
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const { optimizationsDetailsState: _omitted, ...restState } = location?.state || {};
     navigate(formatPath(routes.optimizations.path), {
       replace: true,
       state: {
-        ...(location?.state || {}),
+        ...restState,
         efficiencyState: {
-          ...(location?.state?.efficiencyState || {}),
+          ...(restState.efficiencyState || {}),
           activeTabKey: tabIndex,
         },
       },

--- a/apps/koku-ui-ros/src/routes/optimizations/optimizationsTable/optimizationsContainersTable/optimizationsContainersTable.tsx
+++ b/apps/koku-ui-ros/src/routes/optimizations/optimizationsTable/optimizationsContainersTable/optimizationsContainersTable.tsx
@@ -94,7 +94,15 @@ const OptimizationsContainersTable: React.FC<OptimizationsContainersTableProps> 
     if (restoreState === false) {
       return { ...baseQuery };
     }
-    return { ...baseQuery, ...queryState?.containers };
+    // Prefer containers state when returning from breakdown; otherwise apply
+    // top-level filter_by (e.g., from the efficiency page link state).
+    if (queryState?.containers) {
+      return { ...baseQuery, ...queryState.containers };
+    }
+    return {
+      ...baseQuery,
+      ...(queryState?.filter_by && { filter_by: queryState.filter_by }),
+    };
   });
   const { report, reportError, reportFetchStatus } = useMapToProps({
     project,

--- a/apps/koku-ui-ros/src/routes/optimizations/optimizationsTable/optimizationsProjectsTable/optimizationsProjectsTable.tsx
+++ b/apps/koku-ui-ros/src/routes/optimizations/optimizationsTable/optimizationsProjectsTable/optimizationsProjectsTable.tsx
@@ -98,7 +98,15 @@ const OptimizationsProjectsTable: React.FC<OptimizationsProjectsTableProps> = ({
     if (restoreState === false) {
       return { ...baseQuery };
     }
-    return { ...baseQuery, ...queryState?.projects };
+    // Prefer projects state when returning from breakdown; otherwise apply
+    // top-level filter_by (e.g., from the efficiency page link state).
+    if (queryState?.projects) {
+      return { ...baseQuery, ...queryState.projects };
+    }
+    return {
+      ...baseQuery,
+      ...(queryState?.filter_by && { filter_by: queryState.filter_by }),
+    };
   });
   const { report, reportError, reportFetchStatus } = useMapToProps({
     project,


### PR DESCRIPTION
Efficiency tab breakdown links do not filter optimizations table
https://redhat.atlassian.net/browse/COST-7955

## Summary by Sourcery

Ensure efficiency breakdown links correctly filter the optimizations tables and avoid restoring stale optimization filters when switching tabs.

Bug Fixes:
- Apply top-level filter_by from navigation state to containers and projects optimizations tables when no per-table state is present so efficiency breakdown links correctly filter results.
- Stop restoring optimizations details state when returning to the optimizations tab to prevent outdated filters from being reapplied across tab changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Optimizations tab navigation from carrying over breakdown-specific details/filter state back to the tab.
  * Updated the Optimizations containers table to restore the correct query filters when returning from breakdown views.
  * Updated the Optimizations projects table to prefer breakdown-specific project filters, falling back to saved top-level filters when breakdown state isn’t available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->