### PR TITLE
Update buildah to fix trust violation

### DIFF
--- a/.tekton/koku-ui-hccm-pull-request.yaml
+++ b/.tekton/koku-ui-hccm-pull-request.yaml
@@ -239,7 +239,7 @@ spec:
         - name: name
           value: buildah
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.10.7@sha256:aec102623c7948379d9c13c0223ac6fcbc592fed318ef1e9fa5e2898a88a2943
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.10.7@sha256:3b3689fd223d3369e35de2ee01ede60919e611aee08497bddef5c7350de4881e
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/koku-ui-hccm-push.yaml
+++ b/.tekton/koku-ui-hccm-push.yaml
@@ -225,7 +225,7 @@ spec:
         - name: name
           value: buildah
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.10.7@sha256:aec102623c7948379d9c13c0223ac6fcbc592fed318ef1e9fa5e2898a88a2943
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.10.7@sha256:3b3689fd223d3369e35de2ee01ede60919e611aee08497bddef5c7350de4881e
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/koku-ui-ros-pull-request.yaml
+++ b/.tekton/koku-ui-ros-pull-request.yaml
@@ -228,7 +228,7 @@ spec:
         - name: name
           value: buildah
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.10.7@sha256:aec102623c7948379d9c13c0223ac6fcbc592fed318ef1e9fa5e2898a88a2943
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.10.7@sha256:3b3689fd223d3369e35de2ee01ede60919e611aee08497bddef5c7350de4881e
         - name: kind
           value: task
         resolver: bundles

--- a/.tekton/koku-ui-ros-push.yaml
+++ b/.tekton/koku-ui-ros-push.yaml
@@ -225,7 +225,7 @@ spec:
         - name: name
           value: buildah
         - name: bundle
-          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.10.7@sha256:aec102623c7948379d9c13c0223ac6fcbc592fed318ef1e9fa5e2898a88a2943
+          value: quay.io/konflux-ci/tekton-catalog/task-buildah:0.10.7@sha256:3b3689fd223d3369e35de2ee01ede60919e611aee08497bddef5c7350de4881e
         - name: kind
           value: task
         resolver: bundles


### PR DESCRIPTION
Update buildah to fix trust violation

## Summary by Sourcery

CI:
- Point all koku-ui Tekton pull-request and push pipelines to the updated buildah task bundle image digest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated pinned container build task references across pull request and push pipelines.
  * Preserved existing pipeline versions, configuration, parameters, and behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->