### PR TITLE
Omit main branch

### DIFF
--- a/.tekton/koku-ui-hccm-push.yaml
+++ b/.tekton/koku-ui-hccm-push.yaml
@@ -7,7 +7,7 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch in ["main", "stage-hccm", "prod-hccm"]
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch in ["stage-hccm", "prod-hccm"]
   creationTimestamp:
   labels:
     appstudio.openshift.io/application: koku-ui-hccm


### PR DESCRIPTION
Only needed to test Konflux PRs, not pushes

## Summary by Sourcery

CI:
- Update pipelines-as-code CEL expression so the koku-ui-hccm push pipeline runs only for pushes to stage-hccm and prod-hccm, excluding main.