### PR TITLE
Revert insights-rbac-ui vendor bump for hermetic builds

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8100,62 +8100,6 @@
         "tslib": "^2.6.2"
       }
     },
-    "node_modules/@redhat-cloud-services/hcc-storybook-hub": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@redhat-cloud-services/hcc-storybook-hub/-/hcc-storybook-hub-0.2.2.tgz",
-      "integrity": "sha512-eG44HW8lpLIGIMUk+NdduM/Tisji27GXEvgDTJFkZMuHTqqNcBBcnRldioNAHNKVbWWGTLEirvoDPEVKTz8vPg==",
-      "dev": true,
-      "dependencies": {
-        "@storybook/addon-a11y": "^10.2.0",
-        "@storybook/addon-docs": "^10.2.0",
-        "@storybook/addon-webpack5-compiler-swc": "^4.0.0",
-        "@storybook/react-webpack5": "^10.2.0",
-        "@storybook/test-runner": "^0.24.0",
-        "chromatic": "^17.0.0",
-        "eslint-plugin-storybook": "^10.2.0",
-        "msw": "^2.12.0",
-        "msw-storybook-addon": "^2.0.6",
-        "storybook": "^10.2.0"
-      },
-      "peerDependencies": {
-        "react": "^18.0.0 || ^19.0.0",
-        "react-dom": "^18.0.0 || ^19.0.0"
-      }
-    },
-    "node_modules/@redhat-cloud-services/hcc-storybook-hub/node_modules/chromatic": {
-      "version": "17.8.0",
-      "resolved": "https://registry.npmjs.org/chromatic/-/chromatic-17.8.0.tgz",
-      "integrity": "sha512-xcn2TGdbrKHQbGAo3wZc5qoKaPe+CEvhAEcky9OCpofGd3DJucLFEYpk8wYgHKgR5XAI9X8Op1C6fWlvdjxE/g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.3.5"
-      },
-      "bin": {
-        "chroma": "dist/bin.cjs",
-        "chromatic": "dist/bin.cjs",
-        "chromatic-cli": "dist/bin.cjs"
-      },
-      "engines": {
-        "node": ">=22.0.0"
-      },
-      "peerDependencies": {
-        "@chromatic-com/cypress": "^0.*.* || ^1.0.0",
-        "@chromatic-com/playwright": "^0.*.* || ^1.0.0",
-        "@chromatic-com/vitest": "^0.*.* || ^1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "@chromatic-com/cypress": {
-          "optional": true
-        },
-        "@chromatic-com/playwright": {
-          "optional": true
-        },
-        "@chromatic-com/vitest": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/@redhat-cloud-services/host-inventory-client": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@redhat-cloud-services/host-inventory-client/-/host-inventory-client-4.1.7.tgz",
@@ -8967,24 +8911,6 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
       "license": "MIT"
-    },
-    "node_modules/@storybook/addon-a11y": {
-      "version": "10.5.8",
-      "resolved": "https://registry.npmjs.org/@storybook/addon-a11y/-/addon-a11y-10.5.8.tgz",
-      "integrity": "sha512-yunl+sKa29NaUC3I4yjESwk6ED8waEgmmvIJzNAJvdhb7thFzZYYEld68RzKmOVcGBkD3snK5eZ/Xf0l4VWliQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@storybook/global": "^5.0.0",
-        "axe-core": "^4.2.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/storybook"
-      },
-      "peerDependencies": {
-        "storybook": "^10.5.8"
-      }
     },
     "node_modules/@storybook/addon-docs": {
       "version": "10.4.1",
@@ -12666,16 +12592,6 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.13.2.tgz",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/axe-core": {
-      "version": "4.13.0",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.13.0.tgz",
-      "integrity": "sha512-UzGt8zg7Ny8djbYMhxl2zuEevVa7r2gJjYY5Lwr1xM7+XU2nd6CkIWFTVcCIbAP63vSz71NaVyyuSk9lHKcy0A==",
-      "dev": true,
-      "license": "MPL-2.0",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/axios": {
       "version": "1.19.0",
@@ -18668,12 +18584,6 @@
       "engines": {
         "node": ">=12.0.0"
       }
-    },
-    "node_modules/experience-ui-governance": {
-      "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/RedHatInsights/experience-ui-governance.git#5b1eaab981d12bbaad76737b93049f99df04861c",
-      "dev": true,
-      "license": "Apache-2.0"
     },
     "node_modules/express": {
       "version": "4.22.2",
@@ -38563,7 +38473,7 @@
         "@redhat-cloud-services/frontend-components-utilities": "^7.0.36",
         "@redhat-cloud-services/host-inventory-client": "^4.1.7",
         "@redhat-cloud-services/javascript-clients-shared": "^2.0.5",
-        "@redhat-cloud-services/rbac-client": "^9.0.7",
+        "@redhat-cloud-services/rbac-client": "^9.0.0",
         "@redhat-cloud-services/types": "^3.4.1",
         "@tanstack/react-query": "^5.90.16",
         "@tanstack/react-query-devtools": "^5.91.2",
@@ -38597,7 +38507,6 @@
         "@playwright/test": "^1.57.0",
         "@redhat-cloud-services/eslint-config-redhat-cloud-services": "^3.0.12",
         "@redhat-cloud-services/frontend-components-config": "^6.7.51",
-        "@redhat-cloud-services/hcc-storybook-hub": "^0.2.2",
         "@redhat-cloud-services/tsc-transform-imports": "^1.0.37",
         "@storybook/addon-docs": "^10.2.19",
         "@storybook/addon-webpack5-compiler-swc": "^4.0.2",
@@ -38629,7 +38538,6 @@
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-storybook": "^10.2.8",
         "eslint-plugin-testing-library": "^7.15.4",
-        "experience-ui-governance": "github:RedHatInsights/experience-ui-governance",
         "happy-dom": "^20.10.2",
         "http-server": "^14.1.1",
         "https-proxy-agent": "^7.0.6",


### PR DESCRIPTION
## Summary
- Revert `vendor/insights-rbac-ui` from `76dd18ce` to `0b948d64` (pre-#5585).
- Refresh `package-lock.json` to drop the `experience-ui-governance` `git+ssh` dependency (and related `hcc-storybook-hub` tree) that caused Konflux hermetic `npm ci` to fail with `spawn git ENOENT` on `ubi10/nodejs-24-minimal`.

Fixes the Konflux `build-container` failure on https://github.com/project-koku/koku-ui/pull/5588.

## Test plan
- [ ] Konflux `koku-ui-onprem-on-pull-request` `build-container` passes
- [ ] Confirm `package-lock.json` has no `git+ssh` / `experience-ui-governance` entries
- [ ] Re-run or refresh stage-onprem merge PR #5588 after this lands on `main`


Made with [Cursor](https://cursor.com)

## Summary by Sourcery

Revert the vendored insights-rbac-ui version and refresh package-lock.json to restore hermetic Konflux builds by removing git+ssh dependencies.

Build:
- Update package-lock.json to eliminate git+ssh experience-ui-governance and related hcc-storybook-hub dependencies that break hermetic npm ci in Konflux.

Chores:
- Revert vendor/insights-rbac-ui to the previous commit to align with stable build behavior prior to the recent vendor bump.