### PR TITLE
Date range picker to support 90 days

### DIFF
--- a/apps/koku-ui-hccm/src/routes/explorer/explorerDatePicker.tsx
+++ b/apps/koku-ui-hccm/src/routes/explorer/explorerDatePicker.tsx
@@ -29,8 +29,10 @@ interface ExplorerDatePickerState {
 
 type ExplorerDatePickerProps = ExplorerDatePickerOwnProps;
 
+// Cost Management SaaS retains 5 months of data and limits user queries to a maximum range of 90 days
+
 const API_MAX_DAYS = 366; // Max date range allowed for cost API when retention feature is enabled
-const LEGACY_MAX_DAYS = 62; // Max date range allowed for cost API when retention feature is disabled
+const LEGACY_MAX_DAYS = 90; // Max date range allowed for cost API when retention feature is disabled
 
 // See https://docs.google.com/document/d/1Dl8lKUz-fVTyWdyvZ4_8JjK1-ZjU3UrBKk7KGC3AwgE/edit?tab=t.0
 const getMaxDays = (dataRetentionMonths?: number) => {


### PR DESCRIPTION
Updated custom date range picker to support 90 days of data and match APIs

## Summary by Sourcery

Enhancements:
- Increase the legacy cost API date range limit used by the explorer date picker from 62 days to 90 days to match current retention and query constraints.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Expanded the allowable date range from 62 to 90 days when data retention is disabled.
  * Added guidance clarifying the date range limitation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->