### PR TITLE
Fix hermetic build for koku-ui-onprem

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+# Hermeto/Konflux hermetic builds need resolved URLs in package-lock.json.
+omit-lockfile-registry-resolved=false

--- a/.tekton/koku-ui-onprem-pull-request.yaml
+++ b/.tekton/koku-ui-onprem-pull-request.yaml
@@ -555,7 +555,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 1Gi
+            storage: 10Gi
       status: {}
   - name: git-auth
     secret:

--- a/.tekton/koku-ui-onprem-push.yaml
+++ b/.tekton/koku-ui-onprem-push.yaml
@@ -552,7 +552,7 @@ spec:
         - ReadWriteOnce
         resources:
           requests:
-            storage: 1Gi
+            storage: 10Gi
       status: {}
   - name: git-auth
     secret:

--- a/apps/koku-ui-onprem/Containerfile
+++ b/apps/koku-ui-onprem/Containerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi10/nodejs-22-minimal AS builder
+FROM registry.access.redhat.com/ubi10/nodejs-24-minimal AS builder
 WORKDIR /app
 
 USER 0
@@ -19,7 +19,9 @@ ENV HUSKY=0
 # Webpack prod builds (esp. koku-ui-hccm) exceed Node's ~2Gi default heap on GHA.
 # Cap below ubuntu-latest ~7Gi RAM so the runner itself is not OOM-killed.
 ENV NODE_OPTIONS=--max-old-space-size=6144
-RUN npm ci
+ENV CYPRESS_INSTALL_BINARY=0
+ENV SENTRYCLI_SKIP_DOWNLOAD=1
+RUN npm ci --no-audit --no-fund
 
 COPY apps/koku-ui-onprem ./apps/koku-ui-onprem/
 RUN npm run build --workspace=@koku-ui/koku-ui-onprem


### PR DESCRIPTION
- Switch base image to nodejs-24-minimal (npm 11.16.0) to fix "Exit handler never called" crash with hermeto-modified lockfiles
- Add .npmrc with omit-lockfile-registry-resolved=false so hermeto can prefetch all packages
- Skip Cypress and Sentry binary downloads in hermetic mode
- Use npm ci --no-audit --no-fund to avoid network calls
- Increase tekton workspace storage from 1Gi to 10Gi for prefetch

## Summary by Sourcery

Improve koku-ui-onprem hermetic build reliability and resource provisioning.

New Features:
- Enable hermetic npm package prefetching for koku-ui-onprem builds.

Bug Fixes:
- Resolve koku-ui-onprem hermetic build crash related to Node.js and npm behavior.

Build:
- Update koku-ui-onprem container base image to Node.js 24 minimal.
- Configure npm to skip audits, funding checks, and Cypress/Sentry binary downloads during CI installs.
- Add project-level npm configuration to support hermetic lockfile-based dependency resolution.

CI:
- Increase Tekton workspace storage from 1Gi to 10Gi for koku-ui-onprem pull request and push pipelines to support dependency prefetching.