### PR TITLE
fix: add required Container First Security labels for Konflux release

### DIFF
--- a/apps/koku-ui-onprem/Containerfile
+++ b/apps/koku-ui-onprem/Containerfile
@@ -52,6 +52,10 @@ LABEL summary="Cost Management UI for on-premise deployments" \
     com.redhat.component="costmanagement-ui-rhel10-container" \
     name="$IMAGE_NAME" \
     version="$VERSION" \
+    release="1" \
+    vendor="Red Hat, Inc." \
+    distribution-scope="public" \
+    cpe="cpe:/a:redhat:cost_management_on_premise:1::el10" \
     maintainer="Red Hat Cost Management Services <cost-mgmt@redhat.com>"
 
 COPY --from=builder /app/apps/koku-ui-onprem/dist ./onprem


### PR DESCRIPTION
Add cpe, release, vendor, and distribution-scope labels to satisfy the check-labels task in the Konflux release pipeline. The cpe label must match the product CPE rendered by the prodsec template.

## Summary by Sourcery

Build:
- Include release, vendor, distribution-scope, and CPE labels in the koku-ui-onprem Containerfile to satisfy Konflux check-labels requirements.