### PR TITLE
Add "Last 3 months" option

### DIFF
--- a/apps/koku-ui-hccm/src/routes/components/dateRange/dateRange.test.tsx
+++ b/apps/koku-ui-hccm/src/routes/components/dateRange/dateRange.test.tsx
@@ -7,6 +7,10 @@ import { DateRangeType } from 'routes/utils/dateRange';
 
 import { DateRange } from './dateRange';
 
+jest.mock('components/featureToggle', () => ({
+  isSettingsDataRetentionPeriodEnabled: true,
+}));
+
 jest.mock('@patternfly/react-core', () => {
   const React = require('react');
 

--- a/apps/koku-ui-hccm/src/routes/components/dateRange/dateRange.tsx
+++ b/apps/koku-ui-hccm/src/routes/components/dateRange/dateRange.tsx
@@ -3,6 +3,7 @@ import './dateRange.scss';
 import type { MessageDescriptor } from '@formatjs/intl';
 import type { MenuToggleElement } from '@patternfly/react-core';
 import { Dropdown, DropdownItem, DropdownList, MenuToggle } from '@patternfly/react-core';
+import { isSettingsDataRetentionPeriodEnabled } from 'components/featureToggle';
 import messages from 'locales/messages';
 import React from 'react';
 import { useIntl } from 'react-intl';
@@ -60,31 +61,39 @@ const DateRange: React.FC<DateRangeProps> = ({
         value: DateRangeType.lastTwoMonths,
         isDisabled: isDataAvailable === false,
       });
-      if (dataRetentionMonths > 3) {
+      if (isSettingsDataRetentionPeriodEnabled) {
+        if (dataRetentionMonths > 3) {
+          options.push({
+            label: messages.explorerDateRange,
+            value: DateRangeType.lastThreeMonths,
+            isDisabled: isDataAvailable === false,
+          });
+        }
+        if (dataRetentionMonths > 6) {
+          options.push({
+            label: messages.explorerDateRange,
+            value: DateRangeType.lastSixMonths,
+            isDisabled: isDataAvailable === false,
+          });
+        }
+        if (dataRetentionMonths > 12) {
+          options.push({
+            label: messages.explorerDateRange,
+            value: DateRangeType.lastTwelveMonths,
+            isDisabled: isDataAvailable === false,
+          });
+        }
+        if (dataRetentionMonths) {
+          options.push({
+            label: messages.explorerDateRange,
+            value: DateRangeType.maximum,
+            isDisabled: isDataAvailable === false,
+          });
+        }
+      } else {
         options.push({
           label: messages.explorerDateRange,
           value: DateRangeType.lastThreeMonths,
-          isDisabled: isDataAvailable === false,
-        });
-      }
-      if (dataRetentionMonths > 6) {
-        options.push({
-          label: messages.explorerDateRange,
-          value: DateRangeType.lastSixMonths,
-          isDisabled: isDataAvailable === false,
-        });
-      }
-      if (dataRetentionMonths > 12) {
-        options.push({
-          label: messages.explorerDateRange,
-          value: DateRangeType.lastTwelveMonths,
-          isDisabled: isDataAvailable === false,
-        });
-      }
-      if (dataRetentionMonths) {
-        options.push({
-          label: messages.explorerDateRange,
-          value: DateRangeType.maximum,
           isDisabled: isDataAvailable === false,
         });
       }


### PR DESCRIPTION
Add "Last 3 months" option to date range component
https://redhat.atlassian.net/browse/COST-7396

## Summary by Sourcery

Gate extended date range options, including the new "Last 3 months" selection, behind the settings data retention period feature toggle.

New Features:
- Expose a "Last 3 months" date range option in the date range component when data retention supports it.

Enhancements:
- Adjust date range option availability to respect the settings data retention period feature flag rather than always using retention thresholds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Updated explorer date-range options to reflect configured data-retention periods.
  * Added support for 3-, 6-, 12-month, and maximum-range options when available.
  * Date-range options are now disabled when data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->