### PR TITLE
fix: use single onprem-candidate branch for koku-ui-onprem builds

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,8 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - stage-onprem
-      - prod-onprem
+      - onprem-candidate
 
 env:
   NODEJS_VERSION: '22'

--- a/.github/workflows/koku-ui-onprem-push.yml
+++ b/.github/workflows/koku-ui-onprem-push.yml
@@ -1,9 +1,9 @@
-name: Koku UI OnPrem - Push to stage/tag
+name: Koku UI OnPrem - Push/tag
 
 on:
   push:
     branches:
-      - stage-onprem
+      - onprem-candidate
     tags:
       - 'onprem-*'
 env:

--- a/.tekton/koku-ui-onprem-pull-request.yaml
+++ b/.tekton/koku-ui-onprem-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      in ["stage-onprem", "prod-onprem"]
+      == "onprem-candidate"
   labels:
     appstudio.openshift.io/application: koku-ui-onprem
     appstudio.openshift.io/component: koku-ui-onprem

--- a/.tekton/koku-ui-onprem-push.yaml
+++ b/.tekton/koku-ui-onprem-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      in ["stage-onprem", "prod-onprem"]
+      == "onprem-candidate"
   labels:
     appstudio.openshift.io/application: koku-ui-onprem
     appstudio.openshift.io/component: koku-ui-onprem


### PR DESCRIPTION
Replace the two-branch pattern (stage-onprem + prod-onprem) with a single onprem-candidate branch. Prod releases use the same snapshot via manual trigger in Konflux UI.

## Summary by Sourcery

Use the single `onprem-candidate` branch as the source for Koku UI on-premise builds and validation.

Enhancements:
- Consolidate on-premise build and pull-request validation workflows around the single `onprem-candidate` branch.

CI:
- Update Cypress and Tekton automation to target `onprem-candidate` instead of separate stage and production branches.