### PR TITLE
Fix koku-ui-onprem: enable hermetic build and source image

### DIFF
--- a/.tekton/koku-ui-onprem-pull-request.yaml
+++ b/.tekton/koku-ui-onprem-pull-request.yaml
@@ -30,6 +30,12 @@ spec:
     value: apps/koku-ui-onprem/Containerfile
   - name: path-context
     value: .
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "npm", "path": "."}'
+  - name: build-source-image
+    value: "true"
   - name: build-args
     value:
     - IMAGE_NAME=costmanagement-ui-rhel10

--- a/.tekton/koku-ui-onprem-push.yaml
+++ b/.tekton/koku-ui-onprem-push.yaml
@@ -27,6 +27,12 @@ spec:
     value: apps/koku-ui-onprem/Containerfile
   - name: path-context
     value: .
+  - name: hermetic
+    value: "true"
+  - name: prefetch-input
+    value: '{"type": "npm", "path": "."}'
+  - name: build-source-image
+    value: "true"
   - name: build-args
     value:
     - IMAGE_NAME=costmanagement-ui-rhel10


### PR DESCRIPTION
## Summary
- Enable `hermetic: "true"` and `build-source-image: "true"` in both push and pull-request tekton pipelines for koku-ui-onprem
- These are required by the Enterprise Contract registry release policy

## EC violations fixed
- `hermetic_task.hermetic` — buildah task must be invoked with HERMETIC=true
- `source_image.exists` — source image must be built
- `tasks.required_tasks_found` — source-build task was missing (enabled by build-source-image)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Enable hermetic, source-image-enabled Tekton build pipelines for koku-ui-onprem and align container metadata with enterprise requirements.

New Features:
- Add dedicated Tekton PipelineRuns for koku-ui-onprem push and pull-request events targeting stage-onprem and prod-onprem branches.

Enhancements:
- Set hermetic and source-image build parameters in koku-ui-onprem pipelines to satisfy Enterprise Contract policies.
- Add image metadata labels and configurable image name/version build args to the koku-ui-onprem Containerfile for consistent image publishing.