### PR TITLE
Refactor optimizations efficiency tab to apply exact filters

### DIFF
--- a/apps/koku-ui-hccm/src/routes/optimizations/efficiency/components/workload/workloadTable.test.tsx
+++ b/apps/koku-ui-hccm/src/routes/optimizations/efficiency/components/workload/workloadTable.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, screen } from '@testing-library/react';
 import React from 'react';
 import { useLocation } from 'react-router-dom';
+import { exactPrefix } from 'utils/props';
 
 // Capture the rows/columns/onSort that WorkloadTable passes to DataTable
 let capturedRows: any[] = [];
@@ -110,7 +111,7 @@ describe('WorkloadTable', () => {
       expect(capturedState?.efficiencyState?.activeTabKey).toBe(1);
     });
 
-    it('sets optimizationsDetailsState.filter_by keyed by groupBy with the item label', () => {
+    it('sets optimizationsDetailsState.filter_by keyed by exact groupBy with the item label', () => {
       renderWithProviders(
         <>
           <LocationCapture />
@@ -118,7 +119,7 @@ describe('WorkloadTable', () => {
         </>
       );
       fireEvent.click(screen.getByRole('link', { name: 'cluster-1' }));
-      expect(capturedState?.optimizationsDetailsState?.filter_by?.cluster).toEqual(['cluster-1']);
+      expect(capturedState?.optimizationsDetailsState?.filter_by?.[`${exactPrefix}cluster`]).toEqual(['cluster-1']);
     });
 
     it('preserves existing location state when building the link state', () => {
@@ -131,7 +132,7 @@ describe('WorkloadTable', () => {
       fireEvent.click(screen.getByRole('link', { name: 'cluster-2' }));
       // efficiencyState.activeTabKey must be 1 and filter_by has the second item
       expect(capturedState?.efficiencyState?.activeTabKey).toBe(1);
-      expect(capturedState?.optimizationsDetailsState?.filter_by?.cluster).toEqual(['cluster-2']);
+      expect(capturedState?.optimizationsDetailsState?.filter_by?.[`${exactPrefix}cluster`]).toEqual(['cluster-2']);
     });
   });
 

--- a/apps/koku-ui-hccm/src/routes/optimizations/efficiency/components/workload/workloadTable.tsx
+++ b/apps/koku-ui-hccm/src/routes/optimizations/efficiency/components/workload/workloadTable.tsx
@@ -7,6 +7,7 @@ import { Link, useLocation } from 'react-router-dom';
 import { DataTable } from 'routes/components/dataTable';
 import { getUnsortedComputedReportItems } from 'routes/utils/computedReport/getComputedReportItems';
 import { formatCurrency, formatPercentage } from 'utils/format';
+import { exactPrefix } from 'utils/props';
 
 import { styles } from './workloadTable.styles';
 
@@ -102,7 +103,7 @@ const WorkloadTable: React.FC<WorkloadTableProps> = ({
             optimizationsDetailsState: {
               ...(location?.state?.optimizationsDetailsState || {}),
               filter_by: {
-                [groupBy]: [label], // Filter by cluster or project name
+                [`${exactPrefix}${groupBy}`]: [label], // Filter by cluster or project name
               },
             },
           }}


### PR DESCRIPTION
Refactor optimizations efficiency tab to apply exact filters

## Summary by Sourcery

Enhancements:
- Use exact-prefixed groupBy keys when building workload table filter state to ensure precise filtering by cluster or project name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workload table navigation so cluster or project name filters are correctly applied when opening a workload’s details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->