### PR TITLE
fix(onprem): default MUA deep link to OpenShift bundle (COST-8160)

### DIFF
--- a/apps/koku-ui-onprem/cypress/e2e/live/01-app-loads.cy.ts
+++ b/apps/koku-ui-onprem/cypress/e2e/live/01-app-loads.cy.ts
@@ -25,6 +25,13 @@ describe('Live app loads', { testTimeout: 180_000 }, () => {
     IamPage.visitMyUserAccess();
   });
 
+  it('iam-my-user-access-defaults-to-openshift-bundle', () => {
+    IamPage.visitMyUserAccessWithoutBundle();
+    cy.url({ timeout: 30_000 }).should('include', 'bundle=openshift');
+    cy.url().should('not.include', 'bundle=rhel');
+    cy.contains('h2', /Your OpenShift roles/i, { timeout: 30_000 }).should('be.visible');
+  });
+
   it('cost-overview-loads', () => {
     HostNavPage.visitCostOverview();
     cy.url({ timeout: 30_000 }).should('include', '/openshift/cost-management');

--- a/apps/koku-ui-onprem/cypress/support/pages/iam.page.ts
+++ b/apps/koku-ui-onprem/cypress/support/pages/iam.page.ts
@@ -7,6 +7,12 @@ export const IamPage = {
     cy.contains('h1', /My User Access/i, { timeout: 30_000 }).should('be.visible');
   },
 
+  /** COST-8160: bare deep link must default to OpenShift, not SaaS RHEL. */
+  visitMyUserAccessWithoutBundle() {
+    cy.visit('/iam/my-user-access');
+    cy.contains('h1', /My User Access/i, { timeout: 30_000 }).should('be.visible');
+  },
+
   visitIamOverview() {
     cy.visit('/iam/user-access/overview');
     cy.contains('h1', /User Access/i, { timeout: 30_000 }).should('be.visible');

--- a/apps/rbac-ui-onprem/src/shims/insights-rbac/constants.ts
+++ b/apps/rbac-ui-onprem/src/shims/insights-rbac/constants.ts
@@ -1,0 +1,15 @@
+/**
+ * insights-rbac-frontend/shared/utilities/constants
+ *
+ * On-prem has no RHEL entitlement (COST-7589). Upstream DEFAULT_MUA_BUNDLE is
+ * 'rhel' for SaaS; unparameterized /iam/my-user-access deep links must default
+ * to OpenShift (COST-8160).
+ */
+export const RBAC_API_BASE = `/api/rbac/v1` as const;
+export const RBAC_API_BASE_2 = `/api/rbac/v2` as const;
+export const COST_API_BASE = `/api/cost-management/v1` as const;
+export const INVENTORY_API_BASE = `/api/inventory/v1` as const;
+
+export const DEFAULT_MUA_BUNDLE = 'openshift' as const;
+
+export const DEFAULT_ACCESS_GROUP_ID = 'default-access' as const;

--- a/apps/rbac-ui-onprem/src/shims/insights-rbac/constants.ts
+++ b/apps/rbac-ui-onprem/src/shims/insights-rbac/constants.ts
@@ -4,6 +4,9 @@
  * On-prem has no RHEL entitlement (COST-7589). Upstream DEFAULT_MUA_BUNDLE is
  * 'rhel' for SaaS; unparameterized /iam/my-user-access deep links must default
  * to OpenShift (COST-8160).
+ *
+ * Keep exports in sync with vendor/insights-rbac-ui/src/shared/utilities/constants.ts
+ * on submodule bump (only DEFAULT_MUA_BUNDLE should differ).
  */
 export const RBAC_API_BASE = `/api/rbac/v1` as const;
 export const RBAC_API_BASE_2 = `/api/rbac/v2` as const;

--- a/apps/rbac-ui-onprem/webpack.config.ts
+++ b/apps/rbac-ui-onprem/webpack.config.ts
@@ -12,11 +12,16 @@ const NODE_ENV = (process.env.NODE_ENV || 'development') as Configuration['mode'
 const distDir = path.resolve(__dirname, './dist');
 const srcDir = path.resolve(__dirname, './src');
 const useAppLinkShim = path.join(srcDir, 'shims/insights-rbac/useAppLink.ts');
+const constantsShim = path.join(srcDir, 'shims/insights-rbac/constants.ts');
 
 const insightsRbacModuleReplacements: readonly { match: RegExp; replacement: string }[] = [
   {
     match: /[/\\]insights-rbac-frontend[/\\]src[/\\]shared[/\\]hooks[/\\]useAppLink\.ts$/,
     replacement: useAppLinkShim,
+  },
+  {
+    match: /[/\\]insights-rbac-frontend[/\\]src[/\\]shared[/\\]utilities[/\\]constants\.ts$/,
+    replacement: constantsShim,
   },
 ];
 
@@ -137,6 +142,7 @@ const config: Configuration = {
     alias: {
       'insights-rbac-frontend': rbacPkgRoot,
       [path.join(rbacSrcDir, 'shared/hooks/useAppLink')]: useAppLinkShim,
+      [path.join(rbacSrcDir, 'shared/utilities/constants')]: constantsShim,
       '@redhat-cloud-services/frontend-components/useChrome': path.join(
         onpremDepsSrc,
         'frontend-components/useChrome.ts'


### PR DESCRIPTION
## Summary
- Shim `DEFAULT_MUA_BUNDLE` to `openshift` in `rbac-ui-onprem` webpack build (upstream SaaS default is `rhel`)
- Add live Cypress regression for bare `/iam/my-user-access` deep link

Fixes COST-8160: unparameterized My User Access URL was rewriting to `?bundle=rhel` on-prem while the bundle selector only shows OpenShift + Settings.

## Test plan
- [x] `npm run -w @koku-ui/rbac-ui-onprem build:onprem`
- [x] `npm run start:onprem:auth` + `npm run test:cypress:live -w @koku-ui/koku-ui-onprem -- --spec 'cypress/e2e/live/01-app-loads.cy.ts'` (**4/4**)
- [x] Manual: `/iam/my-user-access` (no query) → `?bundle=openshift`, heading "Your OpenShift roles"

Made with [Cursor](https://cursor.com)