### PR TITLE
Disable "Last X months" options

### DIFF
--- a/apps/koku-ui-hccm/src/routes/components/dateRange/dateRange.tsx
+++ b/apps/koku-ui-hccm/src/routes/components/dateRange/dateRange.tsx
@@ -56,12 +56,14 @@ const DateRange: React.FC<DateRangeProps> = ({
       },
     ];
     if (isExplorer) {
-      options.push({
-        label: messages.explorerDateRange,
-        value: DateRangeType.lastTwoMonths,
-        isDisabled: isDataAvailable === false,
-      });
       if (isSettingsDataRetentionPeriodEnabled) {
+        if (dataRetentionMonths > 2) {
+          options.push({
+            label: messages.explorerDateRange,
+            value: DateRangeType.lastTwoMonths,
+            isDisabled: isDataAvailable === false,
+          });
+        }
         if (dataRetentionMonths > 3) {
           options.push({
             label: messages.explorerDateRange,
@@ -91,11 +93,20 @@ const DateRange: React.FC<DateRangeProps> = ({
           });
         }
       } else {
-        options.push({
-          label: messages.explorerDateRange,
-          value: DateRangeType.lastThreeMonths,
-          isDisabled: isDataAvailable === false,
-        });
+        // Todo: Temp until individual flags are available
+        const isDisabled = isDataAvailable === false || isPreviousMonthData === false;
+        options.push(
+          {
+            label: messages.explorerDateRange,
+            value: DateRangeType.lastTwoMonths,
+            isDisabled,
+          },
+          {
+            label: messages.explorerDateRange,
+            value: DateRangeType.lastThreeMonths,
+            isDisabled,
+          }
+        );
       }
       options.push({
         label: messages.explorerDateRange,


### PR DESCRIPTION
Disable "Last X months" options if `isPreviousMonthData=false`. This is temporary until individual flags are available (i.e., if the previous month doesn't have data, then the "last X months" do not either).
https://redhat.atlassian.net/browse/COST-7396

## Summary by Sourcery

Adjust explorer date range options to respect data retention settings and availability of previous month data.

New Features:
- Add conditional availability of last two and three months explorer date ranges based on configured data retention period.

Bug Fixes:
- Prevent selection of last two and three months explorer date ranges when previous month data is unavailable.

Enhancements:
- Tighten date range option enabling logic in the explorer view to better reflect actual data availability.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated date-range options to respect configured data-retention periods.
  * Prevented unavailable two-month and three-month ranges from appearing as selectable when the required data is not available.
  * Improved date-range availability handling for Explorer views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->