### PR TITLE
Unable to update price list due to decimal separator

### DIFF
--- a/apps/koku-ui-hccm/src/routes/settings/costModels/costModelBreakdown/costCalculations/markup/markupModal.test.tsx
+++ b/apps/koku-ui-hccm/src/routes/settings/costModels/costModelBreakdown/costCalculations/markup/markupModal.test.tsx
@@ -53,6 +53,22 @@ describe('MarkupModal', () => {
     expect(onSave).toHaveBeenCalled();
   });
 
+  test('save stays disabled when markup is unchanged from baseline', () => {
+    render(
+      <Provider store={setupStore()}>
+        <IntlProvider locale="en">
+          <MarkupModal canWrite costModel={costModel} isDispatch={false} isOpen onClose={jest.fn()} onSave={jest.fn()} />
+        </IntlProvider>
+      </Provider>
+    );
+    const dialog = within(screen.getByRole('dialog'));
+    expect(dialog.getByRole('button', { name: /save/i })).toBeDisabled();
+    fireEvent.change(dialog.getByLabelText(/rate/i), { target: { value: '1,000.5' } });
+    expect(dialog.getByRole('button', { name: /save/i })).not.toBeDisabled();
+    fireEvent.change(dialog.getByLabelText(/rate/i), { target: { value: '10' } });
+    expect(dialog.getByRole('button', { name: /save/i })).toBeDisabled();
+  });
+
   test('discount radio and keydown handlers update state', () => {
     render(
       <Provider store={setupStore()}>

--- a/apps/koku-ui-hccm/src/routes/settings/costModels/costModelBreakdown/costCalculations/markup/markupModal.tsx
+++ b/apps/koku-ui-hccm/src/routes/settings/costModels/costModelBreakdown/costCalculations/markup/markupModal.tsx
@@ -260,7 +260,7 @@ const MarkupModal: React.FC<MarkupModalProps> = ({
             isLoading ||
             validated === 'error' ||
             markupOrDiscount.trim().length === 0 ||
-            Number(markupOrDiscount) === Number(costModel?.markup?.value)
+            Number(unFormat(markupOrDiscount)) === Number(costModel?.markup?.value)
           }
           key="save"
           onClick={handleOnSave}

--- a/apps/koku-ui-hccm/src/routes/settings/priceLists/priceList/components/details/detailContent.test.tsx
+++ b/apps/koku-ui-hccm/src/routes/settings/priceLists/priceList/components/details/detailContent.test.tsx
@@ -169,15 +169,23 @@ describe('DetailContent', () => {
       end: new Date('2025-12-01'),
       start: new Date('2024-06-01'),
     });
+    const onCurrencyChange = jest.fn();
     const onDisabled = jest.fn();
     const onSave = jest.fn();
     const ref = createRef<DetailContentHandle>();
     renderDetails(
-      <DetailContent ref={ref} onDisabled={onDisabled} onSave={onSave} priceList={basePriceList} />
+      <DetailContent
+        ref={ref}
+        onCurrencyChange={onCurrencyChange}
+        onDisabled={onDisabled}
+        onSave={onSave}
+        priceList={basePriceList}
+      />
     );
     await waitFor(() => expect(onDisabled).toHaveBeenCalledWith(true));
 
     fireEvent.click(screen.getByTestId('currency-picker'));
+    expect(onCurrencyChange).toHaveBeenCalledWith('EUR');
     fireEvent.change(nameInput(), {
       target: { value: `${basePriceList.name}x` },
     });

--- a/apps/koku-ui-hccm/src/routes/settings/priceLists/priceList/components/details/detailContent.tsx
+++ b/apps/koku-ui-hccm/src/routes/settings/priceLists/priceList/components/details/detailContent.tsx
@@ -35,6 +35,8 @@ import {
 
 interface DetailContentOwnProps {
   isEditDetails?: boolean;
+  /** Fired when currency changes in the create flow so sibling UI (e.g. add rate) stays in sync. */
+  onCurrencyChange?: (currency: string) => void;
   onDisabled?: (value: boolean) => void;
   onSave?: (payload: PriceListData) => void;
   priceList?: PriceListData;
@@ -48,7 +50,7 @@ export interface DetailContentHandle {
 type DetailContentProps = DetailContentOwnProps;
 
 const DetailContent = forwardRef<DetailContentHandle, DetailContentProps>(
-  ({ isEditDetails, onDisabled, onSave, priceList }, ref) => {
+  ({ isEditDetails, onCurrencyChange, onDisabled, onSave, priceList }, ref) => {
     const intl = useIntl();
 
     /** Latest save handler for imperative `save()` — updated in layout effect (not during render). */
@@ -127,6 +129,11 @@ const DetailContent = forwardRef<DetailContentHandle, DetailContentProps>(
     };
 
     // Handlers
+
+    const handleOnCurrencySelect = (value: string) => {
+      setCurrency(value);
+      onCurrencyChange?.(value);
+    };
 
     const handleOnDescriptionChange = (value: string) => {
       setDescription(value);
@@ -234,7 +241,7 @@ const DetailContent = forwardRef<DetailContentHandle, DetailContentProps>(
                 <Currency currency={currency} id="currency" isDisabled showLabel={false} />
               </Tooltip>
             ) : (
-              <Currency currency={currency} id="currency" onSelect={setCurrency} showLabel={false} />
+              <Currency currency={currency} id="currency" onSelect={handleOnCurrencySelect} showLabel={false} />
             )}
           </FormGroup>
           <FormGroup isRequired fieldId="start-date" label={intl.formatMessage(messages.validityPeriod)}>

--- a/apps/koku-ui-hccm/src/routes/settings/priceLists/priceListBreakdown/rates/components/rateContent.tsx
+++ b/apps/koku-ui-hccm/src/routes/settings/priceLists/priceListBreakdown/rates/components/rateContent.tsx
@@ -39,6 +39,7 @@ import {
   hasDirtyTagValues,
   hasInvalidTagValues,
   hasTagValuesErrors,
+  parseRateValue,
   validateDescription,
   validateName,
   validateRate,
@@ -50,7 +51,7 @@ import type { RootState } from 'store';
 import { FetchStatus } from 'store/common';
 import { metricsActions, metricsSelectors } from 'store/metrics';
 import { resourceActions, resourceSelectors } from 'store/resources';
-import { unitsLookupKey } from 'utils/format';
+import { formatCurrencyRateRaw, unitsLookupKey } from 'utils/format';
 
 import { GpuTagKey } from './gpu/gpuTagKey';
 import { GpuTagValues } from './gpu/gpuTagValues';
@@ -103,12 +104,15 @@ const RateContent = forwardRef<RateContentHandle, RateContentProps>(
 
     const initialTagValues = rate?.tag_rates?.tag_values?.map(tagValue => ({
       ...tagValue,
-      valueInput: tagValue?.value?.toString() ?? '',
+      // Locale-format for the input (e.g. "2,5" in fr) — matches cost-models `formatCurrencyRateRaw`
+      valueInput:
+        tagValue?.value != null ? formatCurrencyRateRaw(Number(tagValue.value), tagValue.unit || defaultCurrency) : '',
     })) ?? [defaultTagValue];
     const initialTieredRates =
       rate?.tiered_rates?.map(tieredRate => ({
         ...tieredRate,
-        valueInput: tieredRate?.value?.toString() ?? '',
+        valueInput:
+          tieredRate?.value != null ? formatCurrencyRateRaw(tieredRate.value, tieredRate.unit || defaultCurrency) : '',
       })) ?? undefined;
 
     // State management
@@ -349,7 +353,7 @@ const RateContent = forwardRef<RateContentHandle, RateContentProps>(
 
       const newTagValues = cloneDeep(gpuTagValues ?? []);
       newTagValues[index].valueInput = value;
-      newTagValues[index].value = error ? undefined : Number(value);
+      newTagValues[index].value = error ? undefined : parseRateValue(value);
       setGpuTagValues(newTagValues);
     };
 
@@ -513,7 +517,7 @@ const RateContent = forwardRef<RateContentHandle, RateContentProps>(
 
       const newTagValues = cloneDeep(tagValues ?? []);
       newTagValues[index].valueInput = value;
-      newTagValues[index].value = error ? undefined : Number(value);
+      newTagValues[index].value = error ? undefined : parseRateValue(value);
       setTagValues(newTagValues);
     };
 
@@ -529,7 +533,7 @@ const RateContent = forwardRef<RateContentHandle, RateContentProps>(
     const handleOnTieredRateValueChange = (value: string) => {
       const error = validateRate(value);
       setTieredRateValueError(error || undefined);
-      setTieredRateValue({ value: error ? undefined : Number(value), valueInput: value });
+      setTieredRateValue({ value: error ? undefined : parseRateValue(value), valueInput: value });
     };
 
     // Update functions

--- a/apps/koku-ui-hccm/src/routes/settings/priceLists/priceListBreakdown/rates/components/utils/utils.test.ts
+++ b/apps/koku-ui-hccm/src/routes/settings/priceLists/priceListBreakdown/rates/components/utils/utils.test.ts
@@ -8,6 +8,7 @@ import {
   hasDuplicateTagRates,
   hasInvalidTagValues,
   hasTagValuesErrors,
+  parseRateValue,
   validateDescription,
   validateName,
   validateRate,
@@ -126,6 +127,17 @@ describe('rates/utils', () => {
       expect(validateRate('-1')).toBe(messages.priceListPosNumberRate);
       expect(validateRate('1.' + '2'.repeat(11))).toBe(messages.costModelsRateTooLong);
       expect(validateRate('12.34')).toBeUndefined();
+    });
+
+    test('accepts grouped USD-style rates', () => {
+      expect(validateRate('1,234.56')).toBeUndefined();
+    });
+  });
+
+  describe('parseRateValue', () => {
+    test('parses locale-formatted rates to API numbers', () => {
+      expect(parseRateValue('12.34')).toBe(12.34);
+      expect(parseRateValue('1,234.56')).toBe(1234.56);
     });
   });
 

--- a/apps/koku-ui-hccm/src/routes/settings/priceLists/priceListBreakdown/rates/components/utils/utils.ts
+++ b/apps/koku-ui-hccm/src/routes/settings/priceLists/priceListBreakdown/rates/components/utils/utils.ts
@@ -2,7 +2,7 @@ import type { Metric, MetricHash } from 'api/metrics';
 import type { Rate, TagValue, TieredRate } from 'api/rates';
 import messages from 'locales/messages';
 import type { MessageDescriptor } from 'react-intl';
-import { countDecimals, isCurrencyFormatValid } from 'utils/format';
+import { countDecimals, isCurrencyFormatValid, unFormat } from 'utils/format';
 
 interface TagRate {
   metric: string | Metric;
@@ -112,7 +112,8 @@ export const validateRate = (value: string): MessageDescriptor => {
   if (!isCurrencyFormatValid(value)) {
     return messages.priceListNumberRate;
   }
-  if (Number(value) < 0) {
+  // Normalize locale decimal/group separators before numeric checks (e.g. "0,25590" → "0.25590")
+  if (Number(unFormat(value)) < 0) {
     return messages.priceListPosNumberRate;
   }
   // Test number of decimals
@@ -122,6 +123,9 @@ export const validateRate = (value: string): MessageDescriptor => {
   }
   return undefined;
 };
+
+/** Parse a locale-formatted rate string to a number for API payloads (matches cost-models `unFormat` usage). */
+export const parseRateValue = (value: string): number => Number(unFormat(value));
 
 export const validateTagKey = (value: string, isGpuMetric = false) => {
   if (value?.trim()?.length === 0) {

--- a/apps/koku-ui-hccm/src/routes/settings/priceLists/priceListCreate/priceListCreate.tsx
+++ b/apps/koku-ui-hccm/src/routes/settings/priceLists/priceListCreate/priceListCreate.tsx
@@ -54,7 +54,7 @@ const PriceListCreate: React.FC<PriceListCreateProps> = () => {
   const contentRef = useRef<DetailContentHandle>(null);
   const [isDisabled, setIsDisabled] = useState(true);
   const [isFinish, setIsFinish] = useState(false);
-  const [priceList, setPriceList] = useState<PriceListData>({});
+  const [priceList, setPriceList] = useState<PriceListData>({ currency: 'USD' });
   const [rates, setRates] = useState<Rate[]>([]);
 
   const { priceListError, priceListFetchStatus, userAccess, userAccessError, userAccessFetchStatus } = useMapToProps();
@@ -67,6 +67,34 @@ const PriceListCreate: React.FC<PriceListCreateProps> = () => {
 
   const handleOnCancel = () => {
     navigateToPriceListDetail();
+  };
+
+  const handleOnCurrencyChange = (currency: string) => {
+    // Keep draft price list currency in sync for add-rate / empty-state UI before create
+    setPriceList(prev => ({
+      ...(prev ?? {}),
+      currency,
+    }));
+    setRates(prev =>
+      prev?.map(rate => ({
+        ...rate,
+        ...(rate?.tag_rates && {
+          tag_rates: {
+            ...rate.tag_rates,
+            tag_values: rate.tag_rates.tag_values?.map(tagValue => ({
+              ...tagValue,
+              unit: currency,
+            })),
+          },
+        }),
+        ...(rate?.tiered_rates && {
+          tiered_rates: rate.tiered_rates.map(tieredRate => ({
+            ...tieredRate,
+            unit: currency,
+          })),
+        }),
+      }))
+    );
   };
 
   const handleOnSave = (payload: PriceListData) => {
@@ -116,10 +144,10 @@ const PriceListCreate: React.FC<PriceListCreateProps> = () => {
   // Effects
 
   useEffect(() => {
-    setPriceList({
-      ...(priceList ?? {}),
+    setPriceList(prev => ({
+      ...(prev ?? {}),
       rates,
-    });
+    }));
   }, [rates]);
 
   useEffect(() => {
@@ -155,7 +183,13 @@ const PriceListCreate: React.FC<PriceListCreateProps> = () => {
       <PageSection>
         <Stack hasGutter>
           <StackItem style={styles.detailsContent}>
-            <DetailContent onDisabled={setIsDisabled} onSave={handleOnSave} priceList={priceList} ref={contentRef} />
+            <DetailContent
+              onCurrencyChange={handleOnCurrencyChange}
+              onDisabled={setIsDisabled}
+              onSave={handleOnSave}
+              priceList={priceList}
+              ref={contentRef}
+            />
           </StackItem>
           <StackItem style={styles.divider}>
             <Divider />


### PR DESCRIPTION
Updated the new price list feature to mimic the old cost model rates input
https://redhat.atlassian.net/browse/COST-7951

## Summary by Sourcery

Align price list rate input and validation with cost model behavior, including locale-aware currency handling and markup comparison.

New Features:
- Default new price lists to USD currency and keep draft currency in sync across details and rates UI before creation.

Bug Fixes:
- Ensure markup save button correctly enables or disables based on locale-formatted input matching the existing markup value.
- Allow price list rate validation and parsing to accept locale-formatted and grouped currency values, preventing failures due to decimal separators.

Enhancements:
- Use locale-formatted currency values for rate inputs and convert them to API numbers via a shared unformat utility.
- Propagate currency changes from the price list details view to associated rate units for tag and tiered rates.

Tests:
- Add tests covering grouped USD-style rate validation, locale-formatted rate parsing, currency change propagation in price list details, and markup modal save-state behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved markup and discount change detection so the Save button accurately reflects whether values have changed.
  - Price list currency selections now remain synchronized across rate fields and saved details.
  - Rate inputs better support locale-formatted values, including thousands separators, while preserving accurate numeric values for saving.

- **Tests**
  - Added coverage for markup Save-button behavior, currency changes, and formatted rate parsing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->