### PR TITLE
Updated quick start

### DIFF
--- a/QUICK_START_KOKU.md
+++ b/QUICK_START_KOKU.md
@@ -20,17 +20,18 @@ The setup script (`scripts/quick-start-koku.sh`) automates the backend setup. On
 
 ### The onprem build
 
-The `start:onprem:koku` npm script starts the **koku-ui-onprem** build, which differs from the SaaS build in a few meaningful ways:
+The `start:quick:start:koku` / `start:quick:start:koku:onprem` npm scripts start the **koku-ui-onprem** build, which differs from the SaaS build in a few meaningful ways:
 
 - **No login required** — skips Red Hat SSO entirely, which is ideal for local backend testing
-- **Includes a Sources tab** in the Settings page for adding integrations directly (this tab does not exist in the SaaS build — see [PR #4977](https://github.com/project-koku/koku-ui/pull/4977))
+- **Sources tab** — enabled for `start:quick:start:koku:onprem` (on-prem Settings); disabled for `start:quick:start:koku` to match SaaS-local (see [PR #4977](https://github.com/project-koku/koku-ui/pull/4977))
 - **Omits** SaaS-only libraries such as the Red Hat notification service
 - Designed for customers running Cost Management in self-managed / on-premises OpenShift
 
 For local backend development and feature testing, this is the recommended path. For changes that must match the SaaS experience exactly, use the standard `start:hccm` workflow instead.
 
 ```bash
-npm run start:onprem:koku    # http://localhost:9001  (no login required)
+npm run start:quick:start:koku         # SaaS-local (data retention / Sources tab off)
+npm run start:quick:start:koku:onprem  # on-prem (data retention / Sources tab on)
 ```
 
 - Proxies `/api/cost-management/v1/*` to `localhost:8000`
@@ -186,20 +187,30 @@ ls "${NISE_DIR:-../nise}/pyproject.toml"                  # confirms nise repo c
 Run from inside the `koku-ui` directory. First run takes 10–15 minutes — most of that is
 pulling ~1–2 GB of container images.
 
-> **⚠ Warning:** `npm run quick:start:koku` always includes the `-c` (clean) flag.
-> It deletes all data in the local database and starts fresh. Only use this command
+> **⚠ Warning:** Both quick-start targets include the `-c` (clean) flag.
+> They delete all data in the local database and start fresh. Only use these
 > when you want a clean environment. To resume an existing environment, see
 > [Resuming Development](#resuming-development).
 
+Choose the backend mode that matches how you will run the UI:
+
+| npm target | Backend mode | Data loaded | Typical frontend |
+|------------|--------------|-------------|------------------|
+| `quick:start:koku` | `ONPREM=False`, `test_source=all` | AWS, Azure, GCP, OCP (incl. on-prem) | `start:quick:start:koku` or `start:hccm` with local API proxy |
+| `quick:start:koku:onprem` | `ONPREM=True`, `test_source=ONPREM` | On-prem OCP only | `start:quick:start:koku:onprem` |
+
 ```bash
 cd ~/code/koku-ui
-npm run quick:start:koku
+npm run quick:start:koku          # full / SaaS-local providers
+# or
+npm run quick:start:koku:onprem   # on-prem OCP only
 ```
 
-This is equivalent to running the script directly with the `-c`, `-k`, and `-n` flags:
+Equivalent direct invocations:
 
 ```bash
-bash scripts/quick-start-koku.sh -c -k -n
+bash scripts/quick-start-koku.sh -c -k -n       # full
+bash scripts/quick-start-koku.sh -c -k -n -o    # on-prem (-o)
 ```
 
 Expected output on success:
@@ -258,7 +269,9 @@ curl http://localhost:8000/api/cost-management/v1/status/
 
 ```bash
 cd ~/code/koku-ui
-npm run start:onprem:koku
+npm run start:quick:start:koku         # after quick:start:koku
+# or
+npm run start:quick:start:koku:onprem  # after quick:start:koku:onprem
 ```
 
 Open <http://localhost:9001>. The first build takes about 60 seconds.
@@ -294,7 +307,9 @@ curl http://localhost:8000/api/cost-management/v1/status/
 
 ```bash
 cd ~/code/koku-ui
-npm run start:onprem:koku
+npm run start:quick:start:koku         # SaaS-local
+# or
+npm run start:quick:start:koku:onprem  # on-prem
 ```
 
 ---
@@ -311,20 +326,22 @@ npm run start:onprem:koku
 | Create/update `../koku/.env`               | Install pipenv and uv          |
 | Pull container images (~1–2 GB first time) | Clone the koku and nise repos  |
 | Start all backend containers               | Set up SSH key for GitHub      |
-| Fix Trino empty-credential crash           |                                |
-| Wait up to 3 min for migrations            |                                |
+| Refresh S4 / currency `.env` values        |                                |
+| Wait up to 5 min for migrations            |                                |
 | Create test customer account               |                                |
 | Load sample cost data via nise             |                                |
+| Wait until all required sources have has_data=true |                                |
 
 ### Script flags
 
-```
-bash scripts/quick-start-koku.sh [-h|-c|-k|-n|-v]
+```text
+bash scripts/quick-start-koku.sh [-h|-c|-k|-n|-o|-v]
 
     h    Display the usage message
     c    Clean previous build (removes containers and all data — destructive)
     k    Create or update koku/.env
     n    Create or update nise/.env
+    o    On-prem mode (ONPREM=True, test_source=ONPREM); default is full/all
     v    Verbose (interactive) mode — prompts before running each command
 ```
 
@@ -413,14 +430,14 @@ podman compose logs -f koku-worker
 
 ### `localhost:9001` shows a blank page
 
-The `start:onprem:koku` npm script sets the required environment variables inline. If you are running the frontend a different way and see a blank page, verify these are set:
+The `start:quick:start:koku` / `start:quick:start:koku:onprem` npm scripts set the required environment variables inline. If you are running the frontend a different way and see a blank page, verify these are set:
 
 ```bash
 export API_PROXY_URL=http://localhost:8000/api/cost-management/v1
 export API_TOKEN=
 ```
 
-Then restart `npm run start:onprem`.
+Then restart `npm run start:quick:start:koku` (or `start:quick:start:koku:onprem`).
 
 ### Browser shows 504 on API calls
 
@@ -460,6 +477,39 @@ podman compose down -v
 
 Then re-run the setup script.
 
+### Script hangs on Unleash / “still bringing up stack”
+
+Unleash itself usually starts in under a minute (`curl http://localhost:4242/health` → `{"health":"GOOD"}`). If the script sits much longer, Podman’s `docker-compose up -d unleash` is likely stuck on a dependency health wait even though the container is already up.
+
+Ctrl+C and re-run with the latest `scripts/quick-start-koku.sh` (it starts services with `--no-deps` and polls health directly).
+
+### Script hangs after “Scaling koku-worker” / `koku-koku-base-1 Started`
+
+Same Podman + docker-compose issue: scaling workers without `--no-deps` waits on dependency health and can hang forever. Current quick-start uses `--no-deps` for worker scale up/down. Ctrl+C a hung run and re-run with the updated script.
+
+### `has_data` never becomes true / `HIVE_PATH_ALREADY_EXISTS`
+
+If the loader logs `Failed to find has_data=true for source_name Test OCP on AWS` and worker logs show:
+
+```
+TrinoExternalError: HIVE_PATH_ALREADY_EXISTS
+Target directory for table 'org1234567.reporting_ocpusagelineitem_daily_summary' already exists
+```
+
+the S4 volume still has Hive warehouse objects from a previous run while the metastore does not. OCP summary fails immediately, so `has_data` stays false.
+
+Fix with a full wipe (the `-c` flag now removes `koku-s4-data`), then re-run:
+
+```bash
+cd ~/code/koku
+make DOCKER="$(command -v podman)" docker-down
+podman volume rm -f koku-s4-data
+cd ~/code/koku-ui
+npm run quick:start:koku
+```
+
+The setup script also clears known Hive managed-table prefixes in S4 before loading data.
+
 ### Trino exits immediately after startup
 
 Trino's Glue connector requires non-empty AWS credentials. If your shell or `koku/.env` has `AWS_ACCESS_KEY_ID=` (blank), Trino crashes with:
@@ -468,21 +518,77 @@ Trino's Glue connector requires non-empty AWS credentials. If your shell or `kok
 NullPointerException: Access key ID cannot be blank
 ```
 
-Koku uses a local hive/thrift metastore, not AWS Glue, so the value just needs to be non-empty. The setup script handles this automatically when run with `-k`. To fix manually:
+Koku uses a local hive/thrift metastore, not AWS Glue, so the value just needs to be non-empty. The setup script sets dummy values when run with `-k`. To fix manually:
 
 ```bash
 cd ~/code/koku
-cat > /tmp/trino-ovr.yml << 'EOF'
-services:
-  trino:
-    links: !reset
-EOF
+# Ensure .env has non-empty AWS_* values (local-dev is fine; not S4's s4admin keys)
+sed -i '' 's|^AWS_ACCESS_KEY_ID=.*|AWS_ACCESS_KEY_ID=local-dev|' .env
+sed -i '' 's|^AWS_SECRET_ACCESS_KEY=.*|AWS_SECRET_ACCESS_KEY=local-dev|' .env
 AWS_ACCESS_KEY_ID=local-dev AWS_SECRET_ACCESS_KEY=local-dev \
-  podman compose -f docker-compose.yml -f /tmp/trino-ovr.yml up -d --no-deps --force-recreate trino
-rm /tmp/trino-ovr.yml
+  podman compose up -d --no-deps --force-recreate trino
 ```
 
-The `links: !reset` override is required because Podman rejects the legacy `links:` directive in koku's `docker-compose.yml`.
+### S3 / create-s3-buckets fails with InvalidAccessKeyId
+
+Koku replaced MinIO with S4. Legacy MinIO keys in `.env` (`kokuminioaccess` / `kokuminiosecret`) cause `make docker-up-min-trino` to fail during bucket creation, so `koku_server` never starts. Use the S4 defaults:
+
+```bash
+cd ~/code/koku
+sed -i '' 's|^S3_ACCESS_KEY=.*|S3_ACCESS_KEY=s4admin|' .env
+sed -i '' 's|^S3_SECRET=.*|S3_SECRET=s4secret|' .env
+# Recreate the path proxy so it picks up the new keys
+podman compose up -d --force-recreate s4-path-proxy
+podman compose run --rm --no-deps create-s3-buckets
+```
+
+Or re-run the setup script with `-k` so it rewrites these values.
+
+### `has_data=false` / "Failed to find has_data=true … after 50 retries"
+
+That message comes from koku's `load_test_customer_data.sh`, which only waits
+~8 minutes. It is **non-fatal inside koku** — the load script continues, and the
+worker often finishes shortly afterward.
+
+Our quick-start then waits until **all required sources** report `has_data=true`
+(full mode: every source; on-prem mode: `Test OCP on Premises` only). If any are
+still false, it remediates up to 3 times:
+
+1. Scale workers down and **recreate Trino** if it is not running (Podman can still
+   report `Health=healthy` after an OOM exit — the script checks `Running=true`)
+2. Clear stale Hive warehouse paths in S4 when summary can fail on orphans
+3. Reload only the provider group(s) still missing data (`AWS` / `AZURE` / `GCP` / `ONPREM`)
+
+`Test OCP on Premises` is last in `test_source=all`, so it often fails when Trino
+was OOM-killed during AWS/Azure/GCP ingest. After the multi-cloud load the script
+recovers Trino before the has_data gate. Give Podman at least **8 GB** of memory.
+
+Setup exits if sources are still without data after remediation.
+
+`quick:start:koku` loads all cloud providers in one `test_source=all` pass.
+`quick:start:koku:onprem` loads on-prem OCP only.
+
+To check manually:
+
+```bash
+curl -s 'http://localhost:8000/api/cost-management/v1/sources/?limit=100' | python3 -m json.tool
+```
+
+### Broken host `aws` CLI / OCP payload "not found"
+
+`load-test-customer-data` verifies OCP uploads with the host `aws` CLI. A stale
+install (often under `~/Library/Python/3.7/bin/aws` with a missing interpreter)
+fails that check even when nise uploaded successfully. Fix or remove it:
+
+```bash
+aws --version   # should print a version, not "bad interpreter"
+# If broken:
+mv ~/Library/Python/3.7/bin/aws ~/Library/Python/3.7/bin/aws.bak
+# Optional: brew install awscli
+```
+
+The setup script skips non-working `aws` binaries and falls back to a Podman
+`aws-cli` container for verification.
 
 ### Unleash fails to start — "Admin token cannot be scoped to single project"
 

--- a/apps/koku-ui-hccm/src/routes/details/components/providerStatus/utils/normailize.test.ts
+++ b/apps/koku-ui-hccm/src/routes/details/components/providerStatus/utils/normailize.test.ts
@@ -1,0 +1,20 @@
+import { normalize } from './normailize';
+
+describe('normalize', () => {
+  test('lowercases and replaces hyphens for status keys', () => {
+    expect(normalize('in-progress')).toBe('in_progress');
+    expect(normalize('COMPLETE')).toBe('complete');
+  });
+
+  test('strips -local so source message keys match', () => {
+    expect(normalize('AWS-local')).toBe('aws');
+    expect(normalize('Azure-local')).toBe('azure');
+    expect(normalize('GCP-local')).toBe('gcp');
+    expect(normalize('aws')).toBe('aws');
+  });
+
+  test('returns undefined for empty values', () => {
+    expect(normalize('')).toBeUndefined();
+    expect(normalize(undefined as unknown as string)).toBeUndefined();
+  });
+});

--- a/apps/koku-ui-hccm/src/routes/details/components/providerStatus/utils/normailize.ts
+++ b/apps/koku-ui-hccm/src/routes/details/components/providerStatus/utils/normailize.ts
@@ -1,3 +1,10 @@
+// Normalize status / source_type strings for message keys and lookups.
+// Strips the local-dev "-local" suffix (AWS-local → aws) so message keys match.
 export const normalize = (value: string) => {
-  return value ? value.toLowerCase().replace('-', '_') : undefined;
+  if (!value) {
+    return undefined;
+  }
+  const lower = value.toLowerCase();
+  const withoutLocal = lower.endsWith('-local') ? lower.slice(0, -'-local'.length) : lower;
+  return withoutLocal.replace(/-/g, '_');
 };

--- a/apps/koku-ui-hccm/src/routes/details/components/providerStatus/utils/status.test.ts
+++ b/apps/koku-ui-hccm/src/routes/details/components/providerStatus/utils/status.test.ts
@@ -1,0 +1,31 @@
+import { ProviderType } from 'api/providers';
+import type { Provider } from 'api/providers';
+import messages from 'locales/messages';
+
+import { getProviderAvailability, StatusType } from './status';
+
+describe('getProviderAvailability', () => {
+  test('uses OCP message for OCP sources regardless of case', () => {
+    const result = getProviderAvailability({ source_type: 'OCP', active: true, paused: false } as Provider);
+    expect(result.msg).toBe(messages.dataDetailsIntegrationStatus);
+    expect(result.status).toBe(StatusType.complete);
+  });
+
+  test('uses cloud message for AWS-local and other cloud sources', () => {
+    expect(getProviderAvailability({ source_type: 'AWS-local', active: true } as Provider).msg).toBe(
+      messages.dataDetailsCloudIntegrationStatus
+    );
+    expect(getProviderAvailability({ source_type: 'AWS', active: true } as Provider).msg).toBe(
+      messages.dataDetailsCloudIntegrationStatus
+    );
+  });
+
+  test('marks inactive sources as failed', () => {
+    const result = getProviderAvailability({
+      source_type: ProviderType.aws,
+      active: false,
+      paused: false,
+    } as Provider);
+    expect(result.status).toBe(StatusType.failed);
+  });
+});

--- a/apps/koku-ui-hccm/src/routes/details/components/providerStatus/utils/status.ts
+++ b/apps/koku-ui-hccm/src/routes/details/components/providerStatus/utils/status.ts
@@ -3,6 +3,7 @@ import { ProviderType } from 'api/providers';
 import messages from 'locales/messages';
 import type { MessageDescriptor } from 'react-intl';
 import { normalize } from 'routes/details/components/providerStatus/utils/normailize';
+import { matchesProviderType } from 'routes/utils/providers';
 
 export const enum StatusType {
   complete = 'complete',
@@ -36,10 +37,9 @@ export const getProviderAvailability = (provider: Provider): { msg: MessageDescr
     return status;
   }
 
-  const msg =
-    provider.source_type === ProviderType.ocp
-      ? messages.dataDetailsIntegrationStatus
-      : messages.dataDetailsCloudIntegrationStatus;
+  const msg = matchesProviderType(provider.source_type, ProviderType.ocp)
+    ? messages.dataDetailsIntegrationStatus
+    : messages.dataDetailsCloudIntegrationStatus;
 
   if (provider.active === false && provider.paused === false) {
     status = StatusType.failed; // Inactive sources

--- a/apps/koku-ui-hccm/src/routes/settings/costModels/costModel/utils/utils.test.ts
+++ b/apps/koku-ui-hccm/src/routes/settings/costModels/costModel/utils/utils.test.ts
@@ -5,9 +5,19 @@ import { getSourceType } from './utils';
 describe('costModels/utils', () => {
   test('getSourceType maps known provider labels', () => {
     expect(getSourceType('Amazon Web Services')).toBe(ProviderType.aws);
+    expect(getSourceType('AWS')).toBe(ProviderType.aws);
     expect(getSourceType('Google Cloud')).toBe(ProviderType.gcp);
+    expect(getSourceType('GCP')).toBe(ProviderType.gcp);
     expect(getSourceType('Microsoft Azure')).toBe(ProviderType.azure);
+    expect(getSourceType('Azure')).toBe(ProviderType.azure);
     expect(getSourceType('OpenShift Container Platform')).toBe(ProviderType.ocp);
+    expect(getSourceType('OCP')).toBe(ProviderType.ocp);
+  });
+
+  test('getSourceType maps local koku source types', () => {
+    expect(getSourceType('AWS-local')).toBe(ProviderType.aws);
+    expect(getSourceType('Azure-local')).toBe(ProviderType.azure);
+    expect(getSourceType('GCP-local')).toBe(ProviderType.gcp);
   });
 
   test('getSourceType returns undefined for unknown label', () => {

--- a/apps/koku-ui-hccm/src/routes/settings/costModels/costModel/utils/utils.ts
+++ b/apps/koku-ui-hccm/src/routes/settings/costModels/costModel/utils/utils.ts
@@ -1,15 +1,20 @@
 import { ProviderType } from 'api/providers';
 
+// Map API / cost-model source labels to ProviderType.
+// Local koku backends use AWS-local / Azure-local / GCP-local — treat like aws / azure / gcp.
 export const getSourceType = (value: string) => {
   switch (value) {
     case 'Amazon Web Services':
     case 'AWS':
+    case 'AWS-local':
       return ProviderType.aws;
     case 'Google Cloud':
     case 'GCP':
+    case 'GCP-local':
       return ProviderType.gcp;
     case 'Microsoft Azure':
     case 'Azure':
+    case 'Azure-local':
       return ProviderType.azure;
     case 'OpenShift Container Platform':
     case 'OCP':

--- a/apps/koku-ui-hccm/src/routes/settings/costModelsDeprecated/costModelBreakdown/utils/sourceType.test.ts
+++ b/apps/koku-ui-hccm/src/routes/settings/costModelsDeprecated/costModelBreakdown/utils/sourceType.test.ts
@@ -1,0 +1,15 @@
+import { getSourceType } from './sourceType';
+
+describe('deprecated getSourceType', () => {
+  test('maps cloud and local source types to API strings', () => {
+    expect(getSourceType('Amazon Web Services')).toBe('AWS');
+    expect(getSourceType('AWS-local')).toBe('AWS');
+    expect(getSourceType('Azure-local')).toBe('Azure');
+    expect(getSourceType('GCP-local')).toBe('GCP');
+    expect(getSourceType('OCP')).toBe('OCP');
+  });
+
+  test('returns undefined for unknown labels', () => {
+    expect(getSourceType('Unknown')).toBeUndefined();
+  });
+});

--- a/apps/koku-ui-hccm/src/routes/settings/costModelsDeprecated/costModelBreakdown/utils/sourceType.ts
+++ b/apps/koku-ui-hccm/src/routes/settings/costModelsDeprecated/costModelBreakdown/utils/sourceType.ts
@@ -1,18 +1,23 @@
+// Map cost-model display labels to API source_type strings used by deprecated wizards.
+// Local koku backends use AWS-local / Azure-local / GCP-local — treat like AWS / Azure / GCP.
 export const getSourceType = (sourceType: string) => {
-  let result;
   switch (sourceType) {
     case 'Amazon Web Services':
-      result = 'AWS';
-      break;
+    case 'AWS':
+    case 'AWS-local':
+      return 'AWS';
     case 'Google Cloud':
-      result = 'GCP';
-      break;
+    case 'GCP':
+    case 'GCP-local':
+      return 'GCP';
     case 'Microsoft Azure':
-      result = 'Azure';
-      break;
+    case 'Azure':
+    case 'Azure-local':
+      return 'Azure';
     case 'OpenShift Container Platform':
-      result = 'OCP';
-      break;
+    case 'OCP':
+      return 'OCP';
+    default:
+      return undefined;
   }
-  return result;
 };

--- a/apps/koku-ui-hccm/src/routes/utils/providers.test.ts
+++ b/apps/koku-ui-hccm/src/routes/utils/providers.test.ts
@@ -1,0 +1,45 @@
+import { ProviderType } from 'api/providers';
+import type { Providers } from 'api/providers';
+
+import { filterProviders, matchesProviderType } from './providers';
+
+describe('matchesProviderType', () => {
+  test('matches cloud and local source types without new ProviderType values', () => {
+    expect(matchesProviderType('AWS', ProviderType.aws)).toBe(true);
+    expect(matchesProviderType('AWS-local', ProviderType.aws)).toBe(true);
+    expect(matchesProviderType('Azure-local', ProviderType.azure)).toBe(true);
+    expect(matchesProviderType('GCP-local', ProviderType.gcp)).toBe(true);
+    expect(matchesProviderType('OCP', ProviderType.ocp)).toBe(true);
+  });
+
+  test('does not cross-match provider types', () => {
+    expect(matchesProviderType('AWS-local', ProviderType.azure)).toBe(false);
+    expect(matchesProviderType('GCP', ProviderType.aws)).toBe(false);
+    expect(matchesProviderType(undefined, ProviderType.aws)).toBe(false);
+    expect(matchesProviderType('AWS', ProviderType.all)).toBe(false);
+  });
+});
+
+describe('filterProviders', () => {
+  const providers = {
+    meta: { count: 4 },
+    data: [
+      { name: 'Test AWS Source', source_type: 'AWS-local' },
+      { name: 'Test Azure Source', source_type: 'Azure-local' },
+      { name: 'Test GCP Source', source_type: 'GCP-local' },
+      { name: 'Test OCP on AWS', source_type: 'OCP' },
+    ],
+  } as Providers;
+
+  test('includes *-local sources for aws/azure/gcp filters', () => {
+    expect(filterProviders(providers, ProviderType.aws).data).toHaveLength(1);
+    expect(filterProviders(providers, ProviderType.aws).data[0].name).toBe('Test AWS Source');
+    expect(filterProviders(providers, ProviderType.azure).meta.count).toBe(1);
+    expect(filterProviders(providers, ProviderType.gcp).meta.count).toBe(1);
+    expect(filterProviders(providers, ProviderType.ocp).meta.count).toBe(1);
+  });
+
+  test('returns undefined providers unchanged', () => {
+    expect(filterProviders(undefined as unknown as Providers, ProviderType.aws)).toBeUndefined();
+  });
+});

--- a/apps/koku-ui-hccm/src/routes/utils/providers.ts
+++ b/apps/koku-ui-hccm/src/routes/utils/providers.ts
@@ -1,5 +1,5 @@
 import type { Providers } from 'api/providers';
-import type { ProviderType } from 'api/providers';
+import { ProviderType } from 'api/providers';
 
 const enum DataType {
   currentMonthData = 'current_month_data',
@@ -22,6 +22,18 @@ const _getOcpProvider = (ocpProviders: Providers, uuid?: string) => {
   return result;
 };
 
+// True when API source_type matches ProviderType (case-insensitive).
+// Local koku/nise backends use AWS-local / Azure-local / GCP-local; treat those
+// as aws / azure / gcp without adding separate ProviderType values.
+export const matchesProviderType = (sourceType: string | undefined, providerType: ProviderType) => {
+  if (!sourceType || providerType === ProviderType.all) {
+    return false;
+  }
+  const normalized = sourceType.toLowerCase();
+  const baseType = normalized.endsWith('-local') ? normalized.slice(0, -'-local'.length) : normalized;
+  return baseType === providerType;
+};
+
 // Returns new Provider matching the given provider type
 //
 // See https://redhat.atlassian.net/browse/COST-2202
@@ -30,7 +42,7 @@ export const filterProviders = (providers: Providers, sourceType: ProviderType) 
     return providers;
   }
 
-  const data = providers.data.filter(provider => provider.source_type.toLowerCase() === sourceType);
+  const data = providers.data.filter(provider => matchesProviderType(provider.source_type, sourceType));
   const meta = {
     ...providers.meta,
     count: data.length,

--- a/apps/koku-ui-hccm/webpack-onprem.config.ts
+++ b/apps/koku-ui-hccm/webpack-onprem.config.ts
@@ -111,8 +111,12 @@ const config: Configuration = {
     new DefinePlugin({
       'process.env.KOKU_UI_COMMITHASH': undefined,
       'process.env.KOKU_UI_PKGNAME': undefined,
-      'process.env.KOKU_UI_SETTINGS_DATA_RETENTION_PERIOD': JSON.stringify('true'),
-      'process.env.KOKU_UI_SETTINGS_SOURCES_TAB': JSON.stringify('true'),
+      'process.env.KOKU_UI_SETTINGS_DATA_RETENTION_PERIOD': JSON.stringify(
+        process.env.KOKU_UI_SETTINGS_DATA_RETENTION_PERIOD?.trim() || 'true'
+      ),
+      'process.env.KOKU_UI_SETTINGS_SOURCES_TAB': JSON.stringify(
+        process.env.KOKU_UI_SETTINGS_SOURCES_TAB?.trim() || 'true'
+      ),
       'process.env.ONPREM_UNLEASH_FLAGS': JSON.stringify(
         process.env.ONPREM_UNLEASH_FLAGS?.trim() ||
           [

--- a/apps/koku-ui-ros/src/routes/utils/providers.test.ts
+++ b/apps/koku-ui-ros/src/routes/utils/providers.test.ts
@@ -1,0 +1,34 @@
+import { ProviderType } from 'api/providers';
+import type { Providers } from 'api/providers';
+
+import { filterProviders, matchesProviderType } from './providers';
+
+describe('matchesProviderType', () => {
+  test('matches cloud and local source types', () => {
+    expect(matchesProviderType('AWS', ProviderType.aws)).toBe(true);
+    expect(matchesProviderType('AWS-local', ProviderType.aws)).toBe(true);
+    expect(matchesProviderType('Azure-local', ProviderType.azure)).toBe(true);
+    expect(matchesProviderType('GCP-local', ProviderType.gcp)).toBe(true);
+    expect(matchesProviderType('OCP', ProviderType.ocp)).toBe(true);
+  });
+
+  test('does not cross-match provider types', () => {
+    expect(matchesProviderType('AWS-local', ProviderType.azure)).toBe(false);
+    expect(matchesProviderType(undefined, ProviderType.aws)).toBe(false);
+  });
+});
+
+describe('filterProviders', () => {
+  const providers = {
+    meta: { count: 2 },
+    data: [
+      { name: 'Test AWS Source', source_type: 'AWS-local' },
+      { name: 'Test OCP', source_type: 'OCP' },
+    ],
+  } as Providers;
+
+  test('includes *-local sources', () => {
+    expect(filterProviders(providers, ProviderType.aws).data).toHaveLength(1);
+    expect(filterProviders(providers, ProviderType.ocp).data).toHaveLength(1);
+  });
+});

--- a/apps/koku-ui-ros/src/routes/utils/providers.ts
+++ b/apps/koku-ui-ros/src/routes/utils/providers.ts
@@ -1,5 +1,5 @@
 import type { Providers } from 'api/providers';
-import type { ProviderType } from 'api/providers';
+import { ProviderType } from 'api/providers';
 
 const enum DataType {
   currentMonthData = 'current_month_data',
@@ -22,6 +22,18 @@ const _getOcpProvider = (ocpProviders: Providers, uuid?: string) => {
   return result;
 };
 
+// True when API source_type matches ProviderType (case-insensitive).
+// Local koku/nise backends use AWS-local / Azure-local / GCP-local; treat those
+// as aws / azure / gcp without adding separate ProviderType values.
+export const matchesProviderType = (sourceType: string | undefined, providerType: ProviderType) => {
+  if (!sourceType || providerType === ProviderType.all) {
+    return false;
+  }
+  const normalized = sourceType.toLowerCase();
+  const baseType = normalized.endsWith('-local') ? normalized.slice(0, -'-local'.length) : normalized;
+  return baseType === providerType;
+};
+
 // Returns new Provider matching the given provider type
 //
 // See https://redhat.atlassian.net/browse/COST-2202
@@ -30,7 +42,7 @@ export const filterProviders = (providers: Providers, sourceType: ProviderType) 
     return providers;
   }
 
-  const data = providers.data.filter(provider => provider.source_type.toLowerCase() === sourceType);
+  const data = providers.data.filter(provider => matchesProviderType(provider.source_type, sourceType));
   const meta = {
     ...providers.meta,
     count: data.length,

--- a/package.json
+++ b/package.json
@@ -28,22 +28,26 @@
     "test": "npm exec --workspaces -- npm run test --",
     "test:update": "npm exec --workspaces -- npm run test:update",
     "quick:start:koku": "bash scripts/quick-start-koku.sh -c -k -n",
+    "quick:start:koku:onprem": "bash scripts/quick-start-koku.sh -c -k -n -o",
     "release:all": "node scripts/release-all.js",
     "start:hccm": "npm run -w @koku-ui/koku-ui-hccm start",
     "start:ros": "npm run -w @koku-ui/koku-ui-ros start",
     "start:onprem": "concurrently -k --names \"HOST,HCCM,ROS,SRCS,RBAC\" --prefix-colors \"yellow,cyan,magenta,green,blue\" \"npm run -w @koku-ui/koku-ui-onprem start\" \"npm run -w @koku-ui/koku-ui-hccm start:onprem\" \"npm run -w @koku-ui/koku-ui-ros start:onprem\" \"npm run -w @koku-ui/koku-ui-sources start:onprem\" \"npm run -w @koku-ui/rbac-ui-onprem start:onprem\"",
     "start:onprem:auth": ". scripts/setup-onprem-env.sh && scripts/start-onprem-auth.mts",
-    "start:onprem:koku": "API_TOKEN=false API_PROXY_URL=http://localhost:8000/api/cost-management/v1 npm run start:onprem"
+    "start:quick:start:koku": "API_TOKEN=false API_PROXY_URL=http://localhost:8000/api/cost-management/v1 KOKU_UI_SETTINGS_DATA_RETENTION_PERIOD=false KOKU_UI_SETTINGS_SOURCES_TAB=false npm run start:onprem",
+    "start:quick:start:koku:onprem": "API_TOKEN=false API_PROXY_URL=http://localhost:8000/api/cost-management/v1 npm run start:onprem"
   },
   "scripts-info": {
     "check:dependencies": "Checks for outdated dependencies in each workspace",
-    "quick:start:koku": "Start Koku and load sample cost data",
+    "quick:start:koku": "Start Koku (ONPREM=False) and load all sample cost data",
+    "quick:start:koku:onprem": "Start Koku (ONPREM=True) and load on-prem OCP sample data",
     "release:all": "Used to merge stage/prod branches and deploy app-interface with the latest SHA refs from same branches",
     "start:hccm": "Run Koku UI",
     "start:ros": "Run ROS UI",
     "start:onprem": "Run onprem UI",
     "start:onprem:auth": "Runs onprem UI against a deployment made with the cost-onprem Helm chart, behind a local oauth2-proxy container (real OIDC PKCE flow, login screen, session expiry, logout redirect) — requires Podman or Docker",
-    "start:onprem:koku": "Run onprem UI with local Koku API"
+    "start:quick:start:koku": "Run onprem UI with local Koku API (SaaS-local; data retention and Sources tab disabled)",
+    "start:quick:start:koku:onprem": "Run onprem UI with local Koku API (on-prem; data retention and Sources tab enabled)"
   },
   "devDependencies": {
     "@eslint/compat": "^2.1.0",

--- a/scripts/quick-start-koku.sh
+++ b/scripts/quick-start-koku.sh
@@ -8,13 +8,18 @@
 # sample cost data so you can develop and test koku-ui against
 # the latest koku source without a Red Hat SSO account.
 #
+# Modes (npm targets):
+#   npm run quick:start:koku         -> ONPREM=False, test_source=all
+#   npm run quick:start:koku:onprem  -> ONPREM=True,  test_source=ONPREM (-o)
+#
 # Expected directory layout (overridable via env vars):
 #   ../koku   -- project-koku/koku   (set KOKU_DIR to override)
 #   ../nise   -- project-koku/nise   (set NISE_DIR to override)
 #   .         -- project-koku/koku-ui (this repo)
 #
 # After this script completes, start the frontend with:
-#   npm run start:onprem:koku   -> http://localhost:9001
+#   npm run start:quick:start:koku         -> http://localhost:9001  (SaaS-local)
+#   npm run start:quick:start:koku:onprem  -> http://localhost:9001  (on-prem)
 #
 # See also: QUICK_START_KOKU.md
 # Based on: https://github.com/project-koku/koku-ui/pull/4976
@@ -91,6 +96,39 @@ default()
       fi
     fi
   done
+
+  # koku's load_test_customer_data.sh prefers a host `aws` CLI to verify OCP
+  # uploads. A broken leftover (common: old Homebrew/python3.7 aws) makes
+  # verification fail even when nise uploaded successfully. Shadow only `aws`
+  # with a containerized wrapper (do not strip its whole directory from PATH).
+  if command -v aws >/dev/null 2>&1; then
+    if ! aws --version >/dev/null 2>&1; then
+      echo "*** Ignoring broken aws CLI at $(command -v aws); using containerized aws-cli"
+      mkdir -p "$TMP_DIR/bin"
+      # load_test_customer_data.sh checks `command -v aws` first; a failing stub
+      # would skip the docker fallback and exit. Provide a working wrapper instead.
+      cat > "$TMP_DIR/bin/aws" <<EOF
+#!/bin/sh
+RUNTIME="${PODMAN:-docker}"
+exec "\$RUNTIME" run --rm --network host \\
+  -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e AWS_DEFAULT_REGION \\
+  amazon/aws-cli:latest "\$@"
+EOF
+      chmod +x "$TMP_DIR/bin/aws"
+      PATH="$TMP_DIR/bin:$PATH"
+      export PATH
+      hash -r 2>/dev/null || true
+    fi
+  fi
+
+  # Same script falls back to `docker` when aws is absent. On Podman-only
+  # machines, provide a temporary docker -> podman shim for that check.
+  if ! command -v docker >/dev/null 2>&1 && [ -n "$PODMAN" ]; then
+    mkdir -p "$TMP_DIR/bin"
+    ln -sf "$PODMAN" "$TMP_DIR/bin/docker"
+    PATH="$TMP_DIR/bin:$PATH"
+    export PATH
+  fi
 }
 
 # Verify that all required tools are installed and the environment is ready.
@@ -210,48 +248,38 @@ cat <<- EEOOFF
 
     Sets up the koku backend with sample cost data for local UI development.
 
-    bash [-x] $SCRIPT [-h|-c|-k|-n|-v]
+    bash [-x] $SCRIPT [-h|-c|-k|-n|-o|-v]
 
     OPTIONS:
     h       Display this message
     c       Clean previous build
     k       Create or update koku/.env
     n       Create or update nise/.env
+    o       On-prem mode (ONPREM=True, test_source=ONPREM)
+            Default without -o: SaaS/local mode (ONPREM=False, test_source=all)
     v       Verbose mode
 
 EEOOFF
 }
 
 # Tear down the koku virtualenv and stop/remove containers from a previous run.
-# Always destructive — removes volumes and all database data.
+# Always destructive — removes volumes (Postgres, S4/Hive warehouse) and all data.
+# Leaving the koku-s4-data volume causes Trino HIVE_PATH_ALREADY_EXISTS on the next
+# OCP summary (metastore empty, S3 path still present) so has_data never becomes true.
 clean()
 {
-  cd $KOKU_DIR
+  cd "$KOKU_DIR" || exit 1
 
   echo "*** Running make clean..."
   make clean >/dev/null 2>&1
 
-  if [ -d .venv ]; then
-    echo "*** Shutting down $PODMAN_COMPOSE..."
-    $PODMAN_COMPOSE down >/dev/null 2>&1
-  fi
-
-  # If this is a re-run (containers from a previous attempt exist in a broken state),
-  # Koku recommends running `make clean` first. We check for leftover Koku containers
-  # and suggest a clean if found. We do NOT run clean automatically because it is
-  # destructive (removes volumes and all data).
-  CONTAINERS=$($PODMAN ps -a --format "{{.Names}}" 2>/dev/null | grep -c "^koku" || true)
-  if [ "$CONTAINERS" -gt 0 ]; then
-    echo -e "\n*** Found $CONTAINERS Koku container(s) from a previous run"
-    echo "If this is a fresh start after a failed attempt, consider running:"
-cat <<- EEOOFF
-  make DOCKER="$PODMAN" docker-down
-EEOOFF
-
-    runCommand
-    if [ -n "$RUN_COMMAND" ];then
-      make DOCKER="$PODMAN" docker-down
-    fi
+  echo "*** Shutting down stack and wiping volumes (including S4/Hive data)..."
+  echo "    make DOCKER=\"$PODMAN\" docker-down"
+  runCommand
+  if [ -n "$RUN_COMMAND" ]; then
+    make DOCKER="$PODMAN" docker-down >/dev/null 2>&1 || true
+    # Belt-and-suspenders: compose may leave the named volume if labels differ.
+    $PODMAN volume rm -f koku-s4-data >/dev/null 2>&1 || true
   fi
 }
 
@@ -264,24 +292,31 @@ cleanup()
   exit 0
 }
 
-# Print the command to start the koku-ui-onprem frontend once the backend is ready.
+# Print the command to start the frontend once the backend is ready.
 frontend() {
   echo -e "\n*** To start the frontend, run:"
 
+  if [ -n "$MODE_ONPREM" ]; then
 cat <<- EEOOFF
-  npm run start:onprem:koku
-    -> http://localhost:9001 no SSO login required
-    -> proxies /api/cost-management/v1/* to your local koku backend
-    -> runs koku-ui-hccm + koku-ui-ros via webpack Module Federation
+  npm run start:quick:start:koku:onprem
+    -> http://localhost:9001  (on-prem UI, no SSO)
+    -> proxies /api/cost-management/v1/* to local koku (ONPREM=True)
 EEOOFF
+  else
+cat <<- EEOOFF
+  npm run start:quick:start:koku
+    -> http://localhost:9001  (no SSO; good for local API testing)
+    -> proxies /api/cost-management/v1/* to local koku (ONPREM=False, full providers)
+EEOOFF
+  fi
 }
 
 # Create or update koku/.env with values required for local development:
-# local-dev AWS credentials, API path prefixes, Unleash tokens, and the
+# S4 object-store credentials, API path prefixes, Unleash tokens, and the
 # current user/group IDs required by docker-compose.yml.
 kokuEnv()
 {
-  cd $KOKU_DIR
+  cd "$KOKU_DIR" || exit 1
 
   if [[ ! -f .env && -n "$KOKU_ENV" ]]; then
     echo -e "\n*** Copying $KOKU_DIR/.env.example..."
@@ -302,40 +337,66 @@ kokuEnv()
     # Second pass (sed below): overwrite all known keys to their local-dev values.
     # Together these handle both a freshly copied .env.example and a previously
     # customised .env without leaving stale or duplicate entries.
-    if ! grep -q "AWS_ACCESS_KEY_ID=" .env 2>/dev/null; then
+    # Match only active assignments (^KEY=). A commented "# KEY=..." must not
+    # skip the append — otherwise sed can leave the real value unset.
+    if ! grep -q "^AWS_ACCESS_KEY_ID=" .env 2>/dev/null; then
       echo "AWS_ACCESS_KEY_ID=local-dev" >> .env
     fi
-    if ! grep -q "AWS_SECRET_ACCESS_KEY=" .env 2>/dev/null; then
+    if ! grep -q "^AWS_SECRET_ACCESS_KEY=" .env 2>/dev/null; then
       echo "AWS_SECRET_ACCESS_KEY=local-dev" >> .env
     fi
-    if ! grep -q "KOKU_API_PATH_PREFIX=" .env 2>/dev/null; then
+    if ! grep -q "^CURRENCY_URL=" .env 2>/dev/null; then
+      echo "CURRENCY_URL=https://open.er-api.com/v6/latest/USD" >> .env
+    fi
+    if ! grep -q "^KOKU_API_PATH_PREFIX=" .env 2>/dev/null; then
       echo "KOKU_API_PATH_PREFIX='/api/cost-management'" >> .env
     fi
-    if ! grep -q "MASU_API_PATH_PREFIX=" .env 2>/dev/null; then
+    if ! grep -q "^MASU_API_PATH_PREFIX=" .env 2>/dev/null; then
       echo "MASU_API_PATH_PREFIX='/api/cost-management'" >> .env
     fi
-    if ! grep -q "GROUP_ID=" .env 2>/dev/null; then
+    if ! grep -q "^GROUP_ID=" .env 2>/dev/null; then
       echo "GROUP_ID=$(id -g)" >> .env
     fi
-    if ! grep -q "USER_ID=" .env 2>/dev/null; then
+    if ! grep -q "^USER_ID=" .env 2>/dev/null; then
       echo "USER_ID=$(id -u)" >> .env
     fi
-#    if ! grep -q "ONPREM=" .env 2>/dev/null; then
-#      echo "ONPREM=True" >> .env
-#    fi
+    if ! grep -q "^ONPREM=" .env 2>/dev/null; then
+      echo "ONPREM=${ONPREM_VALUE}" >> .env
+    fi
+    if ! grep -q "^S3_ACCESS_KEY=" .env 2>/dev/null; then
+      echo "S3_ACCESS_KEY=s4admin" >> .env
+    fi
+    if ! grep -q "^S3_SECRET=" .env 2>/dev/null; then
+      echo "S3_SECRET=s4secret" >> .env
+    fi
+    if ! grep -q "^S3_ENDPOINT=" .env 2>/dev/null; then
+      echo "S3_ENDPOINT=http://localhost:9000" >> .env
+    fi
+    if ! grep -q "^S4_PROXY_ENDPOINT=" .env 2>/dev/null; then
+      echo "S4_PROXY_ENDPOINT=http://koku-s4-proxy:7480" >> .env
+    fi
 
-#       -e "s|ONPREM=.*|ONPREM=True|" \
-    sed -e "s|AWS_ACCESS_KEY_ID=.*|AWS_ACCESS_KEY_ID=local-dev|" \
-        -e "s|AWS_SECRET_ACCESS_KEY=.*|AWS_SECRET_ACCESS_KEY=local-dev|" \
-        -e "s|# GROUP_ID=.*|GROUP_ID=|" \
-        -e "s|GROUP_ID=.*|GROUP_ID=$(id -g)|" \
-        -e "s|KOKU_API_PATH_PREFIX=.*|KOKU_API_PATH_PREFIX='/api/cost-management'|" \
-        -e "s|MASU_API_PATH_PREFIX=.*|MASU_API_PATH_PREFIX='/api/cost-management'|" \
-        -e "s|S3_ENDPOINT=.*|S3_ENDPOINT=http://localhost:9000|" \
-        -e "s|UNLEASH_ADMIN_TOKEN=.*|UNLEASH_ADMIN_TOKEN=*:*.unleash-insecure-api-token|" \
-        -e "s|UNLEASH_TOKEN=.*|UNLEASH_TOKEN=default:development.unleash-insecure-api-token|" \
-        -e "s|# USER_ID=.*|USER_ID=|" \
-        -e "s|USER_ID=.*|USER_ID=$(id -u)|" .env > .env.tmp
+    # Apple Silicon: the default S4 image is amd64; prefer the arm64 build when
+    # present so Podman does not need qemu emulation for the object store.
+    # Overridable: set S4_IMAGE in .env before -k, or export it in the shell.
+    if [[ "$(uname -m)" == "arm64" ]] && ! grep -q "^S4_IMAGE=" .env 2>/dev/null; then
+      echo "S4_IMAGE=quay.io/dnakabaa/s4:0.3.2-arm64" >> .env
+    fi
+
+    sed -e "s|^[# ]*AWS_ACCESS_KEY_ID=.*|AWS_ACCESS_KEY_ID=local-dev|" \
+        -e "s|^[# ]*AWS_SECRET_ACCESS_KEY=.*|AWS_SECRET_ACCESS_KEY=local-dev|" \
+        -e "s|^[# ]*CURRENCY_URL=.*|CURRENCY_URL=https://open.er-api.com/v6/latest/USD|" \
+        -e "s|^[# ]*GROUP_ID=.*|GROUP_ID=$(id -g)|" \
+        -e "s|^[# ]*KOKU_API_PATH_PREFIX=.*|KOKU_API_PATH_PREFIX='/api/cost-management'|" \
+        -e "s|^[# ]*MASU_API_PATH_PREFIX=.*|MASU_API_PATH_PREFIX='/api/cost-management'|" \
+        -e "s|^[# ]*ONPREM=.*|ONPREM=${ONPREM_VALUE}|" \
+        -e "s|^[# ]*S3_ACCESS_KEY=.*|S3_ACCESS_KEY=s4admin|" \
+        -e "s|^[# ]*S3_SECRET=.*|S3_SECRET=s4secret|" \
+        -e "s|^[# ]*S3_ENDPOINT=.*|S3_ENDPOINT=http://localhost:9000|" \
+        -e "s|^[# ]*S4_PROXY_ENDPOINT=.*|S4_PROXY_ENDPOINT=http://koku-s4-proxy:7480|" \
+        -e "s|^[# ]*UNLEASH_ADMIN_TOKEN=.*|UNLEASH_ADMIN_TOKEN=*:*.unleash-insecure-api-token|" \
+        -e "s|^[# ]*UNLEASH_TOKEN=.*|UNLEASH_TOKEN=default:development.unleash-insecure-api-token|" \
+        -e "s|^[# ]*USER_ID=.*|USER_ID=$(id -u)|" .env > .env.tmp
 
     mv .env.tmp .env
   fi
@@ -344,7 +405,7 @@ kokuEnv()
 # Create a fresh Python 3.11 virtualenv for the koku repo using pipenv.
 # Always deletes the existing .venv first to ensure a clean, reproducible install.
 kokuVEnv() {
-  cd $KOKU_DIR
+  cd "$KOKU_DIR" || exit 1
 
   echo "*** Deleting Koku virtual env..."
   rm -rf .venv
@@ -365,36 +426,25 @@ kokuVEnv() {
   $PIPENV_BIN run pre-commit install
 }
 
-# Start the full koku backend stack via podman compose and wait up to 3 minutes
-# for the API to become healthy. Applies compose overrides to work around two
-# Podman quirks: port ranges and legacy 'links:' directives.
+# Start the full koku backend stack via podman compose and wait for the API.
+# Applies a compose override for a Podman quirk with worker port ranges.
+#
+# We deliberately avoid `compose up` dependency health waits (depends_on:
+# condition: service_healthy / compose --wait). With Podman + docker-compose,
+# those waits can hang indefinitely even after containers are healthy
+# (commonly on `up -d unleash`). Dependencies are started with --no-deps and
+# polled directly instead.
 kokuServices() {
-  cd $KOKU_DIR
+  cd "$KOKU_DIR" || exit 1
 
-  # docker-up-min-trino starts PostgreSQL, Valkey, Unleash, koku-server,
-  # masu-server, koku-worker, Trino, MinIO, and Hive metastore.
-  # First run pulls ~1-2 GB of images. Subsequent starts are fast.
-  #
-  # Pass DOCKER=podman explicitly so the koku Makefile routes all compose
-  # operations through Podman, even on machines where Docker is also installed.
-  # Without this override, the Makefile's auto-detection picks Docker first.
-  #
-  # Podman's Docker-compat API has two quirks that require compose overrides:
-  #   1. koku-worker maps host ports 6001-6020 to container port 9000. Podman
-  #      rejects port ranges ("strconv.Atoi: parsing "6001-6020": invalid
-  #      syntax"). Replace the range with a single mapping — sufficient for
-  #      one local worker instance.
-  #   2. Trino uses a legacy `links:` directive. Podman rejects links entirely
-  #      ("bad parameter: link is not supported"). Services on a shared compose
-  #      network can reach each other by name already, so links are redundant.
+  # Podman quirk: koku-worker maps host ports 6001-6020 to container port 9000.
+  # Podman rejects port ranges ("strconv.Atoi: parsing "6001-6020": invalid
+  # syntax"). Clear published ports entirely so we can also scale workers during
+  # data load without host-port collisions.
 cat <<- EEOOFF > $PODMAN_OVERRIDE_FILE
 services:
   koku-worker:
     ports: !reset
-      - "6001:9000"
-      - "5678:5678"
-  trino:
-    links: !reset
 EEOOFF
 
   # Export USER_ID and GROUP_ID so docker-compose.yml's ${USER_ID:?} / ${GROUP_ID:?}
@@ -403,32 +453,156 @@ EEOOFF
   export USER_ID=$(id -u)
   export GROUP_ID=$(id -g)
 
-  echo -e "\n*** Starting the full stack with Trino..."
-  $PIPENV_BIN run make DOCKER="$PODMAN" \
-    COMPOSE_FILES="-f docker-compose.yml -f $PODMAN_OVERRIDE_FILE" \
-    docker-up-min-trino
+  # Non-empty AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY keep Trino's Glue
+  # connector from NPEing. koku uses hive/thrift locally, so dummy values
+  # (local-dev) are fine — these are not the S4 S3_ACCESS_KEY/S3_SECRET pair.
+  if [ -z "${AWS_ACCESS_KEY_ID:-}" ]; then
+    export AWS_ACCESS_KEY_ID=local-dev
+  fi
+  if [ -z "${AWS_SECRET_ACCESS_KEY:-}" ]; then
+    export AWS_SECRET_ACCESS_KEY=local-dev
+  fi
 
-  # Koku's .env sets AWS_ACCESS_KEY_ID= (empty string). Compose's
-  # ${VAR-default} syntax only substitutes when the variable is UNSET, not empty,
-  # so the blank value flows into Trino's Glue connector, which NPEs with
-  # "Access key ID cannot be blank". koku uses hive/thrift, not AWS Glue, so a
-  # dummy value is safe. Always force-recreate Trino with non-empty credentials.
-  #
-  # The PODMAN_OVERRIDE_FILE override (links: !reset) is reused here so the Trino
-  # recreate doesn't hit the same Podman link-not-supported rejection.
-  echo -e "\n*** Restarting Trino with local-dev credentials (Glue connector fix)"
-  export AWS_ACCESS_KEY_ID=local-dev
-  export AWS_SECRET_ACCESS_KEY=local-dev
-  $PODMAN_COMPOSE -f docker-compose.yml -f "$PODMAN_OVERRIDE_FILE" up -d --no-deps --force-recreate trino 2>&1
+  compose() {
+    $PODMAN_COMPOSE -f docker-compose.yml -f "$PODMAN_OVERRIDE_FILE" "$@"
+  }
+
+  waitForHealthy() {
+    local name=$1
+    local max_wait=${2:-180}
+    local elapsed=0
+    echo "    waiting for $name to be healthy (up to ${max_wait}s)..."
+    while [ "$elapsed" -lt "$max_wait" ]; do
+      # Require Running=true. After OOM, Podman can still report Health=healthy
+      # on an exited container — that must not count as ready.
+      local running health
+      running=$($PODMAN inspect --format '{{.State.Running}}' "$name" 2>/dev/null || echo false)
+      health=$($PODMAN inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}running{{end}}' "$name" 2>/dev/null || echo missing)
+      if [ "$running" = "true" ] && { [ "$health" = "healthy" ] || [ "$health" = "running" ]; }; then
+        echo "    $name is $health"
+        return 0
+      fi
+      echo -n "."
+      sleep 2
+      elapsed=$(( elapsed + 2 ))
+    done
+    echo -e "\nError: $name did not become healthy within ${max_wait}s (running=$running health=$health)"
+    $PODMAN logs --tail 40 "$name" 2>&1 || true
+    return 1
+  }
+
+  waitForHttp() {
+    local url=$1
+    local max_wait=${2:-120}
+    local elapsed=0
+    echo "    waiting for $url (up to ${max_wait}s)..."
+    while [ "$elapsed" -lt "$max_wait" ]; do
+      if curl -sf --max-time 3 "$url" >/dev/null 2>&1; then
+        echo "    $url is ready"
+        return 0
+      fi
+      echo -n "."
+      sleep 2
+      elapsed=$(( elapsed + 2 ))
+    done
+    echo -e "\nError: $url did not respond within ${max_wait}s"
+    return 1
+  }
+
+  waitForExit() {
+    local name=$1
+    local max_wait=${2:-60}
+    local elapsed=0
+    while [ "$elapsed" -lt "$max_wait" ]; do
+      local status
+      status=$($PODMAN inspect --format '{{.State.Status}}' "$name" 2>/dev/null || echo missing)
+      if [ "$status" = "exited" ]; then
+        local code
+        code=$($PODMAN inspect --format '{{.State.ExitCode}}' "$name" 2>/dev/null || echo 1)
+        if [ "$code" = "0" ]; then
+          return 0
+        fi
+        echo "Error: $name exited with code $code"
+        $PODMAN logs --tail 40 "$name" 2>&1 || true
+        return 1
+      fi
+      sleep 1
+      elapsed=$(( elapsed + 1 ))
+    done
+    echo "Error: $name did not exit within ${max_wait}s"
+    return 1
+  }
+
+  echo -e "\n*** Building koku base image (first run can take several minutes)..."
+  if ! $PIPENV_BIN run make DOCKER="$PODMAN" \
+    COMPOSE_FILES="-f docker-compose.yml -f $PODMAN_OVERRIDE_FILE" \
+    docker-host-dir-setup docker-build; then
+    echo "Error: make docker-build failed"
+    exit 1
+  fi
+
+  echo -e "\n*** Starting database..."
+  compose up -d --no-deps db
+  waitForHealthy koku-db 120 || exit 1
+
+  echo -e "\n*** Starting Unleash..."
+  compose up -d --no-deps unleash
+  waitForHttp "http://localhost:4242/health" 120 || exit 1
+  echo "*** Configuring Unleash flags..."
+  if ! $PIPENV_BIN run $PYTHON_BIN dev/scripts/setup_unleash.py; then
+    echo "Error: setup_unleash.py failed"
+    exit 1
+  fi
+
+  echo -e "\n*** Starting S4 (object storage)..."
+  compose up -d --no-deps s4-data-init
+  # Compose names one-shot containers <project>-<service>-<n>
+  local s4_init
+  s4_init=$($PODMAN ps -a --format '{{.Names}}' | grep -E 's4-data-init' | head -1)
+  if [ -n "$s4_init" ]; then
+    waitForExit "$s4_init" 60 || exit 1
+  fi
+  compose up -d --no-deps s4
+  waitForHealthy koku-s4 180 || exit 1
+  compose up -d --no-deps s4-path-proxy
+  waitForHealthy koku-s4-proxy 120 || exit 1
+
+  echo -e "\n*** Creating S3 buckets..."
+  if ! compose run --rm --no-deps create-s3-buckets; then
+    echo "Error: create-s3-buckets failed"
+    echo "Expected S4 credentials: S3_ACCESS_KEY=s4admin S3_SECRET=s4secret"
+    echo "Re-run with -k to refresh .env, or: cd $KOKU_DIR && cp .env.example .env"
+    exit 1
+  fi
+
+  echo -e "\n*** Starting Hive metastore and Trino..."
+  compose up -d --no-deps hive-metastore
+  compose up -d --no-deps trino
+  waitForHealthy trino 180 || exit 1
+
+  echo -e "\n*** Starting Valkey, koku-server, masu-server, and worker..."
+  compose up -d --no-deps valkey
+  compose up -d --no-deps koku-base
+  compose up -d --no-deps koku-server
+  compose up -d --no-deps masu-server
+  compose up -d --no-deps --scale koku-worker=1 koku-worker
 
   echo -e "\n*** To check all services are up, run:"
 cat <<- EEOOFF
-  $PODMAN_COMPOSE ps
+  $PODMAN_COMPOSE -f docker-compose.yml -f $PODMAN_OVERRIDE_FILE ps
 EEOOFF
 
   runCommand
   if [ -n "$RUN_COMMAND" ];then
-    $PODMAN_COMPOSE ps
+    compose ps
+  fi
+
+  # Fail fast if the API container never started (e.g. make aborted mid-stack).
+  # Compose names the container koku_server (underscore).
+  if ! $PODMAN ps --format '{{.Names}}' | grep -qx 'koku_server'; then
+    echo "Error: koku_server container is not running"
+    echo "Check logs: cd $KOKU_DIR && $PODMAN logs --tail 80 koku_server"
+    exit 1
   fi
 
   echo -e "\n*** To verify koku-server API responds, run:"
@@ -436,7 +610,9 @@ cat <<- EEOOFF
   curl -s http://localhost:8000/api/cost-management/v1/status/ | python3 -m json.tool
 EEOOFF
 
-  MAX_WAIT=180 # seconds total before giving up
+  # Fresh DB after -c runs all Django migrations on first boot; 3 minutes is often
+  # not enough. Allow up to 5 minutes and surface container logs on timeout.
+  MAX_WAIT=300 # seconds total before giving up
   MAX_WAIT_MIN=$(( MAX_WAIT / 60 ))
   POLL_INTERVAL=2 # seconds between health-check attempts
   MAX_TRIES=$(( MAX_WAIT / POLL_INTERVAL ))
@@ -453,13 +629,14 @@ EEOOFF
   done
   if [ -z "$SERVER_UP" ]; then
     echo -e "\n*** koku-server did not respond after ${MAX_WAIT_MIN} minutes"
+    echo "*** Recent koku_server logs:"
+    $PODMAN logs --tail 40 koku_server 2>&1 || true
     exit 1
   fi
 
   # Also wait for masu-server (port 5042). load_test_customer_data.sh checks masu
   # with a single curl and exits immediately if it is not ready. masu depends on
-  # trino being healthy (added in koku commit ed1fb1e75), so after the trino
-  # force-recreate above it may lag koku-server by 30+ seconds.
+  # trino being healthy, so it may lag koku-server.
 
   echo -e "\n*** To verify masu-server API responds, run:"
 cat <<- EEOOFF
@@ -479,26 +656,374 @@ EEOOFF
   done
   if [ -z "$MASU_UP" ]; then
     echo -e "\n*** masu-server did not respond after ${MAX_WAIT_MIN} minutes"
+    echo "*** Recent masu_server logs:"
+    $PODMAN logs --tail 40 masu_server 2>&1 || true
     exit 1
   fi
 
-  echo -e "\n***"
-
-cat <<- EEOOFF
-  Koku API   -> http://localhost:8000/api/cost-management/v1/status/
-  MASU       -> http://localhost:5042
-  PostgreSQL -> localhost:15432 (user: koku, db: koku)
-
-  Logs:      -> cd $KOKU_DIR && $PODMAN logs -f koku-server koku-worker
-  Restart:   -> cd $KOKU_DIR && $PODMAN_COMPOSE start
-EEOOFF
+  echo -e "\n*** Services are up (see verify output at the end for status and shutdown)"
 }
 
-# Create a test customer account and seed sample cost data for all provider types
-# (AWS, Azure, GCP, OCP). The koku-worker processes uploaded data asynchronously —
-# reports may take a minute or two to populate after this function returns.
+# Resolve a running koku-worker container name (compose may use -1, -2, …).
+kokuWorkerContainer() {
+  $PODMAN ps --format '{{.Names}}' 2>/dev/null | grep -E 'koku[-_]koku-worker' | head -n1
+}
+
+# Poll the sources API until the named source reports has_data=true.
+# Returns 0 on success, 1 on timeout. Used after nise/masu ingest because
+# load_test_customer_data.sh only waits ~8 minutes and may log a false failure
+# while the worker is still summarizing.
+waitForSourceHasData() {
+  local source_name=$1
+  local max_wait=${2:-600} # seconds
+  local poll=10
+  local elapsed=0
+  local has_data=
+
+  echo -e "\n*** Waiting for source \"$source_name\" to report has_data=true (up to $(( max_wait / 60 )) min)..."
+  # Bust Django cache_page on /sources/ so we do not sit on stale has_data=false.
+  $PODMAN exec koku_valkey valkey-cli FLUSHDB >/dev/null 2>&1 || true
+  while [ "$elapsed" -lt "$max_wait" ]; do
+    has_data=$(curl -sf "http://localhost:8000/api/cost-management/v1/sources/?type=OCP&limit=100&_ts=${elapsed}" 2>/dev/null | \
+      $PYTHON_BIN -c "
+import json, sys
+name = sys.argv[1]
+try:
+    data = json.load(sys.stdin).get('data') or []
+except Exception:
+    data = []
+for s in data:
+    if s.get('name') == name:
+        print('true' if s.get('has_data') else 'false')
+        break
+else:
+    print('missing')
+" "$source_name" 2>/dev/null || echo "error")
+
+    if [ "$has_data" = "true" ]; then
+      echo "  \"$source_name\" has_data=true"
+      return 0
+    fi
+    echo -n "."
+    sleep "$poll"
+    elapsed=$(( elapsed + poll ))
+  done
+  echo -e "\n*** Timed out waiting for \"$source_name\" (last status: $has_data)"
+  local worker
+  worker=$(kokuWorkerContainer)
+  if [ -n "$worker" ] && $PODMAN logs --since 30m "$worker" 2>/dev/null | grep -q 'HIVE_PATH_ALREADY_EXISTS'; then
+    echo "Worker logs show Trino HIVE_PATH_ALREADY_EXISTS — stale S4/Hive warehouse data."
+    echo "Re-run with a full wipe: npm run quick:start:koku   # includes -c"
+    echo "Or: cd $KOKU_DIR && make DOCKER=\"$PODMAN\" docker-down && $PODMAN volume rm -f koku-s4-data"
+  fi
+  return 1
+}
+
+# Print name/type/has_data for every source (used by verify and ensureAllSourcesHaveData).
+printSourcesHasData() {
+  if ! curl -sf --max-time 10 'http://localhost:8000/api/cost-management/v1/sources/?limit=100' 2>/dev/null | \
+    $PYTHON_BIN -c "
+import json, sys
+try:
+    data = json.load(sys.stdin).get('data') or []
+except Exception:
+    print('  (unable to parse sources response)')
+    sys.exit(1)
+if not data:
+    print('  (no sources found)')
+    sys.exit(0)
+print(f\"  {'name':<36} {'type':<12} has_data\")
+print('  ' + '-' * 56)
+for s in sorted(data, key=lambda x: ((x.get('source_type') or ''), (x.get('name') or ''))):
+    name = s.get('name') or ''
+    stype = s.get('source_type') or ''
+    has = 'true' if s.get('has_data') else 'false'
+    print(f'  {name:<36} {stype:<12} {has}')
+ok = sum(1 for s in data if s.get('has_data'))
+print(f'  {ok}/{len(data)} sources have data')
+"; then
+    echo "  (API not reachable — is koku-server up?)"
+    return 1
+  fi
+}
+
+# Names of sources that still have has_data=false.
+# On-prem mode only requires "Test OCP on Premises"; full mode requires every source.
+sourcesMissingData() {
+  local mode_filter=${1:-}
+  curl -sf --max-time 10 'http://localhost:8000/api/cost-management/v1/sources/?limit=100' 2>/dev/null | \
+    $PYTHON_BIN -c "
+import json, sys
+mode = sys.argv[1]
+try:
+    data = json.load(sys.stdin).get('data') or []
+except Exception:
+    sys.exit(0)
+if mode == 'onprem':
+    data = [s for s in data if s.get('name') == 'Test OCP on Premises']
+for s in data:
+    if not s.get('has_data'):
+        print(s.get('name') or '')
+" "$mode_filter" 2>/dev/null
+}
+
+# Map a source name to the load-test-customer-data test_source value to reload it.
+providerForSource() {
+  case "$1" in
+    "Test OCP on Premises") echo ONPREM ;;
+    "Test OCP on AWS"|"Test AWS Source") echo AWS ;;
+    "Test OCP on Azure"|"Test Azure Source"|"Test Azure v2 Source") echo AZURE ;;
+    "Test OCP on GCP"|"Test OCP on GCP duplicate"|"Test GCP Source"|"Test OCPGCP Source") echo GCP ;;
+    *) echo "" ;;
+  esac
+}
+
+# True when a container is actually running and healthy (or has no healthcheck).
+# Podman keeps the last Health.Status after OOM/exit — e.g. trino can show
+# Health=healthy while State.Running=false. Never trust health alone.
+isContainerUsable() {
+  local name=$1
+  local running health
+  running=$($PODMAN inspect --format '{{.State.Running}}' "$name" 2>/dev/null || echo false)
+  [ "$running" = "true" ] || return 1
+  health=$($PODMAN inspect --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}running{{end}}' "$name" 2>/dev/null || echo missing)
+  [ "$health" = "healthy" ] || [ "$health" = "running" ]
+}
+
+# Ensure Trino is running and healthy (common cause of late OCP has_data=false).
+ensureTrinoHealthy() {
+  if isContainerUsable trino; then
+    return 0
+  fi
+
+  local running oom
+  running=$($PODMAN inspect --format '{{.State.Running}}' trino 2>/dev/null || echo false)
+  oom=$($PODMAN inspect --format '{{.State.OOMKilled}}' trino 2>/dev/null || echo false)
+  echo "*** Trino is not usable (running=$running oom_killed=$oom) — recreating..."
+
+  # Force recreate: `start` after OOM often leaves a broken container; recreate
+  # re-attaches DNS so workers can resolve host `trino` again.
+  if [ -f "$PODMAN_OVERRIDE_FILE" ]; then
+    $PODMAN_COMPOSE -f docker-compose.yml -f "$PODMAN_OVERRIDE_FILE" \
+      up -d --no-deps --force-recreate trino >/dev/null 2>&1 \
+      || $PODMAN start trino >/dev/null 2>&1 \
+      || true
+  else
+    $PODMAN start trino >/dev/null 2>&1 || $PODMAN restart trino >/dev/null 2>&1 || true
+  fi
+
+  local elapsed=0
+  local max_wait=180
+  while [ "$elapsed" -lt "$max_wait" ]; do
+    if isContainerUsable trino; then
+      echo "    trino is usable"
+      return 0
+    fi
+    echo -n "."
+    sleep 2
+    elapsed=$(( elapsed + 2 ))
+  done
+  echo -e "\nError: trino did not become usable within ${max_wait}s"
+  $PODMAN logs --tail 40 trino 2>&1 || true
+  return 1
+}
+
+# Poll until every required source has has_data=true (or timeout).
+waitForAllSourcesHaveData() {
+  local max_wait=${1:-600}
+  local mode_filter=${2:-}
+  local poll=15
+  local elapsed=0
+  local missing=
+
+  echo -e "\n*** Waiting for all required sources to report has_data=true (up to $(( max_wait / 60 )) min)..."
+  $PODMAN exec koku_valkey valkey-cli FLUSHDB >/dev/null 2>&1 || true
+
+  while [ "$elapsed" -lt "$max_wait" ]; do
+    # Trino often OOMs during multi-cloud ingest; revive it so in-flight
+    # Premises/OCP summary can finish instead of sitting on processing=failed.
+    if ! isContainerUsable trino; then
+      echo -e "\n  trino went down during wait — recovering..."
+      ensureTrinoHealthy || true
+    fi
+
+    missing=$(sourcesMissingData "$mode_filter" | tr '\n' ' ' | sed 's/[[:space:]]*$//')
+    if [ -z "$missing" ]; then
+      echo "  all required sources have data"
+      printSourcesHasData || true
+      return 0
+    fi
+    if [ $(( elapsed % 60 )) -eq 0 ]; then
+      echo "  still waiting on: $missing"
+    else
+      echo -n "."
+    fi
+    sleep "$poll"
+    elapsed=$(( elapsed + poll ))
+  done
+
+  echo -e "\n*** Timed out; sources still without data:"
+  sourcesMissingData "$mode_filter" | sed 's/^/  - /'
+  printSourcesHasData || true
+  return 1
+}
+
+# After load, require has_data for all expected sources. If any are missing,
+# fix common failures (Trino down, stale Hive paths) and reload only the
+# provider groups that still need data.
+ensureAllSourcesHaveData() {
+  local load_fn=$1   # name of function that accepts a test_source arg
+  local mode_filter=
+  if [ -n "$MODE_ONPREM" ]; then
+    mode_filter=onprem
+  fi
+
+  local round
+  for round in 1 2 3; do
+    # Trino OOM/exits mid-load leave late OCP sources stuck forever — fix first.
+    if ! ensureTrinoHealthy; then
+      echo "Error: Trino is required for OCP summary / has_data"
+      return 1
+    fi
+
+    if waitForAllSourcesHaveData 600 "$mode_filter"; then
+      return 0
+    fi
+
+    local missing
+    missing=$(sourcesMissingData "$mode_filter")
+    if [ -z "$missing" ]; then
+      return 0
+    fi
+
+    echo -e "\n*** Remediation round $round/3 for sources without data:"
+    echo "$missing" | sed 's/^/  - /'
+
+    # Free RAM before reload — Trino is often OOM-killed while 3 workers +
+    # multi-cloud ingest are running. Premises reload needs Trino alive.
+    echo "*** Scaling koku-worker to 1 to free memory for Trino..."
+    if [ -f "$PODMAN_OVERRIDE_FILE" ]; then
+      $PODMAN_COMPOSE -f docker-compose.yml -f "$PODMAN_OVERRIDE_FILE" \
+        up -d --no-deps --scale koku-worker=1 koku-worker >/dev/null 2>&1 || true
+    fi
+    if ! ensureTrinoHealthy; then
+      echo "Error: Trino is required for OCP summary / has_data"
+      return 1
+    fi
+
+    local worker
+    worker=$(kokuWorkerContainer)
+    if [ -n "$worker" ] && $PODMAN logs --since 60m "$worker" 2>/dev/null | grep -q 'HIVE_PATH_ALREADY_EXISTS'; then
+      echo "*** Detected HIVE_PATH_ALREADY_EXISTS — clearing stale Hive paths..."
+    fi
+    # Clear orphans before reload (summary can fail when Trino died mid-create).
+    clearStaleHivePaths
+
+    # Unique provider reloads for the missing sources (AWS / AZURE / GCP / ONPREM).
+    local providers=""
+    local name prov
+    while IFS= read -r name; do
+      [ -z "$name" ] && continue
+      prov=$(providerForSource "$name")
+      if [ -n "$prov" ] && ! echo " $providers " | grep -q " $prov "; then
+        providers="$providers $prov"
+      fi
+    done <<< "$missing"
+
+    if [ -z "$(echo "$providers" | tr -d ' ')" ]; then
+      echo "Error: could not map missing sources to a reload provider"
+      return 1
+    fi
+
+    for prov in $providers; do
+      echo -e "\n*** Reloading test_source=$prov after remediation..."
+      "$load_fn" "$prov"
+    done
+  done
+
+  if ! ensureTrinoHealthy; then
+    return 1
+  fi
+  if waitForAllSourcesHaveData 300 "$mode_filter"; then
+    return 0
+  fi
+
+  echo "Error: not all required sources have has_data=true after remediation"
+  echo "Check: trino status, worker logs, and S4/Hive warehouse"
+  return 1
+}
+
+# Remove leftover Hive managed-table objects under the local S4 warehouse.
+# CREATE TABLE IF NOT EXISTS only checks the metastore; an orphaned S3 path makes
+# Trino fail with HIVE_PATH_ALREADY_EXISTS and OCP has_data never becomes true.
+# Deletes go to koku-s4 directly (path proxy remaps list keys and can no-op deletes).
+# Only restart S4 when objects were removed (RGW can keep ghost LIST entries).
+clearStaleHivePaths() {
+  echo -e "\n*** Clearing stale Hive warehouse paths in S4 (if any)..."
+  local worker
+  worker=$(kokuWorkerContainer)
+  if [ -z "$worker" ]; then
+    echo "    no koku-worker container found; skipping"
+    return 0
+  fi
+  local deleted_count
+  deleted_count=$($PODMAN exec "$worker" python - <<'PY' || echo 0
+import boto3
+from botocore.client import Config
+
+s3 = boto3.client(
+    "s3",
+    endpoint_url="http://koku-s4:7480",
+    aws_access_key_id="s4admin",
+    aws_secret_access_key="s4secret",
+    config=Config(signature_version="s3v4"),
+)
+bucket = "koku-bucket"
+# Physical short paths from koku/dev/containers/s4-path-proxy/path_maps.yaml
+prefixes = [f"1/{i}/" for i in range(1, 13)]
+total = 0
+for prefix in prefixes:
+    token = None
+    while True:
+        kw = {"Bucket": bucket, "Prefix": prefix, "MaxKeys": 1000}
+        if token:
+            kw["ContinuationToken"] = token
+        resp = s3.list_objects_v2(**kw)
+        objs = [{"Key": c["Key"]} for c in resp.get("Contents") or []]
+        if objs:
+            s3.delete_objects(Bucket=bucket, Delete={"Objects": objs, "Quiet": True})
+            total += len(objs)
+        if not resp.get("IsTruncated"):
+            break
+        token = resp["NextContinuationToken"]
+print(total)
+PY
+)
+  deleted_count=${deleted_count:-0}
+  # Keep only trailing digits if python printed warnings before the count.
+  deleted_count=$(echo "$deleted_count" | tr -cd '0-9\n' | tail -n1)
+  deleted_count=${deleted_count:-0}
+  if [ "$deleted_count" -gt 0 ] 2>/dev/null; then
+    echo "    deleted $deleted_count stale object(s); restarting S4 to refresh LIST index..."
+    $PODMAN restart koku-s4 >/dev/null 2>&1 || true
+    sleep 5
+  else
+    echo "    no stale managed-table objects found"
+  fi
+}
+
+# Create a test customer account and seed sample cost data.
+# On-prem mode (-o): ONPREM=True + test_source=ONPREM (OCP only).
+# Default mode: ONPREM=False + test_source=all (one koku load). Do not call
+# load once per cloud — each provider already waits ~8 min inside koku for its
+# OCP has_data; stacking that with another 15 min outer wait made full mode
+# take an hour+.
 loadData() {
-  cd $KOKU_DIR
+  cd "$KOKU_DIR" || exit 1
+
+  # Drop orphaned Hive warehouse paths from prior failed summaries before nise
+  # upload. Otherwise OCP summary hits HIVE_PATH_ALREADY_EXISTS immediately.
+  clearStaleHivePaths
 
   # Must call the script directly with --api-prefix. The koku .env sets
   # API_PATH_PREFIX=/api/cost-management; without the flag the script sends
@@ -506,16 +1031,60 @@ loadData() {
   echo -e "\n*** Creating test customer (org_id: 1234567, username: test_customer) and providers..."
   $PIPENV_BIN run $PYTHON_BIN dev/scripts/create_test_customer.py --api-prefix /api/cost-management
 
-  # Note: test_source=ONPREM times out and doesn't load OCP data
-  # Using test_source=all will load OCP data, but produces empty tables for AWS, Azure, and GCP
+  # Scale workers for OCP ingest. Override clears published ports so scale>1
+  # does not collide on host bindings. Keep at 2 in full mode — 3 workers plus
+  # Trino during test_source=all often OOM-kills Trino before Premises finishes.
+  local worker_scale=2
+  echo -e "\n*** Scaling koku-worker to ${worker_scale} for data load..."
+  # --no-deps: stack is already up. Without it, Podman+docker-compose can hang
+  # forever waiting on dependency health (often after "koku-koku-base-1 Started").
+  $PODMAN_COMPOSE -f docker-compose.yml -f "$PODMAN_OVERRIDE_FILE" \
+    up -d --no-deps --scale koku-worker="$worker_scale" koku-worker
 
-  # koku-worker processes this asynchronously — wait a minute or two before expecting report pages to show rows.
-  # This step uploads to MinIO at localhost:9000
-  echo -e "\n*** Loading sample cost data..."
-  $PIPENV_BIN run make DOCKER="$PODMAN" load-test-customer-data test_source=all || \
-    echo "load-test-customer-data had errors (partial upload) — reports may show less data"
+  scaleWorkersDown() {
+    echo -e "\n*** Scaling koku-worker back to 1..."
+    $PODMAN_COMPOSE -f docker-compose.yml -f "$PODMAN_OVERRIDE_FILE" \
+      up -d --no-deps --scale koku-worker=1 koku-worker >/dev/null 2>&1 || true
+  }
 
-  echo -e "\n*** Data seeded — worker will process in the background..."
+  loadProvider() {
+    local test_source=$1
+    echo -e "\n*** Loading sample cost data (test_source=$test_source, ONPREM=${ONPREM_VALUE})..."
+    echo "    (koku may log has_data timeouts after ~8 min per OCP source; that is often OK)"
+    if ! $PIPENV_BIN run make DOCKER="$PODMAN" load-test-customer-data test_source="$test_source"; then
+      echo "load-test-customer-data ($test_source) returned an error — waiting for worker..."
+    fi
+  }
+
+  if [ -n "$MODE_ONPREM" ]; then
+    loadProvider ONPREM
+  else
+    # Single koku load (AWS→Azure→GCP→ONPREM inside the script).
+    loadProvider all
+    # Premises is last in test_source=all and often fails when Trino was
+    # OOM-killed during cloud ingest. Free RAM and revive Trino before the
+    # has_data gate remediates with an ONPREM reload.
+    echo -e "\n*** Recovering Trino after multi-cloud load (often OOM-killed)..."
+    scaleWorkersDown
+    if ! ensureTrinoHealthy; then
+      echo "Error: Trino did not recover after data load"
+      exit 1
+    fi
+    $PODMAN_COMPOSE -f docker-compose.yml -f "$PODMAN_OVERRIDE_FILE" \
+      up -d --no-deps --scale koku-worker=2 koku-worker >/dev/null 2>&1 || true
+  fi
+
+  # Require has_data for every expected source. Remediates Trino/Hive failures
+  # and reloads only the provider groups that are still missing data.
+  if ! ensureAllSourcesHaveData loadProvider; then
+    echo "Check worker logs: cd $KOKU_DIR && $PODMAN_COMPOSE logs --tail 80 koku-worker"
+    scaleWorkersDown
+    exit 1
+  fi
+
+  scaleWorkersDown
+
+  echo -e "\n*** Data seeded — all required sources have has_data=true"
 }
 
 # Create or update nise/.env. When -n is passed, sets KOKU_PATH to point at the
@@ -550,7 +1119,12 @@ niseVEnv() {
   echo -e "\n*** Creating NISE virtual env"
   rm -rf .venv
 
-  uv run nise -h
+  # Warm the uv env / verify nise installs; hide -h usage text so it is not
+  # mistaken for an error.
+  if ! uv run nise -h >/dev/null 2>&1; then
+    echo "Error: uv run nise failed. Check that uv and the nise checkout are working."
+    exit 1
+  fi
   uv build
 }
 
@@ -568,10 +1142,33 @@ runCommand() {
   fi
 }
 
-# Print post-setup verification hints, including the Trino CLI command for
-# querying the local data warehouse directly.
+# Print post-setup status: running services, endpoints, Trino CLI, and shutdown.
 verify() {
-  cd $KOKU_DIR
+  cd "$KOKU_DIR" || exit 1
+
+  echo -e "\n*** Running services:"
+  # Include the podman override used at startup so compose finds the same project.
+  if [ -f "$PODMAN_OVERRIDE_FILE" ]; then
+    if ! $PODMAN_COMPOSE -f docker-compose.yml -f "$PODMAN_OVERRIDE_FILE" ps; then
+      $PODMAN ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
+    fi
+  elif ! $PODMAN_COMPOSE ps; then
+    $PODMAN ps --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}'
+  fi
+
+  echo -e "\n*** Endpoints:"
+cat <<- EEOOFF
+  Koku API      -> http://localhost:8000/api/cost-management/v1/status/
+  MASU          -> http://localhost:5042
+  PostgreSQL    -> localhost:15432
+  Valkey        -> localhost:6379
+  Unleash       -> http://localhost:4242
+  S4 (S3)       -> http://localhost:9000  (proxy; UI http://localhost:5002)
+  Trino         -> http://localhost:8080
+  Hive metastore-> localhost:9083
+
+  Logs:         -> cd $KOKU_DIR && $PODMAN_COMPOSE logs -f koku-server koku-worker
+EEOOFF
 
   echo -e "\n*** To access the Trino CLI, run:"
 cat <<- EEOOFF
@@ -580,6 +1177,13 @@ cat <<- EEOOFF
   Example usage:
     SHOW tables;
     SELECT * from aws_line_items LIMIT 10;
+EEOOFF
+
+  echo -e "\n*** To shut down the stack, run:"
+cat <<- EEOOFF
+  cd $KOKU_DIR
+  $PODMAN_COMPOSE down       # stop containers, keep volumes/data
+  $PODMAN_COMPOSE down -v    # stop and wipe DB, S4, and other volumes
 EEOOFF
 }
 
@@ -595,16 +1199,25 @@ EEOOFF
     exit 1
   fi
 
-  while getopts hcknv z; do
+  while getopts hcknov z; do
     case $z in
       c) CLEAN=1;;
       k) KOKU_ENV=1;;
       n) NISE_ENV=1;;
+      o) MODE_ONPREM=1;;
       v) VERBOSE=1; RUN_COMMAND=;;
       h) usage; exit 0;;
       \?) usage; exit 1;;
     esac
   done
+
+  if [ -n "$MODE_ONPREM" ]; then
+    ONPREM_VALUE=True
+    echo "*** Mode: on-prem (ONPREM=True, test_source=ONPREM)"
+  else
+    ONPREM_VALUE=False
+    echo "*** Mode: full / SaaS-local (ONPREM=False, test_source=all)"
+  fi
 
   if [ -n "$CLEAN" ]; then
     clean


### PR DESCRIPTION
Updated quick start per latest koku repo changes

## Summary by Sourcery

Add an on-prem aware quick-start path for Koku and make the quick-start script more robust against common local environment issues.

New Features:
- Introduce an on-prem quick-start mode that sets ONPREM=True and loads only on-prem OCP sample data.
- Add a dedicated npm script and CLI flag to choose between full (SaaS-local) and on-prem backend modes when starting Koku.
- Automatically scale koku-worker during sample data load and wait until an OCP source reports has_data=true before completing setup.

Bug Fixes:
- Handle broken or stale host aws CLI installations by removing them from PATH so OCP upload verification can fall back to a containerized aws-cli.
- Ensure non-empty AWS credentials are provided to avoid Trino Glue connector crashes during local setup.
- Detect missing or invalid S3/S4 credentials that prevent the stack from starting and provide corrective guidance.
- Fail fast when Koku API or MASU containers are not running or do not become healthy within the extended startup timeout, surfacing recent logs for debugging.

Enhancements:
- Populate Koku .env with updated S4, currency, and ONPREM values, including Apple Silicon-friendly S4 image defaults.
- Adjust Podman compose overrides to clear koku-worker port publications, allowing worker scaling without host port collisions.
- Extend startup waits and health checks, and add helper logic to poll sources for has_data status to reduce false negatives from asynchronous processing.
- Improve post-setup verification output with a consolidated view of running services, endpoints, logging commands, and shutdown instructions.

Build:
- Add a new npm quick-start target and script metadata for the on-prem Koku backend mode.

Documentation:
- Update the quick-start guide to document full vs on-prem modes, script flags, and expected behavior of the new quick-start targets.
- Expand troubleshooting sections to cover Trino credential issues, S3/S4 key mismatches, has_data problems, and broken aws CLI setups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an on-prem quick-start mode flag (`-o`) with new npm targets to load OCP sample data in on-prem mode.
  * Updated Koku UI on-prem behavior to respect environment-driven settings for data retention and the Sources tab (with safe defaults).

* **Bug Fixes**
  * Improved quick-start reliability with clearer startup diagnostics, longer readiness waits, safer ingest scaling/port handling, and more robust source/data readiness checks.
  * Enhanced verification and added targeted troubleshooting for AWS/S3/Trino, stuck setup scenarios, and stale Hive path/volume issues.

* **Documentation**
  * Refreshed quick-start and troubleshooting guidance, including backend-mode selection, updated script invocations, and expanded “What the script does”/flags reference.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->