### PR TITLE
Enable "last X months" options

### DIFF
--- a/apps/koku-ui-hccm/src/routes/components/dateRange/dateRange.tsx
+++ b/apps/koku-ui-hccm/src/routes/components/dateRange/dateRange.tsx
@@ -93,18 +93,18 @@ const DateRange: React.FC<DateRangeProps> = ({
           });
         }
       } else {
-        // Todo: Temp until individual flags are available
-        const isDisabled = isDataAvailable === false || isPreviousMonthData === false;
+        // The "last X months" options may not be full months. They include the current month and the previous month.
+        // The sources API doesn't have a flag for these specific options, so enable if there is any data available.
         options.push(
           {
             label: messages.explorerDateRange,
             value: DateRangeType.lastTwoMonths,
-            isDisabled,
+            isDisabled: isDataAvailable === false,
           },
           {
             label: messages.explorerDateRange,
             value: DateRangeType.lastThreeMonths,
-            isDisabled,
+            isDisabled: isDataAvailable === false,
           }
         );
       }

--- a/apps/koku-ui-hccm/src/routes/explorer/explorerDatePicker.tsx
+++ b/apps/koku-ui-hccm/src/routes/explorer/explorerDatePicker.tsx
@@ -30,6 +30,7 @@ interface ExplorerDatePickerState {
 type ExplorerDatePickerProps = ExplorerDatePickerOwnProps;
 
 // Cost Management SaaS retains 5 months of data and limits user queries to a maximum range of 90 days
+// For on-prem the max data retention period is 366 days
 
 const API_MAX_DAYS = 366; // Max date range allowed for cost API when retention feature is enabled
 const LEGACY_MAX_DAYS = 90; // Max date range allowed for cost API when retention feature is disabled


### PR DESCRIPTION
Enable "last X months" options if there is any data available

## Summary by Sourcery

Enable the "last X months" date range options when any data is available and clarify API data retention limits in the explorer date picker comments.

Enhancements:
- Adjust "last two/three months" date range availability to depend only on overall data availability rather than previous-month data.
- Document the on-premise maximum data retention period alongside existing SaaS retention comments in the explorer date picker.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Explorer date-range options so available month ranges are enabled consistently when data exists.

* **Documentation**
  * Clarified the maximum on-premises data retention period as 366 days.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->