### PR TITLE
Gate the on-prem Integrations tab on sources permissions

### DIFF
--- a/apps/koku-ui-hccm/src/api/userAccess.ts
+++ b/apps/koku-ui-hccm/src/api/userAccess.ts
@@ -24,6 +24,7 @@ export const enum UserAccessType {
   ocp = 'ocp',
   priceList = 'price_list',
   settings = 'settings',
+  sources = 'sources', // on-prem only: gates the Settings > Integrations tab
 }
 
 // If the user-access API is called without a query parameter, all types are returned in the response

--- a/apps/koku-ui-hccm/src/components/permissions/permissions.tsx
+++ b/apps/koku-ui-hccm/src/components/permissions/permissions.tsx
@@ -2,6 +2,7 @@ import { getUserAccessQuery } from 'api/queries/userAccessQuery';
 import type { UserAccess } from 'api/userAccess';
 import { UserAccessType } from 'api/userAccess';
 import type { AxiosError } from 'axios';
+import { isOnPremEnabled } from 'components/featureToggle';
 import React from 'react';
 import { connect } from 'react-redux';
 import { routes } from 'routes';
@@ -20,6 +21,7 @@ import {
   hasGcpAccess,
   hasOcpAccess,
   hasSettingsAccess,
+  hasSourcesAccess,
 } from 'utils/userAccess';
 
 interface PermissionsOwnProps extends ChromeComponentProps {
@@ -53,6 +55,9 @@ const PermissionsBase: React.FC<PermissionsProps> = ({
     const gcp = hasGcpAccess(userAccess);
     const ocp = hasOcpAccess(userAccess);
     const settings = hasSettingsAccess(userAccess);
+    // On-prem, the Settings page also hosts the Integrations tab, which is gated
+    // by sources (not settings) permissions — e.g. the "Sources administrator" role.
+    const sources = isOnPremEnabled && hasSourcesAccess(userAccess);
 
     switch (pathname) {
       case formatPath(routes.explorer.path):
@@ -80,7 +85,7 @@ const PermissionsBase: React.FC<PermissionsProps> = ({
       case formatPath(routes.priceListCreate.path):
         return costModel;
       case formatPath(routes.settings.path):
-        return settings || costModel;
+        return settings || costModel || sources;
       default:
         return false;
     }

--- a/apps/koku-ui-hccm/src/routes/settings/settings.test.tsx
+++ b/apps/koku-ui-hccm/src/routes/settings/settings.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import React from 'react';
 import { IntlProvider } from 'react-intl';
 import { Provider } from 'react-redux';
@@ -30,6 +31,10 @@ jest.mock('utils/chrome', () => ({
 
 jest.mock('@scalprum/react-core', () => ({
   ScalprumComponent: () => <div data-testid="sources" />,
+}));
+
+jest.mock('routes/components/page/notAuthorized', () => ({
+  NotAuthorized: () => <div data-testid="not-authorized" />,
 }));
 
 jest.mock('./costCategory', () => ({
@@ -76,17 +81,19 @@ describe('Settings', () => {
     mockIsOnPremEnabled = false;
   });
 
-  const renderSettings = () => {
+  const defaultUserAccessData = [
+    { type: UserAccessType.costModel, access: true, write: true },
+    { type: UserAccessType.settings, access: true, write: true },
+  ];
+
+  const renderSettings = (userAccessData: any[] = defaultUserAccessData) => {
     const store = configureStore({
       [userAccessStateKey]: {
         byId: new Map([
           [
             userAccessFetchId,
             {
-              data: [
-                { type: UserAccessType.costModel, access: true, write: true },
-                { type: UserAccessType.settings, access: true, write: true },
-              ],
+              data: userAccessData,
             },
           ],
         ]),
@@ -115,5 +122,27 @@ describe('Settings', () => {
     mockIsOnPremEnabled = true;
     renderSettings();
     expect(screen.queryByRole('tab', { name: /cost categories/i })).not.toBeInTheDocument();
+  });
+
+  test('renders the Integrations tab content for a user with sources access but no settings access', async () => {
+    mockIsOnPremEnabled = true;
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    renderSettings([{ type: UserAccessType.sources, access: true, write: true }]);
+
+    await user.click(screen.getByRole('tab', { name: /integrations/i }));
+
+    expect(await screen.findByTestId('sources')).toBeInTheDocument();
+    expect(screen.queryByTestId('not-authorized')).not.toBeInTheDocument();
+  });
+
+  test('denies the Integrations tab for a user with settings access but no sources access', async () => {
+    mockIsOnPremEnabled = true;
+    const user = userEvent.setup({ advanceTimers: jest.advanceTimersByTime });
+    renderSettings([{ type: UserAccessType.settings, access: true, write: true }]);
+
+    await user.click(screen.getByRole('tab', { name: /integrations/i }));
+
+    expect(await screen.findByTestId('not-authorized')).toBeInTheDocument();
+    expect(screen.queryByTestId('sources')).not.toBeInTheDocument();
   });
 });

--- a/apps/koku-ui-hccm/src/routes/settings/settings.tsx
+++ b/apps/koku-ui-hccm/src/routes/settings/settings.tsx
@@ -35,6 +35,8 @@ import {
   hasCostModelWritePermission,
   hasSettingsAccess,
   hasSettingsWritePermission,
+  hasSourcesAccess,
+  hasSourcesWritePermission,
 } from 'utils/userAccess';
 
 import { CostCategory } from './costCategory';
@@ -227,6 +229,7 @@ const Settings: React.FC<SettingsProps> = () => {
 
     const canWriteCostModels = hasCostModelWritePermission(userAccess);
     const canWriteSettings = hasSettingsWritePermission(userAccess);
+    const canWriteSources = hasSourcesWritePermission(userAccess);
     const currentTab = getIdKeyForTab(tab);
 
     if (currentTab === SettingsTab.costModels) {
@@ -254,12 +257,14 @@ const Settings: React.FC<SettingsProps> = () => {
     } else if (currentTab === SettingsTab.tags) {
       return hasSettingsAccess(userAccess) ? <TagLabels canWrite={canWriteSettings} /> : notAuthorized;
     } else if (currentTab === SettingsTab.sources) {
-      return hasSettingsAccess(userAccess) ? (
+      // On-prem only. The Integrations tab is gated by sources permissions
+      // (e.g. the "Sources administrator" role), not settings permissions.
+      return hasSourcesAccess(userAccess) ? (
         <ScalprumComponent
           scope="sources"
           module="./SourcesPage"
           fallback={<LoadingState />}
-          {...({ canWrite: canWriteSettings } as Record<string, unknown>)}
+          {...({ canWrite: canWriteSources } as Record<string, unknown>)}
         />
       ) : (
         notAuthorized

--- a/apps/koku-ui-hccm/src/utils/userAccess.ts
+++ b/apps/koku-ui-hccm/src/utils/userAccess.ts
@@ -113,3 +113,13 @@ export const hasSettingsAccess = (userAccess: UserAccess) => {
 export const hasSettingsWritePermission = (userAccess: UserAccess) => {
   return hasWritePermission(userAccess, UserAccessType.settings);
 };
+
+// Returns true if user has access to sources (on-prem: gates the Integrations tab)
+export const hasSourcesAccess = (userAccess: UserAccess) => {
+  return hasAccess(userAccess, UserAccessType.sources);
+};
+
+// Returns true if user has sources write permission (on-prem)
+export const hasSourcesWritePermission = (userAccess: UserAccess) => {
+  return hasWritePermission(userAccess, UserAccessType.sources);
+};


### PR DESCRIPTION
## JIRA

https://redhat.atlassian.net/browse/COST-8189

## Problem

On an on-prem deployment, a user whose only RBAC role is **Sources
administrator** (`sources:*:*`) lands on **Not authorized** when trying to
reach Settings, and so cannot open the **Integrations** tab where sources are
managed.

- `components/permissions/permissions.tsx` allows `/settings` only when
  `hasSettingsAccess || hasCostModelAccess`. `sources:*:*` satisfies neither.
- `routes/settings/settings.tsx` gates the on-prem Integrations (Sources) tab
  on `hasSettingsAccess` — the wrong capability.

to be merged after https://github.com/project-koku/koku/pull/6286