### PR TITLE
fix(koku-ui-onprem): prefetch vendor/insights-rbac-ui for hermetic build

### DIFF
--- a/.tekton/koku-ui-onprem-pull-request.yaml
+++ b/.tekton/koku-ui-onprem-pull-request.yaml
@@ -33,7 +33,9 @@ spec:
   - name: hermetic
     value: "true"
   - name: prefetch-input
-    value: '{"type": "npm", "path": "."}'
+    value: >-
+      [{"type": "npm", "path": "."},
+       {"type": "npm", "path": "vendor/insights-rbac-ui"}]
   - name: build-source-image
     value: "true"
   - name: build-args

--- a/.tekton/koku-ui-onprem-push.yaml
+++ b/.tekton/koku-ui-onprem-push.yaml
@@ -30,7 +30,9 @@ spec:
   - name: hermetic
     value: "true"
   - name: prefetch-input
-    value: '{"type": "npm", "path": "."}'
+    value: >-
+      [{"type": "npm", "path": "."},
+       {"type": "npm", "path": "vendor/insights-rbac-ui"}]
   - name: build-source-image
     value: "true"
   - name: build-args


### PR DESCRIPTION
## Summary

- Hermeto only rewrites lockfiles for npm projects listed in `prefetch-input`.
- With a single path `"."`, root `package-lock.json` is injected but `vendor/insights-rbac-ui/package-lock.json` is not.
- Hermetic `npm ci` in `build-container` then resolves `experience-ui-governance` (`github:`) via git → `spawn git ENOENT` on `ubi10/nodejs-24-minimal`.
- Add a second prefetch path for `vendor/insights-rbac-ui` so Hermeto injects the vendor lockfile with `file:///tmp/cachi2/output/...` paths.

Fixes COST-8090. PR targets `main`; flows to `release-onprem` via normal release.

## Test plan

- [ ] Merge and re-attempt vendor bump past `0b948d64` (revert of #5589)
- [ ] Konflux `koku-ui-onprem-on-pull-request` → `prefetch-dependencies` and `build-container` green on `release-onprem`
- [ ] No `spawn git` / `ENOENT` in `build-container` logs


Made with [Cursor](https://cursor.com)