### PR TITLE
Ensure SHAs are updated only for stage or prod blocks

### DIFF
--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -23,6 +23,7 @@ jobs:
       - uses: actions/checkout@v5
         with:
           fetch-depth: 0
+          fetch-tags: true
           ref: ${{ inputs.commit }}
       - name: Tag this release
         env:
@@ -32,18 +33,26 @@ jobs:
         run: |
           DATE=$(date +"%Y.%m.%d")
           APP_SUFFIX=${APP#koku-ui-}
-          PREV_RELEASE=$(git tag --list | grep -E "^r\.[0-9]{4}\.[0-9]{2}\.[0-9]{2}\.[0-9]+-${APP_SUFFIX}$" | tail -1)
-          PREV_SAME_DAY=$(git tag --list | grep -E "^r\.${DATE}\.[0-9]+-${APP_SUFFIX}$" | tail -1)
+          PREV_RELEASE=$(git tag --list | grep -E "^r\.[0-9]{4}\.[0-9]{2}\.[0-9]{2}\.[0-9]+-${APP_SUFFIX}$" | tail -1 || true)
+          PREV_SAME_DAY=$(git tag --list | grep -E "^r\.${DATE}\.[0-9]+-${APP_SUFFIX}$" | tail -1 || true)
           MINOR_VERSION=0
           if [ -n "$PREV_SAME_DAY" ]; then
             MINOR_VERSION=$(echo "$PREV_SAME_DAY" | cut -d'.' -f5 | cut -d'-' -f1)
             MINOR_VERSION=$((MINOR_VERSION+1))
           fi
           TAG="r.$DATE.$MINOR_VERSION-$APP_SUFFIX"
+          echo "PREV_RELEASE=$PREV_RELEASE"
+          echo "PREV_SAME_DAY=$PREV_SAME_DAY"
+          echo "TAG=$TAG"
           git config --local user.email "koku-ui-bot@redhat.com"
           git config --local user.name "Koku UI Bot"
           if [ -n "$PREV_RELEASE" ]; then
-            git log "$PREV_RELEASE".."$RELEASE_COMMIT" | git tag -a "$TAG" "$RELEASE_COMMIT" -F -
+            BODY=$(git log "$PREV_RELEASE".."$RELEASE_COMMIT")
+            if [ -n "$BODY" ]; then
+              echo "$BODY" | git tag -a "$TAG" "$RELEASE_COMMIT" -F -
+            else
+              git tag -a "$TAG" "$RELEASE_COMMIT" -m "Release $TAG"
+            fi
           else
             git tag -a "$TAG" "$RELEASE_COMMIT" -m "Release $TAG"
           fi

--- a/scripts/release-app-interface.sh
+++ b/scripts/release-app-interface.sh
@@ -159,11 +159,13 @@ tagProdReleases()
   if [ "$DEPLOY_HCCM_PROD" = true ]; then
     echo "\n*** Tagging prod release for $KOKU_UI_HCCM at $HCCM_SHA..."
     gh workflow run tag_release.yml -f commit="$HCCM_SHA" -f app="$KOKU_UI_HCCM"
+    echo "Dispatched Tag Release. Check status: https://github.com/project-koku/koku-ui/actions/workflows/tag_release.yml"
   fi
 
   if [ "$DEPLOY_ROS_PROD" = true ]; then
     echo "\n*** Tagging prod release for $KOKU_UI_ROS at $ROS_SHA..."
     gh workflow run tag_release.yml -f commit="$ROS_SHA" -f app="$KOKU_UI_ROS"
+    echo "Dispatched Tag Release. Check status: https://github.com/project-koku/koku-ui/actions/workflows/tag_release.yml"
   fi
 }
 

--- a/scripts/release-app-interface.sh
+++ b/scripts/release-app-interface.sh
@@ -28,6 +28,7 @@ default()
   KOKU_UI_ROS=koku-ui-ros
 
   PROD_FRONTENDS=/services/insights/frontend-operator/namespaces/prod-frontends.yml
+  PROD_MULTICLUSTER_FRONTENDS=/services/insights/frontend-operator/namespaces/prod-multicluster-frontends.yml
   STAGE_FRONTENDS=/services/insights/frontend-operator/namespaces/stage-frontends.yml
   STAGE_MULTICLUSTER_FRONTENDS=/services/insights/frontend-operator/namespaces/stage-multicluster-frontends.yml
 
@@ -233,6 +234,9 @@ initAppInterfaceSHA()
   getAppInterfaceSHA $KOKU_UI_HCCM $PROD_FRONTENDS
   HCCM_PROD_FRONTENDS_SHA="$RESULT"
 
+  getAppInterfaceSHA $KOKU_UI_HCCM $PROD_MULTICLUSTER_FRONTENDS
+  HCCM_PROD_MULTICLUSTER_FRONTENDS_SHA="$RESULT"
+
   getAppInterfaceSHA $KOKU_UI_ROS $STAGE_FRONTENDS
   ROS_STAGE_FRONTENDS_SHA="$RESULT"
 
@@ -242,13 +246,18 @@ initAppInterfaceSHA()
   getAppInterfaceSHA $KOKU_UI_ROS $PROD_FRONTENDS
   ROS_PROD_FRONTENDS_SHA="$RESULT"
 
+  getAppInterfaceSHA $KOKU_UI_ROS $PROD_MULTICLUSTER_FRONTENDS
+  ROS_PROD_MULTICLUSTER_FRONTENDS_SHA="$RESULT"
+
   echo "Existing SHA refs..."
   echo "koku-ui-hccm stage: $HCCM_STAGE_FRONTENDS_SHA"
   echo "koku-ui-hccm stage multicluster: $HCCM_STAGE_MULTICLUSTER_FRONTENDS_SHA"
   echo "koku-ui-hccm prod: $HCCM_PROD_FRONTENDS_SHA"
+  echo "koku-ui-hccm prod multicluster: $HCCM_PROD_MULTICLUSTER_FRONTENDS_SHA"
   echo "koku-ui-ros stage: $ROS_STAGE_FRONTENDS_SHA"
   echo "koku-ui-ros stage multicluster: $ROS_STAGE_MULTICLUSTER_FRONTENDS_SHA"
   echo "koku-ui-ros prod: $ROS_PROD_FRONTENDS_SHA"
+  echo "koku-ui-ros prod multicluster: $ROS_PROD_MULTICLUSTER_FRONTENDS_SHA"
 }
 
 initKokuUISHA()
@@ -263,24 +272,41 @@ initKokuUISHA()
   echo "koku-ui-ros ($ROS_BRANCH): $ROS_SHA"
 }
 
-# Replace old SHA with new SHA only inside the given resource block
+# Replace the commit SHA only on the target whose namespace $ref matches.
+# Stage and prod can share the same SHA after consolidating to a single
+# release branch, so we must not gsub across the whole resource block.
+#
 # $1: resource name (koku-ui-hccm or koku-ui-ros)
-# $2: old SHA
+# $2: namespace $ref path
 # $3: new SHA
 replaceSHA()
 {
   RESOURCE="$1"
-  OLD_SHA="$2"
+  NAMESPACE="$2"
   NEW_SHA="$3"
 
-  if [ -z "$OLD_SHA" ] || [ "$OLD_SHA" = "$MAIN_BRANCH" ] || [ "$OLD_SHA" = "$NEW_SHA" ]; then
+  if [ -z "$NEW_SHA" ] || [ "$NEW_SHA" = "$MAIN_BRANCH" ]; then
     return
   fi
 
-  awk -v resource="$RESOURCE" -v old="$OLD_SHA" -v new="$NEW_SHA" '
-    $0 ~ "name:[[:space:]]*" resource "([[:space:]]|$)" { in_block = 1; print; next }
-    in_block && $0 ~ /name:[[:space:]]*koku-ui-/ { in_block = 0 }
-    in_block { gsub(old, new) }
+  awk -v resource="$RESOURCE" -v ns="$NAMESPACE" -v new="$NEW_SHA" '
+    /^[[:space:]]*- name:[[:space:]]+/ {
+      in_block = ($0 ~ ("name:[[:space:]]*" resource "([[:space:]]|$)"))
+      match_ns = 0
+      print
+      next
+    }
+    in_block && index($0, "$ref: " ns) {
+      match_ns = 1
+      print
+      next
+    }
+    in_block && match_ns && $0 ~ /^[[:space:]]*ref:[[:space:]]/ {
+      sub(/ref:[[:space:]].*/, "ref: " new)
+      match_ns = 0
+      print
+      next
+    }
     { print }
   ' "$DEPLOY_CLOWDER_FILE" > "${DEPLOY_CLOWDER_FILE}.tmp"
   mv "${DEPLOY_CLOWDER_FILE}.tmp" "$DEPLOY_CLOWDER_FILE"
@@ -290,24 +316,26 @@ updateDeploySHA()
 {
   # koku-ui-hccm stage deploy
   if [ "$DEPLOY_HCCM_STAGE" = true ]; then
-    replaceSHA "$KOKU_UI_HCCM" "$HCCM_STAGE_FRONTENDS_SHA" "$HCCM_SHA"
-    replaceSHA "$KOKU_UI_HCCM" "$HCCM_STAGE_MULTICLUSTER_FRONTENDS_SHA" "$HCCM_SHA"
+    replaceSHA "$KOKU_UI_HCCM" "$STAGE_FRONTENDS" "$HCCM_SHA"
+    replaceSHA "$KOKU_UI_HCCM" "$STAGE_MULTICLUSTER_FRONTENDS" "$HCCM_SHA"
   fi
 
   # koku-ui-hccm prod deploy
   if [ "$DEPLOY_HCCM_PROD" = true ]; then
-    replaceSHA "$KOKU_UI_HCCM" "$HCCM_PROD_FRONTENDS_SHA" "$HCCM_SHA"
+    replaceSHA "$KOKU_UI_HCCM" "$PROD_FRONTENDS" "$HCCM_SHA"
+    replaceSHA "$KOKU_UI_HCCM" "$PROD_MULTICLUSTER_FRONTENDS" "$HCCM_SHA"
   fi
 
   # koku-ui-ros stage deploy
   if [ "$DEPLOY_ROS_STAGE" = true ]; then
-    replaceSHA "$KOKU_UI_ROS" "$ROS_STAGE_FRONTENDS_SHA" "$ROS_SHA"
-    replaceSHA "$KOKU_UI_ROS" "$ROS_STAGE_MULTICLUSTER_FRONTENDS_SHA" "$ROS_SHA"
+    replaceSHA "$KOKU_UI_ROS" "$STAGE_FRONTENDS" "$ROS_SHA"
+    replaceSHA "$KOKU_UI_ROS" "$STAGE_MULTICLUSTER_FRONTENDS" "$ROS_SHA"
   fi
 
   # koku-ui-ros prod deploy
   if [ "$DEPLOY_ROS_PROD" = true ]; then
-    replaceSHA "$KOKU_UI_ROS" "$ROS_PROD_FRONTENDS_SHA" "$ROS_SHA"
+    replaceSHA "$KOKU_UI_ROS" "$PROD_FRONTENDS" "$ROS_SHA"
+    replaceSHA "$KOKU_UI_ROS" "$PROD_MULTICLUSTER_FRONTENDS" "$ROS_SHA"
   fi
 }
 


### PR DESCRIPTION
Using a single release-hccm branch means SHAs may be shared for stage and prod. This PR ensure SHAs are updated only for stage or prod blocks. 