### PR TITLE
fix: add registry namespace prefix to IMAGE_NAME build-arg

### DIFF
--- a/.tekton/koku-ui-onprem-pull-request.yaml
+++ b/.tekton/koku-ui-onprem-pull-request.yaml
@@ -38,7 +38,7 @@ spec:
     value: "true"
   - name: build-args
     value:
-    - IMAGE_NAME=costmanagement-ui-rhel10
+    - IMAGE_NAME=costmanagement/costmanagement-ui-rhel10
     - VERSION=1
   pipelineSpec:
     description: |

--- a/.tekton/koku-ui-onprem-push.yaml
+++ b/.tekton/koku-ui-onprem-push.yaml
@@ -35,7 +35,7 @@ spec:
     value: "true"
   - name: build-args
     value:
-    - IMAGE_NAME=costmanagement-ui-rhel10
+    - IMAGE_NAME=costmanagement/costmanagement-ui-rhel10
     - VERSION=1
   pipelineSpec:
     description: |


### PR DESCRIPTION
The release pipeline check-labels task expects the name label to include the registry namespace prefix (costmanagement/costmanagement-ui-rhel10), matching the pattern used by koku-onprem.

## Summary by Sourcery

Align koku-ui-onprem Tekton pipelines with release label expectations by updating the image name to include the registry namespace prefix.

Bug Fixes:
- Update IMAGE_NAME build argument in koku-ui-onprem pull-request and push Tekton pipelines to include the costmanagement registry namespace prefix so labels match release pipeline checks.

Build:
- Adjust Tekton koku-ui-onprem pipeline build arguments to use the fully qualified costmanagement/costmanagement-ui-rhel10 image name.