### PR TITLE
Rename onprem-candidate as release-onprem

### DIFF
--- a/.github/workflows/cypress.yml
+++ b/.github/workflows/cypress.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-      - onprem-candidate
+      - release-onprem
 
 env:
   NODEJS_VERSION: '22'

--- a/.github/workflows/koku-ui-onprem-push.yml
+++ b/.github/workflows/koku-ui-onprem-push.yml
@@ -3,7 +3,7 @@ name: Koku UI OnPrem - Push/tag
 on:
   push:
     branches:
-      - onprem-candidate
+      - release-onprem
     tags:
       - 'onprem-*'
 env:

--- a/.tekton/koku-ui-onprem-pull-request.yaml
+++ b/.tekton/koku-ui-onprem-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "onprem-candidate"
+      == "release-onprem"
   labels:
     appstudio.openshift.io/application: koku-ui-onprem
     appstudio.openshift.io/component: koku-ui-onprem

--- a/.tekton/koku-ui-onprem-push.yaml
+++ b/.tekton/koku-ui-onprem-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "onprem-candidate"
+      == "release-onprem"
   labels:
     appstudio.openshift.io/application: koku-ui-onprem
     appstudio.openshift.io/component: koku-ui-onprem


### PR DESCRIPTION
Rename onprem-candidate as release-onprem to be consistent with match release-hccm and release-ros

## Summary by Sourcery

Rename the on-prem release branch to `release-onprem` and update all associated automation and guidance.

Enhancements:
- Rename the on-prem release branch from `onprem-candidate` to `release-onprem` across release documentation, scripts, CI workflows, and Tekton pipelines.

CI:
- Update Cypress, push, and Tekton pipeline triggers to use the `release-onprem` branch.

Documentation:
- Update on-prem release instructions and package metadata to reference `release-onprem`.